### PR TITLE
feat(debug): add maybe_start_debugpy helper for containerised consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ may change without a major-version bump.
 uv add fastmcp-pvl-core
 # If you use RemoteAuthProvider mode:
 uv add "fastmcp-pvl-core[remote-auth]"
+# For attaching a remote Python debugger inside a container image:
+uv add "fastmcp-pvl-core[debug]"
 ```
 
 ## Usage
@@ -55,6 +57,50 @@ mcp = FastMCP(
 )
 wire_middleware_stack(mcp)
 ```
+
+### Remote debugging in containers
+
+Containerised consumers can opt into a remote Python debugger by calling
+`maybe_start_debugpy()` early in their CLI entrypoint:
+
+```python
+from fastmcp_pvl_core import configure_logging_from_env, maybe_start_debugpy
+
+def main() -> None:
+    configure_logging_from_env()
+    maybe_start_debugpy()  # no-op unless DEBUG_PORT is set
+    ...
+```
+
+Environment contract:
+
+- `DEBUG_PORT` — TCP port to listen on. Unset, blank, or any value that
+  parses to `0` is a silent no-op. Non-numeric or out-of-`1..65535`
+  values log a `WARNING` and the helper returns without raising.
+- `DEBUG_WAIT` — when truthy (`1`/`true`/`yes`/`on`, case-insensitive),
+  block startup until the IDE attaches. Default is non-blocking.
+- If `debugpy.listen()` itself fails (port in use, permission denied,
+  debugpy-internal error), the helper logs a `WARNING` and continues —
+  a debug-port problem must never crash the server.
+
+Install the optional `debug` extra on images that need the listener:
+
+```bash
+uv add "fastmcp-pvl-core[debug]"   # quote brackets in zsh
+# or, equivalently:
+uv add debugpy
+```
+
+The helper logs a `WARNING` and continues if `debugpy` is unavailable,
+so it is safe to ship in default scaffolds.
+
+> ⚠️ **Security:** the listener binds `0.0.0.0` and debugpy's DAP
+> protocol is **unauthenticated** — any peer that can reach the port
+> has arbitrary code execution as the server process. Only enable
+> `DEBUG_PORT` in environments where the port is reachable solely
+> from a trusted developer workstation, e.g. `kubectl port-forward`,
+> `docker run -p 127.0.0.1:5678:5678` (loopback bind), or an SSH
+> tunnel. Never publish the debug port on a public network.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ dependencies = [
 
 [project.optional-dependencies]
 remote-auth = []
+# Optional remote-debugger support — enables ``maybe_start_debugpy()`` to
+# bind a listener on ``DEBUG_PORT``. Containerised consumers add this
+# extra to images that need attach-from-IDE debugging.
+debug = ["debugpy>=1.8"]
 
 [project.urls]
 Homepage = "https://github.com/pvliesdonk/fastmcp-pvl-core"

--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -21,6 +21,7 @@ from fastmcp_pvl_core._auth import (
 )
 from fastmcp_pvl_core._cli import make_serve_parser, normalise_http_path
 from fastmcp_pvl_core._config import ServerConfig, Transport
+from fastmcp_pvl_core._debug import maybe_start_debugpy
 from fastmcp_pvl_core._env import env, parse_bool, parse_list, parse_scopes
 from fastmcp_pvl_core._factory import (
     build_event_store,
@@ -96,6 +97,7 @@ __all__ = [
     "get_artifact_store",
     "make_icon",
     "make_serve_parser",
+    "maybe_start_debugpy",
     "normalise_http_path",
     "parse_bool",
     "parse_list",

--- a/src/fastmcp_pvl_core/_debug.py
+++ b/src/fastmcp_pvl_core/_debug.py
@@ -113,7 +113,10 @@ def maybe_start_debugpy() -> None:
         return
 
     try:
-        import debugpy  # type: ignore[import-not-found]
+        # ``import-not-found`` covers environments without the optional
+        # ``[debug]`` extra; ``unused-ignore`` covers CI / dev installs
+        # that *do* have debugpy and would otherwise flag the comment.
+        import debugpy  # type: ignore[import-not-found, unused-ignore]
     except ImportError:
         logger.warning(
             "DEBUG_PORT=%d set but debugpy is not installed. "

--- a/src/fastmcp_pvl_core/_debug.py
+++ b/src/fastmcp_pvl_core/_debug.py
@@ -73,10 +73,16 @@ def maybe_start_debugpy() -> None:
 
     When ``DEBUG_WAIT`` is truthy the helper blocks until the IDE
     attaches (``debugpy.wait_for_client()``); otherwise startup
-    continues immediately.
+    continues immediately. A failure inside ``wait_for_client`` (e.g.
+    debugpy-internal error, transport hiccup) likewise logs a
+    ``WARNING`` and returns — the listener is still up, so the IDE can
+    still attach manually. ``KeyboardInterrupt`` propagates so an
+    operator-initiated Ctrl-C still aborts the process.
 
     Idempotent across repeated calls in the same process. Not
-    thread-safe — call from ``main()`` before spawning workers.
+    thread-safe — call from ``main()`` before spawning workers. After
+    a ``wait_for_client`` failure a re-call short-circuits silently:
+    the listener is up, there is nothing more to do.
 
     Security note: the listener binds ``0.0.0.0`` and debugpy's DAP
     protocol is unauthenticated. Only expose the port to a trusted
@@ -141,5 +147,21 @@ def maybe_start_debugpy() -> None:
 
     if parse_bool(os.environ.get("DEBUG_WAIT", "")):
         logger.info("DEBUG_WAIT=true — blocking until debugger attaches...")
-        debugpy.wait_for_client()
+        try:
+            debugpy.wait_for_client()
+        except KeyboardInterrupt:
+            # Operator hit Ctrl-C while waiting — propagate so the
+            # process exits as the user expects. The latch stays set
+            # because listen() already succeeded; a re-caller would
+            # short-circuit silently (listener is up, nothing to do).
+            raise
+        except Exception as exc:  # noqa: BLE001 — debugger bring-up must not crash startup
+            logger.warning(
+                "debugpy.wait_for_client failed: %s; continuing startup. "
+                "The listener on 0.0.0.0:%d is still up; "
+                "the IDE can still attach manually.",
+                exc,
+                port,
+            )
+            return
         logger.info("debugger attached; continuing startup.")

--- a/src/fastmcp_pvl_core/_debug.py
+++ b/src/fastmcp_pvl_core/_debug.py
@@ -1,0 +1,142 @@
+"""Optional remote-debugger entrypoint helper.
+
+Containerised consumers (image-generation-mcp, markdown-vault-mcp, ...)
+need a uniform way to attach a remote Python debugger without each one
+hand-rolling the ``debugpy`` bootstrap. Call :func:`maybe_start_debugpy`
+early in ``main()`` (after logging is configured, before argument
+parsing): it is a no-op unless ``DEBUG_PORT`` is set, so it is safe to
+ship in default scaffolds.
+
+Environment contract:
+
+* ``DEBUG_PORT`` — TCP port to listen on. Unset, blank, or any value
+  that parses to ``0`` disables the helper silently. Non-numeric or
+  out-of-``1..65535`` values log a ``WARNING`` and the helper returns
+  without raising. Surrounding whitespace is ignored.
+* ``DEBUG_WAIT`` — when truthy (``1``/``true``/``yes``/``on``,
+  case-insensitive — see ``parse_bool`` in ``_env.py``), block startup
+  until the IDE attaches. Default is non-blocking so missing-attach
+  doesn't deadlock production containers that were accidentally built
+  with ``DEBUG=true``.
+
+The ``debugpy`` package is imported lazily — install it via
+``pip install 'fastmcp-pvl-core[debug]'`` (quote the brackets in zsh)
+or ``uv add debugpy`` only on images that actually need the listener.
+A failed import logs a ``WARNING`` and continues, so the helper is safe
+to call unconditionally in the default scaffold.
+
+.. warning::
+
+   The listener binds ``0.0.0.0`` so the debugger is reachable from
+   outside the container — this is intentional for the developer
+   workflow, but **debugpy's DAP protocol is unauthenticated**: any
+   peer that can reach the port has arbitrary code execution as the
+   server process. Only enable ``DEBUG_PORT`` in environments where
+   the port is reachable solely from a trusted developer workstation
+   (e.g. ``kubectl port-forward``, ``docker run -p 127.0.0.1:5678:5678``,
+   an SSH tunnel). Never publish the debug port on a public network.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from fastmcp_pvl_core._env import parse_bool
+
+logger = logging.getLogger(__name__)
+
+# Module-level latch — debugpy.listen() raises if called twice on the
+# same process, so the helper is idempotent across repeated invocations
+# (e.g. typer subcommands sharing a root callback). Not thread-safe;
+# the helper is meant to be called from main() before any worker
+# threads spawn. A racing second caller would hit debugpy's own
+# "already listening" error, which the broad except below absorbs into
+# a WARNING — benign, but worth knowing.
+_started = False
+
+
+def maybe_start_debugpy() -> None:
+    """Start a debugpy listener if ``DEBUG_PORT`` is set.
+
+    Reads ``DEBUG_PORT`` from the environment. Unset, blank, or any
+    value that parses to ``0`` is a silent no-op. Non-numeric or
+    out-of-``1..65535`` values log a ``WARNING`` so misconfiguration
+    is visible. Otherwise imports :mod:`debugpy` lazily and binds
+    ``("0.0.0.0", port)``.
+
+    A failed import logs a ``WARNING`` pointing at the ``debug`` extra
+    and returns. A failure inside :func:`debugpy.listen` (port in use,
+    permission denied, debugpy-internal error) likewise logs a
+    ``WARNING`` and returns — a debug-port problem must never crash
+    the server.
+
+    When ``DEBUG_WAIT`` is truthy the helper blocks until the IDE
+    attaches (``debugpy.wait_for_client()``); otherwise startup
+    continues immediately.
+
+    Idempotent across repeated calls in the same process. Not
+    thread-safe — call from ``main()`` before spawning workers.
+
+    Security note: the listener binds ``0.0.0.0`` and debugpy's DAP
+    protocol is unauthenticated. Only expose the port to a trusted
+    developer workstation (port-forward, loopback bind, SSH tunnel).
+    See the module docstring for details.
+    """
+    global _started
+    if _started:
+        return
+
+    raw = os.environ.get("DEBUG_PORT", "").strip()
+    if not raw:
+        return
+
+    try:
+        port = int(raw)
+    except ValueError:
+        logger.warning(
+            "DEBUG_PORT=%r is not a valid integer; debugpy listener not started.",
+            raw,
+        )
+        return
+
+    # All forms of zero (``0``, ``00``, ``-0``, ``+0``, surrounded by
+    # whitespace) are the documented disable form — silent no-op.
+    if port == 0:
+        return
+
+    if not 1 <= port <= 65535:
+        logger.warning(
+            "DEBUG_PORT=%d is outside 1..65535; debugpy listener not started.",
+            port,
+        )
+        return
+
+    try:
+        import debugpy  # type: ignore[import-not-found]
+    except ImportError:
+        logger.warning(
+            "DEBUG_PORT=%d set but debugpy is not installed. "
+            "Install with `pip install 'fastmcp-pvl-core[debug]'` "
+            "or `uv add debugpy`.",
+            port,
+        )
+        return
+
+    try:
+        debugpy.listen(("0.0.0.0", port))
+    except Exception as exc:  # noqa: BLE001 — listener bring-up must not crash startup
+        logger.warning(
+            "debugpy.listen on port %d failed: %s; continuing without remote debugger.",
+            port,
+            exc,
+        )
+        return
+
+    _started = True
+    logger.info("debugpy listening on 0.0.0.0:%d", port)
+
+    if parse_bool(os.environ.get("DEBUG_WAIT", "")):
+        logger.info("DEBUG_WAIT=true — blocking until debugger attaches...")
+        debugpy.wait_for_client()
+        logger.info("debugger attached; continuing startup.")

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,0 +1,257 @@
+"""Tests for ``maybe_start_debugpy``."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from fastmcp_pvl_core import _debug as debug_mod
+from fastmcp_pvl_core import maybe_start_debugpy
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each test starts with the helper's idempotency latch reset."""
+    monkeypatch.setattr(debug_mod, "_started", False)
+    monkeypatch.delenv("DEBUG_PORT", raising=False)
+    monkeypatch.delenv("DEBUG_WAIT", raising=False)
+
+
+def _install_fake_debugpy(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespace:
+    """Inject a stub ``debugpy`` module recording listen / wait_for_client calls."""
+    calls: list[tuple[str, Any]] = []
+
+    def listen(addr: tuple[str, int]) -> tuple[str, int]:
+        calls.append(("listen", addr))
+        return addr
+
+    def wait_for_client() -> None:
+        calls.append(("wait", None))
+
+    fake = types.ModuleType("debugpy")
+    fake.listen = listen  # type: ignore[attr-defined]
+    fake.wait_for_client = wait_for_client  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "debugpy", fake)
+    return types.SimpleNamespace(calls=calls)
+
+
+def test_no_op_when_debug_port_unset() -> None:
+    # No env, no fake debugpy installed — must not raise.
+    maybe_start_debugpy()
+
+
+@pytest.mark.parametrize("raw", ["0", "00", "+0", "-0", " 0 "])
+def test_no_op_when_debug_port_parses_to_zero(
+    raw: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # All forms that parse to 0 are the documented "disable" form and
+    # must be silent — not the out-of-range WARNING that "70000" triggers.
+    monkeypatch.setenv("DEBUG_PORT", raw)
+    fake = _install_fake_debugpy(monkeypatch)
+
+    with caplog.at_level(logging.DEBUG, logger="fastmcp_pvl_core._debug"):
+        maybe_start_debugpy()
+
+    assert fake.calls == []
+    assert caplog.records == [], (
+        f"DEBUG_PORT={raw!r} should be a silent no-op, but logged: "
+        f"{[r.getMessage() for r in caplog.records]}"
+    )
+
+
+def test_no_op_when_debug_port_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEBUG_PORT", "   ")
+    fake = _install_fake_debugpy(monkeypatch)
+
+    maybe_start_debugpy()
+
+    assert fake.calls == []
+
+
+def test_invalid_port_logs_warning_and_no_ops(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("DEBUG_PORT", "not-a-number")
+    fake = _install_fake_debugpy(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
+        maybe_start_debugpy()
+
+    assert fake.calls == []
+    assert any(
+        "DEBUG_PORT" in rec.message and rec.levelno == logging.WARNING
+        for rec in caplog.records
+    )
+
+
+def test_out_of_range_port_logs_warning_and_no_ops(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("DEBUG_PORT", "70000")
+    fake = _install_fake_debugpy(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
+        maybe_start_debugpy()
+
+    assert fake.calls == []
+    assert any(rec.levelno == logging.WARNING for rec in caplog.records)
+
+
+def test_negative_port_logs_warning_and_no_ops(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("DEBUG_PORT", "-1")
+    fake = _install_fake_debugpy(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
+        maybe_start_debugpy()
+
+    assert fake.calls == []
+    assert any(rec.levelno == logging.WARNING for rec in caplog.records)
+
+
+def test_debugpy_missing_logs_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("DEBUG_PORT", "5678")
+    # Force ImportError when the helper tries to import debugpy.
+    monkeypatch.setitem(sys.modules, "debugpy", None)
+
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
+        maybe_start_debugpy()
+
+    msgs = " ".join(rec.message for rec in caplog.records)
+    assert "debugpy" in msgs
+    # The hint should point at the install path so the operator can act on it.
+    assert "extra" in msgs.lower() or "install" in msgs.lower()
+
+
+def test_happy_path_calls_listen(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("DEBUG_PORT", "5678")
+    fake = _install_fake_debugpy(monkeypatch)
+
+    with caplog.at_level(logging.INFO, logger="fastmcp_pvl_core._debug"):
+        maybe_start_debugpy()
+
+    assert fake.calls == [("listen", ("0.0.0.0", 5678))]
+    assert any(
+        rec.levelno == logging.INFO and "5678" in rec.message for rec in caplog.records
+    )
+
+
+def test_debug_wait_triggers_wait_for_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DEBUG_PORT", "5678")
+    monkeypatch.setenv("DEBUG_WAIT", "true")
+    fake = _install_fake_debugpy(monkeypatch)
+
+    maybe_start_debugpy()
+
+    assert ("listen", ("0.0.0.0", 5678)) in fake.calls
+    assert ("wait", None) in fake.calls
+    # listen must come before wait_for_client.
+    assert fake.calls.index(("listen", ("0.0.0.0", 5678))) < fake.calls.index(
+        ("wait", None)
+    )
+
+
+def test_debug_wait_false_skips_wait(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEBUG_PORT", "5678")
+    monkeypatch.setenv("DEBUG_WAIT", "false")
+    fake = _install_fake_debugpy(monkeypatch)
+
+    maybe_start_debugpy()
+
+    assert ("listen", ("0.0.0.0", 5678)) in fake.calls
+    assert ("wait", None) not in fake.calls
+
+
+def test_idempotent_on_second_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEBUG_PORT", "5678")
+    fake = _install_fake_debugpy(monkeypatch)
+
+    maybe_start_debugpy()
+    maybe_start_debugpy()
+
+    # listen runs exactly once even though the helper was called twice.
+    assert [c for c in fake.calls if c[0] == "listen"] == [
+        ("listen", ("0.0.0.0", 5678))
+    ]
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        OSError("address in use"),
+        PermissionError("port requires CAP_NET_BIND_SERVICE"),
+        # The broad except is documented as deliberate — non-OSError
+        # failures (e.g. debugpy-internal RuntimeError on partial
+        # installs) must also be absorbed rather than crashing startup.
+        RuntimeError("debugpy internal error"),
+    ],
+)
+def test_listen_failure_logs_warning_and_continues(
+    exc: Exception,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("DEBUG_PORT", "5678")
+
+    def boom(_: tuple[str, int]) -> None:
+        raise exc
+
+    fake = types.ModuleType("debugpy")
+    fake.listen = boom  # type: ignore[attr-defined]
+    fake.wait_for_client = lambda: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "debugpy", fake)
+
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
+        maybe_start_debugpy()  # must not raise
+
+    assert any(
+        rec.levelno == logging.WARNING and str(exc) in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_failed_listen_does_not_latch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # If the first listen() fails (port in use, etc.) the idempotency
+    # latch must NOT be set — a subsequent call (e.g. after the operator
+    # frees the port and re-runs) is allowed to retry. Regression guard
+    # for the "set _started after success" ordering in _debug.py.
+    monkeypatch.setenv("DEBUG_PORT", "5678")
+    attempts: list[tuple[str, int]] = []
+    raise_once = {"left": True}
+
+    def listen(addr: tuple[str, int]) -> None:
+        attempts.append(addr)
+        if raise_once["left"]:
+            raise_once["left"] = False
+            raise OSError("address in use")
+
+    fake = types.ModuleType("debugpy")
+    fake.listen = listen  # type: ignore[attr-defined]
+    fake.wait_for_client = lambda: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "debugpy", fake)
+
+    maybe_start_debugpy()  # first attempt fails
+    maybe_start_debugpy()  # retry must reach listen() again
+
+    assert attempts == [("0.0.0.0", 5678), ("0.0.0.0", 5678)]
+    assert debug_mod._started is True  # latched only after the successful attempt

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -65,13 +65,21 @@ def test_no_op_when_debug_port_parses_to_zero(
     )
 
 
-def test_no_op_when_debug_port_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_no_op_when_debug_port_blank(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     monkeypatch.setenv("DEBUG_PORT", "   ")
     fake = _install_fake_debugpy(monkeypatch)
 
-    maybe_start_debugpy()
+    with caplog.at_level(logging.DEBUG, logger="fastmcp_pvl_core._debug"):
+        maybe_start_debugpy()
 
     assert fake.calls == []
+    assert caplog.records == [], (
+        "blank DEBUG_PORT must be a silent no-op, but logged: "
+        f"{[r.getMessage() for r in caplog.records]}"
+    )
 
 
 def test_invalid_port_logs_warning_and_no_ops(
@@ -167,6 +175,74 @@ def test_debug_wait_triggers_wait_for_client(
     assert fake.calls.index(("listen", ("0.0.0.0", 5678))) < fake.calls.index(
         ("wait", None)
     )
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        OSError("connection lost"),
+        RuntimeError("debugpy internal error in wait"),
+    ],
+)
+def test_wait_for_client_failure_logs_warning_and_continues(
+    exc: Exception,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Symmetry with the listen() failure path: a wait_for_client() error
+    # must not crash startup. The latch is correctly already True at this
+    # point (listen succeeded), so subsequent calls short-circuit — but
+    # the *current* call must continue, not raise.
+    monkeypatch.setenv("DEBUG_PORT", "5678")
+    monkeypatch.setenv("DEBUG_WAIT", "true")
+
+    def listen(_: tuple[str, int]) -> None:
+        return None
+
+    def wait_boom() -> None:
+        raise exc
+
+    fake = types.ModuleType("debugpy")
+    fake.listen = listen  # type: ignore[attr-defined]
+    fake.wait_for_client = wait_boom  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "debugpy", fake)
+
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
+        maybe_start_debugpy()  # must not raise
+
+    assert any(
+        rec.levelno == logging.WARNING
+        and "wait_for_client" in rec.message
+        and str(exc) in rec.message
+        for rec in caplog.records
+    )
+    # The listener bound successfully — the latch must stay set so a
+    # re-caller correctly short-circuits. This is the contract the
+    # wait-failure handling exists to preserve.
+    assert debug_mod._started is True
+
+
+def test_wait_for_client_keyboard_interrupt_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Ctrl-C during wait must propagate so the operator can abort —
+    # swallowing it would prevent process shutdown via SIGINT.
+    monkeypatch.setenv("DEBUG_PORT", "5678")
+    monkeypatch.setenv("DEBUG_WAIT", "true")
+
+    def listen(_: tuple[str, int]) -> None:
+        return None
+
+    def wait_interrupt() -> None:
+        raise KeyboardInterrupt
+
+    fake = types.ModuleType("debugpy")
+    fake.listen = listen  # type: ignore[attr-defined]
+    fake.wait_for_client = wait_interrupt  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "debugpy", fake)
+
+    with pytest.raises(KeyboardInterrupt):
+        maybe_start_debugpy()
 
 
 def test_debug_wait_false_skips_wait(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -475,6 +475,35 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/be/8bd693a0b9d53d48c8978fa5d889e06f3b5b03e45fd1ea1e78267b4887cb/debugpy-1.8.20-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:157e96ffb7f80b3ad36d808646198c90acb46fdcfd8bb1999838f0b6f2b59c64", size = 2099192, upload-time = "2026-01-29T23:03:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1b/85326d07432086a06361d493d2743edd0c4fc2ef62162be7f8618441ac37/debugpy-1.8.20-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:c1178ae571aff42e61801a38b007af504ec8e05fde1c5c12e5a7efef21009642", size = 3088568, upload-time = "2026-01-29T23:03:31.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/60/3e08462ee3eccd10998853eb35947c416e446bfe2bc37dbb886b9044586c/debugpy-1.8.20-cp310-cp310-win32.whl", hash = "sha256:c29dd9d656c0fbd77906a6e6a82ae4881514aa3294b94c903ff99303e789b4a2", size = 5284399, upload-time = "2026-01-29T23:03:33.678Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/09d49106e770fe558ced5e80df2e3c2ebee10e576eda155dcc5670473663/debugpy-1.8.20-cp310-cp310-win_amd64.whl", hash = "sha256:3ca85463f63b5dd0aa7aaa933d97cbc47c174896dcae8431695872969f981893", size = 5316388, upload-time = "2026-01-29T23:03:35.095Z" },
+    { url = "https://files.pythonhosted.org/packages/51/56/c3baf5cbe4dd77427fd9aef99fcdade259ad128feeb8a786c246adb838e5/debugpy-1.8.20-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:eada6042ad88fa1571b74bd5402ee8b86eded7a8f7b827849761700aff171f1b", size = 2208318, upload-time = "2026-01-29T23:03:36.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/7d/4fa79a57a8e69fe0d9763e98d1110320f9ecd7f1f362572e3aafd7417c9d/debugpy-1.8.20-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:7de0b7dfeedc504421032afba845ae2a7bcc32ddfb07dae2c3ca5442f821c344", size = 3171493, upload-time = "2026-01-29T23:03:37.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f2/1e8f8affe51e12a26f3a8a8a4277d6e60aa89d0a66512f63b1e799d424a4/debugpy-1.8.20-cp311-cp311-win32.whl", hash = "sha256:773e839380cf459caf73cc533ea45ec2737a5cc184cf1b3b796cd4fd98504fec", size = 5209240, upload-time = "2026-01-29T23:03:39.109Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/92/1cb532e88560cbee973396254b21bece8c5d7c2ece958a67afa08c9f10dc/debugpy-1.8.20-cp311-cp311-win_amd64.whl", hash = "sha256:1f7650546e0eded1902d0f6af28f787fa1f1dbdbc97ddabaf1cd963a405930cb", size = 5233481, upload-time = "2026-01-29T23:03:40.659Z" },
+    { url = "https://files.pythonhosted.org/packages/14/57/7f34f4736bfb6e00f2e4c96351b07805d83c9a7b33d28580ae01374430f7/debugpy-1.8.20-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:4ae3135e2089905a916909ef31922b2d733d756f66d87345b3e5e52b7a55f13d", size = 2550686, upload-time = "2026-01-29T23:03:42.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/b193a3975ca34458f6f0e24aaf5c3e3da72f5401f6054c0dfd004b41726f/debugpy-1.8.20-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:88f47850a4284b88bd2bfee1f26132147d5d504e4e86c22485dfa44b97e19b4b", size = 4310588, upload-time = "2026-01-29T23:03:43.314Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/55/f14deb95eaf4f30f07ef4b90a8590fc05d9e04df85ee379712f6fb6736d7/debugpy-1.8.20-cp312-cp312-win32.whl", hash = "sha256:4057ac68f892064e5f98209ab582abfee3b543fb55d2e87610ddc133a954d390", size = 5331372, upload-time = "2026-01-29T23:03:45.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/39/2bef246368bd42f9bd7cba99844542b74b84dacbdbea0833e610f384fee8/debugpy-1.8.20-cp312-cp312-win_amd64.whl", hash = "sha256:a1a8f851e7cf171330679ef6997e9c579ef6dd33c9098458bd9986a0f4ca52e3", size = 5372835, upload-time = "2026-01-29T23:03:47.245Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/fc500524cc6f104a9d049abc85a0a8b3f0d14c0a39b9c140511c61e5b40b/debugpy-1.8.20-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:5dff4bb27027821fdfcc9e8f87309a28988231165147c31730128b1c983e282a", size = 2539560, upload-time = "2026-01-29T23:03:48.738Z" },
+    { url = "https://files.pythonhosted.org/packages/90/83/fb33dcea789ed6018f8da20c5a9bc9d82adc65c0c990faed43f7c955da46/debugpy-1.8.20-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:84562982dd7cf5ebebfdea667ca20a064e096099997b175fe204e86817f64eaf", size = 4293272, upload-time = "2026-01-29T23:03:50.169Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/25/b1e4a01bfb824d79a6af24b99ef291e24189080c93576dfd9b1a2815cd0f/debugpy-1.8.20-cp313-cp313-win32.whl", hash = "sha256:da11dea6447b2cadbf8ce2bec59ecea87cc18d2c574980f643f2d2dfe4862393", size = 5331208, upload-time = "2026-01-29T23:03:51.547Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f7/a0b368ce54ffff9e9028c098bd2d28cfc5b54f9f6c186929083d4c60ba58/debugpy-1.8.20-cp313-cp313-win_amd64.whl", hash = "sha256:eb506e45943cab2efb7c6eafdd65b842f3ae779f020c82221f55aca9de135ed7", size = 5372930, upload-time = "2026-01-29T23:03:53.585Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2e/f6cb9a8a13f5058f0a20fe09711a7b726232cd5a78c6a7c05b2ec726cff9/debugpy-1.8.20-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9c74df62fc064cd5e5eaca1353a3ef5a5d50da5eb8058fcef63106f7bebe6173", size = 2538066, upload-time = "2026-01-29T23:03:54.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/56/6ddca50b53624e1ca3ce1d1e49ff22db46c47ea5fb4c0cc5c9b90a616364/debugpy-1.8.20-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:077a7447589ee9bc1ff0cdf443566d0ecf540ac8aa7333b775ebcb8ce9f4ecad", size = 4269425, upload-time = "2026-01-29T23:03:56.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d9/d64199c14a0d4c476df46c82470a3ce45c8d183a6796cfb5e66533b3663c/debugpy-1.8.20-cp314-cp314-win32.whl", hash = "sha256:352036a99dd35053b37b7803f748efc456076f929c6a895556932eaf2d23b07f", size = 5331407, upload-time = "2026-01-29T23:03:58.481Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d9/1f07395b54413432624d61524dfd98c1a7c7827d2abfdb8829ac92638205/debugpy-1.8.20-cp314-cp314-win_amd64.whl", hash = "sha256:a98eec61135465b062846112e5ecf2eebb855305acc1dfbae43b72903b8ab5be", size = 5372521, upload-time = "2026-01-29T23:03:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7", size = 5337658, upload-time = "2026-01-29T23:04:17.404Z" },
+]
+
+[[package]]
 name = "diff-cover"
 version = "10.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -576,11 +605,16 @@ wheels = [
 
 [[package]]
 name = "fastmcp-pvl-core"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "httpx" },
+]
+
+[package.optional-dependencies]
+debug = [
+    { name = "debugpy" },
 ]
 
 [package.dev-dependencies]
@@ -596,10 +630,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "debugpy", marker = "extra == 'debug'", specifier = ">=1.8" },
     { name = "fastmcp", specifier = ">=3.2.4,<4" },
     { name = "httpx", specifier = ">=0.27" },
 ]
-provides-extras = ["remote-auth"]
+provides-extras = ["remote-auth", "debug"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #34.

## Summary

- Adds `maybe_start_debugpy()` — an opt-in remote-debugger entrypoint that consumers call early in `main()`. Silent no-op unless `DEBUG_PORT` is set, so safe to ship in default scaffolds.
- Adds `[debug]` optional dep (`debugpy>=1.8`); helper logs `WARNING` and continues if `debugpy` is unavailable.
- README "Remote debugging in containers" section documents the env-var contract and carries the security warning for the `0.0.0.0` bind.

## Behaviour

| Input | Result |
| --- | --- |
| `DEBUG_PORT` unset / blank / parses-to-0 (`"0"`, `"00"`, `"+0"`, `"-0"`, `" 0 "`) | Silent no-op |
| `DEBUG_PORT` non-numeric or out of `1..65535` | `WARNING`, return |
| `DEBUG_PORT=5678`, `debugpy` not installed | `WARNING` (with install hint), return |
| `DEBUG_PORT=5678`, `debugpy.listen` fails (port in use, perm denied, etc.) | `WARNING`, return — server must not crash |
| `DEBUG_PORT=5678`, `DEBUG_WAIT=true` | listen, then block on `wait_for_client()` |
| Called twice in the same process | Second call is no-op (module-level latch, set only after `listen()` succeeds) |

## Naming choice

Env vars are `DEBUG_PORT` / `DEBUG_WAIT` — unprefixed — to match issue #34's spec verbatim and stay consistent with the sibling template-side change. The recorded trade-off: these names collide trivially with other tools that read the same names, but the alternative (`FASTMCP_DEBUG_PORT`) would diverge from the original contract and the consumer-facing docs in pvliesdonk/image-generation-mcp#154. If the collision becomes a real problem we can add a `FASTMCP_DEBUG_PORT` alias later without breaking the existing contract.

## Security

The listener binds `0.0.0.0` (intentional for container networking) and debugpy's DAP protocol is **unauthenticated** — any peer that reaches the port has arbitrary code execution as the server process. README and module docstring both warn explicitly: only enable in environments where the port is reachable solely from a trusted developer workstation (`kubectl port-forward`, `docker run -p 127.0.0.1:5678:5678`, SSH tunnel). Never publish on a public network.

## Out of scope (tracked separately)

The Dockerfile `DEBUG=false` build arg, conditional `--extra debug` install, `cli.py.jinja` wiring, and `docs/deployment/docker.md.jinja` are tracked in pvliesdonk/fastmcp-server-template#105 — they shape generated consumer repos rather than this shared library, and depend on a 1.2.x release that exposes `maybe_start_debugpy` and the `[debug]` extra.

## Test plan

- [x] `uv run pytest tests/test_debug.py -v` — 19 cases pass (parametrised zero-forms, parametrised `listen()`-failure exception types `OSError` / `PermissionError` / `RuntimeError`, latch-on-success ordering regression guard, idempotency, `DEBUG_WAIT` truthy + falsy paths)
- [x] `uv run pytest -q` — full suite 404 passing
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run mypy src` — clean
- [x] Coverage: 100% line coverage on `src/fastmcp_pvl_core/_debug.py`
- [x] Manual: `DEBUG_PORT=5678 python -c "from fastmcp_pvl_core import maybe_start_debugpy; maybe_start_debugpy()"` — only meaningful with `debugpy` installed; the listener path is exercised via the parametrised tests

## Local review circus

Both `pr-review-toolkit:code-reviewer` and `superpowers:code-reviewer` ran on the diff and came back nothing-flagged after addressing first-round findings (security note, `"00"` consistency bug, thread-safety doc, shell-quoting, broader failure-shape test coverage, latch-on-success regression guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)