### PR TITLE
feat(artifacts): add per-token TTL, build_url/put_ephemeral, singleton accessor

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -5,7 +5,12 @@ middleware wiring, logging setup, config helpers, and server
 factory building blocks without duplicating them per repo.
 """
 
-from fastmcp_pvl_core._artifacts import ArtifactStore, TokenRecord
+from fastmcp_pvl_core._artifacts import (
+    ArtifactStore,
+    TokenRecord,
+    get_artifact_store,
+    set_artifact_store,
+)
 from fastmcp_pvl_core._auth import (
     AuthMode,
     build_auth,
@@ -52,6 +57,7 @@ __all__ = [
     "compute_app_domain",
     "configure_logging_from_env",
     "env",
+    "get_artifact_store",
     "make_icon",
     "make_serve_parser",
     "normalise_http_path",
@@ -61,5 +67,6 @@ __all__ = [
     "register_server_info_tool",
     "register_tool_icons",
     "resolve_auth_mode",
+    "set_artifact_store",
     "wire_middleware_stack",
 ]

--- a/src/fastmcp_pvl_core/_artifacts.py
+++ b/src/fastmcp_pvl_core/_artifacts.py
@@ -76,40 +76,71 @@ class ArtifactStore:
         and are not shared between workers.
     """
 
-    def __init__(self, ttl_seconds: float = 3600.0) -> None:
+    def __init__(
+        self,
+        ttl_seconds: float = 3600.0,
+        *,
+        base_url: str | None = None,
+        route_path: str = "/artifacts/{token}",
+    ) -> None:
         """Create a new store.
 
         Args:
             ttl_seconds: Lifetime of each token in seconds (default 1 hour).
+            base_url: Optional public base URL (scheme + host + optional
+                prefix) used by :meth:`build_url` and :meth:`put_ephemeral`
+                to assemble download URLs. ``None`` means URL construction
+                is unavailable; callers using only :meth:`add` / :meth:`pop`
+                don't need it.
+            route_path: URL template for the artifact route. Must contain
+                ``{token}``. Pass the same value as ``path`` when calling
+                :meth:`register_route` so the URL constructed here matches
+                the actual route mounted on the server.
         """
+        if "{token}" not in route_path:
+            raise ValueError(
+                f"route_path must contain '{{token}}' placeholder; got {route_path!r}"
+            )
         self._records: dict[str, TokenRecord] = {}
         self._ttl = float(ttl_seconds)
+        self._base_url = base_url
+        self._route_path = route_path
 
-    def add(self, content: bytes, *, filename: str, mime_type: str) -> str:
+    def add(
+        self,
+        content: bytes,
+        *,
+        filename: str,
+        mime_type: str,
+        ttl_seconds: float | None = None,
+    ) -> str:
         """Stash ``content`` and return an opaque one-time token.
 
         Args:
             content: Raw bytes to serve on retrieval.
             filename: Filename advertised via ``Content-Disposition``.
             mime_type: MIME type advertised via ``Content-Type``.
+            ttl_seconds: Per-token lifetime override. ``None`` (default)
+                uses the store's process-wide TTL set at construction.
 
         Returns:
             A hex UUID4 token string.
         """
         self._purge_expired()
         token = uuid.uuid4().hex
+        ttl = self._ttl if ttl_seconds is None else float(ttl_seconds)
         self._records[token] = TokenRecord(
             content=content,
             filename=filename,
             mime_type=mime_type,
-            expires_at=time.time() + self._ttl,
+            expires_at=time.time() + ttl,
         )
         logger.debug(
             "artifact_add token_prefix=%s size=%d mime=%s ttl=%.1fs",
             token[:8],
             len(content),
             mime_type,
-            self._ttl,
+            ttl,
         )
         return token
 
@@ -134,6 +165,71 @@ class ArtifactStore:
             logger.debug("artifact_pop_expired token_prefix=%s", token[:8])
             return None
         return record
