### PR TITLE
feat(middleware): add include_traceback and transform_errors kwargs

### DIFF
--- a/src/fastmcp_pvl_core/_middleware.py
+++ b/src/fastmcp_pvl_core/_middleware.py
@@ -7,6 +7,7 @@ The logging flavor is controlled by ``FASTMCP_ENABLE_RICH_LOGGING``.
 
 from __future__ import annotations
 
+import logging
 import os
 
 from fastmcp import FastMCP
@@ -20,13 +21,18 @@ from fastmcp.server.middleware.timing import TimingMiddleware
 from fastmcp_pvl_core._env import parse_bool
 
 
-def wire_middleware_stack(mcp: FastMCP) -> None:
+def wire_middleware_stack(
+    mcp: FastMCP,
+    *,
+    include_traceback: bool | None = None,
+    transform_errors: bool = False,
+) -> None:
     """Install the standard middleware stack on a FastMCP instance.
 
     Installation order (outermost first):
 
     1. :class:`ErrorHandlingMiddleware` — catches unhandled exceptions and
-       logs them with a traceback.
+       (optionally) logs them with a traceback.
     2. :class:`TimingMiddleware` — records tool invocation duration.
     3. :class:`LoggingMiddleware` (rich) or
        :class:`StructuredLoggingMiddleware` (JSON) — selected by the
@@ -34,8 +40,24 @@ def wire_middleware_stack(mcp: FastMCP) -> None:
 
     Args:
         mcp: The :class:`FastMCP` instance to install middleware on.
+        include_traceback: Whether ``ErrorHandlingMiddleware`` should log
+            tracebacks for unhandled exceptions. ``None`` (default) infers
+            from the root logger: tracebacks are enabled when the root
+            logger is at ``DEBUG`` or below. Pass ``True``/``False`` to
+            override. Call this *after* CLI/log-level setup so inference
+            sees the right level.
+        transform_errors: Whether ``ErrorHandlingMiddleware`` should
+            convert exceptions into MCP error responses. Defaults to
+            ``False`` (let exceptions propagate to FastMCP's own handlers).
     """
-    mcp.add_middleware(ErrorHandlingMiddleware(include_traceback=True))
+    if include_traceback is None:
+        include_traceback = logging.getLogger().isEnabledFor(logging.DEBUG)
+    mcp.add_middleware(
+        ErrorHandlingMiddleware(
+            include_traceback=include_traceback,
+            transform_errors=transform_errors,
+        )
+    )
     mcp.add_middleware(TimingMiddleware())
 
     rich_raw = os.environ.get("FASTMCP_ENABLE_RICH_LOGGING", "true")

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastmcp import FastMCP
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 from fastmcp.server.middleware.logging import (
@@ -66,9 +68,53 @@ def test_rich_when_rich_explicitly_enabled(monkeypatch):
     assert types[2] is LoggingMiddleware
 
 
-def test_error_handling_middleware_includes_traceback():
-    """Verify ErrorHandlingMiddleware is configured with include_traceback=True."""
+def _error_mw(mcp: FastMCP) -> ErrorHandlingMiddleware:
+    return next(m for m in mcp.middleware if isinstance(m, ErrorHandlingMiddleware))
+
+
+def test_include_traceback_inferred_from_debug_log_level(caplog):
+    """Default (None) infers include_traceback from root logger DEBUG-enabled."""
+    with caplog.at_level("DEBUG"):
+        mcp = FastMCP(name="t")
+        wire_middleware_stack(mcp)
+    assert _error_mw(mcp).include_traceback is True
+
+
+def test_include_traceback_inferred_off_when_root_above_debug():
+    """Default (None) yields False when root logger sits above DEBUG."""
+    root = logging.getLogger()
+    prev = root.level
+    root.setLevel(logging.WARNING)
+    try:
+        mcp = FastMCP(name="t")
+        wire_middleware_stack(mcp)
+        assert _error_mw(mcp).include_traceback is False
+    finally:
+        root.setLevel(prev)
+
+
+def test_include_traceback_explicit_override():
+    """Explicit include_traceback wins over log-level inference."""
+    root = logging.getLogger()
+    prev = root.level
+    root.setLevel(logging.WARNING)
+    try:
+        mcp = FastMCP(name="t")
+        wire_middleware_stack(mcp, include_traceback=True)
+        assert _error_mw(mcp).include_traceback is True
+    finally:
+        root.setLevel(prev)
+
+
+def test_transform_errors_default_false():
+    """Default transform_errors is False (matches MV behavior)."""
     mcp = FastMCP(name="t")
     wire_middleware_stack(mcp)
-    error_mw = next(m for m in mcp.middleware if isinstance(m, ErrorHandlingMiddleware))
-    assert error_mw.include_traceback is True
+    assert _error_mw(mcp).transform_errors is False
+
+
+def test_transform_errors_explicit_true():
+    """transform_errors=True is honored."""
+    mcp = FastMCP(name="t")
+    wire_middleware_stack(mcp, transform_errors=True)
+    assert _error_mw(mcp).transform_errors is True


### PR DESCRIPTION
## Summary

Extends \`wire_middleware_stack()\` with two opt-in keyword-only arguments needed by markdown-vault-mcp adoption:

- \`include_traceback: bool | None = None\` — when \`None\`, infers from the root logger (\`True\` if DEBUG-enabled, else \`False\`). Pass \`True\`/\`False\` to override.
- \`transform_errors: bool = False\` — matches MV default; let exceptions propagate to FastMCP's own handlers rather than synthesizing MCP error responses inside \`ErrorHandlingMiddleware\`.

This is the v0.2 prep step gating the upcoming MV PR-MV3 (middleware + logging adoption). Without these kwargs, MV would lose its current traceback verbosity and error-propagation semantics on switch-over.

### Behavior change

Existing callers that pass no args see a behavior change: \`include_traceback\` flips from hard-coded \`True\` to inferred (\`False\` unless root logger is at DEBUG). This intentional tightening avoids leaking internal stack traces into client-visible MCP errors in non-debug deployments. To restore the previous behavior explicitly, pass \`include_traceback=True\`.

PSR will treat this as a \`feat:\` and bump to v0.2.0 on the next release.

## Test plan

- [x] \`uv run ruff check --fix . && uv run ruff format .\`
- [x] \`uv run mypy src/\` — no errors
- [x] \`uv run pytest -x -q\` — 146 passed
- [x] \`_middleware.py\` coverage 100% on changed lines
- [x] Five new tests cover: DEBUG inference → True, WARNING inference → False, explicit override, transform_errors default False, transform_errors=True

🤖 Generated with [Claude Code](https://claude.com/claude-code)