### PR TITLE
feat: add ArtifactStore and TokenRecord

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -5,6 +5,7 @@ middleware wiring, logging setup, config helpers, and server
 factory building blocks without duplicating them per repo.
 """
 
+from fastmcp_pvl_core._artifacts import ArtifactStore, TokenRecord
 from fastmcp_pvl_core._auth import (
     AuthMode,
     build_auth,
@@ -26,8 +27,10 @@ from fastmcp_pvl_core._middleware import wire_middleware_stack
 __version__ = "0.0.0"  # PSR overrides at build time
 
 __all__ = [
+    "ArtifactStore",
     "AuthMode",
     "ServerConfig",
+    "TokenRecord",
     "Transport",
     "build_auth",
     "build_bearer_auth",

--- a/src/fastmcp_pvl_core/_artifacts.py
+++ b/src/fastmcp_pvl_core/_artifacts.py
@@ -148,9 +148,8 @@ class ArtifactStore:
         if expired:
             logger.debug("artifact_purge count=%d", len(expired))
 
-    @classmethod
+    @staticmethod
     def register_route(
-        cls,
         mcp: FastMCP,
         store: ArtifactStore,
         *,

--- a/src/fastmcp_pvl_core/_artifacts.py
+++ b/src/fastmcp_pvl_core/_artifacts.py
@@ -1,0 +1,200 @@
+"""One-time artifact download support.
+
+Downstream tools stash bytes and return an HTTP URL pointing at
+``GET /artifacts/{token}``. The first retrieval consumes the token and
+removes it from the store — subsequent retrievals 404. Tokens have a
+TTL; expired entries are purged lazily on every access.
+
+Domain-specific wrapping (e.g. loading bytes on demand from some
+external source) should live in the downstream project; this module
+provides only the generic token store and HTTP route.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from starlette.responses import Response
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from starlette.requests import Request
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TokenRecord:
+    """A one-time downloadable artifact.
+
+    Attributes:
+        content: The raw bytes to serve.
+        filename: Suggested filename for the ``Content-Disposition`` header.
+        mime_type: MIME type served in the ``Content-Type`` header.
+        expires_at: Unix timestamp after which the record is considered expired.
+    """
+
+    content: bytes
+    filename: str
+    mime_type: str
+    expires_at: float
+
+
+def _sanitize_filename(filename: str) -> str:
+    """Strip characters that would break a ``Content-Disposition`` header.
+
+    The HTTP header grammar forbids raw CR/LF and treats double quote and
+    backslash as structural characters. We remove CR/LF entirely (prevents
+    header injection) and replace quote and backslash with ``_`` so the
+    header remains parseable. Non-ASCII code points are not percent-encoded
+    here — callers that need them should pass an already-sanitised filename.
+
+    Args:
+        filename: Raw filename supplied by the caller.
+
+    Returns:
+        A filename safe to embed inside a quoted-string ``filename=`` param.
+    """
+    cleaned = filename.replace("\r", "").replace("\n", "")
+    cleaned = cleaned.replace('"', "_").replace("\\", "_")
+    return cleaned or "download"
+
+
+class ArtifactStore:
+    """In-memory one-time artifact store with TTL expiry.
+
+    Tokens are UUID4 hex strings (cryptographically unguessable). Each
+    :meth:`add` / :meth:`pop` call triggers a lazy sweep of expired
+    entries, so the store never needs a background task.
+
+    Note:
+        The store is process-local — tokens do not survive a restart
+        and are not shared between workers.
+    """
+
+    def __init__(self, ttl_seconds: float = 3600.0) -> None:
+        """Create a new store.
+
+        Args:
+            ttl_seconds: Lifetime of each token in seconds (default 1 hour).
+        """
+        self._records: dict[str, TokenRecord] = {}
+        self._ttl = float(ttl_seconds)
+
+    def add(self, content: bytes, *, filename: str, mime_type: str) -> str:
+        """Stash ``content`` and return an opaque one-time token.
+
+        Args:
+            content: Raw bytes to serve on retrieval.
+            filename: Filename advertised via ``Content-Disposition``.
+            mime_type: MIME type advertised via ``Content-Type``.
+
+        Returns:
+            A hex UUID4 token string.
+        """
+        self._purge_expired()
+        token = uuid.uuid4().hex
+        self._records[token] = TokenRecord(
+            content=content,
+            filename=filename,
+            mime_type=mime_type,
+            expires_at=time.time() + self._ttl,
+        )
+        logger.debug(
+            "artifact_add token_prefix=%s size=%d mime=%s ttl=%.1fs",
+            token[:8],
+            len(content),
+            mime_type,
+            self._ttl,
+        )
+        return token
+
+    def pop(self, token: str) -> TokenRecord | None:
+        """Consume ``token``, returning its record or ``None``.
+
+        The token is always removed from the store, even if it has
+        already expired. The return value is ``None`` when the token is
+        unknown or when it has passed its ``expires_at`` timestamp.
+
+        Args:
+            token: The hex UUID token string returned by :meth:`add`.
+
+        Returns:
+            The :class:`TokenRecord`, or ``None`` if unknown/expired.
+        """
+        self._purge_expired()
+        record = self._records.pop(token, None)
+        if record is None:
+            return None
+        if time.time() > record.expires_at:
+            logger.debug("artifact_pop_expired token_prefix=%s", token[:8])
+            return None
+        return record
+
+    def _purge_expired(self) -> None:
+        """Remove expired records (lazy cleanup).
+
+        Called from :meth:`add` and :meth:`pop` so the store self-trims
+        without needing a background task.
+        """
+        now = time.time()
+        expired = [t for t, r in self._records.items() if now > r.expires_at]
+        for t in expired:
+            del self._records[t]
+        if expired:
+            logger.debug("artifact_purge count=%d", len(expired))
+
+    @classmethod
+    def register_route(
+        cls,
+        mcp: FastMCP,
+        store: ArtifactStore,
+        *,
+        path: str = "/artifacts/{token}",
+    ) -> None:
+        """Mount ``GET {path}`` on a FastMCP HTTP app to serve artifacts.
+
+        Unknown / expired / already-consumed tokens return HTTP 404. A
+        hit returns the stored bytes with the stored ``Content-Type`` and
+        an ``attachment`` ``Content-Disposition`` header.
+
+        The route is registered via :meth:`FastMCP.custom_route`, which
+        places it outside FastMCP's auth middleware — by design, since
+        the token itself is the capability.
+
+        Args:
+            mcp: FastMCP server instance (HTTP/SSE transport).
+            store: Shared :class:`ArtifactStore` holding tokens.
+            path: URL template. Must contain ``{token}``. Defaults to
+                ``/artifacts/{token}``.
+        """
+
+        @mcp.custom_route(path, methods=["GET"])
+        async def _artifact_handler(request: Request) -> Response:
+            token = request.path_params.get("token", "")
+            record = store.pop(token)
+            if record is None:
+                logger.debug(
+                    "artifact_handler_miss token_prefix=%s",
+                    (token or "")[:8],
+                )
+                return Response(content="Not Found", status_code=404)
+
+            safe_filename = _sanitize_filename(record.filename)
+            logger.info(
+                "artifact_handler_serve token_prefix=%s size=%d mime=%s",
+                token[:8],
+                len(record.content),
+                record.mime_type,
+            )
+            return Response(
+                content=record.content,
+                media_type=record.mime_type,
+                headers={
+                    "Content-Disposition": (f'attachment; filename="{safe_filename}"'),
+                },
+            )

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,183 @@
+"""Tests for :mod:`fastmcp_pvl_core._artifacts`."""
+
+from __future__ import annotations
+
+import dataclasses
+import time
+
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core import ArtifactStore, TokenRecord
+
+
+class TestTokenRecord:
+    def test_is_frozen(self) -> None:
+        record = TokenRecord(
+            content=b"x",
+            filename="x.txt",
+            mime_type="text/plain",
+            expires_at=0.0,
+        )
+        assert dataclasses.is_dataclass(record)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            record.filename = "y.txt"  # type: ignore[misc]
+
+
+class TestArtifactStore:
+    def test_add_returns_token(self) -> None:
+        store = ArtifactStore()
+        token = store.add(b"hello", filename="a.txt", mime_type="text/plain")
+        assert isinstance(token, str)
+        assert len(token) > 0
+
+    def test_add_returns_unique_tokens(self) -> None:
+        store = ArtifactStore()
+        t1 = store.add(b"a", filename="a", mime_type="text/plain")
+        t2 = store.add(b"b", filename="b", mime_type="text/plain")
+        assert t1 != t2
+
+    def test_pop_returns_data_and_removes_token(self) -> None:
+        store = ArtifactStore()
+        token = store.add(b"hello", filename="a.txt", mime_type="text/plain")
+        record = store.pop(token)
+        assert record is not None
+        assert record.content == b"hello"
+        assert record.filename == "a.txt"
+        assert record.mime_type == "text/plain"
+        # Second pop is idempotent — returns None.
+        assert store.pop(token) is None
+
+    def test_pop_unknown_token_returns_none(self) -> None:
+        store = ArtifactStore()
+        assert store.pop("nonexistent") is None
+
+    def test_expired_tokens_are_purged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        store = ArtifactStore(ttl_seconds=1)
+        token = store.add(b"x", filename="x", mime_type="application/octet-stream")
+        original_time = time.time()
+        monkeypatch.setattr(time, "time", lambda: original_time + 10)
+        assert store.pop(token) is None
+
+    def test_purge_runs_on_add(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Expired tokens should be pruned from memory when a new token is added."""
+        store = ArtifactStore(ttl_seconds=1)
+        t1 = store.add(b"one", filename="one.txt", mime_type="text/plain")
+        original_time = time.time()
+        monkeypatch.setattr(time, "time", lambda: original_time + 10)
+        # Add a fresh token at the shifted time — the prior one should purge.
+        store.add(b"two", filename="two.txt", mime_type="text/plain")
+        # Internal store no longer retains t1.
+        assert t1 not in store._records  # type: ignore[attr-defined]
+
+    def test_custom_ttl(self) -> None:
+        store = ArtifactStore(ttl_seconds=42.0)
+        token = store.add(b"x", filename="x.txt", mime_type="text/plain")
+        record = store.pop(token)
+        assert record is not None
+        # expires_at roughly now + 42 seconds
+        assert record.expires_at > time.time()
+        assert record.expires_at <= time.time() + 42.0 + 1.0
+
+
+class TestRegisterRoute:
+    """HTTP behaviour via a real FastMCP instance."""
+
+    async def test_handler_returns_404_for_unknown_token(self) -> None:
+        from starlette.testclient import TestClient
+
+        mcp = FastMCP("test")
+        store = ArtifactStore()
+        ArtifactStore.register_route(mcp, store)
+
+        app = mcp.http_app()
+        with TestClient(app) as client:
+            resp = client.get("/artifacts/nonexistent")
+        assert resp.status_code == 404
+
+    async def test_handler_returns_content_and_invalidates(self) -> None:
+        from starlette.testclient import TestClient
+
+        mcp = FastMCP("test")
+        store = ArtifactStore()
+        ArtifactStore.register_route(mcp, store)
+
+        token = store.add(
+            b"hello world",
+            filename="greeting.txt",
+            mime_type="text/plain; charset=utf-8",
+        )
+
+        app = mcp.http_app()
+        with TestClient(app) as client:
+            resp = client.get(f"/artifacts/{token}")
+            assert resp.status_code == 200
+            assert resp.content == b"hello world"
+            assert resp.headers["content-type"].startswith("text/plain")
+            cd = resp.headers["content-disposition"]
+            assert "attachment" in cd
+            assert 'filename="greeting.txt"' in cd
+
+            # Second request is 404 — token is single-use.
+            resp2 = client.get(f"/artifacts/{token}")
+        assert resp2.status_code == 404
+
+    async def test_handler_returns_404_for_expired_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from starlette.testclient import TestClient
+
+        mcp = FastMCP("test")
+        store = ArtifactStore(ttl_seconds=1)
+        ArtifactStore.register_route(mcp, store)
+
+        token = store.add(b"x", filename="x.txt", mime_type="text/plain")
+        original_time = time.time()
+        monkeypatch.setattr(time, "time", lambda: original_time + 10)
+
+        app = mcp.http_app()
+        with TestClient(app) as client:
+            resp = client.get(f"/artifacts/{token}")
+        assert resp.status_code == 404
+
+    async def test_register_route_custom_path(self) -> None:
+        from starlette.testclient import TestClient
+
+        mcp = FastMCP("test")
+        store = ArtifactStore()
+        ArtifactStore.register_route(mcp, store, path="/downloads/{token}")
+
+        token = store.add(
+            b"payload", filename="payload.bin", mime_type="application/octet-stream"
+        )
+
+        app = mcp.http_app()
+        with TestClient(app) as client:
+            resp = client.get(f"/downloads/{token}")
+        assert resp.status_code == 200
+        assert resp.content == b"payload"
+
+    async def test_filename_with_quote_is_sanitised(self) -> None:
+        """Quote/backslash/newline in filename must not break the header."""
+        from starlette.testclient import TestClient
+
+        mcp = FastMCP("test")
+        store = ArtifactStore()
+        ArtifactStore.register_route(mcp, store)
+
+        token = store.add(
+            b"data",
+            filename='evil".txt\r\nX-Injected: yes',
+            mime_type="text/plain",
+        )
+
+        app = mcp.http_app()
+        with TestClient(app) as client:
+            resp = client.get(f"/artifacts/{token}")
+        assert resp.status_code == 200
+        cd = resp.headers["content-disposition"]
+        # No raw CR/LF in the header value.
+        assert "\r" not in cd
+        assert "\n" not in cd
+        # No unescaped injection header leaked.
+        assert "X-Injected" not in resp.headers


### PR DESCRIPTION
## Summary

Port the generic artifact store from markdown-vault-mcp. Tokens are consumed on first read; expired tokens are purged lazily on any access. UUID4 hex tokens are cryptographically unguessable.

`ArtifactStore.register_route` mounts `GET /artifacts/{token}` on a FastMCP HTTP app, returning 404 for unknown/expired tokens and 200 + `Content-Disposition` for valid ones. Registration uses `FastMCP.custom_route`, which places the route outside auth middleware by design (the token itself is the capability).

Filenames in `Content-Disposition` are sanitised: CR/LF stripped (prevents header injection), quote and backslash replaced with underscore to keep the quoted-string parseable.

Domain-specific MV wrapping (`set_collection_store`, vault-side lookup inside `make_artifact_handler`) stays in MV for Task 18 adoption.

### Notes on divergence from MV

MV's `TokenRecord` stores a vault `path` and resolves it to bytes on each request inside `make_artifact_handler`. The generic core version inverts the ownership: callers pass `content` + `filename` + `mime_type` at `add` time, and the route serves them verbatim. MV's Collection-aware handler can then be rebuilt on top of core by storing a composite token payload and dereferencing through its own layer, or by eagerly reading bytes into the store.

## Test plan

- [x] `add` returns a unique UUID4 hex token
- [x] `pop` returns the record and removes it; second `pop` returns `None`
- [x] Unknown tokens return `None`
- [x] Expired tokens are purged lazily on both `add` and `pop`
- [x] `TokenRecord` is frozen
- [x] `register_route` integrates with a real `FastMCP` instance — 404 for unknown/expired/consumed tokens, 200 + Content-Disposition on hit
- [x] Custom `path` parameter works
- [x] Malicious filenames (quotes, CR/LF) cannot inject headers
- [x] `uv run pytest -x -q` → 123 passed (was 110)
- [x] `uv run ruff check .` → clean
- [x] `uv run ruff format --check .` → clean
- [x] `uv run mypy src/` → clean
- [x] Patch coverage on `_artifacts.py`: 96%
- [ ] CI green 3.10-3.13