### PR TITLE
docs(readme): bump API stability to 2.x; document ConfigurationError surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ auth, middleware, logging, config helpers, server-factory building blocks.
 
 - [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template) —
   copier template that scaffolds new FastMCP servers on top of this library.
-- Active consumers (as of 2026-04):
+- Active consumers:
   [`markdown-vault-mcp`](https://github.com/pvliesdonk/markdown-vault-mcp),
   [`scholar-mcp`](https://github.com/pvliesdonk/scholar-mcp),
   [`image-generation-mcp`](https://github.com/pvliesdonk/image-generation-mcp).
@@ -18,7 +18,7 @@ auth, middleware, logging, config helpers, server-factory building blocks.
 
 ## API stability
 
-This package is stable at 1.x and follows
+This package is stable at 2.x and follows
 [semantic versioning](https://semver.org/): breaking changes bump the
 major version, new features bump the minor, bugfixes bump the patch.
 "Public API" means symbols re-exported from the top-level
@@ -83,9 +83,18 @@ the file wins and a `WARNING` is logged. Subject strings are opaque to
 the library; the `<kind>:<id>` convention (`user:`, `service:`,
 `token:`) is documentation only.
 
-`MY_APP_BEARER_DEFAULT_SUBJECT` only applies to single-token mode; it
-is ignored when `MY_APP_BEARER_TOKENS_FILE` is set (mapped mode uses
-the per-token subjects from the TOML file).
+If `MY_APP_BEARER_TOKENS_FILE` is set but the file is missing,
+unparseable, or schema-invalid, the loader raises
+`fastmcp_pvl_core.ConfigurationError` at startup — the server fails
+fast rather than silently denying every request. The exception type
+is part of the public API; downstream code can `import` and `except`
+it as a stable contract.
+
+`MY_APP_BEARER_DEFAULT_SUBJECT` only applies when bearer auth runs in
+single-token mode (either standalone or as the bearer side of `multi`
+mode alongside OIDC). It is ignored when `MY_APP_BEARER_TOKENS_FILE`
+is set, including in `multi` mode — mapped mode uses the per-token
+subjects from the TOML file.
 
 ### Identifying the caller — `get_subject`
 

--- a/uv.lock
+++ b/uv.lock
@@ -605,7 +605,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp-pvl-core"
-version = "1.2.0"
+version = "2.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- README "stable at 1.x" → "stable at 2.x" (PR #39 cut the major).
- Drops bit-rotting "(as of 2026-04)" date in the Active consumers list.
- Adds a paragraph documenting that bearer-tokens-file errors raise `fastmcp_pvl_core.ConfigurationError` — type is in `__all__`, public-API contract.
- Clarifies `BEARER_DEFAULT_SUBJECT` behaviour in `multi` mode (was undocumented for the multi case).
- `uv.lock`: catches up the self-version line `1.2.0` → `2.0.0rc1` that PSR's release commit didn't touch; `uv lock --check` is now clean.

Closes #50.

Surfaced by the post-#40 forensic audit on 2026-05-04 (PRs #38/#39/#40 cumulative diff `48f7301..main`).

## Local review

- `pr-review-toolkit:code-reviewer`  ✅ (2 rounds — round 2 clean)
- `superpowers:code-reviewer`        ✅ (2 rounds — round 2 clean)

Round 1 second-opinion findings (both addressed in round 2):
- public-API surface of `ConfigurationError` was named but not made importable in the new prose
- terminology drift "multi deployments" vs "multi mode"

## Test plan

- [x] `uv sync --all-extras` clean
- [x] `uv run mypy src/` clean (no source change)
- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [x] `uv run pytest -q` 448 passing
- [x] `uv lock --check` clean after the version-line bump