### PR TITLE
feat: add env and parse helpers

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -5,4 +5,8 @@ middleware wiring, logging setup, config helpers, and server
 factory building blocks without duplicating them per repo.
 """
 
+from fastmcp_pvl_core._env import env, parse_bool, parse_list, parse_scopes
+
 __version__ = "0.0.0"  # PSR overrides at build time
+
+__all__ = ["env", "parse_bool", "parse_list", "parse_scopes"]

--- a/src/fastmcp_pvl_core/_env.py
+++ b/src/fastmcp_pvl_core/_env.py
@@ -1,0 +1,70 @@
+"""Environment variable helpers.
+
+All env var reads in the library and downstream projects route
+through :func:`env` to keep naming consistent.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def env(prefix: str, name: str, default: str | None = None) -> str | None:
+    """Read ``{PREFIX}_{NAME}`` from the environment.
+
+    Args:
+        prefix: Env var prefix (trailing underscore optional).
+        name: Variable name (without prefix).
+        default: Value to return if unset or empty after strip.
+
+    Returns:
+        The env var value stripped of whitespace, or ``default``.
+    """
+    key = f"{prefix.rstrip('_')}_{name}"
+    raw = os.environ.get(key)
+    if raw is None:
+        return default
+    value = raw.strip()
+    return value or default
+
+
+def parse_bool(value: str) -> bool:
+    """Parse common truthy strings to ``bool``.
+
+    Args:
+        value: Raw string value.
+
+    Returns:
+        ``True`` for ``1``, ``true``, ``yes``, ``on`` (case-insensitive);
+        ``False`` otherwise.
+    """
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def parse_list(value: str) -> list[str]:
+    """Parse a comma-separated list, trimming and dropping empties.
+
+    Args:
+        value: Comma-separated string.
+
+    Returns:
+        List of non-empty, stripped items.  Returns ``[]`` when *value* is
+        blank.
+    """
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def parse_scopes(value: str | None) -> list[str] | None:
+    """Parse an OIDC/OAuth scopes string (space- or comma-separated).
+
+    Args:
+        value: Raw scopes string, or ``None``.
+
+    Returns:
+        List of scope tokens.  ``None`` when *value* is ``None``; ``[]``
+        when *value* is a blank string.
+    """
+    if value is None:
+        return None
+    normalized = value.replace(",", " ")
+    return [s for s in normalized.split() if s]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,71 @@
+"""Tests for env var reading helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from fastmcp_pvl_core import env, parse_bool, parse_list, parse_scopes
+
+
+class TestEnv:
+    def test_returns_default_when_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("MYAPP_FOO", raising=False)
+        assert env("MYAPP", "FOO", default="bar") == "bar"
+
+    def test_returns_value_when_set(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_FOO", "hello")
+        assert env("MYAPP", "FOO") == "hello"
+
+    def test_empty_string_treated_as_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_FOO", "")
+        assert env("MYAPP", "FOO", default="fallback") == "fallback"
+
+    def test_strips_whitespace(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_FOO", "  value  ")
+        assert env("MYAPP", "FOO") == "value"
+
+    def test_prefix_can_have_trailing_underscore(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_FOO", "x")
+        assert env("MYAPP_", "FOO") == "x"
+        assert env("MYAPP", "FOO") == "x"
+
+
+class TestParseBool:
+    @pytest.mark.parametrize("value", ["1", "true", "True", "TRUE", "yes", "on"])
+    def test_truthy(self, value: str):
+        assert parse_bool(value) is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "False", "no", "off", ""])
+    def test_falsy(self, value: str):
+        assert parse_bool(value) is False
+
+
+class TestParseList:
+    def test_empty(self):
+        assert parse_list("") == []
+
+    def test_comma_separated(self):
+        assert parse_list("a,b,c") == ["a", "b", "c"]
+
+    def test_strips_whitespace(self):
+        assert parse_list(" a , b , c ") == ["a", "b", "c"]
+
+    def test_drops_empty_items(self):
+        assert parse_list("a,,b,") == ["a", "b"]
+
+
+class TestParseScopes:
+    def test_none_returns_none(self):
+        assert parse_scopes(None) is None
+
+    def test_empty_returns_empty_list(self):
+        assert parse_scopes("") == []
+
+    def test_space_separated(self):
+        assert parse_scopes("read write") == ["read", "write"]
+
+    def test_comma_separated(self):
+        assert parse_scopes("read,write") == ["read", "write"]
+
+    def test_mixed(self):
+        assert parse_scopes("read, write profile") == ["read", "write", "profile"]


### PR DESCRIPTION
## Summary

First real extraction — `env()`, `parse_bool`, `parse_list`, `parse_scopes` from MV's `config.py`.

All four symbols are exported from the package root. Subsequent Task 5–12 extractions will import from here.

Semantic notes vs MV source:

- `env()` additionally strips whitespace and treats empty strings as unset (MV's `_env` did neither). This is a deliberate hardening.
- `parse_scopes()` accepts both space- and comma-separated input (MV's was comma-only) and returns `[]` for empty string, `None` only for `None` input. Matches plan test cases.
- `parse_bool` adds `on` to the truthy set.

## Test plan

- [x] `uv run pytest -v tests/test_env.py` — 26 parametrized cases pass
- [x] `uv run ruff check .` + `ruff format --check .` clean
- [x] `uv run mypy src/` clean
- [ ] CI green on 3.10–3.13

Closes Task 4 of the `fastmcp-pvl-core` extraction plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)