### PR TITLE
feat: add ServerConfig dataclass

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -5,8 +5,16 @@ middleware wiring, logging setup, config helpers, and server
 factory building blocks without duplicating them per repo.
 """
 
+from fastmcp_pvl_core._config import ServerConfig, Transport
 from fastmcp_pvl_core._env import env, parse_bool, parse_list, parse_scopes
 
 __version__ = "0.0.0"  # PSR overrides at build time
 
-__all__ = ["env", "parse_bool", "parse_list", "parse_scopes"]
+__all__ = [
+    "ServerConfig",
+    "Transport",
+    "env",
+    "parse_bool",
+    "parse_list",
+    "parse_scopes",
+]

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -55,14 +55,16 @@ class ServerConfig:
             A populated :class:`ServerConfig` instance.
         """
         transport_raw = env(env_prefix, "TRANSPORT", "stdio")
-        if transport_raw not in ("stdio", "http", "sse"):
-            transport_raw = "stdio"
-        transport: Transport = transport_raw  # type: ignore[assignment]
+        transport: Transport
+        if transport_raw == "http":
+            transport = "http"
+        elif transport_raw == "sse":
+            transport = "sse"
+        else:
+            transport = "stdio"
 
         host = env(env_prefix, "HOST", "127.0.0.1")
-        assert host is not None
         port_str = env(env_prefix, "PORT", "8000")
-        assert port_str is not None
 
         scopes_raw = env(env_prefix, "OIDC_REQUIRED_SCOPES")
         scopes = tuple(parse_scopes(scopes_raw) or ())
@@ -82,6 +84,3 @@ class ServerConfig:
             event_store_url=env(env_prefix, "EVENT_STORE_URL"),
             app_domain=env(env_prefix, "APP_DOMAIN"),
         )
-
-
-__all__ = ["ServerConfig", "Transport"]

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -1,0 +1,87 @@
+"""Universal server configuration.
+
+Downstream projects compose this into their own domain config dataclass
+(they do not inherit). Core only owns fields that are universal to any
+FastMCP server: transport, host, port, auth credentials, event store URL,
+MCP Apps domain.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from fastmcp_pvl_core._env import env, parse_scopes
+
+Transport = Literal["stdio", "http", "sse"]
+
+
+@dataclass(frozen=True)
+class ServerConfig:
+    """Universal fields every FastMCP server needs.
+
+    Compose into a domain config; never inherit from this class.
+    """
+
+    transport: Transport = "stdio"
+    host: str = "127.0.0.1"
+    port: int = 8000
+    base_url: str | None = None
+
+    bearer_token: str | None = None
+
+    oidc_config_url: str | None = None
+    oidc_client_id: str | None = None
+    oidc_client_secret: str | None = None
+    oidc_audience: str | None = None
+    oidc_required_scopes: tuple[str, ...] = field(default_factory=tuple)
+    oidc_jwt_signing_key: str | None = None
+
+    event_store_url: str | None = None
+    app_domain: str | None = None
+
+    @classmethod
+    def from_env(cls, env_prefix: str) -> ServerConfig:
+        """Load all fields from ``{env_prefix}_*`` environment variables.
+
+        Unknown values for ``TRANSPORT`` silently fall back to ``"stdio"``
+        rather than raising.  This matches the rest of the env-reading
+        helpers, which prefer permissive defaults over hard failures.
+
+        Args:
+            env_prefix: Env var prefix, no trailing underscore needed.
+
+        Returns:
+            A populated :class:`ServerConfig` instance.
+        """
+        transport_raw = env(env_prefix, "TRANSPORT", "stdio")
+        if transport_raw not in ("stdio", "http", "sse"):
+            transport_raw = "stdio"
+        transport: Transport = transport_raw  # type: ignore[assignment]
+
+        host = env(env_prefix, "HOST", "127.0.0.1")
+        assert host is not None
+        port_str = env(env_prefix, "PORT", "8000")
+        assert port_str is not None
+
+        scopes_raw = env(env_prefix, "OIDC_REQUIRED_SCOPES")
+        scopes = tuple(parse_scopes(scopes_raw) or ())
+
+        return cls(
+            transport=transport,
+            host=host,
+            port=int(port_str),
+            base_url=env(env_prefix, "BASE_URL"),
+            bearer_token=env(env_prefix, "BEARER_TOKEN"),
+            oidc_config_url=env(env_prefix, "OIDC_CONFIG_URL"),
+            oidc_client_id=env(env_prefix, "OIDC_CLIENT_ID"),
+            oidc_client_secret=env(env_prefix, "OIDC_CLIENT_SECRET"),
+            oidc_audience=env(env_prefix, "OIDC_AUDIENCE"),
+            oidc_required_scopes=scopes,
+            oidc_jwt_signing_key=env(env_prefix, "OIDC_JWT_SIGNING_KEY"),
+            event_store_url=env(env_prefix, "EVENT_STORE_URL"),
+            app_domain=env(env_prefix, "APP_DOMAIN"),
+        )
+
+
+__all__ = ["ServerConfig", "Transport"]

--- a/src/fastmcp_pvl_core/_env.py
+++ b/src/fastmcp_pvl_core/_env.py
@@ -7,8 +7,15 @@ through :func:`env` to keep naming consistent.
 from __future__ import annotations
 
 import os
+from typing import overload
 
 
+@overload
+def env(prefix: str, name: str) -> str | None: ...
+@overload
+def env(prefix: str, name: str, default: None) -> str | None: ...
+@overload
+def env(prefix: str, name: str, default: str) -> str: ...
 def env(prefix: str, name: str, default: str | None = None) -> str | None:
     """Read ``{PREFIX}_{NAME}`` from the environment.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,73 @@
