### PR TITLE
feat(ci): add release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,101 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force version bump (leave empty for auto)'
+        type: choice
+        default: ''
+        options:
+          - ''
+          - patch
+          - minor
+          - major
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   release:
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    concurrency:
+      group: release
+      cancel-in-progress: false
+
+    permissions:
+      contents: write
+      id-token: write
+
     steps:
-      - name: Placeholder
-        run: echo "Release pipeline to be wired in a follow-up task (Phase H)"
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          version: "0.6"
+
+      - name: Setup Python
+        run: uv python install 3.12
+
+      - name: Semantic Version Release
+        id: release
+        uses: python-semantic-release/python-semantic-release@v10.5.3
+        with:
+          github_token: ${{ secrets.RELEASE_TOKEN }}
+          git_committer_name: "github-actions"
+          git_committer_email: "actions@users.noreply.github.com"
+          force: ${{ inputs.force }}
+
+      - name: Build package
+        if: steps.release.outputs.released == 'true'
+        run: uv build
+
+      - name: Upload to GitHub Release Assets
+        uses: python-semantic-release/publish-action@v10.5.3
+        if: steps.release.outputs.released == 'true'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.release.outputs.tag }}
+
+      - name: Upload build artifacts
+        if: steps.release.outputs.released == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+    outputs:
+      released: ${{ steps.release.outputs.released }}
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
+
+  publish-pypi:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fastmcp-pvl-core
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        with:
+          packages-dir: dist/
+          print-hash: true
+          verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,18 @@ venvPath = "."
 venv = ".venv"
 pythonVersion = "3.10"
 include = ["src", "tests"]
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+version_variables = ["src/fastmcp_pvl_core/__init__.py:__version__"]
+commit_parser = "angular"
+tag_format = "v{version}"
+build_command = "uv build"
+major_on_zero = false
+
+[tool.semantic_release.changelog]
+changelog_file = "CHANGELOG.md"
+
+[tool.semantic_release.commit_parser_options]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf"]


### PR DESCRIPTION
## Summary

Replaces the placeholder `release.yml` with a real PSR + PyPI Trusted Publishing pipeline, mirroring the first two jobs of markdown-vault-mcp's release workflow.

- **`release` job**: PSR analyzes conventional commits, bumps version in `pyproject.toml` + `src/fastmcp_pvl_core/__init__.py`, creates git tag, uploads build artifacts + GitHub Release Assets.
- **`publish-pypi` job**: downloads artifacts and publishes via `pypa/gh-action-pypi-publish` using OIDC Trusted Publishing (no PyPI API token needed).

Downstream MV jobs (Docker, Linux packages, MCPB, plugin catalog, MCP registry) are omitted — those are MV-specific.

## PSR Config

Mirrors MV field-for-field with three deviations:

- `version_variables = ["src/fastmcp_pvl_core/__init__.py:__version__"]` added (MV uses `assets` for multi-manifest bumps; core only needs `__init__.py`).
- `major_on_zero = false` — we're on 0.x and don't want `feat:` auto-bumping to 1.0.
- `build_command = "uv build"` (MV uses a custom `bump_manifests.py` script for its extra manifests).

## Prerequisites before first release

1. **Register a PyPI Pending Publisher**: https://pypi.org/manage/account/publishing/
   - PyPI Project Name: `fastmcp-pvl-core`
   - Owner: `pvliesdonk`
   - Repository name: `fastmcp-pvl-core`
   - Workflow filename: `release.yml`
   - Environment name: `pypi`
2. **Create GitHub environment `pypi`** on this repo (Settings → Environments → New environment → `pypi`).
3. **Confirm `RELEASE_TOKEN` secret exists** (already configured per task #1).

## Test plan

- [x] `uv build` succeeds locally (wheel + sdist build from current source)
- [x] pyproject.toml `[tool.semantic_release]` parses via `tomllib`
- [ ] Workflow YAML validates on PR push (CI)
- [ ] After merge + PyPI/environment setup, dispatching the workflow cuts `v0.1.0` on PyPI

## Not merging yet

Do not merge until the PyPI Pending Publisher and `pypi` GitHub environment are in place. The workflow only runs on `workflow_dispatch`, so merging is safe in isolation, but the first release dispatch will fail without prereqs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)