### PR TITLE
feat(server-info): add register_server_info_tool helper

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -24,6 +24,7 @@ from fastmcp_pvl_core._factory import (
 )
 from fastmcp_pvl_core._logging import configure_logging_from_env
 from fastmcp_pvl_core._middleware import wire_middleware_stack
+from fastmcp_pvl_core._server_info import register_server_info_tool
 
 __version__ = "1.0.0"  # PSR overrides at build time
 
@@ -47,6 +48,7 @@ __all__ = [
     "parse_bool",
     "parse_list",
     "parse_scopes",
+    "register_server_info_tool",
     "resolve_auth_mode",
     "wire_middleware_stack",
 ]

--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -24,7 +24,11 @@ from fastmcp_pvl_core._factory import (
 )
 from fastmcp_pvl_core._logging import configure_logging_from_env
 from fastmcp_pvl_core._middleware import wire_middleware_stack
-from fastmcp_pvl_core._server_info import register_server_info_tool
+from fastmcp_pvl_core._server_info import (
+    UpstreamProvider,
+    UpstreamResult,
+    register_server_info_tool,
+)
 
 __version__ = "1.0.0"  # PSR overrides at build time
 
@@ -34,6 +38,8 @@ __all__ = [
     "ServerConfig",
     "TokenRecord",
     "Transport",
+    "UpstreamProvider",
+    "UpstreamResult",
     "build_auth",
     "build_bearer_auth",
     "build_event_store",

--- a/src/fastmcp_pvl_core/_server_info.py
+++ b/src/fastmcp_pvl_core/_server_info.py
@@ -1,0 +1,122 @@
+"""Reusable ``get_server_info`` tool factory.
+
+Lets domain MCP servers register a single tool that reports both the
+wrapper's own version (``server_version``) and, optionally, the upstream
+service's version.  This is the one-call sanity check operators want when
+verifying that a fresh image is actually serving traffic — see issue #17
+for the motivating story (a ``docker pull`` without rebuild leaving an
+old image up).
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+UpstreamResult = str | dict[str, Any] | None
+"""What an ``upstream_version`` callable may return.
+
+- ``str`` — bare version string; wrapped as ``{"version": <str>}``.
+- ``dict`` — full upstream block; used as-is.
+- ``None`` — wrapped as ``{"version": None}``.
+"""
+
+UpstreamProvider = Callable[[], UpstreamResult | Awaitable[UpstreamResult]]
+"""Sync or async zero-arg callable returning an :data:`UpstreamResult`."""
+
+
+def register_server_info_tool(
+    mcp: FastMCP,
+    *,
+    server_version: str,
+    server_name: str,
+    upstream_version: UpstreamProvider | None = None,
+    upstream_label: str = "upstream",
+    tool_name: str = "get_server_info",
+    description: str | None = None,
+) -> None:
+    """Register a ``get_server_info`` tool on a FastMCP instance.
+
+    The registered tool is read-only and returns a structured payload::
+
+        {
+          "server_name": "<server_name>",
+          "server_version": "<server_version>",
+          "core_version": "<fastmcp_pvl_core.__version__>",
+          "<upstream_label>": {"version": "..."}   # only when upstream_version set
+        }
+
+    If the upstream lookup raises, the upstream block becomes
+    ``{"error": "<message>"}`` so the tool still returns the wrapper info
+    instead of failing the whole call.
+
+    Args:
+        mcp: The :class:`FastMCP` instance to register on.
+        server_version: The wrapper's own version (typically the domain
+            project's ``__version__``).
+        server_name: The wrapper's package/distribution name (e.g.
+            ``"paperless-mcp"``).
+        upstream_version: Optional zero-arg callable (sync or async)
+            returning either a bare version string, a full dict block, or
+            ``None``.  Wrapped automatically.
+        upstream_label: Key under which the upstream block appears in the
+            response.  Defaults to ``"upstream"``.  Ignored when
+            ``upstream_version`` is ``None``.
+        tool_name: Tool name to register.  Defaults to ``"get_server_info"``.
+        description: Override for the tool description.  Defaults to a
+            built-in description that mentions the wrapper name.
+    """
+    # Imported lazily so callers that never use this helper don't pay
+    # for the mcp.types import.
+    from mcp.types import ToolAnnotations
+
+    from fastmcp_pvl_core import __version__ as core_version
+
+    default_description = (
+        f"Report wrapper and upstream version info for {server_name}. "
+        "Returns server_name, server_version, core_version "
+        "(fastmcp-pvl-core), and (when configured) an upstream version "
+        "block.  Useful for verifying a deployment matches the expected "
+        "build."
+    )
+
+    async def get_server_info() -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "server_name": server_name,
+            "server_version": server_version,
+            "core_version": core_version,
+        }
+        if upstream_version is None:
+            return payload
+
+        try:
+            result: Any = upstream_version()
+            if inspect.isawaitable(result):
+                result = await result
+        except Exception as exc:  # noqa: BLE001 — surface as structured error
+            logger.warning(
+                "get_server_info upstream lookup failed: %s", exc, exc_info=True
+            )
+            payload[upstream_label] = {"error": str(exc)}
+            return payload
+
+        if isinstance(result, dict):
+            payload[upstream_label] = result
+        elif result is None:
+            payload[upstream_label] = {"version": None}
+        else:
+            payload[upstream_label] = {"version": str(result)}
+        return payload
+
+    mcp.tool(
+        name=tool_name,
+        description=description or default_description,
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )(get_server_info)

--- a/src/fastmcp_pvl_core/_server_info.py
+++ b/src/fastmcp_pvl_core/_server_info.py
@@ -20,16 +20,22 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-UpstreamResult = str | dict[str, Any] | None
+UpstreamResult = Any
 """What an ``upstream_version`` callable may return.
 
