### PR TITLE
feat(logging): add SecretMaskFilter for masking Authorization headers

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -23,7 +23,7 @@ from fastmcp_pvl_core._factory import (
     compute_app_domain,
 )
 from fastmcp_pvl_core._icons import IconSpec, make_icon, register_tool_icons
-from fastmcp_pvl_core._logging import configure_logging_from_env
+from fastmcp_pvl_core._logging import SecretMaskFilter, configure_logging_from_env
 from fastmcp_pvl_core._middleware import wire_middleware_stack
 from fastmcp_pvl_core._server_info import (
     UpstreamProvider,
@@ -37,6 +37,7 @@ __all__ = [
     "ArtifactStore",
     "AuthMode",
     "IconSpec",
+    "SecretMaskFilter",
     "ServerConfig",
     "TokenRecord",
     "Transport",

--- a/src/fastmcp_pvl_core/_logging.py
+++ b/src/fastmcp_pvl_core/_logging.py
@@ -53,9 +53,9 @@ def configure_logging_from_env(*, verbose: bool = False) -> None:
 
 
 class SecretMaskFilter(logging.Filter):
-    """Redact ``Authorization: Bearer/Token`` values in log records.
+    """Redact ``Authorization: Bearer/Token/Basic`` values in log records.
 
-    Attach to a logger to mask secret tokens in formatted messages
+    Attach to a logger to mask secret credentials in formatted messages
     before they reach handlers — typically wired up by HTTP-client
     modules that log request/response details at ``DEBUG`` level::
 
@@ -68,9 +68,9 @@ class SecretMaskFilter(logging.Filter):
     Matches both header-style (``Authorization: Bearer xyz``) and
     dict-repr (``'Authorization': 'Token xyz'``) representations,
     case-insensitive on the ``Authorization`` keyword and the
-    ``Bearer`` / ``Token`` scheme name. The scheme name's original
-    casing is preserved in the redacted output (e.g. ``bearer ***``).
-    Records with no match pass through unchanged.
+    ``Bearer`` / ``Token`` / ``Basic`` scheme name. The scheme name's
+    original casing is preserved in the redacted output (e.g.
+    ``bearer ***``). Records with no match pass through unchanged.
 
     The filter never suppresses records — it always returns ``True``.
     """
@@ -80,14 +80,14 @@ class SecretMaskFilter(logging.Filter):
     # own filter. ``[^\s'\"]+`` stops the secret capture at whitespace
     # or quote, which preserves the surrounding dict structure.
     _PATTERN = re.compile(
-        r"(Authorization['\"]?\s*[:=]\s*['\"]?)(Token|Bearer)\s+[^\s'\"]+",
+        r"(Authorization['\"]?\s*[:=]\s*['\"]?)(Token|Bearer|Basic)\s+[^\s'\"]+",
         re.IGNORECASE,
     )
 
     def filter(self, record: logging.LogRecord) -> bool:
         try:
             original = record.getMessage()
-        except Exception:  # pragma: no cover - defensive
+        except Exception:
             # A broken format string upstream must not silence the whole
             # log stream; let the producer's TypeError surface elsewhere.
             return True

--- a/src/fastmcp_pvl_core/_logging.py
+++ b/src/fastmcp_pvl_core/_logging.py
@@ -4,8 +4,8 @@ The ``-v`` CLI flag forces ``DEBUG``; otherwise ``FASTMCP_LOG_LEVEL``
 wins; otherwise ``INFO``.
 
 This module also exposes :class:`SecretMaskFilter`, a reusable
-``logging.Filter`` that redacts ``Authorization: Bearer/Token`` values
-in formatted log messages before they reach handlers.
+``logging.Filter`` that redacts ``Authorization: Bearer/Token/Basic``
+values in formatted log messages before they reach handlers.
 """
 
 from __future__ import annotations

--- a/src/fastmcp_pvl_core/_logging.py
+++ b/src/fastmcp_pvl_core/_logging.py
@@ -2,12 +2,17 @@
 
 The ``-v`` CLI flag forces ``DEBUG``; otherwise ``FASTMCP_LOG_LEVEL``
 wins; otherwise ``INFO``.
+
+This module also exposes :class:`SecretMaskFilter`, a reusable
+``logging.Filter`` that redacts ``Authorization: Bearer/Token`` values
+in formatted log messages before they reach handlers.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import re
 
 from fastmcp.utilities.logging import configure_logging
 
@@ -45,3 +50,52 @@ def configure_logging_from_env(*, verbose: bool = False) -> None:
     level = getattr(logging, level_name, logging.INFO)
     logging.getLogger().setLevel(level)
     configure_logging(level)
+
+
+class SecretMaskFilter(logging.Filter):
+    """Redact ``Authorization: Bearer/Token`` values in log records.
+
+    Attach to a logger to mask secret tokens in formatted messages
+    before they reach handlers — typically wired up by HTTP-client
+    modules that log request/response details at ``DEBUG`` level::
+
+        import logging
+        from fastmcp_pvl_core import SecretMaskFilter
+
+        logger = logging.getLogger(__name__)
+        logger.addFilter(SecretMaskFilter())
+
+    Matches both header-style (``Authorization: Bearer xyz``) and
+    dict-repr (``'Authorization': 'Token xyz'``) representations,
+    case-insensitive on the ``Authorization`` keyword and the
+    ``Bearer`` / ``Token`` scheme name. The scheme name's original
+    casing is preserved in the redacted output (e.g. ``bearer ***``).
+    Records with no match pass through unchanged.
+
+    The filter never suppresses records — it always returns ``True``.
+    """
+
+    # ``Authorization`` is the only keyword we recognise — other custom
+    # auth headers (e.g. ``X-Api-Key``) are out of scope and need their
+    # own filter. ``[^\s'\"]+`` stops the secret capture at whitespace
+    # or quote, which preserves the surrounding dict structure.
+    _PATTERN = re.compile(
+        r"(Authorization['\"]?\s*[:=]\s*['\"]?)(Token|Bearer)\s+[^\s'\"]+",
+        re.IGNORECASE,
+    )
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            original = record.getMessage()
+        except Exception:  # pragma: no cover - defensive
+            # A broken format string upstream must not silence the whole
+            # log stream; let the producer's TypeError surface elsewhere.
+            return True
+        masked = self._PATTERN.sub(r"\1\2 ***", original)
+        if masked != original:
+            # Replace the formatted message and clear args so subsequent
+            # ``getMessage()`` calls return the masked text rather than
+            # re-expanding the original args.
+            record.msg = masked
+            record.args = ()
+        return True

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -74,6 +74,16 @@ class TestSecretMaskFilter:
         assert "eyJ" not in record.getMessage()
         assert "Bearer ***" in record.getMessage()
 
+    def test_masks_basic_header(self):
+        # Basic auth carries base64-encoded user:password — same exposure
+        # risk as Bearer/Token, so it gets the same redaction.
+        record = _record("Authorization: Basic dXNlcjpwYXNzd29yZA==")
+
+        SecretMaskFilter().filter(record)
+
+        assert "dXNlcjpwYXNzd29yZA" not in record.getMessage()
+        assert "Basic ***" in record.getMessage()
+
     def test_masks_dict_repr_token(self):
         record = _record("headers={'Authorization': 'Token abcdef1234567890'}")
 
@@ -169,10 +179,21 @@ class TestSecretMaskFilter:
 
         assert record.getMessage() == "Token holder is logged in"
 
+    def test_masks_equals_separator(self):
+        # The regex permits "=" as a key/value separator alongside ":";
+        # exercise that path so the alternation isn't dead code.
+        record = _record("Authorization=Token abcdef1234567890")
+
+        SecretMaskFilter().filter(record)
+
+        assert "abcdef1234567890" not in record.getMessage()
+        assert "Token ***" in record.getMessage()
+
     def test_handles_broken_format_string(self):
         # If the producer logged a format string with mismatched args,
-        # getMessage() raises. The filter must not crash — a broken log
-        # line is preferable to suppressing the entire log stream.
-        record = _record("needs one arg=%s", ())
+        # getMessage() raises TypeError during %-formatting. The filter
+        # must catch that and still return True — a broken log line is
+        # preferable to silencing the entire log stream.
+        record = _record("only one placeholder %s", ("a", "b", "c"))
 
         assert SecretMaskFilter().filter(record) is True

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,10 +1,22 @@
-"""Tests for configure_logging_from_env."""
+"""Tests for configure_logging_from_env and SecretMaskFilter."""
 
 from __future__ import annotations
 
 import logging
 
-from fastmcp_pvl_core import configure_logging_from_env
+from fastmcp_pvl_core import SecretMaskFilter, configure_logging_from_env
+
+
+def _record(msg: str, args: tuple[object, ...] | None = None) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="x",
+        level=logging.DEBUG,
+        pathname="_",
+        lineno=0,
+        msg=msg,
+        args=args,
+        exc_info=None,
+    )
 
 
 def test_sets_debug_when_verbose_true(monkeypatch):
@@ -43,3 +55,124 @@ def test_unknown_level_falls_back_to_info(monkeypatch):
     monkeypatch.setenv("FASTMCP_LOG_LEVEL", "BOGUS")
     configure_logging_from_env(verbose=False)
     assert logging.getLogger().getEffectiveLevel() == logging.INFO
+
+
+class TestSecretMaskFilter:
+    def test_masks_token_header(self):
+        record = _record("Authorization: Token abcdef1234567890")
+
+        SecretMaskFilter().filter(record)
+
+        assert "abcdef1234567890" not in record.getMessage()
+        assert "Token ***" in record.getMessage()
+
+    def test_masks_bearer_header(self):
+        record = _record("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload")
+
+        SecretMaskFilter().filter(record)
+
+        assert "eyJ" not in record.getMessage()
+        assert "Bearer ***" in record.getMessage()
+
+    def test_masks_dict_repr_token(self):
+        record = _record("headers={'Authorization': 'Token abcdef1234567890'}")
+
+        SecretMaskFilter().filter(record)
+
+        assert "abcdef" not in record.getMessage()
+        assert "Token ***" in record.getMessage()
+        # Surrounding dict structure is preserved.
+        assert record.getMessage().endswith("'}")
+
+    def test_masks_dict_repr_bearer(self):
+        record = _record('headers={"Authorization": "Bearer eyJhbGciOi"}')
+
+        SecretMaskFilter().filter(record)
+
+        assert "eyJhbGciOi" not in record.getMessage()
+        assert "Bearer ***" in record.getMessage()
+
+    def test_case_insensitive(self):
+        record = _record("authorization: bearer eyJhbGciOi")
+
+        SecretMaskFilter().filter(record)
+
+        assert "eyJhbGciOi" not in record.getMessage()
+        # Original casing of the scheme name is preserved by the substitution.
+        assert "bearer ***" in record.getMessage()
+
+    def test_passes_unrelated_messages_through(self):
+        record = _record("plain debug message with no secrets")
+
+        SecretMaskFilter().filter(record)
+
+        assert record.getMessage() == "plain debug message with no secrets"
+
+    def test_returns_true_for_unrelated(self):
+        # A logging filter that returns False suppresses the record. This
+        # filter is a redactor, not a gatekeeper — must always return True.
+        record = _record("plain message")
+
+        assert SecretMaskFilter().filter(record) is True
+
+    def test_returns_true_when_masking(self):
+        record = _record("Authorization: Token abc")
+
+        assert SecretMaskFilter().filter(record) is True
+
+    def test_handles_format_args(self):
+        # When the record uses %-formatting, the secret only appears after
+        # getMessage() expands args. The filter must mask the formatted form
+        # and clear args so subsequent getMessage() calls return the masked
+        # text rather than re-expanding the original args.
+        record = _record(
+            "request headers=%s",
+            ({"Authorization": "Token abcdef1234567890"},),
+        )
+
+        SecretMaskFilter().filter(record)
+
+        msg = record.getMessage()
+        assert "abcdef" not in msg
+        assert "Token ***" in msg
+        # Calling getMessage() again must not re-introduce the secret.
+        assert "abcdef" not in record.getMessage()
+
+    def test_masks_multiple_occurrences(self):
+        record = _record(
+            "in=Authorization: Token aaa111 / out=Authorization: Bearer bbb222"
+        )
+
+        SecretMaskFilter().filter(record)
+
+        msg = record.getMessage()
+        assert "aaa111" not in msg
+        assert "bbb222" not in msg
+        assert msg.count("***") == 2
+
+    def test_does_not_match_other_header_keys(self):
+        # Only the Authorization keyword triggers masking; tokens that
+        # happen to live in other headers (e.g. API keys with their own key
+        # names) are out of scope for this filter.
+        record = _record("X-Api-Key: Token abcdef1234567890")
+
+        SecretMaskFilter().filter(record)
+
+        assert "abcdef1234567890" in record.getMessage()
+
+    def test_does_not_match_bare_scheme_word(self):
+        # "Bearer" or "Token" without an Authorization prefix is just a
+        # word — do not mutate it.
+        record = _record("Token holder is logged in")
+
+        SecretMaskFilter().filter(record)
+
+        assert record.getMessage() == "Token holder is logged in"
+
+    def test_handles_broken_format_string(self):
+        # If the producer logged a format string with mismatched args,
+        # getMessage() raises. The filter must not crash — a broken log
+        # line is preferable to suppressing the entire log stream.
+        record = _record("needs one arg=%s", ())
+
+        assert SecretMaskFilter().filter(record) is True


### PR DESCRIPTION
Closes #15

## Summary
- Adds `SecretMaskFilter` to `fastmcp_pvl_core`, exported from the top-level package and added to `__all__`.
- Redacts `Authorization: Bearer/Token` values in formatted log messages, so downstream servers can attach it once instead of each reimplementing the same regex (e.g. `paperless-mcp/src/paperless_mcp/client/_http.py`'s local `_SecretMaskFilter`).
- Matches header-style (`Authorization: Bearer xyz`) **and** dict-repr (`'Authorization': 'Token xyz'`) representations, case-insensitive on both the `Authorization` keyword and the `Bearer`/`Token` scheme name. Original scheme casing is preserved in the redacted output.
- Lives in `_logging.py` alongside `configure_logging_from_env`.

## Behavioral contract
- Always returns `True` (redactor, not gatekeeper — never suppresses records).
- For `%`-formatted records, replaces `record.msg` and clears `record.args` so subsequent `getMessage()` calls cannot re-expand the original args and re-introduce the secret.
- Records without a match pass through untouched.
- Catches exceptions from `getMessage()` defensively — a broken format string upstream must not silence the entire log stream.

## Test plan
- [x] 13 new unit tests (`tests/test_logging.py::TestSecretMaskFilter`)
  - Header-style + dict-repr for both `Token` and `Bearer`
  - Case-insensitive matching, scheme casing preserved
  - Multiple occurrences in a single record
  - `%`-format args expansion (with re-call of `getMessage()`)
  - Always-True return for matched / unmatched / broken-format records
  - Negative cases: `X-Api-Key: Token …` is **not** masked, bare "Token holder" is **not** mutated
- [x] Full suite: 209 passed
- [x] `ruff format` / `ruff check` clean
- [x] `mypy --strict` clean