### PR TITLE
fix(ci): empty PSR build_command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,11 @@ version_toml = ["pyproject.toml:project.version"]
 version_variables = ["src/fastmcp_pvl_core/__init__.py:__version__"]
 commit_parser = "angular"
 tag_format = "v{version}"
-build_command = "uv build"
+# PSR's build_command runs inside its Docker container (python:3.14-slim)
+# which has no uv. The real wheel/sdist build happens in the workflow's
+# `uv build` step after PSR commits the version bump. Set to an empty
+# no-op so PSR skips its internal build phase.
+build_command = ""
 major_on_zero = false
 
 [tool.semantic_release.changelog]


### PR DESCRIPTION
## Summary

Release run #24659790556 failed at the PSR "Semantic Version Release" step with exit 127 — `uv: command not found`. PSR runs in `python:3.14-slim` Docker and has no `uv`. Set `build_command = ""` so PSR skips its internal build phase; the workflow's subsequent `uv build` step handles the actual wheel build, matching MV's pattern.

## Test plan

- [ ] CI green
- [ ] After merge, re-trigger Release workflow with `force=minor` and confirm PSR step passes