### PR TITLE
feat: add individual auth builders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,9 @@ warn_unused_ignores = true
 asyncio_mode = "auto"
 addopts = "-ra"
 testpaths = ["tests"]
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+pythonVersion = "3.10"
+include = ["src", "tests"]

--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -5,7 +5,13 @@ middleware wiring, logging setup, config helpers, and server
 factory building blocks without duplicating them per repo.
 """
 
-from fastmcp_pvl_core._auth import AuthMode, resolve_auth_mode
+from fastmcp_pvl_core._auth import (
+    AuthMode,
+    build_bearer_auth,
+    build_oidc_proxy_auth,
+    build_remote_auth,
+    resolve_auth_mode,
+)
 from fastmcp_pvl_core._config import ServerConfig, Transport
 from fastmcp_pvl_core._env import env, parse_bool, parse_list, parse_scopes
 
@@ -15,6 +21,9 @@ __all__ = [
     "AuthMode",
     "ServerConfig",
     "Transport",
+    "build_bearer_auth",
+    "build_oidc_proxy_auth",
+    "build_remote_auth",
     "env",
     "parse_bool",
     "parse_list",

--- a/src/fastmcp_pvl_core/_auth.py
+++ b/src/fastmcp_pvl_core/_auth.py
@@ -244,7 +244,7 @@ def build_remote_auth(config: ServerConfig) -> RemoteAuthProvider | None:
         resp = httpx.get(config.oidc_config_url, timeout=10)
         resp.raise_for_status()
         discovery = resp.json()
-    except Exception:
+    except (httpx.HTTPError, ValueError):
         logger.exception(
             "remote_auth_discovery_failed config_url=%s",
             config.oidc_config_url,

--- a/src/fastmcp_pvl_core/_auth.py
+++ b/src/fastmcp_pvl_core/_auth.py
@@ -8,9 +8,17 @@ Five modes: ``none``, ``bearer``, ``remote``, ``oidc-proxy``, ``multi``.
 from __future__ import annotations
 
 import logging
-from typing import Literal, cast
+import sys
+from typing import TYPE_CHECKING, Literal, cast
 
 from fastmcp_pvl_core._config import ServerConfig
+
+if TYPE_CHECKING:
+    from fastmcp.server.auth import (
+        RemoteAuthProvider,
+        StaticTokenVerifier,
+    )
+    from fastmcp.server.auth.oidc_proxy import OIDCProxy
 
 logger = logging.getLogger(__name__)
 
@@ -89,3 +97,182 @@ def resolve_auth_mode(config: ServerConfig) -> AuthMode:
     if oidc_mode is not None:
         return oidc_mode
     return "none"
+
+
+def build_bearer_auth(config: ServerConfig) -> StaticTokenVerifier | None:
+    """Build a :class:`StaticTokenVerifier` from ``config.bearer_token``.
+
+    Returns a verifier that validates ``Authorization: Bearer <token>``
+    headers against the configured static token.  The token is granted
+    ``read`` and ``write`` scopes; operators scope down at the MCP layer
+    (e.g. tag-based tool hiding) rather than by differentiating bearer
+    scopes.
+
+    Args:
+        config: Populated server configuration.
+
+    Returns:
+        A configured :class:`StaticTokenVerifier`, or ``None`` when the
+        bearer token is absent or blank.
+    """
+    token = (config.bearer_token or "").strip()
+    if not token:
+        logger.debug("bearer_auth_skipped reason=not_configured")
+        return None
+    logger.debug("bearer_auth_enabled token=<redacted>")
+    from fastmcp.server.auth import StaticTokenVerifier
+
+    return StaticTokenVerifier(
+        tokens={token: {"client_id": "bearer", "scopes": ["read", "write"]}},
+    )
+
+
+def build_oidc_proxy_auth(config: ServerConfig) -> OIDCProxy | None:
+    """Build an :class:`OIDCProxy` provider, or return ``None``.
+
+    Requires all four of ``base_url``, ``oidc_config_url``,
+    ``oidc_client_id``, and ``oidc_client_secret`` on *config*.  By
+    default the proxy verifies the upstream ``id_token`` (a standard JWT
+    per OIDC Core) rather than the ``access_token`` — this works with
+    every OIDC provider, including those that issue opaque access tokens
+    (e.g. Authelia).  Set ``config.oidc_verify_access_token=True`` to
+    revert to access-token verification.
+
+    ``required_scopes`` defaults to ``["openid"]`` when *config* does not
+    configure any, matching OIDC Core semantics (``openid`` must be
+    requested for an id_token to be issued).
+
+    Args:
+        config: Populated server configuration.
+
+    Returns:
+        A configured :class:`OIDCProxy`, or ``None`` when any of the
+        four required fields is missing.
+    """
+    # Keep the secret out of the "missing" list so it never enters logs
+    # (static-analysis taint tools flag this otherwise).
+    required_public = {
+        "BASE_URL": config.base_url,
+        "OIDC_CONFIG_URL": config.oidc_config_url,
+        "OIDC_CLIENT_ID": config.oidc_client_id,
+    }
+    has_secret = bool(config.oidc_client_secret)
+    if not all(required_public.values()) or not has_secret:
+        missing = [k for k, v in required_public.items() if not v]
+        if not has_secret:
+            missing.append("OIDC_CLIENT_SECRET")
+        logger.debug("oidc_proxy_auth_skipped missing=%s", ",".join(missing))
+        return None
+
+    # Narrow types — all four are non-None after the guard above.
+    base_url = cast(str, config.base_url)
+    oidc_config_url = cast(str, config.oidc_config_url)
+    oidc_client_id = cast(str, config.oidc_client_id)
+    oidc_client_secret = cast(str, config.oidc_client_secret)
+
+    required_scopes: list[str] = list(config.oidc_required_scopes) or ["openid"]
+
+    verify_access_token = config.oidc_verify_access_token
+    verify_id_token = not verify_access_token
+
+    if verify_id_token and "openid" not in required_scopes:
+        logger.warning(
+            "oidc_proxy_auth_scope_warning "
+            "verify_id_token=True missing_scope=openid — "
+            "the id_token may be absent from the token response; "
+            "add 'openid' to required_scopes or set "
+            "oidc_verify_access_token=True"
+        )
+
+    if config.oidc_jwt_signing_key is None and sys.platform.startswith("linux"):
+        logger.warning(
+            "oidc_proxy_auth_ephemeral_signing_key "
+            "oidc_jwt_signing_key=<unset> — tokens will be invalidated on "
+            "every server restart; configure OIDC_JWT_SIGNING_KEY in "
+            "production"
+        )
+
+    from fastmcp.server.auth.oidc_proxy import OIDCProxy
+
+    return OIDCProxy(
+        config_url=oidc_config_url,
+        client_id=oidc_client_id,
+        client_secret=oidc_client_secret,
+        base_url=base_url,
+        audience=config.oidc_audience,
+        required_scopes=required_scopes,
+        jwt_signing_key=config.oidc_jwt_signing_key,
+        verify_id_token=verify_id_token,
+        require_authorization_consent=False,
+    )
+
+
+def build_remote_auth(config: ServerConfig) -> RemoteAuthProvider | None:
+    """Build a :class:`RemoteAuthProvider` from OIDC discovery.
+
+    Fetches the OIDC discovery document at startup to extract
+    ``jwks_uri`` and ``issuer``, then constructs a ``JWTVerifier`` for
+    local token validation via JWKS.  No client credentials are needed —
+    tokens are validated locally.
+
+    Requires ``base_url`` and ``oidc_config_url`` on *config*.  Returns
+    ``None`` when either is missing, when ``httpx`` is not installed
+    (the ``remote-auth`` extra), when the discovery request fails, or
+    when the discovery document is missing ``jwks_uri``/``issuer``.
+
+    Args:
+        config: Populated server configuration.
+
+    Returns:
+        A configured :class:`RemoteAuthProvider`, or ``None`` when
+        remote auth cannot be built.
+    """
+    if not config.base_url or not config.oidc_config_url:
+        logger.debug("remote_auth_skipped reason=missing_base_url_or_config_url")
+        return None
+
+    try:
+        import httpx
+    except ImportError:
+        logger.warning(
+            "remote_auth_skipped reason=httpx_missing — "
+            "install with `pip install fastmcp-pvl-core[remote-auth]`"
+        )
+        return None
+
+    try:
+        resp = httpx.get(config.oidc_config_url, timeout=10)
+        resp.raise_for_status()
+        discovery = resp.json()
+    except Exception:
+        logger.exception(
+            "remote_auth_discovery_failed config_url=%s",
+            config.oidc_config_url,
+        )
+        return None
+
+    jwks_uri = discovery.get("jwks_uri")
+    issuer = discovery.get("issuer")
+    if not jwks_uri or not issuer:
+        logger.error(
+            "remote_auth_discovery_incomplete jwks_uri=%s issuer=%s",
+            jwks_uri,
+            issuer,
+        )
+        return None
+
+    required_scopes: list[str] | None = list(config.oidc_required_scopes) or None
+
+    from fastmcp.server.auth import JWTVerifier, RemoteAuthProvider
+
+    verifier = JWTVerifier(
+        jwks_uri=jwks_uri,
+        issuer=issuer,
+        audience=config.oidc_audience,
+        required_scopes=required_scopes,
+    )
+    return RemoteAuthProvider(
+        token_verifier=verifier,
+        authorization_servers=[issuer],
+        base_url=config.base_url,
+    )

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-from fastmcp_pvl_core._env import env, parse_scopes
+from fastmcp_pvl_core._env import env, parse_bool, parse_scopes
 
 Transport = Literal["stdio", "http", "sse"]
 
@@ -36,6 +36,7 @@ class ServerConfig:
     oidc_audience: str | None = None
     oidc_required_scopes: tuple[str, ...] = field(default_factory=tuple)
     oidc_jwt_signing_key: str | None = None
+    oidc_verify_access_token: bool = False
 
     event_store_url: str | None = None
     app_domain: str | None = None
@@ -71,6 +72,11 @@ class ServerConfig:
         scopes_raw = env(env_prefix, "OIDC_REQUIRED_SCOPES")
         scopes = tuple(parse_scopes(scopes_raw) or ())
 
+        verify_access_raw = env(env_prefix, "OIDC_VERIFY_ACCESS_TOKEN")
+        verify_access_token = (
+            parse_bool(verify_access_raw) if verify_access_raw is not None else False
+        )
+
         return cls(
             transport=transport,
             host=host,
@@ -83,6 +89,7 @@ class ServerConfig:
             oidc_audience=env(env_prefix, "OIDC_AUDIENCE"),
             oidc_required_scopes=scopes,
             oidc_jwt_signing_key=env(env_prefix, "OIDC_JWT_SIGNING_KEY"),
+            oidc_verify_access_token=verify_access_token,
             event_store_url=env(env_prefix, "EVENT_STORE_URL"),
             app_domain=env(env_prefix, "APP_DOMAIN"),
             auth_mode=env(env_prefix, "AUTH_MODE"),

--- a/tests/test_auth_builders.py
+++ b/tests/test_auth_builders.py
@@ -109,6 +109,17 @@ class TestBuildOIDCProxyAuth:
             build_oidc_proxy_auth(_oidc_config(oidc_verify_access_token=True))
         assert mock_cls.call_args.kwargs["verify_id_token"] is False
 
+    def test_scope_warning_when_verify_id_token_without_openid(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        mock_cls = MagicMock()
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
+            build_oidc_proxy_auth(_oidc_config(oidc_required_scopes=("profile",)))
+        assert any(
+            "scope_warning" in r.message and r.levelname == "WARNING"
+            for r in caplog.records
+        )
+
     def test_linux_ephemeral_key_warning(self, caplog: pytest.LogCaptureFixture):
         mock_cls = MagicMock()
         with (
@@ -197,9 +208,32 @@ class TestBuildRemoteAuth:
         import httpx
 
         def _raise(*a, **kw):
-            raise RuntimeError("network down")
+            raise httpx.ConnectError("network down")
 
         monkeypatch.setattr(httpx, "get", _raise)
+        auth = build_remote_auth(
+            ServerConfig(
+                base_url="https://x.example",
+                oidc_config_url=(
+                    "https://idp.example/.well-known/openid-configuration"
+                ),
+            )
+        )
+        assert auth is None
+
+    def test_returns_none_when_discovery_json_malformed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        import httpx
+
+        class _BadJSONResp:
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> object:
+                raise ValueError("not json")
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _BadJSONResp())
         auth = build_remote_auth(
             ServerConfig(
                 base_url="https://x.example",

--- a/tests/test_auth_builders.py
+++ b/tests/test_auth_builders.py
@@ -1,0 +1,211 @@
+"""Tests for individual auth builders."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fastmcp_pvl_core import (
+    ServerConfig,
+    build_bearer_auth,
+    build_oidc_proxy_auth,
+    build_remote_auth,
+)
+
+
+def _oidc_config(**overrides: object) -> ServerConfig:
+    """Build a fully-populated OIDC proxy config with optional overrides."""
+    base: dict[str, object] = {
+        "base_url": "https://mcp.example.com",
+        "oidc_config_url": "https://idp.example/.well-known/openid-configuration",
+        "oidc_client_id": "test-client",
+        "oidc_client_secret": "test-secret",
+    }
+    base.update(overrides)
+    return ServerConfig(**base)  # type: ignore[arg-type]
+
+
+class TestBuildBearerAuth:
+    def test_returns_none_when_no_token(self):
+        assert build_bearer_auth(ServerConfig()) is None
+
+    def test_returns_none_when_token_is_whitespace(self):
+        assert build_bearer_auth(ServerConfig(bearer_token="   ")) is None
+
+    def test_returns_verifier_when_token_set(self):
+        from fastmcp.server.auth import StaticTokenVerifier
+
+        auth = build_bearer_auth(ServerConfig(bearer_token="secret"))
+        assert isinstance(auth, StaticTokenVerifier)
+
+    def test_token_mapped_with_read_write_scopes(self):
+        auth = build_bearer_auth(ServerConfig(bearer_token="secret"))
+        assert auth is not None
+        # StaticTokenVerifier exposes a ``tokens`` dict for introspection.
+        entry = auth.tokens["secret"]
+        assert entry["client_id"] == "bearer"
+        assert entry["scopes"] == ["read", "write"]
+
+
+class TestBuildOIDCProxyAuth:
+    def test_returns_none_when_all_vars_missing(self):
+        assert build_oidc_proxy_auth(ServerConfig()) is None
+
+    def test_returns_none_when_base_url_only(self):
+        assert build_oidc_proxy_auth(ServerConfig(base_url="https://x")) is None
+
+    def test_returns_none_when_secret_missing(self):
+        cfg = ServerConfig(
+            base_url="https://x.example",
+            oidc_config_url="https://idp.example/.well-known/openid-configuration",
+            oidc_client_id="cid",
+        )
+        assert build_oidc_proxy_auth(cfg) is None
+
+    def test_returns_proxy_when_all_vars_set(self):
+        mock_cls = MagicMock()
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
+            auth = build_oidc_proxy_auth(_oidc_config())
+        assert auth is mock_cls.return_value
+        mock_cls.assert_called_once()
+
+    def test_passes_correct_kwargs(self):
+        mock_cls = MagicMock()
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
+            build_oidc_proxy_auth(_oidc_config())
+        kw = mock_cls.call_args.kwargs
+        assert kw["base_url"] == "https://mcp.example.com"
+        assert kw["client_id"] == "test-client"
+        assert kw["client_secret"] == "test-secret"
+        assert kw["config_url"] == (
+            "https://idp.example/.well-known/openid-configuration"
+        )
+        assert kw["required_scopes"] == ["openid"]
+        assert kw["verify_id_token"] is True
+        assert kw["require_authorization_consent"] is False
+
+    def test_defaults_required_scopes_to_openid(self):
+        mock_cls = MagicMock()
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
+            build_oidc_proxy_auth(_oidc_config())
+        assert mock_cls.call_args.kwargs["required_scopes"] == ["openid"]
+
+    def test_custom_scopes_passed_through(self):
+        mock_cls = MagicMock()
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
+            build_oidc_proxy_auth(
+                _oidc_config(oidc_required_scopes=("openid", "profile"))
+            )
+        assert mock_cls.call_args.kwargs["required_scopes"] == [
+            "openid",
+            "profile",
+        ]
+
+    def test_verify_id_token_false_when_access_token_opt_in(self):
+        mock_cls = MagicMock()
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
+            build_oidc_proxy_auth(_oidc_config(oidc_verify_access_token=True))
+        assert mock_cls.call_args.kwargs["verify_id_token"] is False
+
+    def test_linux_ephemeral_key_warning(self, caplog: pytest.LogCaptureFixture):
+        mock_cls = MagicMock()
+        with (
+            patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
+            patch("fastmcp_pvl_core._auth.sys") as mock_sys,
+        ):
+            mock_sys.platform = "linux"
+            build_oidc_proxy_auth(_oidc_config())
+        assert any(
+            "ephemeral_signing_key" in r.message and r.levelname == "WARNING"
+            for r in caplog.records
+        )
+
+
+class TestBuildRemoteAuth:
+    def test_returns_none_when_config_missing(self):
+        assert build_remote_auth(ServerConfig()) is None
+
+    def test_returns_none_when_only_base_url(self):
+        assert build_remote_auth(ServerConfig(base_url="https://x")) is None
+
+    def test_returns_none_when_httpx_unavailable(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setitem(sys.modules, "httpx", None)
+        result = build_remote_auth(
+            ServerConfig(
+                base_url="https://x",
+                oidc_config_url="https://idp/.well-known/openid-configuration",
+            )
+        )
+        assert result is None
+
+    def test_returns_provider_when_discovery_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        import httpx
+        from fastmcp.server.auth import RemoteAuthProvider
+
+        class _StubResponse:
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, str]:
+                return {
+                    "jwks_uri": "https://idp.example/jwks.json",
+                    "issuer": "https://idp.example/",
+                }
+
+        def _fake_get(url: str, timeout: int = 10) -> _StubResponse:
+            return _StubResponse()
+
+        monkeypatch.setattr(httpx, "get", _fake_get)
+        auth = build_remote_auth(
+            ServerConfig(
+                base_url="https://x.example",
+                oidc_config_url=(
+                    "https://idp.example/.well-known/openid-configuration"
+                ),
+            )
+        )
+        assert isinstance(auth, RemoteAuthProvider)
+
+    def test_returns_none_when_discovery_missing_fields(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        import httpx
+
+        class _StubResponse:
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, str]:
+                return {}  # missing jwks_uri/issuer
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _StubResponse())
+        auth = build_remote_auth(
+            ServerConfig(
+                base_url="https://x.example",
+                oidc_config_url=(
+                    "https://idp.example/.well-known/openid-configuration"
+                ),
+            )
+        )
+        assert auth is None
+
+    def test_returns_none_when_discovery_raises(self, monkeypatch: pytest.MonkeyPatch):
+        import httpx
+
+        def _raise(*a, **kw):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(httpx, "get", _raise)
+        auth = build_remote_auth(
+            ServerConfig(
+                base_url="https://x.example",
+                oidc_config_url=(
+                    "https://idp.example/.well-known/openid-configuration"
+                ),
+            )
+        )
+        assert auth is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,6 +75,13 @@ class TestServerConfigFromEnv:
         monkeypatch.setenv("MYAPP_APP_DOMAIN", "mcp.example.com")
         assert ServerConfig.from_env("MYAPP").app_domain == "mcp.example.com"
 
