### PR TITLE
feat: add middleware stack and logging helpers

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -15,6 +15,8 @@ from fastmcp_pvl_core._auth import (
 )
 from fastmcp_pvl_core._config import ServerConfig, Transport
 from fastmcp_pvl_core._env import env, parse_bool, parse_list, parse_scopes
+from fastmcp_pvl_core._logging import configure_logging_from_env
+from fastmcp_pvl_core._middleware import wire_middleware_stack
 
 __version__ = "0.0.0"  # PSR overrides at build time
 
@@ -26,9 +28,11 @@ __all__ = [
     "build_bearer_auth",
     "build_oidc_proxy_auth",
     "build_remote_auth",
+    "configure_logging_from_env",
     "env",
     "parse_bool",
     "parse_list",
     "parse_scopes",
     "resolve_auth_mode",
+    "wire_middleware_stack",
 ]

--- a/src/fastmcp_pvl_core/_logging.py
+++ b/src/fastmcp_pvl_core/_logging.py
@@ -1,0 +1,47 @@
+"""Logging setup — delegates to FastMCP's ``configure_logging``.
+
+The ``-v`` CLI flag forces ``DEBUG``; otherwise ``FASTMCP_LOG_LEVEL``
+wins; otherwise ``INFO``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from fastmcp.utilities.logging import configure_logging
+
+_VALID_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+
+def configure_logging_from_env(*, verbose: bool = False) -> None:
+    """Configure logging globally based on environment and verbose flag.
+
+    Level resolution order:
+
+    1. If *verbose* is ``True``: force ``DEBUG`` and also set
+       ``FASTMCP_LOG_LEVEL=DEBUG`` in the environment so FastMCP's own
+       loggers (which read the env var at import time) pick up the same
+       level.
+    2. Otherwise, use ``FASTMCP_LOG_LEVEL`` if set (case-insensitive).
+    3. Otherwise, default to ``INFO``.
+
+    Unknown level names fall back to ``INFO``.  The root logger is set
+    to the resolved level and FastMCP's ``configure_logging`` is called
+    so its loggers produce matching output.
+
+    Args:
+        verbose: If ``True``, force ``DEBUG`` (overrides
+            ``FASTMCP_LOG_LEVEL``).
+    """
+    if verbose:
+        os.environ["FASTMCP_LOG_LEVEL"] = "DEBUG"
+        level_name = "DEBUG"
+    else:
+        level_name = os.environ.get("FASTMCP_LOG_LEVEL", "INFO").strip().upper()
+        if level_name not in _VALID_LEVELS:
+            level_name = "INFO"
+
+    level = getattr(logging, level_name, logging.INFO)
+    logging.getLogger().setLevel(level)
+    configure_logging(level)

--- a/src/fastmcp_pvl_core/_middleware.py
+++ b/src/fastmcp_pvl_core/_middleware.py
@@ -1,0 +1,45 @@
+"""FastMCP middleware stack installation.
+
+Installs the standard three-middleware stack on a FastMCP instance:
+ErrorHandling, Timing, then either rich or structured Logging.
+The logging flavor is controlled by ``FASTMCP_ENABLE_RICH_LOGGING``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastmcp import FastMCP
+from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
+from fastmcp.server.middleware.logging import (
+    LoggingMiddleware,
+    StructuredLoggingMiddleware,
+)
+from fastmcp.server.middleware.timing import TimingMiddleware
+
+from fastmcp_pvl_core._env import parse_bool
+
+
+def wire_middleware_stack(mcp: FastMCP) -> None:
+    """Install the standard middleware stack on a FastMCP instance.
+
+    Installation order (outermost first):
+
+    1. :class:`ErrorHandlingMiddleware` — catches unhandled exceptions and
+       logs them with a traceback.
+    2. :class:`TimingMiddleware` — records tool invocation duration.
+    3. :class:`LoggingMiddleware` (rich) or
+       :class:`StructuredLoggingMiddleware` (JSON) — selected by the
+       ``FASTMCP_ENABLE_RICH_LOGGING`` environment variable (default: rich).
+
+    Args:
+        mcp: The :class:`FastMCP` instance to install middleware on.
+    """
+    mcp.add_middleware(ErrorHandlingMiddleware(include_traceback=True))
+    mcp.add_middleware(TimingMiddleware())
+
+    rich_raw = os.environ.get("FASTMCP_ENABLE_RICH_LOGGING", "true")
+    if parse_bool(rich_raw):
+        mcp.add_middleware(LoggingMiddleware())
+    else:
+        mcp.add_middleware(StructuredLoggingMiddleware())

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,45 @@
+"""Tests for configure_logging_from_env."""
+
+from __future__ import annotations
+
+import logging
+
+from fastmcp_pvl_core import configure_logging_from_env
+
+
+def test_sets_debug_when_verbose_true(monkeypatch):
+    monkeypatch.delenv("FASTMCP_LOG_LEVEL", raising=False)
+    configure_logging_from_env(verbose=True)
+    assert logging.getLogger().getEffectiveLevel() == logging.DEBUG
+
+
+def test_verbose_sets_fastmcp_log_level_env(monkeypatch):
+    monkeypatch.delenv("FASTMCP_LOG_LEVEL", raising=False)
+    configure_logging_from_env(verbose=True)
+    import os
+
+    assert os.environ.get("FASTMCP_LOG_LEVEL") == "DEBUG"
+
+
+def test_respects_fastmcp_log_level(monkeypatch):
+    monkeypatch.setenv("FASTMCP_LOG_LEVEL", "WARNING")
+    configure_logging_from_env(verbose=False)
+    assert logging.getLogger().getEffectiveLevel() == logging.WARNING
+
+
+def test_defaults_to_info_when_nothing_set(monkeypatch):
+    monkeypatch.delenv("FASTMCP_LOG_LEVEL", raising=False)
+    configure_logging_from_env(verbose=False)
+    assert logging.getLogger().getEffectiveLevel() == logging.INFO
+
+
+def test_lowercase_level_name_handled(monkeypatch):
+    monkeypatch.setenv("FASTMCP_LOG_LEVEL", "warning")
+    configure_logging_from_env(verbose=False)
+    assert logging.getLogger().getEffectiveLevel() == logging.WARNING
+
+
+def test_unknown_level_falls_back_to_info(monkeypatch):
+    monkeypatch.setenv("FASTMCP_LOG_LEVEL", "BOGUS")
+    configure_logging_from_env(verbose=False)
+    assert logging.getLogger().getEffectiveLevel() == logging.INFO

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,74 @@
+"""Tests for wire_middleware_stack."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
+from fastmcp.server.middleware.logging import (
+    LoggingMiddleware,
+    StructuredLoggingMiddleware,
+)
+from fastmcp.server.middleware.timing import TimingMiddleware
+
+from fastmcp_pvl_core import wire_middleware_stack
+
+# Middleware types that wire_middleware_stack installs — used to filter
+# out any built-in middlewares FastMCP installs by default.
+_INSTALLED_BY_HELPER = (
+    ErrorHandlingMiddleware,
+    TimingMiddleware,
+    LoggingMiddleware,
+    StructuredLoggingMiddleware,
+)
+
+
+def _installed_types(mcp: FastMCP) -> list[type]:
+    """Return the ordered types of middlewares added by wire_middleware_stack.
+
+    FastMCP may pre-install its own middlewares (e.g. DereferenceRefsMiddleware);
+    this filters to only those wire_middleware_stack is responsible for so
+    tests assert our installation order, not FastMCP internals.
+    """
+    return [type(m) for m in mcp.middleware if isinstance(m, _INSTALLED_BY_HELPER)]
+
+
+def test_installs_three_middlewares_in_order():
+    mcp = FastMCP(name="t")
+    wire_middleware_stack(mcp)
+    types = _installed_types(mcp)
+    assert len(types) == 3
+    assert types[0] is ErrorHandlingMiddleware
+    assert types[1] is TimingMiddleware
+    assert types[2] in (LoggingMiddleware, StructuredLoggingMiddleware)
+
+
+def test_structured_when_rich_disabled(monkeypatch):
+    monkeypatch.setenv("FASTMCP_ENABLE_RICH_LOGGING", "false")
+    mcp = FastMCP(name="t")
+    wire_middleware_stack(mcp)
+    types = _installed_types(mcp)
+    assert types[2] is StructuredLoggingMiddleware
+
+
+def test_rich_when_rich_unset(monkeypatch):
+    monkeypatch.delenv("FASTMCP_ENABLE_RICH_LOGGING", raising=False)
+    mcp = FastMCP(name="t")
+    wire_middleware_stack(mcp)
+    types = _installed_types(mcp)
+    assert types[2] is LoggingMiddleware
+
+
+def test_rich_when_rich_explicitly_enabled(monkeypatch):
+    monkeypatch.setenv("FASTMCP_ENABLE_RICH_LOGGING", "true")
+    mcp = FastMCP(name="t")
+    wire_middleware_stack(mcp)
+    types = _installed_types(mcp)
+    assert types[2] is LoggingMiddleware
+
+
+def test_error_handling_middleware_includes_traceback():
+    """Verify ErrorHandlingMiddleware is configured with include_traceback=True."""
+    mcp = FastMCP(name="t")
+    wire_middleware_stack(mcp)
+    error_mw = next(m for m in mcp.middleware if isinstance(m, ErrorHandlingMiddleware))
+    assert error_mw.include_traceback is True


### PR DESCRIPTION
## Summary

Two orthogonal server-factory helpers (Task 9 of the extraction plan):

- `wire_middleware_stack(mcp)` — installs the standard three-middleware stack: `ErrorHandlingMiddleware(include_traceback=True)` + `TimingMiddleware` + rich/structured `LoggingMiddleware`. The logging flavor follows `FASTMCP_ENABLE_RICH_LOGGING` (defaults to rich).
- `configure_logging_from_env(verbose=False)` — resolves the log level from `-v` vs `FASTMCP_LOG_LEVEL` (defaulting to `INFO`), delegates to FastMCP's `configure_logging`, and propagates `DEBUG` back into the env so FastMCP's own import-time loggers pick up the same level. Unknown level names fall back to `INFO`.

FastMCP 3.x API paths verified:
- `fastmcp.server.middleware.error_handling.ErrorHandlingMiddleware`
- `fastmcp.server.middleware.timing.TimingMiddleware`
- `fastmcp.server.middleware.logging.{LoggingMiddleware,StructuredLoggingMiddleware}`
- `fastmcp.utilities.logging.configure_logging` accepts `str | int`
- `FastMCP.middleware` is a public list (filtered in tests to skip built-in `DereferenceRefsMiddleware`)

## Test plan

- [x] Middleware install order + rich/structured dispatch tests pass (5 tests)
- [x] Logging level resolution tests pass (6 tests)
- [x] Full suite green: 97 passed
- [x] mypy clean, ruff check + format clean
- [x] 100% coverage on both new modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)