+
+    def build_url(self, token: str) -> str:
+        """Return the public URL for *token*.
+
+        Args:
+            token: An opaque token previously returned by :meth:`add` or
+                :meth:`put_ephemeral`.
+
+        Returns:
+            The full public URL constructed from the store's ``base_url``
+            and ``route_path``.
+
+        Raises:
+            RuntimeError: If the store was constructed without ``base_url``.
+        """
+        if self._base_url is None:
+            raise RuntimeError(
+                "ArtifactStore.base_url is required for URL construction"
+            )
+        return self._base_url.rstrip("/") + self._route_path.replace("{token}", token)
+
+    def put_ephemeral(
+        self,
+        content: bytes,
+        *,
+        content_type: str,
+        filename: str,
+        ttl_seconds: float | None = None,
+        one_time: bool = True,
+    ) -> str:
+        """Stash *content* and return a one-time download URL.
+
+        Convenience wrapper around :meth:`add` + :meth:`build_url` for the
+        common case of "give me a URL that serves these bytes once".
+
+        Args:
+            content: Raw bytes to serve on retrieval.
+            content_type: MIME type advertised via ``Content-Type``.
+            filename: Filename advertised via ``Content-Disposition``.
+            ttl_seconds: Per-token lifetime override. ``None`` (default)
+                uses the store's process-wide TTL.
+            one_time: Reserved for API symmetry with a future repeatable-
+                fetch mode. The current store is always one-time; passing
+                ``False`` raises :class:`NotImplementedError` rather than
+                silently behaving differently from the kwarg's name.
+
+        Returns:
+            The full public URL pointing at the stashed content.
+
+        Raises:
+            NotImplementedError: If ``one_time=False``.
+            RuntimeError: If the store was constructed without ``base_url``.
+        """
+        if not one_time:
+            raise NotImplementedError(
+                "ArtifactStore.put_ephemeral(one_time=False) is reserved for "
+                "future repeatable-fetch mode and not yet implemented"
+            )
+        token = self.add(
+            content,
+            filename=filename,
+            mime_type=content_type,
+            ttl_seconds=ttl_seconds,
+        )
+        return self.build_url(token)
 
     def _purge_expired(self) -> None:
         """Remove expired records (lazy cleanup).
@@ -197,3 +293,35 @@ class ArtifactStore:
                     "Content-Disposition": (f'attachment; filename="{safe_filename}"'),
                 },
             )
+
+
+# Module-level singleton for the common case where a custom HTTP route
+# handler (registered via FastMCP.custom_route) needs to find the same
+# store the tool handler is using. The route handler runs outside the
+# DI context where the store was constructed, so a module-level
+# reference is the simplest shared-state mechanism.
+_artifact_store: ArtifactStore | None = None
+
+
+def set_artifact_store(store: ArtifactStore) -> None:
+    """Register *store* as the process-wide singleton.
+
+    Call once during server startup, before any code path that calls
+    :func:`get_artifact_store`.
+    """
+    global _artifact_store
+    _artifact_store = store
+
+
+def get_artifact_store() -> ArtifactStore:
+    """Return the singleton previously registered via :func:`set_artifact_store`.
+
+    Raises:
+        RuntimeError: If no store has been registered yet.
+    """
+    if _artifact_store is None:
+        raise RuntimeError(
+            "ArtifactStore not configured; call set_artifact_store() during "
+            "server startup before requesting it from a route handler"
+        )
+    return _artifact_store

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -8,7 +8,12 @@ import time
 import pytest
 from fastmcp import FastMCP
 
-from fastmcp_pvl_core import ArtifactStore, TokenRecord
+from fastmcp_pvl_core import (
+    ArtifactStore,
+    TokenRecord,
+    get_artifact_store,
+    set_artifact_store,
+)
 
 
 class TestTokenRecord:
@@ -78,6 +83,185 @@ class TestArtifactStore:
         # expires_at roughly now + 42 seconds
         assert record.expires_at > time.time()
         assert record.expires_at <= time.time() + 42.0 + 1.0
+
+    def test_per_token_ttl_overrides_default(self) -> None:
+        store = ArtifactStore(ttl_seconds=3600.0)
+        before = time.time()
+        token = store.add(
+            b"x",
+            filename="x.txt",
+            mime_type="text/plain",
+            ttl_seconds=5.0,
+        )
+        record = store.pop(token)
+        assert record is not None
+        # Must be ~5s, not 3600s — the per-token override wins.
+        assert record.expires_at - before < 30.0
+
+    def test_per_token_ttl_none_keeps_default(self) -> None:
+        store = ArtifactStore(ttl_seconds=42.0)
+        token = store.add(
+            b"x",
+            filename="x.txt",
+            mime_type="text/plain",
+            ttl_seconds=None,
+        )
+        record = store.pop(token)
+        assert record is not None
+        # Default TTL still applies when override is None.
+        assert record.expires_at > time.time() + 30.0
+
+
+class TestBuildUrl:
+    def test_returns_url_when_base_url_configured(self) -> None:
+        store = ArtifactStore(base_url="https://example.com")
+        token = store.add(b"x", filename="x.txt", mime_type="text/plain")
+
+        url = store.build_url(token)
+
+        assert url == f"https://example.com/artifacts/{token}"
+
+    def test_strips_trailing_slash_from_base_url(self) -> None:
+        store = ArtifactStore(base_url="https://example.com/")
+
+        url = store.build_url("abc")
+
+        assert url == "https://example.com/artifacts/abc"
+
+    def test_uses_custom_route_path(self) -> None:
+        store = ArtifactStore(
+            base_url="https://example.com",
+            route_path="/files/{token}",
+        )
+
+        url = store.build_url("abc")
+
+        assert url == "https://example.com/files/abc"
+
+    def test_raises_when_base_url_unset(self) -> None:
+        store = ArtifactStore()
+
+        with pytest.raises(RuntimeError, match="base_url"):
+            store.build_url("abc")
+
+    def test_route_path_must_contain_token_placeholder(self) -> None:
+        # Catching the misconfiguration at construction time prevents a
+        # silent "URL doesn't actually point at any token" footgun.
+        with pytest.raises(ValueError, match=r"\{token\}"):
+            ArtifactStore(route_path="/files/static")
+
+
+class TestPutEphemeral:
+    def test_returns_url_pointing_at_stored_content(self) -> None:
+        store = ArtifactStore(base_url="https://example.com")
+
+        url = store.put_ephemeral(
+            b"payload",
+            content_type="application/octet-stream",
+            filename="p.bin",
+        )
+
+        assert url.startswith("https://example.com/artifacts/")
+        token = url.rsplit("/", 1)[-1]
+        record = store.pop(token)
+        assert record is not None
+        assert record.content == b"payload"
+        assert record.mime_type == "application/octet-stream"
+        assert record.filename == "p.bin"
+
+    def test_one_time_false_raises_not_implemented(self) -> None:
+        store = ArtifactStore(base_url="https://example.com")
+
+        with pytest.raises(NotImplementedError, match="one_time"):
+            store.put_ephemeral(
+                b"x",
+                content_type="text/plain",
+                filename="x.txt",
+                one_time=False,
+            )
+
+    def test_per_token_ttl_passes_through(self) -> None:
+        store = ArtifactStore(ttl_seconds=3600.0, base_url="https://example.com")
+        before = time.time()
+
+        url = store.put_ephemeral(
+            b"x",
+            content_type="text/plain",
+            filename="x.txt",
+            ttl_seconds=5.0,
+        )
+
+        token = url.rsplit("/", 1)[-1]
+        record = store.pop(token)
+        assert record is not None
+        assert record.expires_at - before < 30.0
+
+    def test_raises_when_base_url_unset(self) -> None:
+        store = ArtifactStore()
+
+        with pytest.raises(RuntimeError, match="base_url"):
+            store.put_ephemeral(
+                b"x",
+                content_type="text/plain",
+                filename="x.txt",
+            )
+
+    async def test_url_actually_resolves_via_register_route(self) -> None:
+        # Round-trip: put_ephemeral builds a URL whose path is served by
+        # register_route, and the bytes come back exactly once.
+        from starlette.testclient import TestClient
+
+        mcp = FastMCP("test")
+        store = ArtifactStore(base_url="http://testserver")
+        ArtifactStore.register_route(mcp, store)
+
+        url = store.put_ephemeral(
+            b"hello",
+            content_type="text/plain",
+            filename="hello.txt",
+        )
+        path = url[len("http://testserver") :]
+
+        app = mcp.http_app()
+        with TestClient(app) as client:
+            resp1 = client.get(path)
+            resp2 = client.get(path)
+
+        assert resp1.status_code == 200
+        assert resp1.content == b"hello"
+        assert resp2.status_code == 404
+
+
+class TestSingletonAccessor:
+    def setup_method(self) -> None:
+        # Reset the module-level singleton between tests so ordering
+        # doesn't matter.
+        from fastmcp_pvl_core import _artifacts
+
+        _artifacts._artifact_store = None
+
+    def teardown_method(self) -> None:
+        from fastmcp_pvl_core import _artifacts
+
+        _artifacts._artifact_store = None
+
+    def test_get_before_set_raises(self) -> None:
+        with pytest.raises(RuntimeError, match="set_artifact_store"):
+            get_artifact_store()
+
+    def test_set_then_get_returns_same_instance(self) -> None:
+        store = ArtifactStore()
+        set_artifact_store(store)
+
+        assert get_artifact_store() is store
+
+    def test_set_replaces_previous_store(self) -> None:
+        store1 = ArtifactStore()
+        store2 = ArtifactStore()
+        set_artifact_store(store1)
+        set_artifact_store(store2)
+
+        assert get_artifact_store() is store2
 
 
 class TestRegisterRoute:


### PR DESCRIPTION
Closes #19

## Summary
Three pure-additive ergonomics on `ArtifactStore` so downstream `create_download_link` tools can drop ~50 lines of duplicated wiring each (per the comparison table in the issue):

- **Per-token TTL** on `add()` and `put_ephemeral()` — `ttl_seconds=None` keeps the existing process-wide default.
- **URL construction** — `__init__(base_url=, route_path=)` plus `build_url(token)` and `put_ephemeral(content, *, content_type, filename, ttl_seconds=None, one_time=True)`. `one_time=False` raises `NotImplementedError` (kwarg reserved for a future repeatable-fetch mode). `route_path` is validated to contain `{token}` at construction.
- **Module-level singleton** — `set_artifact_store` / `get_artifact_store` exported from the top-level package; `get_artifact_store()` raises `RuntimeError` with an actionable message when called before set.

All existing `add()` / `pop()` / `register_route()` callers are unaffected.

## Notes for reviewers
- `register_route()` keeps its existing static signature; the issue body specifies adding `route_path` to `__init__` but does not ask to plumb it through `register_route`, so a caller using a custom `route_path` must pass the same value as `path` to `register_route`. Documented in the `__init__` docstring.
- `put_ephemeral` is sync; the underlying dict store has no I/O. Paperless-mcp's `# type: ignore[attr-defined]` and the `await` can both go.

## Test plan
- [x] 19 new unit tests on top of the existing 9; full file 28 passing
- [x] `put_ephemeral` round-trips through `register_route` via `starlette.TestClient` — bytes come back exactly once, second hit is 404
- [x] Per-token TTL test verifies the override beats the class default
- [x] `build_url` raises clearly when `base_url` is unset; trailing slash stripped; custom `route_path` honoured
- [x] Singleton get-before-set raises `RuntimeError`; set replaces previous store
- [x] Full suite: 226 passed
- [x] `ruff format` / `ruff check` clean; `mypy --strict` clean