+    def test_oidc_verify_access_token_defaults_to_false(self):
+        assert ServerConfig().oidc_verify_access_token is False
+
+    def test_reads_oidc_verify_access_token(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_OIDC_VERIFY_ACCESS_TOKEN", "true")
+        assert ServerConfig.from_env("MYAPP").oidc_verify_access_token is True
+
     def test_reads_auth_mode(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("MYAPP_AUTH_MODE", "oidc-proxy")
         assert ServerConfig.from_env("MYAPP").auth_mode == "oidc-proxy"


### PR DESCRIPTION
## Summary

Ports `build_bearer_auth`, `build_oidc_auth` (renamed to `build_oidc_proxy_auth`), and `build_remote_auth` from markdown-vault-mcp to operate on core's `ServerConfig`. Each builder inspects the config and returns the matching FastMCP auth provider, or `None` when required fields are missing.

Also widens `ServerConfig` with `oidc_verify_access_token: bool = False` (Task 5 augmentation) so the OIDC-proxy builder can choose between `id_token` verification (default — works with opaque-token providers like Authelia) and `access_token` JWT verification. Wired through `from_env()` via the `OIDC_VERIFY_ACCESS_TOKEN` env var.

### Behavior mirrors MV exactly

- **Bearer**: `StaticTokenVerifier(tokens={token: {"client_id": "bearer", "scopes": ["read", "write"]}})`
- **OIDC proxy**: `OIDCProxy(config_url, client_id, client_secret, base_url, audience, required_scopes, jwt_signing_key, verify_id_token, require_authorization_consent=False)`; defaults `required_scopes` to `["openid"]`, warns on missing `openid` scope, warns on ephemeral signing key under Linux
- **Remote**: fetches OIDC discovery via `httpx.get`, builds `JWTVerifier(jwks_uri, issuer, audience, required_scopes)`, wraps in `RemoteAuthProvider(token_verifier, authorization_servers=[issuer], base_url)`; returns `None` when `httpx` is missing (the `remote-auth` extra), discovery raises, or `jwks_uri`/`issuer` absent

### Exports

`build_bearer_auth`, `build_oidc_proxy_auth`, `build_remote_auth` added to `__all__` (alphabetized).

## Test plan

- [x] 19 new builder tests (bearer, oidc-proxy with mocked constructor per MV pattern, remote with mocked `httpx.get`)
- [x] 2 new config tests for `oidc_verify_access_token` (default + env var)
- [x] `uv run pytest -x -q` — 76 passed (was 55)
- [x] `uv run ruff check --fix . && uv run ruff format .` — clean
- [x] `uv run mypy src/` — Success: no issues found in 4 source files
- [ ] CI green on 3.10–3.13