-- ``str`` — bare version string; wrapped as ``{"version": <str>}``.
 - ``dict`` — full upstream block; used as-is.
 - ``None`` — wrapped as ``{"version": None}``.
+- Any other value — coerced via ``str()`` and wrapped as
+  ``{"version": "<str>"}``.  This covers bare version strings as well as
+  ``Path``-like or numeric values.
 """
 
 UpstreamProvider = Callable[[], UpstreamResult | Awaitable[UpstreamResult]]
 """Sync or async zero-arg callable returning an :data:`UpstreamResult`."""
+
+
+_RESERVED_KEYS = frozenset({"server_name", "server_version", "core_version"})
+"""Keys that ``upstream_label`` must not collide with."""
 
 
 def register_server_info_tool(
@@ -64,15 +70,30 @@ def register_server_info_tool(
         server_name: The wrapper's package/distribution name (e.g.
             ``"paperless-mcp"``).
         upstream_version: Optional zero-arg callable (sync or async)
-            returning either a bare version string, a full dict block, or
-            ``None``.  Wrapped automatically.
+            returning a dict (full upstream block), ``None``, or any other
+            value (coerced via ``str()`` and wrapped as
+            ``{"version": "<str>"}``).
         upstream_label: Key under which the upstream block appears in the
-            response.  Defaults to ``"upstream"``.  Ignored when
-            ``upstream_version`` is ``None``.
+            response.  Defaults to ``"upstream"``.  Must not collide with
+            the reserved keys ``server_name``, ``server_version``, or
+            ``core_version``.  Ignored when ``upstream_version`` is
+            ``None``.
         tool_name: Tool name to register.  Defaults to ``"get_server_info"``.
         description: Override for the tool description.  Defaults to a
-            built-in description that mentions the wrapper name.
+            built-in description that mentions the wrapper name.  Pass
+            ``""`` to register an empty description; only ``None`` triggers
+            the default.
+
+    Raises:
+        ValueError: If ``upstream_label`` collides with a reserved payload
+            key (``server_name``, ``server_version``, ``core_version``).
     """
+    if upstream_label in _RESERVED_KEYS:
+        raise ValueError(
+            f"upstream_label {upstream_label!r} conflicts with reserved "
+            f"payload keys {sorted(_RESERVED_KEYS)}"
+        )
+
     # Imported lazily so callers that never use this helper don't pay
     # for the mcp.types import.
     from mcp.types import ToolAnnotations
