### PR TITLE
feat: add build_auth dispatcher

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -7,6 +7,7 @@ factory building blocks without duplicating them per repo.
 
 from fastmcp_pvl_core._auth import (
     AuthMode,
+    build_auth,
     build_bearer_auth,
     build_oidc_proxy_auth,
     build_remote_auth,
@@ -21,6 +22,7 @@ __all__ = [
     "AuthMode",
     "ServerConfig",
     "Transport",
+    "build_auth",
     "build_bearer_auth",
     "build_oidc_proxy_auth",
     "build_remote_auth",

--- a/src/fastmcp_pvl_core/_auth.py
+++ b/src/fastmcp_pvl_core/_auth.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from fastmcp_pvl_core._config import ServerConfig
 
@@ -275,4 +275,76 @@ def build_remote_auth(config: ServerConfig) -> RemoteAuthProvider | None:
         token_verifier=verifier,
         authorization_servers=[issuer],
         base_url=config.base_url,
+    )
+
+
+def build_auth(config: ServerConfig) -> Any:
+    """Dispatch to the correct FastMCP auth provider for *config*.
+
+    Resolves the auth mode via :func:`resolve_auth_mode` and composes the
+    individual builders.  In ``multi`` mode, wraps an OIDC provider and a
+    bearer verifier into a single :class:`~fastmcp.server.auth.MultiAuth`
+    with ``required_scopes=[]``.
+
+    Args:
+        config: Populated server configuration.
+
+    Returns:
+        The appropriate auth provider:
+
+        - ``None`` when no auth is configured.
+        - A :class:`~fastmcp.server.auth.StaticTokenVerifier` in
+          ``bearer`` mode.
+        - An :class:`~fastmcp.server.auth.oidc_proxy.OIDCProxy` in
+          ``oidc-proxy`` mode.
+        - A :class:`~fastmcp.server.auth.RemoteAuthProvider` in
+          ``remote`` mode.
+        - A :class:`~fastmcp.server.auth.MultiAuth` in ``multi`` mode,
+          always constructed with ``required_scopes=[]`` (load-bearing —
+          see implementation comment).
+    """
+    mode = resolve_auth_mode(config)
+    if mode == "none":
+        return None
+    if mode == "bearer":
+        return build_bearer_auth(config)
+    if mode == "oidc-proxy":
+        return build_oidc_proxy_auth(config)
+    if mode == "remote":
+        return build_remote_auth(config)
+
+    # mode == "multi"
+    oidc_auth: OIDCProxy | RemoteAuthProvider | None = build_oidc_proxy_auth(
+        config
+    ) or build_remote_auth(config)
+    bearer_auth = build_bearer_auth(config)
+
+    if oidc_auth is None or bearer_auth is None:
+        # One of the two builders returned None despite resolve_auth_mode
+        # reporting "multi" (e.g. remote-auth discovery failed, or httpx
+        # missing).  Fall back to whichever one is available rather than
+        # silently dropping auth entirely.
+        logger.warning(
+            "multi_auth_degraded oidc=%s bearer=%s — falling back to "
+            "whichever auth provider succeeded",
+            oidc_auth is not None,
+            bearer_auth is not None,
+        )
+        return oidc_auth or bearer_auth
+
+    from fastmcp.server.auth import MultiAuth
+
+    # required_scopes=[] is load-bearing: without it, OIDC's ["openid"]
+    # scope propagates to FastMCP's RequireAuthMiddleware and rejects
+    # bearer tokens lacking "openid" with 403 insufficient_scope
+    # (MV PR #249).
+    #
+    # OIDCProxy / RemoteAuthProvider (both OAuthProvider subclasses) MUST
+    # go in server= — passing an OAuthProvider in verifiers= silently
+    # drops its OAuth routes because get_routes/get_well_known_routes
+    # only delegate to self.server.
+    return MultiAuth(
+        server=oidc_auth,
+        verifiers=[bearer_auth],
+        required_scopes=[],
     )

--- a/tests/test_build_auth.py
+++ b/tests/test_build_auth.py
@@ -1,0 +1,119 @@
+"""Tests for build_auth dispatcher."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastmcp_pvl_core import ServerConfig, build_auth
+
+
+def _oidc_proxy_config(**overrides: object) -> ServerConfig:
+    """Fully-populated OIDC proxy config."""
+    base: dict[str, object] = {
+        "base_url": "https://mcp.example.com",
+        "oidc_config_url": "https://idp.example/.well-known/openid-configuration",
+        "oidc_client_id": "test-client",
+        "oidc_client_secret": "test-secret",
+    }
+    base.update(overrides)
+    return ServerConfig(**base)  # type: ignore[arg-type]
+
+
+def _remote_only_config(**overrides: object) -> ServerConfig:
+    """Config that triggers remote mode (no client_id/secret)."""
+    base: dict[str, object] = {
+        "base_url": "https://mcp.example.com",
+        "oidc_config_url": "https://idp.example/.well-known/openid-configuration",
+    }
+    base.update(overrides)
+    return ServerConfig(**base)  # type: ignore[arg-type]
+
+
+def _mock_discovery() -> MagicMock:
+    """MagicMock httpx.Response with a valid OIDC discovery payload."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {
+        "jwks_uri": "https://idp.example/jwks",
+        "issuer": "https://idp.example/",
+    }
+    return resp
+
+
+class TestBuildAuth:
+    def test_none_when_no_auth_configured(self):
+        assert build_auth(ServerConfig()) is None
+
+    def test_returns_bearer_verifier_alone(self):
+        from fastmcp.server.auth import StaticTokenVerifier
+
+        auth = build_auth(ServerConfig(bearer_token="x"))
+        assert isinstance(auth, StaticTokenVerifier)
+
+    def test_returns_oidc_proxy_alone(self):
+        # OIDCProxy reaches out to config_url at construction time; stub
+        # the class so we only exercise the dispatcher.
+        mock_proxy_cls = MagicMock()
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_proxy_cls):
+            auth = build_auth(_oidc_proxy_config())
+        assert auth is mock_proxy_cls.return_value
+        mock_proxy_cls.assert_called_once()
+
+    def test_returns_remote_auth_alone(self):
+        from fastmcp.server.auth import RemoteAuthProvider
+
+        with patch("httpx.get", return_value=_mock_discovery()):
+            auth = build_auth(_remote_only_config())
+        assert isinstance(auth, RemoteAuthProvider)
+
+    def test_returns_multi_auth_with_empty_required_scopes(self):
+        """The load-bearing invariant: required_scopes=[] in multi mode."""
+        from fastmcp.server.auth import MultiAuth
+
+        mock_proxy_cls = MagicMock()
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_proxy_cls):
+            auth = build_auth(_oidc_proxy_config(bearer_token="x"))
+        assert isinstance(auth, MultiAuth)
+        # CRITICAL: required_scopes must be [] to prevent OIDC's ["openid"]
+        # from propagating to RequireAuthMiddleware and rejecting bearer
+        # tokens with 403 insufficient_scope (MV PR #249).
+        assert auth.required_scopes == []
+
+    def test_multi_places_oidcproxy_as_server_not_verifier(self):
+        """OIDCProxy MUST live in server=, not verifiers=."""
+        from fastmcp.server.auth import MultiAuth, StaticTokenVerifier
+
+        mock_proxy_cls = MagicMock()
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_proxy_cls):
+            auth = build_auth(_oidc_proxy_config(bearer_token="x"))
+        assert isinstance(auth, MultiAuth)
+        # Bearer verifier lives in verifiers=.
+        assert any(isinstance(v, StaticTokenVerifier) for v in auth.verifiers)
+        # OIDCProxy (the mock instance) lives in server=.
+        assert auth.server is mock_proxy_cls.return_value
+        # And is NOT in verifiers=.
+        assert mock_proxy_cls.return_value not in auth.verifiers
+
+    def test_multi_with_bearer_and_remote(self):
+        """Multi mode also works when the OIDC side is RemoteAuthProvider."""
+        from fastmcp.server.auth import MultiAuth, RemoteAuthProvider
+
+        with patch("httpx.get", return_value=_mock_discovery()):
+            auth = build_auth(_remote_only_config(bearer_token="x"))
+        assert isinstance(auth, MultiAuth)
+        assert auth.required_scopes == []
+        assert isinstance(auth.server, RemoteAuthProvider)
+
+    def test_multi_falls_back_to_bearer_when_oidc_build_fails(
+        self,
+    ):
+        """If remote discovery fails, fall back to bearer alone, not None."""
+        import httpx
+        from fastmcp.server.auth import StaticTokenVerifier
+
+        def _boom(*_args: object, **_kw: object) -> MagicMock:
+            raise httpx.ConnectError("boom")
+
+        with patch("httpx.get", side_effect=_boom):
+            auth = build_auth(_remote_only_config(bearer_token="x"))
+        assert isinstance(auth, StaticTokenVerifier)


### PR DESCRIPTION
## Summary

Composes the three auth builders via resolve_auth_mode, returning the right FastMCP auth provider.

Multi mode (bearer + OIDC both configured) wires MultiAuth with:
- OIDCProxy in server=, not verifiers= (OAuthProvider routes would be lost otherwise)
- required_scopes=[] (empty — prevents OIDC's openid scope from rejecting bearer tokens with 403, per MV PR #249)

## Test plan

- [ ] build_auth tests pass (none/bearer/oidc-proxy/remote/multi cases)
- [ ] MultiAuth.required_scopes == [] asserted
- [ ] OIDCProxy placement verified (server=, not in verifiers=)
- [ ] Full suite green, mypy clean, lint clean
- [ ] CI green on 3.10-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)