+"""Tests for ServerConfig."""
+
+from __future__ import annotations
+
+import pytest
+
+from fastmcp_pvl_core import ServerConfig
+
+
+class TestServerConfigDefaults:
+    def test_default_transport_is_stdio(self):
+        config = ServerConfig()
+        assert config.transport == "stdio"
+
+    def test_default_host_port(self):
+        config = ServerConfig()
+        assert config.host == "127.0.0.1"
+        assert config.port == 8000
+
+    def test_auth_fields_default_to_none(self):
+        config = ServerConfig()
+        assert config.bearer_token is None
+        assert config.oidc_config_url is None
+        assert config.oidc_client_id is None
+        assert config.oidc_required_scopes == ()
+
+
+class TestServerConfigFromEnv:
+    def test_reads_transport(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_TRANSPORT", "http")
+        config = ServerConfig.from_env("MYAPP")
+        assert config.transport == "http"
+
+    def test_reads_host_port(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_HOST", "0.0.0.0")
+        monkeypatch.setenv("MYAPP_PORT", "9000")
+        config = ServerConfig.from_env("MYAPP")
+        assert config.host == "0.0.0.0"
+        assert config.port == 9000
+
+    def test_reads_bearer_token(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_BEARER_TOKEN", "secret")
+        config = ServerConfig.from_env("MYAPP")
+        assert config.bearer_token == "secret"
+
+    def test_reads_oidc_vars(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_BASE_URL", "https://x.example")
+        monkeypatch.setenv(
+            "MYAPP_OIDC_CONFIG_URL",
+            "https://idp.example/.well-known/openid-configuration",
+        )
+        monkeypatch.setenv("MYAPP_OIDC_CLIENT_ID", "cid")
+        monkeypatch.setenv("MYAPP_OIDC_CLIENT_SECRET", "csecret")
+        monkeypatch.setenv("MYAPP_OIDC_REQUIRED_SCOPES", "openid profile")
+        config = ServerConfig.from_env("MYAPP")
+        assert config.base_url == "https://x.example"
+        assert (
+            config.oidc_config_url
+            == "https://idp.example/.well-known/openid-configuration"
+        )
+        assert config.oidc_client_id == "cid"
+        assert config.oidc_client_secret == "csecret"
+        assert config.oidc_required_scopes == ("openid", "profile")
+
+    def test_reads_event_store_url(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_EVENT_STORE_URL", "file:///data/events")
+        config = ServerConfig.from_env("MYAPP")
+        assert config.event_store_url == "file:///data/events"
+
+    def test_is_frozen(self):
+        config = ServerConfig()
+        with pytest.raises(AttributeError):
+            config.transport = "http"  # type: ignore[misc]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,6 +51,8 @@ class TestServerConfigFromEnv:
         )
         monkeypatch.setenv("MYAPP_OIDC_CLIENT_ID", "cid")
         monkeypatch.setenv("MYAPP_OIDC_CLIENT_SECRET", "csecret")
+        monkeypatch.setenv("MYAPP_OIDC_AUDIENCE", "aud.example")
+        monkeypatch.setenv("MYAPP_OIDC_JWT_SIGNING_KEY", "sigkey")
         monkeypatch.setenv("MYAPP_OIDC_REQUIRED_SCOPES", "openid profile")
         config = ServerConfig.from_env("MYAPP")
         assert config.base_url == "https://x.example"
@@ -60,12 +62,24 @@ class TestServerConfigFromEnv:
         )
         assert config.oidc_client_id == "cid"
         assert config.oidc_client_secret == "csecret"
+        assert config.oidc_audience == "aud.example"
+        assert config.oidc_jwt_signing_key == "sigkey"
         assert config.oidc_required_scopes == ("openid", "profile")
 
     def test_reads_event_store_url(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("MYAPP_EVENT_STORE_URL", "file:///data/events")
         config = ServerConfig.from_env("MYAPP")
         assert config.event_store_url == "file:///data/events"
+
+    def test_reads_app_domain(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_APP_DOMAIN", "mcp.example.com")
+        assert ServerConfig.from_env("MYAPP").app_domain == "mcp.example.com"
+
+    def test_invalid_transport_falls_back_to_stdio(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("MYAPP_TRANSPORT", "websocket")
+        assert ServerConfig.from_env("MYAPP").transport == "stdio"
 
     def test_is_frozen(self):
         config = ServerConfig()


### PR DESCRIPTION
## Summary

Ports the universal server config fields (transport, host, port, auth credentials, event store URL, MCP Apps domain) into a frozen dataclass with a `from_env` classmethod.

Composition-not-inheritance: downstream projects compose this into their own domain config, they do not inherit.

Field names align with `markdown-vault-mcp`'s `CollectionConfig` so the downstream swap in Task 15 is a straight delegation rather than a rename.

`oidc_required_scopes` is a `tuple[str, ...]` here (frozen dataclass needs hashable + immutable), parsed via `parse_scopes`. MV stores it raw as `str | None`; Task 15 will reconcile at the composition boundary.

Unknown `TRANSPORT` env values silently fall back to `"stdio"` — matches the permissive defaults in `_env.py`.

## Test plan

- [x] `uv run pytest -v tests/test_config.py` — 9 tests pass (defaults + from_env + frozen)
- [x] `uv run pytest -x -q` — full suite 36 passed
- [x] `uv run ruff check --fix .` then `uv run ruff format .` then `uv run ruff format --check .` — clean
- [x] `uv run mypy src/` — no issues
- [ ] CI green on 3.10-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)