### PR TITLE
feat: add server-factory helpers

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -15,6 +15,11 @@ from fastmcp_pvl_core._auth import (
 )
 from fastmcp_pvl_core._config import ServerConfig, Transport
 from fastmcp_pvl_core._env import env, parse_bool, parse_list, parse_scopes
+from fastmcp_pvl_core._factory import (
+    build_event_store,
+    build_instructions,
+    compute_app_domain,
+)
 from fastmcp_pvl_core._logging import configure_logging_from_env
 from fastmcp_pvl_core._middleware import wire_middleware_stack
 
@@ -26,8 +31,11 @@ __all__ = [
     "Transport",
     "build_auth",
     "build_bearer_auth",
+    "build_event_store",
+    "build_instructions",
     "build_oidc_proxy_auth",
     "build_remote_auth",
+    "compute_app_domain",
     "configure_logging_from_env",
     "env",
     "parse_bool",

--- a/src/fastmcp_pvl_core/_factory.py
+++ b/src/fastmcp_pvl_core/_factory.py
@@ -1,0 +1,172 @@
+"""Server-factory building blocks.
+
+Each function returns a piece of the FastMCP wiring so downstream
+projects can compose a ``make_server()`` without inheriting from a
+base class.
+
+Three orthogonal helpers live here:
+
+- :func:`build_instructions` — read-only/read-write-aware MCP instructions
+  template parameterized by environment-variable prefix and a
+  domain-describing sentence.
+- :func:`build_event_store` — construct an MCP event store (in-memory or
+  file-tree-backed) from a :class:`~fastmcp_pvl_core.ServerConfig`.
+- :func:`compute_app_domain` — derive the MCP Apps iframe domain for CSP
+  sandboxing from either an explicit override or the host portion of the
+  public ``base_url``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from fastmcp_pvl_core._config import ServerConfig
+
+if TYPE_CHECKING:
+    from fastmcp.server.event_store import EventStore
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_EVENT_STORE_DIR = "/data/state/events"
+"""Fallback directory for the file-tree event store when no URL is given.
+
+Downstream Docker images typically mount a persistent volume at
+``/data/state``.  Tests monkey-patch this module attribute to redirect the
+default to a tmp path rather than touching the real ``/data/state``.
+"""
+
+
+def build_instructions(
+    *,
+    read_only: bool,
+    env_prefix: str,
+    domain_line: str,
+) -> str:
+    """Build the default MCP instructions string.
+
+    The returned text concatenates three parts: a domain-describing
+    sentence supplied by the caller, a boilerplate line announcing whether
+    the server is read-only or read-write, and a one-line hint telling
+    operators how to override these instructions via environment variable.
+
+    Args:
+        read_only: Whether write tools are hidden on this instance.
+        env_prefix: Environment-variable prefix for the consuming project
+            (with or without a trailing underscore — it is normalized).
+            Used to construct the override env var name
+            ``{prefix}_INSTRUCTIONS``.
+        domain_line: A sentence describing the service's domain and
+            capabilities.  Included verbatim at the top of the instructions.
+
+    Returns:
+        A single string suitable for :class:`~fastmcp.FastMCP`'s
+        ``instructions`` parameter.
+    """
+    write_line = (
+        "This instance is READ-ONLY — write tools are not available."
+        if read_only
+        else "This instance is READ-WRITE — write tools are available."
+    )
+    prefix = env_prefix.rstrip("_")
+    return (
+        f"{domain_line} "
+        f"{write_line} "
+        f"Operators: set {prefix}_INSTRUCTIONS to describe this "
+        "service's domain and capabilities."
+    )
+
+
+def build_event_store(env_prefix: str, config: ServerConfig) -> EventStore:
+    """Construct an MCP event store based on ``config.event_store_url``.
+
+    Parses the URL scheme to select a backend:
+
+    - ``None`` or empty → file-tree store at :data:`_DEFAULT_EVENT_STORE_DIR`
+    - ``file:///path`` → file-tree store at the given path
+    - ``memory://`` → in-memory (lost on restart, for development)
+
+    Args:
+        env_prefix: Env-var prefix of the consuming project.  Currently
+            unused but reserved for future per-project defaults (e.g.
+            ``{prefix}_EVENT_STORE_DIR``).
+        config: A :class:`~fastmcp_pvl_core.ServerConfig` whose
+            ``event_store_url`` field selects the backend.
+
+    Returns:
+        A configured :class:`~fastmcp.server.event_store.EventStore`.
+
+    Raises:
+        ValueError: If the URL scheme is neither ``file`` nor ``memory``.
+        ImportError: If the file-tree backend is requested but
+            ``key_value.aio.stores.filetree`` is not installed.
+    """
+    # Local imports so importing ``fastmcp_pvl_core`` stays light.
+    from fastmcp.server.event_store import EventStore as _EventStore
+
+    del env_prefix  # currently unused; reserved for future per-project config
+
+    url = config.event_store_url
+    if not url:
+        url = f"file://{_DEFAULT_EVENT_STORE_DIR}"
+
+    parsed = urlparse(url)
+
+    if parsed.scheme == "memory":
+        logger.info("event_store backend=memory lost_on_restart=true")
+        return _EventStore(max_events_per_stream=100, ttl=3600)
+
+    if parsed.scheme == "file":
+        directory = parsed.path or _DEFAULT_EVENT_STORE_DIR
+        Path(directory).mkdir(parents=True, exist_ok=True)
+        logger.info("event_store backend=file directory=%s", directory)
+
+        try:
+            from key_value.aio.stores.filetree import FileTreeStore
+        except ImportError as exc:
+            raise ImportError(
+                "FileTreeStore requires fastmcp>=3.0 with key-value support. "
+                "Install the optional key-value dependency (e.g. "
+                "'pip install \"fastmcp[key-value]\"') or switch to "
+                "EVENT_STORE_URL='memory://'."
+            ) from exc
+
+        storage = FileTreeStore(data_directory=directory)
+        return _EventStore(storage=storage, max_events_per_stream=100, ttl=3600)
+
+    raise ValueError(
+        f"Unsupported event store URL scheme {parsed.scheme!r}. "
+        "Use 'file:///path' or 'memory://'."
+    )
+
+
+def compute_app_domain(config: ServerConfig) -> str | None:
+    """Derive the MCP Apps iframe domain for CSP sandboxing.
+
+    Priority:
+
+    1. ``config.app_domain`` (explicit operator override)
+    2. Host portion (``netloc``) of ``config.base_url``
+    3. ``None`` when neither is set
+
+    Projects that need a domain-specific fallback (e.g. a hash-based
+    sandbox subdomain for a specific client) should compute that value in
+    their own code and either pass it as ``app_domain`` or handle the
+    ``None`` return here.
+
+    Args:
+        config: Universal server configuration.
+
+    Returns:
+        The iframe domain, or ``None`` when neither override nor
+        ``base_url`` host is available.
+    """
+    if config.app_domain:
+        return config.app_domain
+    if config.base_url:
+        parsed = urlparse(config.base_url)
+        return parsed.netloc or None
+    return None

--- a/src/fastmcp_pvl_core/_factory.py
+++ b/src/fastmcp_pvl_core/_factory.py
@@ -124,14 +124,16 @@ def build_event_store(env_prefix: str, config: ServerConfig) -> EventStore:
         Path(directory).mkdir(parents=True, exist_ok=True)
         logger.info("event_store backend=file directory=%s", directory)
 
+        # py-key-value-aio[filetree] is a transitive of fastmcp today, so
+        # this guard is defensive — if a future fastmcp release drops the
+        # extra, the message points operators at the right package.
         try:
             from key_value.aio.stores.filetree import FileTreeStore
         except ImportError as exc:
             raise ImportError(
-                "FileTreeStore requires fastmcp>=3.0 with key-value support. "
-                "Install the optional key-value dependency (e.g. "
-                "'pip install \"fastmcp[key-value]\"') or switch to "
-                "EVENT_STORE_URL='memory://'."
+                "FileTreeStore requires 'py-key-value-aio[filetree]'. "
+                "Install with `pip install 'py-key-value-aio[filetree]'` "
+                "or switch to EVENT_STORE_URL='memory://'."
             ) from exc
 
         storage = FileTreeStore(data_directory=directory)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,103 @@
+"""Tests for server-factory helpers."""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from fastmcp_pvl_core import (
+    ServerConfig,
+    build_event_store,
+    build_instructions,
+    compute_app_domain,
+)
+
+
+class TestBuildInstructions:
+    def test_read_only_line(self):
+        text = build_instructions(
+            read_only=True,
+            env_prefix="MY_APP",
+            domain_line="A widget service.",
+        )
+        assert "READ-ONLY" in text
+        assert "A widget service." in text
+        assert "MY_APP_INSTRUCTIONS" in text
+
+    def test_read_write_line(self):
+        text = build_instructions(
+            read_only=False,
+            env_prefix="MY_APP",
+            domain_line="A widget service.",
+        )
+        assert "READ-WRITE" in text
+        assert "READ-ONLY" not in text
+
+    def test_env_prefix_trailing_underscore_stripped(self):
+        """Callers passing 'MY_APP_' or 'MY_APP' should get the same result."""
+        a = build_instructions(read_only=True, env_prefix="MY_APP", domain_line="x.")
+        b = build_instructions(read_only=True, env_prefix="MY_APP_", domain_line="x.")
+        assert a == b
+        assert "MY_APP_INSTRUCTIONS" in a
+        # Should NOT double the underscore.
+        assert "MY_APP__INSTRUCTIONS" not in a
+
+
+class TestBuildEventStore:
+    def test_memory_url(self):
+        config = ServerConfig(event_store_url="memory://")
+        store = build_event_store("MY_APP", config)
+        assert store is not None
+
+    def test_file_url(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = ServerConfig(event_store_url=f"file://{td}/events")
+            store = build_event_store("MY_APP", config)
+            assert store is not None
+
+    def test_default_when_unset(self, tmp_path):
+        config = ServerConfig(event_store_url=f"file://{tmp_path}/default-events")
+        store = build_event_store("MY_APP", config)
+        assert store is not None
+
+    def test_unknown_scheme_raises(self):
+        config = ServerConfig(event_store_url="redis://localhost:6379/0")
+        with pytest.raises(ValueError, match="Unsupported"):
+            build_event_store("MY_APP", config)
+
+    def test_none_url_uses_default_path(self, tmp_path, monkeypatch):
+        """When event_store_url is None, falls back to a file-backed default."""
+        # Redirect the default path so the test doesn't touch /data/state/events.
+        monkeypatch.setattr(
+            "fastmcp_pvl_core._factory._DEFAULT_EVENT_STORE_DIR",
+            str(tmp_path / "events-default"),
+        )
+        config = ServerConfig(event_store_url=None)
+        store = build_event_store("MY_APP", config)
+        assert store is not None
+
+
+class TestComputeAppDomain:
+    def test_override_wins(self):
+        config = ServerConfig(
+            base_url="https://x.example",
+            app_domain="override.example",
+        )
+        assert compute_app_domain(config) == "override.example"
+
+    def test_derives_from_base_url(self):
+        config = ServerConfig(base_url="https://mcp.example.com")
+        assert compute_app_domain(config) == "mcp.example.com"
+
+    def test_derives_from_base_url_with_port(self):
+        config = ServerConfig(base_url="https://mcp.example.com:8443")
+        assert compute_app_domain(config) == "mcp.example.com:8443"
+
+    def test_none_when_no_base_url(self):
+        assert compute_app_domain(ServerConfig()) is None
+
+    def test_none_for_bare_url_without_scheme(self):
+        """urlparse('example.com') yields empty netloc → None."""
+        config = ServerConfig(base_url="example.com")
+        assert compute_app_domain(config) is None


### PR DESCRIPTION
## Summary

Three orthogonal building blocks for `make_server()` composition in a new `_factory` module:

- **`build_instructions`** — read-only/read-write-aware MCP instructions template parameterized by env-var prefix and a domain-describing sentence.  Trailing underscores on the prefix are normalized so callers passing `MY_APP_` or `MY_APP` both produce identical output.
- **`build_event_store`** — construct a FastMCP `EventStore` from a `ServerConfig`.  Supports `file:///path`, `memory://`, and a default file-backed store at `/data/state/events` for Docker deployments.  Unknown URL schemes raise `ValueError`.  Preserves MV's `ImportError` guard for the `key_value` extra.
- **`compute_app_domain`** — derive the MCP Apps iframe sandbox domain from either `config.app_domain` (explicit override) or the `netloc` of `config.base_url`, returning `None` when neither is set.

Divergence from MV (intentional):

- MV's `_build_default_instructions` is vault-specific; the core version is generic and parameterized.
- MV's `_compute_claude_app_domain` computes a hash-based Claude sandbox subdomain.  That fallback is Claude-specific and stays in MV's `_server_apps.py`; core only implements override-or-base_url-host.

## Test plan

- [x] Instructions read-only/read-write assertions
- [x] `env_prefix` trailing-underscore normalization
- [x] Event store built for memory, file, default, and unknown-scheme (raises)
- [x] App domain: override wins, derives netloc from base_url (incl. port), `None` for empty/bare
- [x] Full suite green (110/110), mypy clean, ruff clean
- [ ] CI green on 3.10–3.13

13 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)