### PR TITLE
feat(file-exchange): ship FileExchange runtime (env, exclusive-create, atomic IO, sweep)

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -31,9 +31,12 @@ from fastmcp_pvl_core._file_exchange import (
     SPEC_VERSION as FILE_EXCHANGE_SPEC_VERSION,
 )
 from fastmcp_pvl_core._file_exchange import (
+    ExchangeGroupMismatch,
     ExchangeURI,
     ExchangeURIError,
+    FileExchange,
     FileExchangeCapability,
+    FileExchangeConfigError,
     FileRef,
     FileRefPreview,
     TransferMethods,
@@ -53,10 +56,13 @@ __version__ = "1.0.0"  # PSR overrides at build time
 __all__ = [
     "ArtifactStore",
     "AuthMode",
+    "ExchangeGroupMismatch",
     "ExchangeURI",
     "ExchangeURIError",
     "FILE_EXCHANGE_SPEC_VERSION",
+    "FileExchange",
     "FileExchangeCapability",
+    "FileExchangeConfigError",
     "FileRef",
     "FileRefPreview",
     "IconSpec",

--- a/src/fastmcp_pvl_core/_file_exchange.py
+++ b/src/fastmcp_pvl_core/_file_exchange.py
@@ -1,20 +1,36 @@
-"""MCP File Exchange v0.3 — protocol surface.
+"""MCP File Exchange v0.3 — protocol surface and runtime.
 
-Implements the typed envelope (:class:`FileRef`, :class:`FileRefPreview`),
-the URI parser (:class:`ExchangeURI`), and the capability-declaration
-helper (:func:`register_file_exchange_capability`) for the spec at
-``docs/specs/file-exchange.md``.
+Implements the spec at ``docs/specs/file-exchange.md``:
 
-The runtime side (env detection, atomic writes, exchange-group lifecycle,
-consumer URI resolution) lives in a separate module and is not yet
-implemented — see issue #21.
+- **Protocol surface**: :class:`FileRef`, :class:`FileRefPreview`,
+  :class:`ExchangeURI` (parser + segment validator),
+  :class:`FileExchangeCapability`, and the capability-declaration
+  helper :func:`register_file_exchange_capability`.
+- **Runtime**: :class:`FileExchange` for env-driven group membership,
+  exclusive-create ``.exchange-id`` initialisation, atomic
+  write/read of namespaced files, and producer-side TTL+LRU lifecycle
+  sweep.
+
+Lifecycle constraints from the spec:
+
+- The *producing server* owns its namespace directory's lifecycle
+  exclusively. Only the producer deletes its own files (TTL + LRU
+  eviction via :meth:`FileExchange.sweep`).
+- The *consuming server* treats the exchange directory as read-only —
+  :meth:`FileExchange.read_exchange_uri` never modifies or deletes
+  files. Consumers MUST ignore dotfile names.
 """
 
 from __future__ import annotations
 
+import logging
+import os
 import re
+import time
+import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import unquote
 
@@ -432,3 +448,437 @@ def register_file_exchange_capability(
     # Method-assignment is intentional: this is the documented patching
     # point for FastMCP 3.x's missing experimental_capabilities hook.
     ll.create_initialization_options = _patched  # type: ignore[method-assign]
+
+
+# ---------------------------------------------------------------------------
+# Runtime
+# ---------------------------------------------------------------------------
+
+logger = logging.getLogger(__name__)
+
+#: Default TTL for producer-owned exchange files (spec §7 default).
+_DEFAULT_TTL_SECONDS = 3600.0
+
+
+class FileExchangeConfigError(RuntimeError):
+    """File-exchange runtime cannot be configured.
+
+    Raised when ``MCP_EXCHANGE_DIR`` points at an invalid path or a
+    required configuration value (e.g. namespace) is missing.
+    """
+
+
+class ExchangeGroupMismatch(ValueError):  # noqa: N818  -- spec-defined name
+    """Exchange-group identity disagreement.
+
+    Raised when an explicit ``MCP_EXCHANGE_ID`` conflicts with the
+    persisted ``.exchange-id``, or when
+    :meth:`FileExchange.read_exchange_uri` is asked for a URI from a
+    different exchange group.
+    """
+
+
+def _resolve_exchange_id(base_dir: Path, explicit: str | None) -> str:
+    """Read or exclusive-create ``$base_dir/.exchange-id`` (spec §3.5).
+
+    Uses ``O_CREAT | O_EXCL`` so racing servers cannot split-brain — only
+    one wins the create; the rest read the winner's value. ``rename(2)``
+    is *not* used here: POSIX rename silently overwrites, which would
+    quietly corrupt the group identity if two servers initialised
+    simultaneously.
+
+    Args:
+        base_dir: Resolved ``MCP_EXCHANGE_DIR``.
+        explicit: Value of ``MCP_EXCHANGE_ID`` if set; ``None`` means
+            generate a fresh UUIDv4 on first call, read existing
+            otherwise.
+
+    Returns:
+        The exchange-group ID (lowercase by convention; whitespace
+        stripped per spec).
+
+    Raises:
+        ExchangeGroupMismatch: If *explicit* is set and disagrees with
+            the value already persisted on disk.
+    """
+    id_path = base_dir / ".exchange-id"
+    candidate = explicit if explicit is not None else str(uuid.uuid4())
+    payload = candidate.encode("utf-8") + b"\n"
+    try:
+        fd = os.open(str(id_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    except FileExistsError:
+        # Lost the create race (or override targets an existing file) —
+        # fall through to read the persisted value. The FileExistsError
+        # itself is not the failure cause for the mismatch path; raise
+        # ``from None`` so the traceback shows only the data-level
+        # disagreement.
+        existing = id_path.read_text(encoding="utf-8").strip()
+        if explicit is not None and existing != explicit:
+            raise ExchangeGroupMismatch(
+                f"MCP_EXCHANGE_ID={explicit!r} conflicts with existing "
+                f"{id_path.name} value {existing!r}"
+            ) from None
+        return existing
+    try:
+        os.write(fd, payload)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    logger.debug("exchange_id_created path=%s id=%s", id_path, candidate)
+    return candidate
+
+
+class FileExchange:
+    """Producer/consumer runtime for the ``exchange://`` transfer method.
+
+    Constructed via :meth:`from_env`; falls back to a sentinel
+    "not configured" state when ``MCP_EXCHANGE_DIR`` is unset, so
+    callers can always instantiate one and gate exchange-specific
+    code paths on :attr:`is_configured`.
+
+    Producer side:
+        :meth:`write_atomic` — write content via dotfile-temp + POSIX
+        rename, return an ``exchange://`` URI.
+        :meth:`sweep` — TTL eviction (and optional LRU eviction by mtime)
+        across this server's namespace directory. Producers own their
+        namespace's lifecycle; only the producer deletes its own files.
+
+    Consumer side:
+        :meth:`read_exchange_uri` — parse the URI, verify it belongs to
+        this exchange group, read the bytes. Consumers treat the
+        exchange directory as read-only and ignore dotfile names.
+    """
+
+    def __init__(
+        self,
+        base_dir: Path | None,
+        exchange_id: str | None,
+        namespace: str | None,
+        *,
+        ttl_seconds: float = _DEFAULT_TTL_SECONDS,
+        storage_ceiling_bytes: int | None = None,
+    ) -> None:
+        # Either all three are set (configured) or all three are None
+        # (not configured). The two states are exclusive — there is no
+        # partial-config valid state.
+        configured = (
+            base_dir is not None and exchange_id is not None and namespace is not None
+        )
+        partial = (
+            base_dir is not None or exchange_id is not None or namespace is not None
+        ) and not configured
+        if partial:
+            raise FileExchangeConfigError(
+                "FileExchange requires base_dir, exchange_id, and namespace "
+                "to all be set, or all be None"
+            )
+        self._base_dir = base_dir
+        self._exchange_id = exchange_id
+        self._namespace = namespace
+        self._ttl_seconds = float(ttl_seconds)
+        self._storage_ceiling_bytes = storage_ceiling_bytes
+
+    @classmethod
+    def from_env(
+        cls,
+        default_namespace: str | None = None,
+        *,
+        env: Mapping[str, str] | None = None,
+        ttl_seconds: float = _DEFAULT_TTL_SECONDS,
+        storage_ceiling_bytes: int | None = None,
+    ) -> FileExchange:
+        """Build a :class:`FileExchange` from environment variables.
+
+        Reads ``MCP_EXCHANGE_DIR`` (required to participate),
+        ``MCP_EXCHANGE_ID`` (optional override), and
+        ``MCP_EXCHANGE_NAMESPACE`` (optional override). If
+        ``MCP_EXCHANGE_DIR`` is unset/empty, returns an unconfigured
+        instance — callers gate writes on :attr:`is_configured`.
+
+        Namespace resolution: ``MCP_EXCHANGE_NAMESPACE`` env var wins;
+        falls back to ``default_namespace``. The runtime never reaches
+        into FastMCP for the server name; pass it explicitly.
+
+        Args:
+            default_namespace: Namespace to use when
+                ``MCP_EXCHANGE_NAMESPACE`` is unset. Required when the
+                env var is not provided.
+            env: Override the environment mapping (for tests). Defaults
+                to ``os.environ``.
+            ttl_seconds: TTL for files written by this producer
+                (default 1 hour, per spec §7).
+            storage_ceiling_bytes: Optional LRU ceiling for sweep.
+                ``None`` disables LRU eviction.
+
+        Returns:
+            A configured :class:`FileExchange` if ``MCP_EXCHANGE_DIR``
+            is set, otherwise an unconfigured sentinel
+            (:attr:`is_configured` is ``False``).
+
+        Raises:
+            FileExchangeConfigError: ``MCP_EXCHANGE_DIR`` is set but
+                does not point at an existing directory, or no
+                namespace can be resolved.
+            ExchangeGroupMismatch: ``MCP_EXCHANGE_ID`` is set and
+                disagrees with the persisted ``.exchange-id``.
+            ExchangeURIError: The resolved namespace fails spec §6.3
+                segment validation.
+        """
+        environ = dict(env) if env is not None else dict(os.environ)
+        raw_dir = environ.get("MCP_EXCHANGE_DIR", "").strip()
+        if not raw_dir:
+            return cls(
+                None,
+                None,
+                None,
+                ttl_seconds=ttl_seconds,
+                storage_ceiling_bytes=storage_ceiling_bytes,
+            )
+
+        base_dir = Path(raw_dir)
+        if not base_dir.exists():
+            raise FileExchangeConfigError(
+                f"MCP_EXCHANGE_DIR does not exist: {base_dir}"
+            )
+        if not base_dir.is_dir():
+            raise FileExchangeConfigError(
+                f"MCP_EXCHANGE_DIR is not a directory: {base_dir}"
+            )
+        base_dir = base_dir.resolve()
+
+        ns_env = environ.get("MCP_EXCHANGE_NAMESPACE", "").strip()
+        namespace = ns_env or default_namespace
+        if not namespace:
+            raise FileExchangeConfigError(
+                "namespace is required: set MCP_EXCHANGE_NAMESPACE or pass "
+                "default_namespace"
+            )
+        ExchangeURI.validate_segment(namespace, role="json_param")
+        if namespace.startswith("."):
+            raise ExchangeURIError(
+                f"namespace MUST NOT start with a dot: {namespace!r}"
+            )
+
+        explicit_id = environ.get("MCP_EXCHANGE_ID", "").strip() or None
+        exchange_id = _resolve_exchange_id(base_dir, explicit_id)
+
+        return cls(
+            base_dir,
+            exchange_id,
+            namespace,
+            ttl_seconds=ttl_seconds,
+            storage_ceiling_bytes=storage_ceiling_bytes,
+        )
+
+    @property
+    def is_configured(self) -> bool:
+        return self._base_dir is not None
+
+    @property
+    def base_dir(self) -> Path:
+        if self._base_dir is None:
+            raise FileExchangeConfigError("FileExchange is not configured")
+        return self._base_dir
+
+    @property
+    def exchange_id(self) -> str:
+        if self._exchange_id is None:
+            raise FileExchangeConfigError("FileExchange is not configured")
+        return self._exchange_id
+
+    @property
+    def namespace(self) -> str:
+        if self._namespace is None:
+            raise FileExchangeConfigError("FileExchange is not configured")
+        return self._namespace
+
+    def write_atomic(
+        self,
+        *,
+        origin_id: str,
+        ext: str,
+        content: bytes,
+        mime_type: str | None = None,
+    ) -> str:
+        """Write *content* atomically and return its ``exchange://`` URI.
+
+        Validation:
+            ``origin_id`` and ``ext`` are validated as raw JSON params
+            (spec §6.3 — no URI decoding).
+
+        Atomicity:
+            Content is written to ``$ns/.{origin_id}.{ext}.tmp``
+            (dotfile-prefixed so consumers ignore it), fsynced, then
+            POSIX-renamed to ``$ns/{origin_id}.{ext}``. A crash
+            mid-write leaves only the dotfile behind, which consumers
+            silently skip.
+
+        Args:
+            origin_id: File identifier within this namespace.
+            ext: File extension without leading dot (e.g. ``"png"``).
+            content: Raw bytes to persist.
+            mime_type: Advisory; logged only. The on-disk file has no
+                MIME metadata; the producer's tool result carries it.
+
+        Returns:
+            ``exchange://{exchange_id}/{namespace}/{origin_id}.{ext}``
+
+        Raises:
+            FileExchangeConfigError: The runtime is not configured.
+            ExchangeURIError: ``origin_id`` or ``ext`` violates §6.3.
+        """
+        if (
+            self._base_dir is None
+            or self._namespace is None
+            or self._exchange_id is None
+        ):
+            raise FileExchangeConfigError(
+                "FileExchange is not configured; cannot write_atomic"
+            )
+        ExchangeURI.validate_segment(origin_id, role="json_param")
+        ExchangeURI.validate_segment(ext, role="json_param")
+
+        ns_dir = self._base_dir / self._namespace
+        ns_dir.mkdir(mode=0o755, exist_ok=True)
+        final_path = ns_dir / f"{origin_id}.{ext}"
+        tmp_path = ns_dir / f".{origin_id}.{ext}.tmp"
+
+        # Note: O_TRUNC handles the case where a stale tmp from a prior
+        # crash exists at the same name. The dotfile prefix means
+        # consumers can never see the partial state; rename is the
+        # commit point.
+        fd = os.open(
+            str(tmp_path),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o644,
+        )
+        try:
+            os.write(fd, content)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.rename(tmp_path, final_path)
+
+        logger.info(
+            "exchange_write namespace=%s origin_id=%s ext=%s size=%d mime=%s",
+            self._namespace,
+            origin_id,
+            ext,
+            len(content),
+            mime_type or "-",
+        )
+        return f"exchange://{self._exchange_id}/{self._namespace}/{origin_id}.{ext}"
+
+    def read_exchange_uri(self, uri: str) -> bytes:
+        """Resolve an ``exchange://`` URI to bytes (spec §3.6 + §3.7).
+
+        Cross-namespace reads are allowed (a consumer can read any
+        namespace under its own ``$MCP_EXCHANGE_DIR``); the only
+        gate is the exchange-group identifier match.
+
+        Raises:
+            FileExchangeConfigError: The runtime is not configured.
+            ExchangeURIError: The URI fails spec §6.3 (path traversal,
+                forbidden chars, double-encoded, dotfile name, etc.).
+            ExchangeGroupMismatch: ``parsed.exchange_id`` differs from
+                this server's exchange-group ID.
+            FileNotFoundError: The file is not present on disk (the
+                producer hasn't written it, it expired, or the URI
+                refers to a never-created file).
+        """
+        if self._base_dir is None or self._exchange_id is None:
+            raise FileExchangeConfigError(
+                "FileExchange is not configured; cannot read_exchange_uri"
+            )
+        parsed = ExchangeURI.parse(uri)
+        if parsed.exchange_id != self._exchange_id:
+            raise ExchangeGroupMismatch(
+                f"exchange group mismatch: local={self._exchange_id!r}, "
+                f"uri={parsed.exchange_id!r}"
+            )
+        # Per spec §5: "Consumers MUST ignore dotfiles." A leading-dot
+        # filename id would point at a producer's in-progress write
+        # (or a never-meant-to-be-public file); refuse rather than
+        # serving partial state.
+        if parsed.id.startswith("."):
+            raise ExchangeURIError(
+                f"filename id starts with dot (dotfiles are not consumer-visible): "
+                f"{parsed.id!r}"
+            )
+        path = self._base_dir / parsed.namespace / parsed.filename
+        return path.read_bytes()
+
+    def sweep(self) -> int:
+        """Evict expired and over-ceiling files from this server's namespace.
+
+        Producer-only operation: only acts on files under
+        ``$base_dir/{self.namespace}/``, never on other namespaces.
+        Idempotent — safe to call from a timer or shutdown hook.
+
+        Eviction order:
+            1. TTL: any non-dotfile older than ``ttl_seconds``.
+            2. LRU: if ``storage_ceiling_bytes`` was set and the
+               survivors still exceed it, oldest-by-mtime first
+               until below the ceiling.
+
+        Restart-resume: the implementation rebuilds its working set
+        from the filesystem on every call rather than relying on an
+        in-memory registry, so it works correctly after a process
+        restart.
+
+        Returns:
+            Number of files evicted.
+        """
+        if self._base_dir is None or self._namespace is None:
+            return 0
+        ns_dir = self._base_dir / self._namespace
+        if not ns_dir.is_dir():
+            return 0
+
+        now = time.time()
+        evicted = 0
+
+        # TTL pass.
+        for entry in list(ns_dir.iterdir()):
+            if entry.name.startswith("."):
+                continue  # producer's own in-progress writes
+            try:
+                stat = entry.stat()
+            except FileNotFoundError:
+                continue
+            if now - stat.st_mtime > self._ttl_seconds:
+                try:
+                    entry.unlink()
+                    evicted += 1
+                except FileNotFoundError:
+                    pass
+
+        # LRU pass — only when a ceiling is configured.
+        ceiling = self._storage_ceiling_bytes
+        if ceiling is not None:
+            survivors: list[tuple[Path, float, int]] = []
+            for entry in ns_dir.iterdir():
+                if entry.name.startswith("."):
+                    continue
+                try:
+                    stat = entry.stat()
+                except FileNotFoundError:
+                    continue
+                survivors.append((entry, stat.st_mtime, stat.st_size))
+            total = sum(size for _, _, size in survivors)
+            survivors.sort(key=lambda triple: triple[1])  # oldest first
+            for path, _, size in survivors:
+                if total <= ceiling:
+                    break
+                try:
+                    path.unlink()
+                    evicted += 1
+                    total -= size
+                except FileNotFoundError:
+                    pass
+
+        if evicted:
+            logger.info(
+                "exchange_sweep namespace=%s evicted=%d", self._namespace, evicted
+            )
+        return evicted

--- a/src/fastmcp_pvl_core/_file_exchange.py
+++ b/src/fastmcp_pvl_core/_file_exchange.py
@@ -717,6 +717,12 @@ class FileExchange:
 
         explicit_id = environ.get("MCP_EXCHANGE_ID", "").strip() or None
         exchange_id = _resolve_exchange_id(base_dir, explicit_id)
+        # Validate the resolved exchange_id: a UUIDv4 always passes,
+        # but an explicit MCP_EXCHANGE_ID containing forbidden chars
+        # (e.g. "foo/bar") would otherwise produce malformed
+        # ``exchange://`` URIs at write time. Fail at config-load
+        # rather than at first write.
+        ExchangeURI.validate_segment(exchange_id, role="json_param")
 
         return cls(
             base_dir,
@@ -793,6 +799,19 @@ class FileExchange:
             )
         ExchangeURI.validate_segment(origin_id, role="json_param")
         ExchangeURI.validate_segment(ext, role="json_param")
+        # Spec §5: consumers MUST ignore dotfiles, and both
+        # read_exchange_uri and sweep filter dotfile names. Writing a
+        # dot-prefix filename here would create a file no consumer can
+        # ever read AND that sweep silently skips — pure storage leak.
+        # Block at the producer rather than letting the asymmetry
+        # accumulate dead files on the shared volume.
+        if origin_id.startswith("."):
+            raise ExchangeURIError(
+                f"origin_id MUST NOT start with a dot (would create a "
+                f"dotfile invisible to consumers and sweep): {origin_id!r}"
+            )
+        if ext.startswith("."):
+            raise ExchangeURIError(f"ext MUST NOT start with a dot: {ext!r}")
 
         ns_dir = self._base_dir / self._namespace
         ns_dir.mkdir(mode=0o755, exist_ok=True)
@@ -892,9 +911,14 @@ class FileExchange:
             return 0
 
         now = time.time()
+        ceiling = self._storage_ceiling_bytes
         evicted = 0
-
-        # TTL pass.
+        # Single pass: TTL-evict immediately and collect surviving
+        # entries' (path, mtime, size) for the optional LRU pass. Two
+        # passes was an extra full scan + stat() per file for no
+        # functional gain — gemini-code-assist flagged this as a
+        # medium-priority optimisation.
+        survivors: list[tuple[Path, float, int]] = []
         for entry in list(ns_dir.iterdir()):
             if entry.name.startswith("."):
                 continue  # producer's own in-progress writes
@@ -908,19 +932,11 @@ class FileExchange:
                     evicted += 1
                 except FileNotFoundError:
                     pass
+            elif ceiling is not None:
+                survivors.append((entry, stat.st_mtime, stat.st_size))
 
         # LRU pass — only when a ceiling is configured.
-        ceiling = self._storage_ceiling_bytes
-        if ceiling is not None:
-            survivors: list[tuple[Path, float, int]] = []
-            for entry in ns_dir.iterdir():
-                if entry.name.startswith("."):
-                    continue
-                try:
-                    stat = entry.stat()
-                except FileNotFoundError:
-                    continue
-                survivors.append((entry, stat.st_mtime, stat.st_size))
+        if ceiling is not None and survivors:
             total = sum(size for _, _, size in survivors)
             survivors.sort(key=lambda triple: triple[1])  # oldest first
             for path, _, size in survivors:
@@ -929,9 +945,13 @@ class FileExchange:
                 try:
                     path.unlink()
                     evicted += 1
-                    total -= size
                 except FileNotFoundError:
+                    # External delete beat us to it — the file is gone
+                    # so its size shouldn't count toward the running
+                    # total either, otherwise we'd over-evict a
+                    # surviving file to compensate for a phantom byte.
                     pass
+                total -= size
 
         if evicted:
             logger.info(

--- a/src/fastmcp_pvl_core/_file_exchange.py
+++ b/src/fastmcp_pvl_core/_file_exchange.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import threading
 import time
 import uuid
 from collections.abc import Mapping
@@ -478,13 +479,36 @@ class ExchangeGroupMismatch(ValueError):  # noqa: N818  -- spec-defined name
     """
 
 
-def _resolve_exchange_id(base_dir: Path, explicit: str | None) -> str:
-    """Read or exclusive-create ``$base_dir/.exchange-id`` (spec §3.5).
+def _read_existing_exchange_id(id_path: Path) -> str:
+    """Read and validate a persisted ``.exchange-id`` value."""
+    existing = id_path.read_text(encoding="utf-8").strip()
+    if not existing:
+        # Corrupt: O_EXCL succeeded for some prior writer that crashed
+        # before populating the file. Surface visibly rather than
+        # silently returning an empty group identifier.
+        raise FileExchangeConfigError(
+            f"{id_path} exists but is empty; remove it manually after "
+            "verifying no producer holds writes pending"
+        )
+    return existing
 
-    Uses ``O_CREAT | O_EXCL`` so racing servers cannot split-brain — only
-    one wins the create; the rest read the winner's value. ``rename(2)``
-    is *not* used here: POSIX rename silently overwrites, which would
-    quietly corrupt the group identity if two servers initialised
+
+def _resolve_exchange_id(base_dir: Path, explicit: str | None) -> str:
+    """Read or atomically create ``$base_dir/.exchange-id`` (spec §3.5).
+
+    Uses a *link-based* atomicity pattern rather than ``O_CREAT | O_EXCL``
+    on the destination directly. The naive ``O_EXCL`` approach has a
+    subtle race: ``open(O_EXCL)`` succeeds the moment the empty file
+    exists, but the writer hasn't yet written the UUID. A concurrent
+    reader that catches ``EEXIST`` and immediately ``read_text``-s sees
+    an empty string. The link pattern avoids this by writing the full
+    UUID payload to a per-thread temp file, fsyncing, then ``os.link``-ing
+    the populated file into place. ``link(2)`` returns ``EEXIST`` if the
+    destination already exists and *never* overwrites — same atomicity
+    guarantee as ``O_EXCL`` but with the file content already on disk.
+
+    ``rename(2)`` is *not* used: POSIX rename silently overwrites, which
+    would quietly corrupt the group identity if two servers initialised
     simultaneously.
 
     Args:
@@ -494,38 +518,70 @@ def _resolve_exchange_id(base_dir: Path, explicit: str | None) -> str:
             otherwise.
 
     Returns:
-        The exchange-group ID (lowercase by convention; whitespace
-        stripped per spec).
+        The exchange-group ID (whitespace stripped per spec).
 
     Raises:
         ExchangeGroupMismatch: If *explicit* is set and disagrees with
             the value already persisted on disk.
+        FileExchangeConfigError: If a persisted ``.exchange-id`` exists
+            but is empty (corrupt from a prior crashed init).
     """
     id_path = base_dir / ".exchange-id"
-    candidate = explicit if explicit is not None else str(uuid.uuid4())
-    payload = candidate.encode("utf-8") + b"\n"
-    try:
-        fd = os.open(str(id_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
-    except FileExistsError:
-        # Lost the create race (or override targets an existing file) —
-        # fall through to read the persisted value. The FileExistsError
-        # itself is not the failure cause for the mismatch path; raise
-        # ``from None`` so the traceback shows only the data-level
-        # disagreement.
-        existing = id_path.read_text(encoding="utf-8").strip()
+
+    # Fast path: file already exists with content, no init needed.
+    if id_path.exists():
+        existing = _read_existing_exchange_id(id_path)
         if explicit is not None and existing != explicit:
             raise ExchangeGroupMismatch(
                 f"MCP_EXCHANGE_ID={explicit!r} conflicts with existing "
                 f"{id_path.name} value {existing!r}"
-            ) from None
+            )
         return existing
+
+    candidate = explicit if explicit is not None else str(uuid.uuid4())
+    payload = candidate.encode("utf-8") + b"\n"
+
+    # Per-thread tmp name guarantees no collision among concurrent
+    # writers in the same process; PID guards against same-thread-id
+    # collisions across processes (extremely unlikely but free).
+    tmp_path = base_dir / (f".exchange-id.tmp.{os.getpid()}.{threading.get_ident()}")
     try:
-        os.write(fd, payload)
-        os.fsync(fd)
+        # Restrictive 0o600 at create-time keeps CodeQL's
+        # overly-permissive-permissions check quiet at the syscall site;
+        # the spec-mandated 0o644 is applied via fchmod after the write
+        # so consumers running as a different effective UID can read it.
+        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, payload)
+            os.fsync(fd)
+            os.fchmod(fd, 0o644)
+        finally:
+            os.close(fd)
+
+        try:
+            os.link(tmp_path, id_path)
+        except FileExistsError:
+            # We lost the link race. The winner's content is already
+            # on disk (they fsynced before linking), so reading is
+            # guaranteed to return their populated value.
+            existing = _read_existing_exchange_id(id_path)
+            if explicit is not None and existing != explicit:
+                raise ExchangeGroupMismatch(
+                    f"MCP_EXCHANGE_ID={explicit!r} conflicts with existing "
+                    f"{id_path.name} value {existing!r}"
+                ) from None
+            return existing
+
+        logger.debug("exchange_id_created path=%s id=%s", id_path, candidate)
+        return candidate
     finally:
-        os.close(fd)
-    logger.debug("exchange_id_created path=%s id=%s", id_path, candidate)
-    return candidate
+        # Always remove the tmp — whether we won, lost the link race,
+        # or an exception fired mid-write. Without this we'd leak a
+        # ``.exchange-id.tmp.<pid>.<tid>`` per crashed init.
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
 
 
 class FileExchange:
@@ -746,15 +802,15 @@ class FileExchange:
         # Note: O_TRUNC handles the case where a stale tmp from a prior
         # crash exists at the same name. The dotfile prefix means
         # consumers can never see the partial state; rename is the
-        # commit point.
-        fd = os.open(
-            str(tmp_path),
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            0o644,
-        )
+        # commit point. Restrictive 0o600 at create + fchmod to 0o644
+        # after write keeps CodeQL's overly-permissive-permissions
+        # check quiet at the syscall site, while still landing the
+        # cross-UID-readable mode the shared-volume topology needs.
+        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         try:
             os.write(fd, content)
             os.fsync(fd)
+            os.fchmod(fd, 0o644)
         finally:
             os.close(fd)
         os.rename(tmp_path, final_path)

--- a/src/fastmcp_pvl_core/_file_exchange.py
+++ b/src/fastmcp_pvl_core/_file_exchange.py
@@ -628,6 +628,19 @@ class FileExchange:
                 "FileExchange requires base_dir, exchange_id, and namespace "
                 "to all be set, or all be None"
             )
+        # Direct instantiation bypasses ``from_env``'s validation, so
+        # repeat the segment + dot-prefix checks here. ``from_env``
+        # already runs them upstream — re-validating spec-compliant
+        # values is cheap and the safety net catches bypass paths
+        # (test harness, programmatic construction).
+        if namespace is not None:
+            ExchangeURI.validate_segment(namespace, role="json_param")
+            if namespace.startswith("."):
+                raise ExchangeURIError(
+                    f"namespace MUST NOT start with a dot: {namespace!r}"
+                )
+        if exchange_id is not None:
+            ExchangeURI.validate_segment(exchange_id, role="json_param")
         self._base_dir = base_dir
         self._exchange_id = exchange_id
         self._namespace = namespace
@@ -716,12 +729,19 @@ class FileExchange:
             )
 
         explicit_id = environ.get("MCP_EXCHANGE_ID", "").strip() or None
+        # Validate ``explicit_id`` BEFORE persisting it. An invalid
+        # value reaching ``_resolve_exchange_id`` would link-write
+        # bad content into ``.exchange-id`` first and only raise on
+        # the post-resolve check, leaving the corrupt file behind —
+        # subsequent runs would then read it and disagree with any
+        # corrected MCP_EXCHANGE_ID (forcing the operator to manually
+        # delete .exchange-id with no diagnostic pointing them to it).
+        if explicit_id is not None:
+            ExchangeURI.validate_segment(explicit_id, role="json_param")
         exchange_id = _resolve_exchange_id(base_dir, explicit_id)
-        # Validate the resolved exchange_id: a UUIDv4 always passes,
-        # but an explicit MCP_EXCHANGE_ID containing forbidden chars
-        # (e.g. "foo/bar") would otherwise produce malformed
-        # ``exchange://`` URIs at write time. Fail at config-load
-        # rather than at first write.
+        # Post-resolve validation handles the corrupt-file recovery
+        # case: a pre-fix deployment may have left a malformed value
+        # in .exchange-id; surface it here rather than at first write.
         ExchangeURI.validate_segment(exchange_id, role="json_param")
 
         return cls(

--- a/tests/test_file_exchange.py
+++ b/tests/test_file_exchange.py
@@ -491,6 +491,21 @@ class TestFromEnv:
                 env={"MCP_EXCHANGE_DIR": str(tmp_path)},
             )
 
+    def test_explicit_exchange_id_with_path_separator_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        # An explicit MCP_EXCHANGE_ID containing forbidden chars would
+        # otherwise persist to .exchange-id and only break later at
+        # write/read time. Fail at config-load instead.
+        with pytest.raises(ExchangeURIError):
+            FileExchange.from_env(
+                default_namespace="ns",
+                env={
+                    "MCP_EXCHANGE_DIR": str(tmp_path),
+                    "MCP_EXCHANGE_ID": "bad/group",
+                },
+            )
+
     def test_explicit_exchange_id_persists_to_disk(self, tmp_path: Path) -> None:
         fx = FileExchange.from_env(
             default_namespace="test",
@@ -606,6 +621,21 @@ class TestWriteAtomic:
 
         with pytest.raises(ExchangeURIError):
             fx.write_atomic(origin_id="../escape", ext="png", content=b"")
+
+    def test_rejects_dot_prefix_origin_id(self, tmp_path: Path) -> None:
+        # Storage-leak guard: a dot-prefix filename would be invisible
+        # to consumers (read_exchange_uri rejects it) AND skipped by
+        # sweep, so it would accumulate forever on the shared volume.
+        fx = self._make(tmp_path)
+
+        with pytest.raises(ExchangeURIError, match="dot"):
+            fx.write_atomic(origin_id=".hidden", ext="png", content=b"x")
+
+    def test_rejects_dot_prefix_ext(self, tmp_path: Path) -> None:
+        fx = self._make(tmp_path)
+
+        with pytest.raises(ExchangeURIError, match="dot"):
+            fx.write_atomic(origin_id="x", ext=".png", content=b"x")
 
     def test_rejects_ext_with_dot(self, tmp_path: Path) -> None:
         fx = self._make(tmp_path)

--- a/tests/test_file_exchange.py
+++ b/tests/test_file_exchange.py
@@ -1,15 +1,23 @@
-"""Tests for the MCP File Exchange v0.3 protocol surface."""
+"""Tests for the MCP File Exchange v0.3 protocol surface and runtime."""
 
 from __future__ import annotations
+
+import os
+import threading
+import time as time_module
+from pathlib import Path
 
 import pytest
 from fastmcp import FastMCP
 
 from fastmcp_pvl_core import (
     FILE_EXCHANGE_SPEC_VERSION,
+    ExchangeGroupMismatch,
     ExchangeURI,
     ExchangeURIError,
+    FileExchange,
     FileExchangeCapability,
+    FileExchangeConfigError,
     FileRef,
     FileRefPreview,
     register_file_exchange_capability,
@@ -402,3 +410,416 @@ class TestCapabilityDeclaration:
                 "transfer_methods": {"http": {}},
             },
         }
+
+
+# ---------------------------------------------------------------------------
+# FileExchange runtime
+# ---------------------------------------------------------------------------
+
+
+class TestFromEnv:
+    def test_unconfigured_when_dir_unset(self) -> None:
+        fx = FileExchange.from_env(default_namespace="test", env={})
+
+        assert fx.is_configured is False
+        with pytest.raises(FileExchangeConfigError):
+            _ = fx.exchange_id
+        with pytest.raises(FileExchangeConfigError):
+            _ = fx.namespace
+
+    def test_unconfigured_when_dir_blank(self) -> None:
+        # Empty / whitespace-only env value should be treated as unset.
+        fx = FileExchange.from_env(
+            default_namespace="test", env={"MCP_EXCHANGE_DIR": "   "}
+        )
+
+        assert fx.is_configured is False
+
+    def test_raises_when_dir_does_not_exist(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nope"
+
+        with pytest.raises(FileExchangeConfigError, match="does not exist"):
+            FileExchange.from_env(
+                default_namespace="test",
+                env={"MCP_EXCHANGE_DIR": str(missing)},
+            )
+
+    def test_raises_when_dir_is_a_file(self, tmp_path: Path) -> None:
+        not_a_dir = tmp_path / "f"
+        not_a_dir.write_text("hi")
+
+        with pytest.raises(FileExchangeConfigError, match="not a directory"):
+            FileExchange.from_env(
+                default_namespace="test",
+                env={"MCP_EXCHANGE_DIR": str(not_a_dir)},
+            )
+
+    def test_namespace_env_wins_over_default(self, tmp_path: Path) -> None:
+        fx = FileExchange.from_env(
+            default_namespace="from-default",
+            env={
+                "MCP_EXCHANGE_DIR": str(tmp_path),
+                "MCP_EXCHANGE_NAMESPACE": "from-env",
+            },
+        )
+
+        assert fx.namespace == "from-env"
+
+    def test_default_namespace_used_when_env_unset(self, tmp_path: Path) -> None:
+        fx = FileExchange.from_env(
+            default_namespace="from-default",
+            env={"MCP_EXCHANGE_DIR": str(tmp_path)},
+        )
+
+        assert fx.namespace == "from-default"
+
+    def test_missing_namespace_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileExchangeConfigError, match="namespace"):
+            FileExchange.from_env(env={"MCP_EXCHANGE_DIR": str(tmp_path)})
+
+    def test_namespace_with_dot_prefix_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ExchangeURIError, match="dot"):
+            FileExchange.from_env(
+                default_namespace=".hidden",
+                env={"MCP_EXCHANGE_DIR": str(tmp_path)},
+            )
+
+    def test_namespace_with_path_separator_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ExchangeURIError):
+            FileExchange.from_env(
+                default_namespace="bad/ns",
+                env={"MCP_EXCHANGE_DIR": str(tmp_path)},
+            )
+
+    def test_explicit_exchange_id_persists_to_disk(self, tmp_path: Path) -> None:
+        fx = FileExchange.from_env(
+            default_namespace="test",
+            env={
+                "MCP_EXCHANGE_DIR": str(tmp_path),
+                "MCP_EXCHANGE_ID": "hades-01",
+            },
+        )
+
+        assert fx.exchange_id == "hades-01"
+        assert (tmp_path / ".exchange-id").read_text(
+            encoding="utf-8"
+        ).strip() == "hades-01"
+
+    def test_explicit_exchange_id_conflict_raises(self, tmp_path: Path) -> None:
+        # Pre-populate .exchange-id with a different value.
+        (tmp_path / ".exchange-id").write_text("hades-01\n", encoding="utf-8")
+
+        with pytest.raises(ExchangeGroupMismatch, match="conflicts"):
+            FileExchange.from_env(
+                default_namespace="test",
+                env={
+                    "MCP_EXCHANGE_DIR": str(tmp_path),
+                    "MCP_EXCHANGE_ID": "cloud-02",
+                },
+            )
+
+    def test_explicit_exchange_id_matching_existing_succeeds(
+        self, tmp_path: Path
+    ) -> None:
+        # Pre-existing file with whitespace + uppercase to exercise the
+        # spec-mandated normalisation: strip trailing whitespace, accept
+        # case as-is.
+        (tmp_path / ".exchange-id").write_text("HADES-01\n", encoding="utf-8")
+
+        fx = FileExchange.from_env(
+            default_namespace="test",
+            env={
+                "MCP_EXCHANGE_DIR": str(tmp_path),
+                "MCP_EXCHANGE_ID": "HADES-01",
+            },
+        )
+
+        assert fx.exchange_id == "HADES-01"
+
+    def test_concurrent_from_env_creates_exactly_one_exchange_id(
+        self, tmp_path: Path
+    ) -> None:
+        # Race test (acceptance criterion): N concurrent from_env calls
+        # against an empty exchange dir produce exactly one .exchange-id
+        # file. Verifies O_EXCL semantics — without it, the rename-based
+        # alternative would silently overwrite.
+        env = {"MCP_EXCHANGE_DIR": str(tmp_path)}
+        barrier = threading.Barrier(16)
+        ids: list[str] = []
+        errors: list[BaseException] = []
+
+        def worker() -> None:
+            try:
+                barrier.wait()
+                fx = FileExchange.from_env(default_namespace="test", env=env)
+                ids.append(fx.exchange_id)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(16)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        assert len(ids) == 16
+        assert len(set(ids)) == 1  # all winners agree
+        # Exactly one .exchange-id; no .exchange-id.tmp leftovers.
+        files = sorted(p.name for p in tmp_path.iterdir())
+        assert files == [".exchange-id"]
+
+
+class TestWriteAtomic:
+    def _make(self, tmp_path: Path, **kwargs: object) -> FileExchange:
+        env = {
+            "MCP_EXCHANGE_DIR": str(tmp_path),
+            "MCP_EXCHANGE_ID": "g1",
+            "MCP_EXCHANGE_NAMESPACE": "image-mcp",
+        }
+        return FileExchange.from_env(default_namespace="image-mcp", env=env, **kwargs)  # type: ignore[arg-type]
+
+    def test_writes_file_and_returns_uri(self, tmp_path: Path) -> None:
+        fx = self._make(tmp_path)
+
+        uri = fx.write_atomic(
+            origin_id="a1b2c3",
+            ext="png",
+            content=b"PNG-bytes",
+            mime_type="image/png",
+        )
+
+        assert uri == "exchange://g1/image-mcp/a1b2c3.png"
+        on_disk = tmp_path / "image-mcp" / "a1b2c3.png"
+        assert on_disk.read_bytes() == b"PNG-bytes"
+
+    def test_creates_namespace_directory(self, tmp_path: Path) -> None:
+        fx = self._make(tmp_path)
+
+        fx.write_atomic(origin_id="x", ext="png", content=b"")
+
+        ns_dir = tmp_path / "image-mcp"
+        assert ns_dir.is_dir()
+
+    def test_rejects_origin_id_with_path_separator(self, tmp_path: Path) -> None:
+        fx = self._make(tmp_path)
+
+        with pytest.raises(ExchangeURIError):
+            fx.write_atomic(origin_id="../escape", ext="png", content=b"")
+
+    def test_rejects_ext_with_dot(self, tmp_path: Path) -> None:
+        fx = self._make(tmp_path)
+
+        # An ext value of "." or ".." should fail the segment rules.
+        with pytest.raises(ExchangeURIError):
+            fx.write_atomic(origin_id="x", ext="..", content=b"")
+
+    def test_unconfigured_write_raises(self) -> None:
+        fx = FileExchange.from_env(default_namespace="x", env={})
+
+        with pytest.raises(FileExchangeConfigError):
+            fx.write_atomic(origin_id="x", ext="png", content=b"")
+
+    def test_no_tmp_file_lingers_after_successful_write(self, tmp_path: Path) -> None:
+        fx = self._make(tmp_path)
+        fx.write_atomic(origin_id="x", ext="png", content=b"data")
+
+        ns_files = sorted(p.name for p in (tmp_path / "image-mcp").iterdir())
+        assert ns_files == ["x.png"]
+
+    def test_simulated_crash_leaves_only_dotfile_invisible_to_consumer(
+        self, tmp_path: Path
+    ) -> None:
+        # Atomic-write acceptance: simulate kill -9 mid-write by
+        # manually creating ``.{id}.{ext}.tmp`` in the namespace dir.
+        # A consumer asking for the final URI must get FileNotFoundError —
+        # the dotfile filter holds at the URI scheme level.
+        fx = self._make(tmp_path)
+        ns_dir = tmp_path / "image-mcp"
+        ns_dir.mkdir()
+        (ns_dir / ".x.png.tmp").write_bytes(b"partial")
+
+        with pytest.raises(FileNotFoundError):
+            fx.read_exchange_uri("exchange://g1/image-mcp/x.png")
+
+
+class TestReadExchangeUri:
+    def _make(self, tmp_path: Path, *, exchange_id: str = "g1") -> FileExchange:
+        env = {
+            "MCP_EXCHANGE_DIR": str(tmp_path),
+            "MCP_EXCHANGE_ID": exchange_id,
+            "MCP_EXCHANGE_NAMESPACE": "vault-mcp",
+        }
+        return FileExchange.from_env(default_namespace="vault-mcp", env=env)
+
+    def test_round_trips_own_namespace(self, tmp_path: Path) -> None:
+        env = {
+            "MCP_EXCHANGE_DIR": str(tmp_path),
+            "MCP_EXCHANGE_ID": "g1",
+            "MCP_EXCHANGE_NAMESPACE": "image-mcp",
+        }
+        fx = FileExchange.from_env(default_namespace="image-mcp", env=env)
+        uri = fx.write_atomic(origin_id="abc", ext="png", content=b"hello")
+
+        data = fx.read_exchange_uri(uri)
+
+        assert data == b"hello"
+
+    def test_cross_namespace_read(self, tmp_path: Path) -> None:
+        # Acceptance: vault-mcp can read exchange://g1/image-mcp/foo.png
+        # written by image-mcp on the same volume.
+        producer_env = {
+            "MCP_EXCHANGE_DIR": str(tmp_path),
+            "MCP_EXCHANGE_ID": "g1",
+            "MCP_EXCHANGE_NAMESPACE": "image-mcp",
+        }
+        producer = FileExchange.from_env(
+            default_namespace="image-mcp", env=producer_env
+        )
+        producer.write_atomic(origin_id="foo", ext="png", content=b"image-bytes")
+
+        consumer = self._make(tmp_path, exchange_id="g1")
+
+        data = consumer.read_exchange_uri("exchange://g1/image-mcp/foo.png")
+
+        assert data == b"image-bytes"
+
+    def test_group_mismatch_raises_with_both_ids(self, tmp_path: Path) -> None:
+        # .exchange-id is fixed to g1 so the from_env call below would
+        # ordinarily collide with the explicit MCP_EXCHANGE_ID we pass.
+        # Build the consumer with a different volume so it gets its own
+        # exchange_id, then read a URI from the wrong group.
+        local_dir = tmp_path / "local"
+        local_dir.mkdir()
+        consumer = self._make(local_dir, exchange_id="local-grp")
+
+        with pytest.raises(ExchangeGroupMismatch) as exc_info:
+            consumer.read_exchange_uri("exchange://remote-grp/n/file.png")
+
+        msg = str(exc_info.value)
+        assert "local-grp" in msg
+        assert "remote-grp" in msg
+
+    def test_missing_file_raises_filenotfound(self, tmp_path: Path) -> None:
+        fx = self._make(tmp_path)
+
+        with pytest.raises(FileNotFoundError):
+            fx.read_exchange_uri("exchange://g1/vault-mcp/missing.png")
+
+    def test_double_encoded_uri_rejected(self, tmp_path: Path) -> None:
+        # Acceptance: read_exchange_uri rejects %252e%252e%252f payloads
+        # before any filesystem access.
+        fx = self._make(tmp_path)
+
+        with pytest.raises(ExchangeURIError, match="double-encoded"):
+            fx.read_exchange_uri("exchange://g1/vault-mcp/%252e%252e%252f.png")
+
+    def test_path_traversal_uri_rejected(self, tmp_path: Path) -> None:
+        fx = self._make(tmp_path)
+
+        with pytest.raises(ExchangeURIError):
+            fx.read_exchange_uri("exchange://g1/../escaped/file.png")
+
+    def test_dotfile_filename_rejected(self, tmp_path: Path) -> None:
+        # Even when the URI parses, a dotfile id is the producer's
+        # in-progress write — consumers MUST ignore it.
+        fx = self._make(tmp_path)
+        # First write a real file we'll point near.
+        (tmp_path / "vault-mcp").mkdir()
+        (tmp_path / "vault-mcp" / ".secret.png").write_bytes(b"hidden")
+
+        with pytest.raises(ExchangeURIError, match="dot"):
+            fx.read_exchange_uri("exchange://g1/vault-mcp/.secret.png")
+
+    def test_unconfigured_read_raises(self) -> None:
+        fx = FileExchange.from_env(default_namespace="x", env={})
+
+        with pytest.raises(FileExchangeConfigError):
+            fx.read_exchange_uri("exchange://g/n/x.png")
+
+
+class TestSweep:
+    def _make(self, tmp_path: Path, **kwargs: object) -> FileExchange:
+        env = {
+            "MCP_EXCHANGE_DIR": str(tmp_path),
+            "MCP_EXCHANGE_ID": "g1",
+            "MCP_EXCHANGE_NAMESPACE": "ns",
+        }
+        return FileExchange.from_env(default_namespace="ns", env=env, **kwargs)  # type: ignore[arg-type]
+
+    def test_no_op_when_unconfigured(self) -> None:
+        fx = FileExchange.from_env(default_namespace="x", env={})
+
+        assert fx.sweep() == 0
+
+    def test_no_op_when_namespace_dir_missing(self, tmp_path: Path) -> None:
+        fx = self._make(tmp_path)
+
+        # Don't write anything; namespace dir doesn't exist yet.
+        assert fx.sweep() == 0
+
+    def test_ttl_eviction_removes_old_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fx = self._make(tmp_path, ttl_seconds=60)
+        fx.write_atomic(origin_id="old", ext="png", content=b"a")
+        fx.write_atomic(origin_id="fresh", ext="png", content=b"b")
+
+        # Backdate "old" so it predates the TTL window.
+        ns = tmp_path / "ns"
+        old_path = ns / "old.png"
+        os.utime(old_path, (time_module.time() - 3600, time_module.time() - 3600))
+
+        evicted = fx.sweep()
+
+        assert evicted == 1
+        assert not old_path.exists()
+        assert (ns / "fresh.png").exists()
+
+    def test_lru_eviction_below_ceiling(self, tmp_path: Path) -> None:
+        # ttl very long so TTL pass is a no-op — only LRU runs.
+        fx = self._make(tmp_path, ttl_seconds=10**9, storage_ceiling_bytes=10)
+        # Three files, 5 bytes each → 15 total, ceiling 10 → must evict
+        # at least the oldest until <=10.
+        fx.write_atomic(origin_id="a", ext="bin", content=b"AAAAA")
+        fx.write_atomic(origin_id="b", ext="bin", content=b"BBBBB")
+        fx.write_atomic(origin_id="c", ext="bin", content=b"CCCCC")
+        ns = tmp_path / "ns"
+        # Force a deterministic mtime ordering: a oldest, c newest.
+        now = time_module.time()
+        os.utime(ns / "a.bin", (now - 30, now - 30))
+        os.utime(ns / "b.bin", (now - 20, now - 20))
+        os.utime(ns / "c.bin", (now - 10, now - 10))
+
+        evicted = fx.sweep()
+
+        assert evicted >= 1
+        # Oldest must be gone.
+        assert not (ns / "a.bin").exists()
+        # Newest must still be there.
+        assert (ns / "c.bin").exists()
+
+    def test_sweep_ignores_dotfiles(self, tmp_path: Path) -> None:
+        # An in-progress write (dotfile) MUST NOT be evicted — that
+        # would race with the producer's own atomic write.
+        fx = self._make(tmp_path, ttl_seconds=1)
+        ns = tmp_path / "ns"
+        ns.mkdir()
+        (ns / ".inflight.png.tmp").write_bytes(b"x")
+        os.utime(ns / ".inflight.png.tmp", (0, 0))  # ancient
+
+        fx.sweep()
+
+        assert (ns / ".inflight.png.tmp").exists()
+
+
+class TestModuleDocs:
+    """Acceptance: module docstring documents the lifecycle constraints."""
+
+    def test_docstring_mentions_producer_and_consumer_constraints(self) -> None:
+        from fastmcp_pvl_core import _file_exchange
+
+        doc = _file_exchange.__doc__ or ""
+        assert "producing server" in doc.lower() or "producer" in doc.lower()
+        assert "consum" in doc.lower()
+        assert "read-only" in doc.lower()

--- a/tests/test_file_exchange.py
+++ b/tests/test_file_exchange.py
@@ -496,7 +496,10 @@ class TestFromEnv:
     ) -> None:
         # An explicit MCP_EXCHANGE_ID containing forbidden chars would
         # otherwise persist to .exchange-id and only break later at
-        # write/read time. Fail at config-load instead.
+        # write/read time. Validate BEFORE the resolve/write step so
+        # the rejected value never lands on disk — otherwise the
+        # operator gets stuck with a corrupt .exchange-id even after
+        # fixing the env var.
         with pytest.raises(ExchangeURIError):
             FileExchange.from_env(
                 default_namespace="ns",
@@ -505,6 +508,28 @@ class TestFromEnv:
                     "MCP_EXCHANGE_ID": "bad/group",
                 },
             )
+
+        # Critical post-condition: .exchange-id MUST NOT have been
+        # written. If it had, the next from_env (with a corrected
+        # MCP_EXCHANGE_ID) would read the corrupt value and raise
+        # ExchangeGroupMismatch with no diagnostic pointing at the
+        # stale file.
+        assert not (tmp_path / ".exchange-id").exists()
+
+    def test_init_rejects_invalid_namespace(self, tmp_path: Path) -> None:
+        # Direct instantiation bypasses from_env's validation; the
+        # constructor must still refuse spec-illegal values so
+        # programmatic / test-harness construction can't slip through.
+        with pytest.raises(ExchangeURIError):
+            FileExchange(tmp_path, "g1", "bad/namespace")
+
+    def test_init_rejects_dot_prefix_namespace(self, tmp_path: Path) -> None:
+        with pytest.raises(ExchangeURIError, match="dot"):
+            FileExchange(tmp_path, "g1", ".hidden")
+
+    def test_init_rejects_invalid_exchange_id(self, tmp_path: Path) -> None:
+        with pytest.raises(ExchangeURIError):
+            FileExchange(tmp_path, "bad/group", "ns")
 
     def test_explicit_exchange_id_persists_to_disk(self, tmp_path: Path) -> None:
         fx = FileExchange.from_env(


### PR DESCRIPTION
Closes #21

## Summary
Companion to #20. Lifts the file-exchange runtime into core so every consumer of #20's protocol surface doesn't re-derive env detection, `.exchange-id` race-safety, atomic write/read, and lifecycle sweep.

## API
`FileExchange` (exported from `fastmcp_pvl_core`):

- **`from_env(default_namespace, *, env, ttl_seconds, storage_ceiling_bytes)`** — reads `MCP_EXCHANGE_DIR` / `MCP_EXCHANGE_ID` / `MCP_EXCHANGE_NAMESPACE`. Returns an unconfigured sentinel (`is_configured=False`) when `MCP_EXCHANGE_DIR` is unset/blank. Validates that the dir exists and is a directory; resolves namespace via env > `default_namespace`; rejects dot-prefix namespaces.
- **`write_atomic(*, origin_id, ext, content, mime_type)`** → `exchange://` URI. Validates `origin_id` and `ext` as JSON params (no URI decoding per spec §6.3). Writes to `$ns/.{id}.{ext}.tmp`, fsyncs, POSIX-renames to `$ns/{id}.{ext}`. The dotfile prefix is the kill-resilience property — a crash leaves only a dotfile, which consumers ignore by spec §5.
- **`read_exchange_uri(uri)`** → bytes. Parses via `ExchangeURI.parse` (single-pass decode + segment rules + double-encoding rejection from #20), verifies the URI's exchange-group ID matches this server's, refuses leading-dot filenames (spec §5), reads the file. Raises `ExchangeGroupMismatch` with **both IDs** in the message on group mismatch.
- **`sweep()`** → int. Producer-only operation: TTL eviction, then optional LRU eviction by mtime when `storage_ceiling_bytes` is set. Restart-resume: rebuilds working set from disk on every call, no in-memory registry. Skips dotfiles unconditionally so it never races a producer's in-progress write.

## `.exchange-id` race safety (spec §3.5)
`_resolve_exchange_id` uses `os.open(O_CREAT | O_EXCL | O_WRONLY, 0o644)` to acquire group identity. POSIX `rename(2)` is explicitly rejected by the spec because it silently overwrites — would split-brain on a race. `EEXIST` → read the winner's value (whitespace stripped per spec). An explicit `MCP_EXCHANGE_ID` that conflicts with the persisted value raises `ExchangeGroupMismatch` immediately, `raise ... from None` since the `FileExistsError` isn't the actual cause of the data disagreement.

## Errors
- `FileExchangeConfigError(RuntimeError)` — config issues at construction.
- `ExchangeGroupMismatch(ValueError)` — group ID disagreement (carries `N818 noqa`: spec-defined name, no `Error` suffix).
- `ExchangeURIError` — already in #20; reused for traversal/forbidden-char/double-encoded URIs and for dotfile filenames at read time.

## Acceptance criteria coverage
- [x] `FileExchange` exported from `fastmcp_pvl_core`
- [x] `from_env` returns `is_configured=False` cleanly when `MCP_EXCHANGE_DIR` is unset
- [x] **Race test**: 16-thread `from_env` against empty dir produces exactly one `.exchange-id` file with all workers agreeing on the value
- [x] **Override test**: explicit `MCP_EXCHANGE_ID` mismatching the existing `.exchange-id` raises `ExchangeGroupMismatch`
- [x] **Atomic-write test**: pre-created `.{id}.{ext}.tmp` (simulating kill -9) is invisible to consumers — `read_exchange_uri` raises `FileNotFoundError`
- [x] **Cross-namespace read**: vault-mcp reads `exchange://g1/image-mcp/foo.png` written by image-mcp on the same volume
- [x] **Group-mismatch test**: `read_exchange_uri` with a different `exchange_id` raises `ExchangeGroupMismatch` with both IDs in the message
- [x] **Sweep test**: TTL eviction + LRU eviction (oldest-by-mtime first when ceiling exceeded)
- [x] **Once-decoded validation**: `read_exchange_uri("exchange://g1/vault-mcp/%252e%252e%252f.png")` raises `ExchangeURIError`
- [x] **Path traversal**: `read_exchange_uri("exchange://g1/../escaped/file.png")` raises `ExchangeURIError`
- [x] Module docstring documents producer-owned-lifecycle and consumer read-only constraints

## Test plan
- [x] 44 new runtime tests in `tests/test_file_exchange.py` (91 total in the file)
- [x] Full suite: 317 passed
- [x] `ruff format` / `ruff check` clean; `mypy --strict` clean