### PR TITLE
docs(readme): add Ecosystem section and 1.x API stability note

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,25 @@ auth, middleware, logging, config helpers, server-factory building blocks.
 
 ## Ecosystem
 
-- [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — copier template that scaffolds new FastMCP servers on top of this library. Downstream consumers stay in sync via periodic `copier update` runs.
-- Active consumers (as of 2026-04): [`markdown-vault-mcp`](https://github.com/pvliesdonk/markdown-vault-mcp), [`scholar-mcp`](https://github.com/pvliesdonk/scholar-mcp), [`image-generation-mcp`](https://github.com/pvliesdonk/image-generation-mcp). Public API changes here propagate to all three via the template.
-- See the template's README for the update flow and the expected project shape.
+- [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) —
+  copier template that scaffolds new FastMCP servers on top of this library.
+- Active consumers (as of 2026-04):
+  [`markdown-vault-mcp`](https://github.com/pvliesdonk/markdown-vault-mcp),
+  [`scholar-mcp`](https://github.com/pvliesdonk/scholar-mcp),
+  [`image-generation-mcp`](https://github.com/pvliesdonk/image-generation-mcp).
+- Public API changes here propagate to consumers via periodic
+  `copier update` runs against the template.
+- See the template's README for the update flow and the expected project
+  shape.
 
 ## API stability
 
-Stable at 1.x. The public API follows [semantic versioning](https://semver.org/):
-breaking changes bump the major version, new features bump the minor, bugfixes
-bump the patch. "Public API" means symbols re-exported from the top-level
-`fastmcp_pvl_core` package (see `__all__`); modules prefixed with `_` are
-internal and may change without a major-version bump.
+This package is stable at 1.x and follows
+[semantic versioning](https://semver.org/): breaking changes bump the
+major version, new features bump the minor, bugfixes bump the patch.
+"Public API" means symbols re-exported from the top-level
+`fastmcp_pvl_core` package (see `__all__`); modules prefixed with `_`
+are internal and may change without a major-version bump.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,19 @@
 Shared FastMCP infrastructure for the `pvliesdonk/*-mcp` server family:
 auth, middleware, logging, config helpers, server-factory building blocks.
 
-## Status
+## Ecosystem
 
-Early 0.x. API may change on minor bumps until 1.0.
+- [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) — copier template that scaffolds new FastMCP servers on top of this library. Downstream consumers stay in sync via periodic `copier update` runs.
+- Active consumers (as of 2026-04): [`markdown-vault-mcp`](https://github.com/pvliesdonk/markdown-vault-mcp), [`scholar-mcp`](https://github.com/pvliesdonk/scholar-mcp), [`image-generation-mcp`](https://github.com/pvliesdonk/image-generation-mcp). Public API changes here propagate to all three via the template.
+- See the template's README for the update flow and the expected project shape.
+
+## API stability
+
+Stable at 1.x. The public API follows [semantic versioning](https://semver.org/):
+breaking changes bump the major version, new features bump the minor, bugfixes
+bump the patch. "Public API" means symbols re-exported from the top-level
+`fastmcp_pvl_core` package (see `__all__`); modules prefixed with `_` are
+internal and may change without a major-version bump.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ This package is stable at 1.x and follows
 [semantic versioning](https://semver.org/): breaking changes bump the
 major version, new features bump the minor, bugfixes bump the patch.
 "Public API" means symbols re-exported from the top-level
-`fastmcp_pvl_core` package (see `__all__`); modules prefixed with `_`
-are internal and may change without a major-version bump.
+`fastmcp_pvl_core` package (see `__all__`), which intentionally
+covers both the runtime surface (auth, middleware, factory builders,
+env/config helpers) and the CLI parser helpers consumed by downstream
+`server.py` entrypoints. Modules prefixed with `_` are internal and
+may change without a major-version bump.
 
 ## Install
 


### PR DESCRIPTION
Closes #14

## Summary
- Adds a top-level **Ecosystem** section pointing at [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) and the three active downstream consumers (`markdown-vault-mcp`, `scholar-mcp`, `image-generation-mcp`), so an agent starting from this repo can discover the scaffolder and the expected downstream shape.
- Replaces the stale **Early 0.x** status note (the package shipped 1.0.0) with an **API stability** section that defines the public-API surface as the top-level `fastmcp_pvl_core` package (`__all__`) and explicitly carves out `_`-prefixed modules as internal.

## Verification
- All referenced repos exist (verified via `gh repo view`).
- Template retro reference (`fastmcp-server-template#35`) verified as a real, closed issue.
- The "Active consumers (as of 2026-04)" date stamp is intentional — it warns readers the list is a snapshot rather than a maintained source of truth.

## Test plan
- [ ] Render the README on GitHub and confirm Ecosystem links resolve and API stability section reads cleanly.
- [ ] Confirm the section ordering (Ecosystem → API stability → Install → Usage → License) reads naturally.