### PR TITLE
Add register_tool_icons helper for bulk icon attachment

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -22,6 +22,7 @@ from fastmcp_pvl_core._factory import (
     build_instructions,
     compute_app_domain,
 )
+from fastmcp_pvl_core._icons import register_tool_icons
 from fastmcp_pvl_core._logging import configure_logging_from_env
 from fastmcp_pvl_core._middleware import wire_middleware_stack
 from fastmcp_pvl_core._server_info import (
@@ -55,6 +56,7 @@ __all__ = [
     "parse_list",
     "parse_scopes",
     "register_server_info_tool",
+    "register_tool_icons",
     "resolve_auth_mode",
     "wire_middleware_stack",
 ]

--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -22,7 +22,7 @@ from fastmcp_pvl_core._factory import (
     build_instructions,
     compute_app_domain,
 )
-from fastmcp_pvl_core._icons import register_tool_icons
+from fastmcp_pvl_core._icons import IconSpec, make_icon, register_tool_icons
 from fastmcp_pvl_core._logging import configure_logging_from_env
 from fastmcp_pvl_core._middleware import wire_middleware_stack
 from fastmcp_pvl_core._server_info import (
@@ -36,6 +36,7 @@ __version__ = "1.0.0"  # PSR overrides at build time
 __all__ = [
     "ArtifactStore",
     "AuthMode",
+    "IconSpec",
     "ServerConfig",
     "TokenRecord",
     "Transport",
@@ -50,6 +51,7 @@ __all__ = [
     "compute_app_domain",
     "configure_logging_from_env",
     "env",
+    "make_icon",
     "make_serve_parser",
     "normalise_http_path",
     "parse_bool",

--- a/src/fastmcp_pvl_core/_icons.py
+++ b/src/fastmcp_pvl_core/_icons.py
@@ -172,9 +172,20 @@ def register_tool_icons(
     # not expose a public sync ``tools`` accessor today, so we go one level
     # deep — the public async ``list_tools()`` would force this helper to be
     # async, which is heavier than the maintenance risk of one private attr.
-    # Verified against fastmcp >=3,<4 (see pyproject.toml).
+    # Verified against fastmcp >=3,<4 (see pyproject.toml). The guard turns a
+    # future rename into an actionable error rather than a bare AttributeError
+    # that looks like a caller bug.
+    try:
+        components = mcp.local_provider._components
+    except AttributeError as exc:
+        raise RuntimeError(
+            "FastMCP internal API changed: cannot enumerate tools via "
+            "local_provider._components. Please file an issue against "
+            "fastmcp-pvl-core."
+        ) from exc
+
     tools_by_name: dict[str, list[Tool]] = {}
-    for component in mcp.local_provider._components.values():
+    for component in components.values():
         if isinstance(component, Tool):
             tools_by_name.setdefault(component.name, []).append(component)
 

--- a/src/fastmcp_pvl_core/_icons.py
+++ b/src/fastmcp_pvl_core/_icons.py
@@ -1,10 +1,15 @@
-"""Bulk-attach icons to FastMCP tools from a static directory.
+"""Build :class:`mcp.types.Icon` instances from on-disk files.
 
 Every pvl-family server attaches Lucide icons (and friends) to its tools via
-base64-encoded data URIs.  This module ships a single helper that takes a
-``{tool_name: filename | [filenames]}`` mapping plus a ``static_dir`` and does
-the read → base64 → :class:`mcp.types.Icon` plumbing in one place — see
-issue #16 for the motivation.
+base64-encoded data URIs.  This module ships two helpers — see issue #16 for
+the motivation:
+
+- :func:`make_icon` reads one file and returns a single :class:`Icon` with a
+  ``data:<mime>;base64,<...>`` ``src``.  Use this at decoration time, e.g.
+  ``@mcp.tool(icons=[make_icon(static_dir / "search.svg")])``.
+- :func:`register_tool_icons` is the bulk equivalent: takes a
+  ``{tool_name: filename | [filenames]}`` mapping plus a ``static_dir`` and
+  attaches the resulting icon lists to already-registered tools.
 """
 
 from __future__ import annotations
@@ -38,58 +43,97 @@ Keys are lowercased ``Path.suffix`` values; anything not listed here causes
 """
 
 
-def _load_icon(path: Path) -> Icon:
-    """Read ``path`` and return an :class:`Icon` with a base64 data URI.
+def make_icon(
+    path: str | Path,
+    *,
+    sizes: list[str] | None = None,
+) -> Icon:
+    """Read an icon file and return an :class:`Icon` with a base64 data URI.
+
+    Use this at tool-decoration time when you only need a single icon::
+
+        @mcp.tool(icons=[make_icon(STATIC / "search.svg")])
+        def search(...): ...
+
+    Or call it from your own code when :func:`register_tool_icons` doesn't
+    fit (e.g. you want different icons per tool version).
 
     Args:
-        path: Absolute path to the icon file.  Must exist and have a
-            supported extension (see :data:`_MIME_BY_SUFFIX`).
+        path: Path to the icon file.  Must exist and have a supported
+            extension: ``.svg``, ``.png``, ``.ico``, ``.jpg``/``.jpeg``.
+        sizes: Optional ``["WxH", ...]`` size hints stored on the icon
+            (e.g. ``["48x48", "96x96"]``).  Passed straight through to
+            :class:`mcp.types.Icon`.
 
     Returns:
         An :class:`mcp.types.Icon` whose ``src`` is
-        ``"data:<mime>;base64,<payload>"`` and whose ``mimeType`` matches.
+        ``"data:<mime>;base64,<payload>"`` and whose ``mimeType`` matches
+        the file extension.
 
     Raises:
-        ValueError: If the file's extension is not in
-            :data:`_MIME_BY_SUFFIX`.
+        ValueError: If the file's extension is not supported.
         FileNotFoundError: If the file does not exist.
     """
-    suffix = path.suffix.lower()
+    file_path = Path(path)
+    suffix = file_path.suffix.lower()
     mime = _MIME_BY_SUFFIX.get(suffix)
     if mime is None:
         supported = ", ".join(sorted(_MIME_BY_SUFFIX))
         raise ValueError(
-            f"Unsupported icon extension {suffix!r} for {path}; "
+            f"Unsupported icon extension {suffix!r} for {file_path}; "
             f"supported extensions: {supported}"
         )
-    payload = base64.b64encode(path.read_bytes()).decode("ascii")
-    return Icon(src=f"data:{mime};base64,{payload}", mimeType=mime)
+    payload = base64.b64encode(file_path.read_bytes()).decode("ascii")
+    return Icon(
+        src=f"data:{mime};base64,{payload}",
+        mimeType=mime,
+        sizes=sizes,
+    )
+
+
+IconSpec = str | Path | Sequence[str | Path]
+"""Per-tool value type accepted by :func:`register_tool_icons`.
+
+Either a single filename (``str``/``Path``) or a sequence of filenames.
+Each filename is resolved relative to ``static_dir``; absolute paths are
+accepted as-is.
+"""
 
 
 def register_tool_icons(
     mcp: FastMCP,
-    mapping: Mapping[str, str | Sequence[str]],
+    mapping: Mapping[str, IconSpec],
     *,
     static_dir: str | Path,
 ) -> None:
     """Attach base64-encoded icons to already-registered FastMCP tools.
 
-    Resolves each filename relative to ``static_dir``, reads it, encodes it
-    as ``data:<mime>;base64,<...>``, and assigns the resulting list to the
+    Resolves each filename relative to ``static_dir`` (absolute paths pass
+    through unchanged), reads it, encodes it as
+    ``data:<mime>;base64,<...>``, and assigns the resulting list to the
     matching tool's ``icons`` attribute (replacing any previous icons).
+    Tools registered with multiple versions all receive the same icons.
 
     The mapping is fully validated before any tool is mutated, so a missing
     file or unknown tool name aborts the call without leaving a half-applied
     state.
+
+    For one-off use at decoration time, prefer :func:`make_icon` directly::
+
+        @mcp.tool(icons=[make_icon(STATIC / "search.svg")])
+        def search(...): ...
 
     Args:
         mcp: The :class:`FastMCP` instance whose tools should receive icons.
             Tools must already be registered (e.g. via ``@mcp.tool`` or
             ``mcp.add_tool``) before calling this helper.
         mapping: ``{tool_name: filename}`` or ``{tool_name: [filenames]}``.
-            Filenames are resolved relative to ``static_dir``.  Supported
-            extensions: ``.svg``, ``.png``, ``.ico``, ``.jpg``/``.jpeg``.
-        static_dir: Directory containing the icon files.
+            Filenames may be ``str`` or :class:`~pathlib.Path`.  Relative
+            paths are resolved against ``static_dir``; absolute paths are
+            used as-is.  Supported extensions: ``.svg``, ``.png``, ``.ico``,
+            ``.jpg``/``.jpeg``.
+        static_dir: Directory containing the icon files.  Must exist and be
+            a directory; only used to resolve relative filenames.
 
     Raises:
         ValueError: If a tool name in ``mapping`` is not registered on
@@ -128,16 +172,23 @@ def register_tool_icons(
                 "register_tool_icons()."
             )
 
-        filenames = [files] if isinstance(files, str) else list(files)
+        if isinstance(files, str | Path):
+            entries: list[str | Path] = [files]
+        else:
+            entries = list(files)
+
         icons: list[Icon] = []
-        for filename in filenames:
-            path = base_dir / filename
+        display: list[str] = []
+        for entry in entries:
+            entry_path = Path(entry)
+            path = entry_path if entry_path.is_absolute() else base_dir / entry_path
             if not path.is_file():
                 raise FileNotFoundError(
                     f"Icon file for tool {tool_name!r} not found: {path}"
                 )
-            icons.append(_load_icon(path))
-        resolved.append((tool_name, targets, icons, filenames))
+            icons.append(make_icon(path))
+            display.append(str(entry))
+        resolved.append((tool_name, targets, icons, display))
 
     for tool_name, targets, icons, filenames in resolved:
         for tool in targets:

--- a/src/fastmcp_pvl_core/_icons.py
+++ b/src/fastmcp_pvl_core/_icons.py
@@ -91,6 +91,21 @@ def make_icon(
     )
 
 
+def _is_within(path: Path, base_dir: Path) -> bool:
+    """Return whether ``path`` is at or under ``base_dir``.
+
+    Both arguments must already be resolved (absolute).  Implemented via
+    :meth:`Path.relative_to` because :meth:`Path.is_relative_to` only
+    arrived in 3.9 and we still get the exception-free check via
+    ``try/except``.
+    """
+    try:
+        path.relative_to(base_dir)
+    except ValueError:
+        return False
+    return True
+
+
 IconSpec = str | Path | Sequence[str | Path]
 """Per-tool value type accepted by :func:`register_tool_icons`.
 
@@ -137,7 +152,8 @@ def register_tool_icons(
 
     Raises:
         ValueError: If a tool name in ``mapping`` is not registered on
-            ``mcp``, or a filename has an unsupported extension.
+            ``mcp``, a filename has an unsupported extension, or a relative
+            filename escapes ``static_dir`` via ``..``.
         FileNotFoundError: If ``static_dir`` does not exist or a referenced
             file is missing.
         NotADirectoryError: If ``static_dir`` exists but is not a directory.
@@ -146,18 +162,20 @@ def register_tool_icons(
     # the fastmcp.tools import at package load time.
     from fastmcp.tools.base import Tool
 
-    base_dir = Path(static_dir)
+    base_dir = Path(static_dir).resolve()
     if not base_dir.exists():
         raise FileNotFoundError(f"static_dir does not exist: {base_dir}")
     if not base_dir.is_dir():
         raise NotADirectoryError(f"static_dir is not a directory: {base_dir}")
 
-    # LocalProvider keys components as ``"<prefix>:<name>@<version>"`` (the
-    # ``@`` is always present, version is empty for unversioned tools).
-    # Group tools by name once; the helper applies icons to every registered
-    # version of the named tool.
+    # ``local_provider`` is the public access point on FastMCP; ``_components``
+    # is its internal store keyed as ``"<prefix>:<name>@<version>"`` (the ``@``
+    # is always present; version is empty for unversioned tools). FastMCP does
+    # not expose a public sync ``tools`` accessor today, so we go one level
+    # deep — the public async ``list_tools()`` would force this helper to be
+    # async, which is heavier than the maintenance risk of one private attr.
     tools_by_name: dict[str, list[Tool]] = {}
-    for component in mcp._local_provider._components.values():
+    for component in mcp.local_provider._components.values():
         if isinstance(component, Tool):
             tools_by_name.setdefault(component.name, []).append(component)
 
@@ -181,7 +199,20 @@ def register_tool_icons(
         display: list[str] = []
         for entry in entries:
             entry_path = Path(entry)
-            path = entry_path if entry_path.is_absolute() else base_dir / entry_path
+            if entry_path.is_absolute():
+                # Absolute paths bypass static_dir resolution by design — see
+                # ``IconSpec`` docstring.  Caller takes responsibility for
+                # what's outside static_dir.
+                path = entry_path
+            else:
+                # Relative paths must stay inside static_dir; resolving
+                # collapses ``..`` so we can check containment after the fact.
+                path = (base_dir / entry_path).resolve()
+                if not _is_within(path, base_dir):
+                    raise ValueError(
+                        f"Icon path {str(entry)!r} for tool {tool_name!r} "
+                        f"escapes static_dir ({base_dir})"
+                    )
             if not path.is_file():
                 raise FileNotFoundError(
                     f"Icon file for tool {tool_name!r} not found: {path}"

--- a/src/fastmcp_pvl_core/_icons.py
+++ b/src/fastmcp_pvl_core/_icons.py
@@ -1,0 +1,147 @@
+"""Bulk-attach icons to FastMCP tools from a static directory.
+
+Every pvl-family server attaches Lucide icons (and friends) to its tools via
+base64-encoded data URIs.  This module ships a single helper that takes a
+``{tool_name: filename | [filenames]}`` mapping plus a ``static_dir`` and does
+the read → base64 → :class:`mcp.types.Icon` plumbing in one place — see
+issue #16 for the motivation.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from mcp.types import Icon
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from fastmcp.tools.base import Tool
+
+logger = logging.getLogger(__name__)
+
+
+_MIME_BY_SUFFIX: dict[str, str] = {
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+    ".ico": "image/vnd.microsoft.icon",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+}
+"""Supported icon file extensions and their MIME types.
+
+Keys are lowercased ``Path.suffix`` values; anything not listed here causes
+:func:`register_tool_icons` to raise :class:`ValueError`.
+"""
+
+
+def _load_icon(path: Path) -> Icon:
+    """Read ``path`` and return an :class:`Icon` with a base64 data URI.
+
+    Args:
+        path: Absolute path to the icon file.  Must exist and have a
+            supported extension (see :data:`_MIME_BY_SUFFIX`).
+
+    Returns:
+        An :class:`mcp.types.Icon` whose ``src`` is
+        ``"data:<mime>;base64,<payload>"`` and whose ``mimeType`` matches.
+
+    Raises:
+        ValueError: If the file's extension is not in
+            :data:`_MIME_BY_SUFFIX`.
+        FileNotFoundError: If the file does not exist.
+    """
+    suffix = path.suffix.lower()
+    mime = _MIME_BY_SUFFIX.get(suffix)
+    if mime is None:
+        supported = ", ".join(sorted(_MIME_BY_SUFFIX))
+        raise ValueError(
+            f"Unsupported icon extension {suffix!r} for {path}; "
+            f"supported extensions: {supported}"
+        )
+    payload = base64.b64encode(path.read_bytes()).decode("ascii")
+    return Icon(src=f"data:{mime};base64,{payload}", mimeType=mime)
+
+
+def register_tool_icons(
+    mcp: FastMCP,
+    mapping: Mapping[str, str | Sequence[str]],
+    *,
+    static_dir: str | Path,
+) -> None:
+    """Attach base64-encoded icons to already-registered FastMCP tools.
+
+    Resolves each filename relative to ``static_dir``, reads it, encodes it
+    as ``data:<mime>;base64,<...>``, and assigns the resulting list to the
+    matching tool's ``icons`` attribute (replacing any previous icons).
+
+    The mapping is fully validated before any tool is mutated, so a missing
+    file or unknown tool name aborts the call without leaving a half-applied
+    state.
+
+    Args:
+        mcp: The :class:`FastMCP` instance whose tools should receive icons.
+            Tools must already be registered (e.g. via ``@mcp.tool`` or
+            ``mcp.add_tool``) before calling this helper.
+        mapping: ``{tool_name: filename}`` or ``{tool_name: [filenames]}``.
+            Filenames are resolved relative to ``static_dir``.  Supported
+            extensions: ``.svg``, ``.png``, ``.ico``, ``.jpg``/``.jpeg``.
+        static_dir: Directory containing the icon files.
+
+    Raises:
+        ValueError: If a tool name in ``mapping`` is not registered on
+            ``mcp``, or a filename has an unsupported extension.
+        FileNotFoundError: If ``static_dir`` does not exist or a referenced
+            file is missing.
+        NotADirectoryError: If ``static_dir`` exists but is not a directory.
+    """
+    # Imported lazily so callers that never use this helper don't pay for
+    # the fastmcp.tools import at package load time.
+    from fastmcp.tools.base import Tool
+
+    base_dir = Path(static_dir)
+    if not base_dir.exists():
+        raise FileNotFoundError(f"static_dir does not exist: {base_dir}")
+    if not base_dir.is_dir():
+        raise NotADirectoryError(f"static_dir is not a directory: {base_dir}")
+
+    # LocalProvider keys components as ``"<prefix>:<name>@<version>"`` (the
+    # ``@`` is always present, version is empty for unversioned tools).
+    # Group tools by name once; the helper applies icons to every registered
+    # version of the named tool.
+    tools_by_name: dict[str, list[Tool]] = {}
+    for component in mcp._local_provider._components.values():
+        if isinstance(component, Tool):
+            tools_by_name.setdefault(component.name, []).append(component)
+
+    resolved: list[tuple[str, list[Tool], list[Icon], list[str]]] = []
+
+    for tool_name, files in mapping.items():
+        targets = tools_by_name.get(tool_name)
+        if not targets:
+            raise ValueError(
+                f"Tool {tool_name!r} is not registered on this FastMCP "
+                "instance; register tools before calling "
+                "register_tool_icons()."
+            )
+
+        filenames = [files] if isinstance(files, str) else list(files)
+        icons: list[Icon] = []
+        for filename in filenames:
+            path = base_dir / filename
+            if not path.is_file():
+                raise FileNotFoundError(
+                    f"Icon file for tool {tool_name!r} not found: {path}"
+                )
+            icons.append(_load_icon(path))
+        resolved.append((tool_name, targets, icons, filenames))
+
+    for tool_name, targets, icons, filenames in resolved:
+        for tool in targets:
+            tool.icons = icons
+        logger.info(
+            "icons registered tool=%s files=%s", tool_name, ",".join(filenames)
+        )

--- a/src/fastmcp_pvl_core/_icons.py
+++ b/src/fastmcp_pvl_core/_icons.py
@@ -193,6 +193,4 @@ def register_tool_icons(
     for tool_name, targets, icons, filenames in resolved:
         for tool in targets:
             tool.icons = icons
-        logger.info(
-            "icons registered tool=%s files=%s", tool_name, ",".join(filenames)
-        )
+        logger.info("icons registered tool=%s files=%s", tool_name, ",".join(filenames))

--- a/src/fastmcp_pvl_core/_icons.py
+++ b/src/fastmcp_pvl_core/_icons.py
@@ -29,6 +29,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+#: Supported icon file extensions and their MIME types.
+#: Keys are lowercased ``Path.suffix`` values; anything not listed here causes
+#: :func:`make_icon` to raise :class:`ValueError`.
 _MIME_BY_SUFFIX: dict[str, str] = {
     ".svg": "image/svg+xml",
     ".png": "image/png",
@@ -36,11 +39,6 @@ _MIME_BY_SUFFIX: dict[str, str] = {
     ".jpg": "image/jpeg",
     ".jpeg": "image/jpeg",
 }
-"""Supported icon file extensions and their MIME types.
-
-Keys are lowercased ``Path.suffix`` values; anything not listed here causes
-:func:`register_tool_icons` to raise :class:`ValueError`.
-"""
 
 
 def make_icon(
@@ -174,6 +172,7 @@ def register_tool_icons(
     # not expose a public sync ``tools`` accessor today, so we go one level
     # deep — the public async ``list_tools()`` would force this helper to be
     # async, which is heavier than the maintenance risk of one private attr.
+    # Verified against fastmcp >=3,<4 (see pyproject.toml).
     tools_by_name: dict[str, list[Tool]] = {}
     for component in mcp.local_provider._components.values():
         if isinstance(component, Tool):
@@ -213,15 +212,25 @@ def register_tool_icons(
                         f"Icon path {str(entry)!r} for tool {tool_name!r} "
                         f"escapes static_dir ({base_dir})"
                     )
-            if not path.is_file():
+            # Let make_icon do the read; that's the only place that touches
+            # the file, so any FileNotFoundError or ValueError comes straight
+            # from there and we wrap it once with the tool-name context the
+            # caller needs.  This also closes the TOCTOU window that an
+            # ``is_file()`` pre-check would have left open.
+            try:
+                icons.append(make_icon(path))
+            except FileNotFoundError as exc:
                 raise FileNotFoundError(
                     f"Icon file for tool {tool_name!r} not found: {path}"
-                )
-            icons.append(make_icon(path))
+                ) from exc
+            except ValueError as exc:
+                raise ValueError(f"Tool {tool_name!r}: {exc}") from exc
             display.append(str(entry))
         resolved.append((tool_name, targets, icons, display))
 
     for tool_name, targets, icons, filenames in resolved:
+        # Defensive copy: each registered tool gets its own list so an in-place
+        # mutation by one tool/version doesn't leak into the others.
         for tool in targets:
-            tool.icons = icons
+            tool.icons = list(icons)
         logger.info("icons registered tool=%s files=%s", tool_name, ",".join(filenames))

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -23,7 +23,7 @@ def _write(tmp_path: Path, name: str, data: bytes) -> Path:
 
 
 def _tool_icons(mcp: FastMCP, tool_name: str) -> list:
-    for component in mcp._local_provider._components.values():
+    for component in mcp.local_provider._components.values():
         if getattr(component, "name", None) == tool_name:
             return component.icons or []
     raise KeyError(tool_name)
@@ -176,6 +176,25 @@ class TestRegisterToolIcons:
         assert icons[0].mimeType == "image/svg+xml"
         payload = icons[0].src.split(",", 1)[1]
         assert base64.b64decode(payload) == SVG_BYTES
+
+    def test_relative_path_traversal_rejected(self, tmp_path: Path):
+        # Place the icon outside static_dir so the resolved path actually
+        # exists; the helper must still refuse to read it.
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        (outside_dir / "secret.svg").write_bytes(SVG_BYTES)
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        mcp = _make_mcp_with_tool()
+
+        with pytest.raises(ValueError, match="escapes static_dir"):
+            register_tool_icons(
+                mcp,
+                {"ping": "../outside/secret.svg"},
+                static_dir=static_dir,
+            )
+
+        assert _tool_icons(mcp, "ping") == []
 
     def test_mapping_accepts_mixed_str_and_path_in_list(self, tmp_path: Path):
         _write(tmp_path, "a.svg", SVG_BYTES)

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -58,9 +58,7 @@ class TestRegisterToolIcons:
         _write(tmp_path, "b.png", PNG_BYTES)
         mcp = _make_mcp_with_tool()
 
-        register_tool_icons(
-            mcp, {"ping": ["a.svg", "b.png"]}, static_dir=tmp_path
-        )
+        register_tool_icons(mcp, {"ping": ["a.svg", "b.png"]}, static_dir=tmp_path)
 
         icons = _tool_icons(mcp, "ping")
         assert [i.mimeType for i in icons] == ["image/svg+xml", "image/png"]
@@ -101,9 +99,7 @@ class TestRegisterToolIcons:
         mcp = _make_mcp_with_tool()
 
         with pytest.raises(FileNotFoundError, match="missing.svg"):
-            register_tool_icons(
-                mcp, {"ping": "missing.svg"}, static_dir=tmp_path
-            )
+            register_tool_icons(mcp, {"ping": "missing.svg"}, static_dir=tmp_path)
 
     def test_missing_static_dir_raises(self, tmp_path: Path):
         mcp = _make_mcp_with_tool()
@@ -119,9 +115,7 @@ class TestRegisterToolIcons:
         with pytest.raises(NotADirectoryError):
             register_tool_icons(mcp, {"ping": "x.svg"}, static_dir=regular_file)
 
-    def test_unregistered_tool_raises_and_does_not_mutate(
-        self, tmp_path: Path
-    ):
+    def test_unregistered_tool_raises_and_does_not_mutate(self, tmp_path: Path):
         _write(tmp_path, "ping.svg", SVG_BYTES)
         mcp = _make_mcp_with_tool()
 
@@ -166,9 +160,7 @@ class TestRegisterToolIcons:
         _write(tmp_path, "ping.svg", SVG_BYTES)
         mcp = _make_mcp_with_tool()
 
-        register_tool_icons(
-            mcp, {"ping": Path("ping.svg")}, static_dir=tmp_path
-        )
+        register_tool_icons(mcp, {"ping": Path("ping.svg")}, static_dir=tmp_path)
 
         assert _tool_icons(mcp, "ping")[0].mimeType == "image/svg+xml"
 

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -1,0 +1,163 @@
+"""Tests for ``register_tool_icons``."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core import register_tool_icons
+
+SVG_BYTES = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></svg>'
+PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-png-payload"
+ICO_BYTES = b"\x00\x00\x01\x00fake-ico-payload"
+JPG_BYTES = b"\xff\xd8\xff\xe0fake-jpg-payload"
+
+
+def _write(tmp_path: Path, name: str, data: bytes) -> Path:
+    path = tmp_path / name
+    path.write_bytes(data)
+    return path
+
+
+def _tool_icons(mcp: FastMCP, tool_name: str) -> list:
+    for component in mcp._local_provider._components.values():
+        if getattr(component, "name", None) == tool_name:
+            return component.icons or []
+    raise KeyError(tool_name)
+
+
+def _make_mcp_with_tool(tool_name: str = "ping") -> FastMCP:
+    mcp = FastMCP("t")
+
+    @mcp.tool(name=tool_name)
+    def _ping() -> str:
+        return "pong"
+
+    return mcp
+
+
+class TestRegisterToolIcons:
+    def test_single_svg(self, tmp_path: Path):
+        _write(tmp_path, "ping.svg", SVG_BYTES)
+        mcp = _make_mcp_with_tool()
+
+        register_tool_icons(mcp, {"ping": "ping.svg"}, static_dir=tmp_path)
+
+        icons = _tool_icons(mcp, "ping")
+        assert len(icons) == 1
+        assert icons[0].mimeType == "image/svg+xml"
+        assert icons[0].src.startswith("data:image/svg+xml;base64,")
+        payload = icons[0].src.split(",", 1)[1]
+        assert base64.b64decode(payload) == SVG_BYTES
+
+    def test_list_of_files_preserves_order(self, tmp_path: Path):
+        _write(tmp_path, "a.svg", SVG_BYTES)
+        _write(tmp_path, "b.png", PNG_BYTES)
+        mcp = _make_mcp_with_tool()
+
+        register_tool_icons(
+            mcp, {"ping": ["a.svg", "b.png"]}, static_dir=tmp_path
+        )
+
+        icons = _tool_icons(mcp, "ping")
+        assert [i.mimeType for i in icons] == ["image/svg+xml", "image/png"]
+
+    @pytest.mark.parametrize(
+        ("filename", "data", "expected_mime"),
+        [
+            ("p.png", PNG_BYTES, "image/png"),
+            ("p.ico", ICO_BYTES, "image/vnd.microsoft.icon"),
+            ("p.jpg", JPG_BYTES, "image/jpeg"),
+            ("p.JPEG", JPG_BYTES, "image/jpeg"),
+        ],
+    )
+    def test_supported_extensions(
+        self,
+        tmp_path: Path,
+        filename: str,
+        data: bytes,
+        expected_mime: str,
+    ):
+        _write(tmp_path, filename, data)
+        mcp = _make_mcp_with_tool()
+
+        register_tool_icons(mcp, {"ping": filename}, static_dir=tmp_path)
+
+        icons = _tool_icons(mcp, "ping")
+        assert icons[0].mimeType == expected_mime
+        assert icons[0].src.startswith(f"data:{expected_mime};base64,")
+
+    def test_unknown_extension_rejected(self, tmp_path: Path):
+        _write(tmp_path, "ping.bmp", b"bmp")
+        mcp = _make_mcp_with_tool()
+
+        with pytest.raises(ValueError, match=r"\.bmp"):
+            register_tool_icons(mcp, {"ping": "ping.bmp"}, static_dir=tmp_path)
+
+    def test_missing_file_raises_with_path(self, tmp_path: Path):
+        mcp = _make_mcp_with_tool()
+
+        with pytest.raises(FileNotFoundError, match="missing.svg"):
+            register_tool_icons(
+                mcp, {"ping": "missing.svg"}, static_dir=tmp_path
+            )
+
+    def test_missing_static_dir_raises(self, tmp_path: Path):
+        mcp = _make_mcp_with_tool()
+        missing = tmp_path / "does-not-exist"
+
+        with pytest.raises(FileNotFoundError, match="does-not-exist"):
+            register_tool_icons(mcp, {"ping": "x.svg"}, static_dir=missing)
+
+    def test_static_dir_is_a_file_raises(self, tmp_path: Path):
+        regular_file = _write(tmp_path, "not-a-dir.txt", b"hi")
+        mcp = _make_mcp_with_tool()
+
+        with pytest.raises(NotADirectoryError):
+            register_tool_icons(mcp, {"ping": "x.svg"}, static_dir=regular_file)
+
+    def test_unregistered_tool_raises_and_does_not_mutate(
+        self, tmp_path: Path
+    ):
+        _write(tmp_path, "ping.svg", SVG_BYTES)
+        mcp = _make_mcp_with_tool()
+
+        with pytest.raises(ValueError, match="ghost"):
+            register_tool_icons(
+                mcp,
+                {"ping": "ping.svg", "ghost": "ping.svg"},
+                static_dir=tmp_path,
+            )
+
+        # The valid entry must NOT have been applied — validate-before-mutate.
+        assert _tool_icons(mcp, "ping") == []
+
+    def test_second_call_replaces_icons(self, tmp_path: Path):
+        _write(tmp_path, "a.svg", SVG_BYTES)
+        _write(tmp_path, "b.png", PNG_BYTES)
+        mcp = _make_mcp_with_tool()
+
+        register_tool_icons(mcp, {"ping": "a.svg"}, static_dir=tmp_path)
+        register_tool_icons(mcp, {"ping": "b.png"}, static_dir=tmp_path)
+
+        icons = _tool_icons(mcp, "ping")
+        assert len(icons) == 1
+        assert icons[0].mimeType == "image/png"
+
+    def test_empty_mapping_is_noop(self, tmp_path: Path):
+        mcp = _make_mcp_with_tool()
+
+        register_tool_icons(mcp, {}, static_dir=tmp_path)
+
+        assert _tool_icons(mcp, "ping") == []
+
+    def test_static_dir_accepts_string(self, tmp_path: Path):
+        _write(tmp_path, "ping.svg", SVG_BYTES)
+        mcp = _make_mcp_with_tool()
+
+        register_tool_icons(mcp, {"ping": "ping.svg"}, static_dir=str(tmp_path))
+
+        assert _tool_icons(mcp, "ping")[0].mimeType == "image/svg+xml"

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -69,6 +69,7 @@ class TestRegisterToolIcons:
             ("p.png", PNG_BYTES, "image/png"),
             ("p.ico", ICO_BYTES, "image/vnd.microsoft.icon"),
             ("p.jpg", JPG_BYTES, "image/jpeg"),
+            ("p.jpeg", JPG_BYTES, "image/jpeg"),
             ("p.JPEG", JPG_BYTES, "image/jpeg"),
         ],
     )
@@ -119,6 +120,9 @@ class TestRegisterToolIcons:
         _write(tmp_path, "ping.svg", SVG_BYTES)
         mcp = _make_mcp_with_tool()
 
+        # Order matters: ``ping`` is validated/resolved first (Python 3.7+
+        # dicts preserve insertion order); ``ghost`` then fails validation
+        # before the mutation phase begins, so ``ping`` must remain unchanged.
         with pytest.raises(ValueError, match="ghost"):
             register_tool_icons(
                 mcp,
@@ -147,6 +151,47 @@ class TestRegisterToolIcons:
         register_tool_icons(mcp, {}, static_dir=tmp_path)
 
         assert _tool_icons(mcp, "ping") == []
+
+    def test_empty_mapping_still_validates_static_dir(self, tmp_path: Path):
+        # Locks current behavior: ``static_dir`` must exist even when there
+        # are no entries to read.  Catches misconfigured paths early; if we
+        # ever decide to relax this, this test should be the one to update.
+        mcp = _make_mcp_with_tool()
+        missing = tmp_path / "nope"
+
+        with pytest.raises(FileNotFoundError, match="nope"):
+            register_tool_icons(mcp, {}, static_dir=missing)
+
+    def test_unknown_extension_error_includes_tool_name(self, tmp_path: Path):
+        _write(tmp_path, "ping.bmp", b"bmp")
+        mcp = _make_mcp_with_tool()
+
+        with pytest.raises(ValueError, match=r"Tool 'ping'"):
+            register_tool_icons(mcp, {"ping": "ping.bmp"}, static_dir=tmp_path)
+
+    def test_each_tool_gets_independent_icons_list(self, tmp_path: Path):
+        _write(tmp_path, "a.svg", SVG_BYTES)
+        mcp = FastMCP("t")
+
+        @mcp.tool(name="alpha")
+        def _alpha() -> str:
+            return "a"
+
+        @mcp.tool(name="beta")
+        def _beta() -> str:
+            return "b"
+
+        register_tool_icons(
+            mcp,
+            {"alpha": "a.svg", "beta": "a.svg"},
+            static_dir=tmp_path,
+        )
+
+        alpha_icons = _tool_icons(mcp, "alpha")
+        beta_icons = _tool_icons(mcp, "beta")
+        # Same content but distinct list objects — defends against in-place
+        # mutation on one tool leaking to the other.
+        assert alpha_icons is not beta_icons
 
     def test_static_dir_accepts_string(self, tmp_path: Path):
         _write(tmp_path, "ping.svg", SVG_BYTES)

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -1,4 +1,4 @@
-"""Tests for ``register_tool_icons``."""
+"""Tests for ``make_icon`` and ``register_tool_icons``."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from fastmcp import FastMCP
 
-from fastmcp_pvl_core import register_tool_icons
+from fastmcp_pvl_core import make_icon, register_tool_icons
 
 SVG_BYTES = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></svg>'
 PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-png-payload"
@@ -161,3 +161,88 @@ class TestRegisterToolIcons:
         register_tool_icons(mcp, {"ping": "ping.svg"}, static_dir=str(tmp_path))
 
         assert _tool_icons(mcp, "ping")[0].mimeType == "image/svg+xml"
+
+    def test_mapping_accepts_path_object(self, tmp_path: Path):
+        _write(tmp_path, "ping.svg", SVG_BYTES)
+        mcp = _make_mcp_with_tool()
+
+        register_tool_icons(
+            mcp, {"ping": Path("ping.svg")}, static_dir=tmp_path
+        )
+
+        assert _tool_icons(mcp, "ping")[0].mimeType == "image/svg+xml"
+
+    def test_mapping_accepts_absolute_path(self, tmp_path: Path, tmp_path_factory):
+        # Absolute paths bypass static_dir resolution.
+        elsewhere = tmp_path_factory.mktemp("elsewhere")
+        absolute = _write(elsewhere, "abs.svg", SVG_BYTES)
+        mcp = _make_mcp_with_tool()
+
+        register_tool_icons(mcp, {"ping": absolute}, static_dir=tmp_path)
+
+        icons = _tool_icons(mcp, "ping")
+        assert icons[0].mimeType == "image/svg+xml"
+        payload = icons[0].src.split(",", 1)[1]
+        assert base64.b64decode(payload) == SVG_BYTES
+
+    def test_mapping_accepts_mixed_str_and_path_in_list(self, tmp_path: Path):
+        _write(tmp_path, "a.svg", SVG_BYTES)
+        _write(tmp_path, "b.png", PNG_BYTES)
+        mcp = _make_mcp_with_tool()
+
+        register_tool_icons(
+            mcp,
+            {"ping": ["a.svg", Path("b.png")]},
+            static_dir=tmp_path,
+        )
+
+        icons = _tool_icons(mcp, "ping")
+        assert [i.mimeType for i in icons] == ["image/svg+xml", "image/png"]
+
+
+class TestMakeIcon:
+    def test_svg_returns_data_uri(self, tmp_path: Path):
+        path = _write(tmp_path, "x.svg", SVG_BYTES)
+
+        icon = make_icon(path)
+
+        assert icon.mimeType == "image/svg+xml"
+        assert icon.src.startswith("data:image/svg+xml;base64,")
+        assert base64.b64decode(icon.src.split(",", 1)[1]) == SVG_BYTES
+        assert icon.sizes is None
+
+    def test_accepts_string_path(self, tmp_path: Path):
+        path = _write(tmp_path, "x.png", PNG_BYTES)
+
+        icon = make_icon(str(path))
+
+        assert icon.mimeType == "image/png"
+
+    def test_sizes_passed_through(self, tmp_path: Path):
+        path = _write(tmp_path, "x.svg", SVG_BYTES)
+
+        icon = make_icon(path, sizes=["48x48", "96x96"])
+
+        assert icon.sizes == ["48x48", "96x96"]
+
+    def test_unknown_extension_rejected(self, tmp_path: Path):
+        path = _write(tmp_path, "x.bmp", b"bmp")
+
+        with pytest.raises(ValueError, match=r"\.bmp"):
+            make_icon(path)
+
+    def test_missing_file_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            make_icon(tmp_path / "missing.svg")
+
+    def test_usable_at_decoration_time(self, tmp_path: Path):
+        path = _write(tmp_path, "x.svg", SVG_BYTES)
+        mcp = FastMCP("t")
+
+        @mcp.tool(name="search", icons=[make_icon(path)])
+        def _search() -> str:
+            return "ok"
+
+        icons = _tool_icons(mcp, "search")
+        assert len(icons) == 1
+        assert icons[0].mimeType == "image/svg+xml"

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -287,6 +287,15 @@ class TestMakeIcon:
         with pytest.raises(ValueError, match=r"\.bmp"):
             make_icon(path)
 
+    def test_uppercase_extension_accepted(self, tmp_path: Path):
+        # Direct coverage for the public make_icon contract: case-insensitive
+        # suffix lookup must hold even when register_tool_icons is bypassed.
+        path = _write(tmp_path, "x.SVG", SVG_BYTES)
+
+        icon = make_icon(path)
+
+        assert icon.mimeType == "image/svg+xml"
+
     def test_missing_file_raises(self, tmp_path: Path):
         with pytest.raises(FileNotFoundError):
             make_icon(tmp_path / "missing.svg")

--- a/uv.lock
+++ b/uv.lock
@@ -576,7 +576,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp-pvl-core"
-version = "0.0.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Closes #16

## Summary
Adds a new `register_tool_icons()` helper function that simplifies attaching base64-encoded icons to FastMCP tools from a static directory. This addresses the repetitive plumbing needed across pvl-family servers to register Lucide icons and similar assets.

## Key Changes
- **New module `_icons.py`**: Implements `register_tool_icons()` function that:
  - Takes a mapping of tool names to icon filenames (or lists of filenames)
  - Reads icon files from a specified static directory
  - Encodes them as base64 data URIs
  - Attaches them to the corresponding FastMCP tools
  - Supports `.svg`, `.png`, `.ico`, `.jpg`, and `.jpeg` formats with appropriate MIME types

- **Validation-before-mutation pattern**: The function fully validates all inputs (tool existence, file existence, supported extensions) before mutating any tool state, ensuring no half-applied state on errors

- **Comprehensive error handling**:
  - `ValueError` for unregistered tools or unsupported file extensions
  - `FileNotFoundError` for missing static directory or icon files
  - `NotADirectoryError` if static_dir is not a directory

- **Public API export**: Added `register_tool_icons` to `__init__.py` for easy access

- **Extensive test coverage**: 163 lines of tests covering:
  - Single and multiple icon files
  - All supported file formats
  - Error cases (missing files, unknown extensions, unregistered tools)
  - Edge cases (empty mapping, string vs Path for static_dir, icon replacement)
  - Atomic validation (no partial application on error)

## Implementation Details
- Uses lazy imports to avoid loading `fastmcp.tools` at package initialization time for callers that don't use this helper
- Handles tool versioning by grouping tools by name before applying icons
- Logs successful icon registration for debugging
- Accepts both string and Path objects for the static_dir parameter

https://claude.ai/code/session_015TjRLSJwTrdyRuYepacyfD