@@ -117,6 +138,6 @@ def register_server_info_tool(
 
     mcp.tool(
         name=tool_name,
-        description=description or default_description,
+        description=default_description if description is None else description,
         annotations=ToolAnnotations(readOnlyHint=True),
     )(get_server_info)

--- a/src/fastmcp_pvl_core/_server_info.py
+++ b/src/fastmcp_pvl_core/_server_info.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import inspect
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -30,8 +30,10 @@ UpstreamResult = Any
   ``Path``-like or numeric values.
 """
 
-UpstreamProvider = Callable[[], UpstreamResult | Awaitable[UpstreamResult]]
-"""Sync or async zero-arg callable returning an :data:`UpstreamResult`."""
+UpstreamProvider = Callable[[], Any]
+"""Sync or async zero-arg callable; the return value (or its awaited
+result, if a coroutine is returned) is interpreted per
+:data:`UpstreamResult`."""
 
 
 _RESERVED_KEYS = frozenset({"server_name", "server_version", "core_version"})
@@ -76,8 +78,10 @@ def register_server_info_tool(
         upstream_label: Key under which the upstream block appears in the
             response.  Defaults to ``"upstream"``.  Must not collide with
             the reserved keys ``server_name``, ``server_version``, or
-            ``core_version``.  Ignored when ``upstream_version`` is
-            ``None``.
+            ``core_version``; this is validated eagerly at registration
+            time, even when ``upstream_version`` is ``None``.  When no
+            provider is configured the label is otherwise unused — no
+            block keyed under it appears in the payload.
         tool_name: Tool name to register.  Defaults to ``"get_server_info"``.
         description: Override for the tool description.  Defaults to a
             built-in description that mentions the wrapper name.  Pass
@@ -135,6 +139,11 @@ def register_server_info_tool(
         else:
             payload[upstream_label] = {"version": str(result)}
         return payload
+
+    # Make tracebacks and repr() reflect the registered tool name rather
+    # than always showing ``get_server_info``.
+    get_server_info.__name__ = tool_name
+    get_server_info.__qualname__ = tool_name
 
     mcp.tool(
         name=tool_name,

--- a/tests/test_server_info.py
+++ b/tests/test_server_info.py
@@ -109,6 +109,24 @@ class TestRegisterServerInfoTool:
         # Upstream block carries the error instead of a version.
         assert payload["paperless"] == {"error": "upstream is on fire"}
 
+    async def test_async_upstream_failure_returns_structured_error(self):
+        """Failures raised from the awaited path are caught the same way."""
+
+        async def boom_async():
+            raise RuntimeError("async upstream on fire")
+
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+            upstream_version=boom_async,
+            upstream_label="up",
+        )
+        payload = await _call(mcp)
+        assert payload["server_name"] == "my-mcp"
+        assert payload["up"] == {"error": "async upstream on fire"}
+
     async def test_upstream_returns_none(self):
         mcp = FastMCP("t")
         register_server_info_tool(

--- a/tests/test_server_info.py
+++ b/tests/test_server_info.py
@@ -179,6 +179,42 @@ class TestRegisterServerInfoTool:
         assert target.description is not None
         assert "paperless-mcp" in target.description
 
+    async def test_empty_string_description_not_replaced_by_default(self):
+        """Only None triggers the default; an explicit "" stays empty."""
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+            description="",
+        )
+        tools = await mcp.list_tools()
+        target = next(t for t in tools if t.name == "get_server_info")
+        # FastMCP may normalize "" → None, but it must not contain the
+        # default-description boilerplate.
+        assert not target.description or "Report wrapper" not in target.description
+
+    @pytest.mark.parametrize("label", ["server_name", "server_version", "core_version"])
+    def test_upstream_label_collision_with_reserved_key_raises(self, label):
+        with pytest.raises(ValueError, match="reserved"):
+            register_server_info_tool(
+                FastMCP("t"),
+                server_version="1.0.0",
+                server_name="my-mcp",
+                upstream_version=lambda: "v1",
+                upstream_label=label,
+            )
+
+    def test_reserved_label_check_runs_even_without_upstream(self):
+        """Misconfiguration is caught at registration, not deferred."""
+        with pytest.raises(ValueError, match="reserved"):
+            register_server_info_tool(
+                FastMCP("t"),
+                server_version="1.0.0",
+                server_name="my-mcp",
+                upstream_label="server_name",
+            )
+
 
 @pytest.mark.parametrize("upstream_value", [123, 4.2, True])
 async def test_upstream_non_string_non_dict_coerced_to_str(upstream_value):

--- a/tests/test_server_info.py
+++ b/tests/test_server_info.py
@@ -1,0 +1,194 @@
+"""Tests for ``register_server_info_tool``."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core import __version__ as core_version
+from fastmcp_pvl_core import register_server_info_tool
+
+
+async def _call(mcp: FastMCP, tool_name: str = "get_server_info") -> dict:
+    result = await mcp.call_tool(tool_name, {})
+    return result.structured_content
+
+
+class TestRegisterServerInfoTool:
+    async def test_required_fields_only(self):
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.2.3",
+            server_name="my-mcp",
+        )
+        payload = await _call(mcp)
+        assert payload == {
+            "server_name": "my-mcp",
+            "server_version": "1.2.3",
+            "core_version": core_version,
+        }
+
+    async def test_no_upstream_block_when_provider_omitted(self):
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+            upstream_label="paperless",  # ignored without provider
+        )
+        payload = await _call(mcp)
+        assert "paperless" not in payload
+        assert "upstream" not in payload
+
+    async def test_upstream_string_wrapped_under_label(self):
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="paperless-mcp",
+            upstream_version=lambda: "v2.20.14",
+            upstream_label="paperless",
+        )
+        payload = await _call(mcp)
+        assert payload["paperless"] == {"version": "v2.20.14"}
+        assert payload["server_name"] == "paperless-mcp"
+        assert payload["server_version"] == "1.0.0"
+        assert payload["core_version"] == core_version
+
+    async def test_upstream_dict_used_as_is(self):
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="paperless-mcp",
+            upstream_version=lambda: {
+                "version": "v2.20.14",
+                "update_available": False,
+            },
+            upstream_label="paperless",
+        )
+        payload = await _call(mcp)
+        assert payload["paperless"] == {
+            "version": "v2.20.14",
+            "update_available": False,
+        }
+
+    async def test_upstream_async_callable(self):
+        async def fetch():
+            return "v9.9.9"
+
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+            upstream_version=fetch,
+            upstream_label="up",
+        )
+        payload = await _call(mcp)
+        assert payload["up"] == {"version": "v9.9.9"}
+
+    async def test_upstream_failure_returns_structured_error(self):
+        def boom():
+            raise RuntimeError("upstream is on fire")
+
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+            upstream_version=boom,
+            upstream_label="paperless",
+        )
+        payload = await _call(mcp)
+        # Wrapper info still present.
+        assert payload["server_name"] == "my-mcp"
+        assert payload["server_version"] == "1.0.0"
+        assert payload["core_version"] == core_version
+        # Upstream block carries the error instead of a version.
+        assert payload["paperless"] == {"error": "upstream is on fire"}
+
+    async def test_upstream_returns_none(self):
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+            upstream_version=lambda: None,
+            upstream_label="up",
+        )
+        payload = await _call(mcp)
+        assert payload["up"] == {"version": None}
+
+    async def test_default_upstream_label(self):
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+            upstream_version=lambda: "v1",
+        )
+        payload = await _call(mcp)
+        assert payload["upstream"] == {"version": "v1"}
+
+    async def test_custom_tool_name(self):
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+            tool_name="version_info",
+        )
+        payload = await _call(mcp, tool_name="version_info")
+        assert payload["server_name"] == "my-mcp"
+
+    async def test_tool_is_marked_read_only(self):
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+        )
+        tools = await mcp.list_tools()
+        target = next(t for t in tools if t.name == "get_server_info")
+        assert target.annotations is not None
+        assert target.annotations.readOnlyHint is True
+
+    async def test_custom_description(self):
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+            description="My custom blurb.",
+        )
+        tools = await mcp.list_tools()
+        target = next(t for t in tools if t.name == "get_server_info")
+        assert target.description == "My custom blurb."
+
+    async def test_default_description_mentions_server_name(self):
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="paperless-mcp",
+        )
+        tools = await mcp.list_tools()
+        target = next(t for t in tools if t.name == "get_server_info")
+        assert target.description is not None
+        assert "paperless-mcp" in target.description
+
+
+@pytest.mark.parametrize("upstream_value", [123, 4.2, True])
+async def test_upstream_non_string_non_dict_coerced_to_str(upstream_value):
+    mcp = FastMCP("t")
+    register_server_info_tool(
+        mcp,
+        server_version="1.0.0",
+        server_name="my-mcp",
+        upstream_version=lambda: upstream_value,
+        upstream_label="up",
+    )
+    result = await mcp.call_tool("get_server_info", {})
+    assert result.structured_content["up"] == {"version": str(upstream_value)}


### PR DESCRIPTION
Reusable factory that registers a read-only `get_server_info` tool on a
FastMCP instance. Returns the wrapper's own version, fastmcp-pvl-core's
version, and an optional upstream service version block — the one-call
sanity check operators want when verifying that a deployed image
matches the expected build.

Upstream lookups can be sync or async, may return a string or a full
dict block, and surface failures as a structured `{"error": "..."}`
instead of failing the call.

Closes #17