### PR TITLE
ci: add prerelease mode to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
           - patch
           - minor
           - major
+      prerelease:
+        description: 'Cut a pre-release (rc channel — versions like 0.2.0-rc.1). Uncheck for a real release.'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -51,6 +55,8 @@ jobs:
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
           force: ${{ inputs.force }}
+          prerelease: ${{ inputs.prerelease }}
+          prerelease_token: rc
 
       - name: Build package
         if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
## Summary

Adds \`prerelease: bool\` \`workflow_dispatch\` input (default \`true\`) wired to PSR's \`prerelease\` + \`prerelease_token: rc\`, so manual releases cut rc channel versions like \`0.2.0-rc.1\` by default; unchecking the box cuts a real release.

\`publish-pypi\` stays unconditional on \`released == 'true'\`: prereleases publish to PyPI so downstream consumers (markdown-vault-mcp) can pin to \`fastmcp-pvl-core==0.2.0-rc.1\` for testing before a real v0.2.0 is cut. PEP 440 prereleases are PyPI-safe — pip won't install them unless explicitly requested.

This unblocks the v0.2.0-rc.1 cut once #12 (middleware kwargs) merges.

## Test plan

- [x] YAML structure verified (input wired only into PSR step; downstream jobs unaffected)
- [ ] Validated end-to-end by running the workflow with prerelease=true after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)