### PR TITLE
chore(types): exhaustive build_auth dispatch + narrow set_current_auth_mode + drop AuthMode cast

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ dependencies = [
   # tokens-file loader uses it transparently via a sys.version_info
   # gate. Drop this dep once ``requires-python`` is bumped to >=3.11.
   "tomli>=2.0; python_version < '3.11'",
+  # typing_extensions provides ``assert_never`` on 3.10 (stdlib has it
+  # only in 3.11+). Same sys.version_info gate as tomli; drop alongside
+  # when ``requires-python`` is bumped to >=3.11.
+  "typing_extensions>=4.7; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/src/fastmcp_pvl_core/_auth.py
+++ b/src/fastmcp_pvl_core/_auth.py
@@ -11,15 +11,18 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeGuard, cast
 
 if sys.version_info >= (3, 11):
+    from typing import assert_never
+
     import tomllib
 else:  # pragma: no cover - fallback for Python 3.10
     # ``import-not-found`` covers CI rows where ``tomli`` is excluded by
     # the marker (3.11+); ``unused-ignore`` covers local 3.10 envs where
     # ``tomli`` is installed and the ignore would otherwise be flagged.
     import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
+    from typing_extensions import assert_never
 
 from fastmcp_pvl_core._config import ServerConfig
 from fastmcp_pvl_core._errors import ConfigurationError
@@ -46,6 +49,11 @@ AuthMode = Literal[
 _VALID_MODES: frozenset[Literal["remote", "oidc-proxy"]] = frozenset(
     {"remote", "oidc-proxy"}
 )
+
+
+def _is_valid_override(value: str) -> TypeGuard[Literal["remote", "oidc-proxy"]]:
+    """Narrow ``value`` to the override-valid subset of :data:`AuthMode`."""
+    return value in _VALID_MODES
 
 
 def resolve_auth_mode(config: ServerConfig) -> AuthMode:
@@ -80,9 +88,9 @@ def resolve_auth_mode(config: ServerConfig) -> AuthMode:
     """
     explicit = (config.auth_mode or "").strip().lower()
     if explicit:
-        if explicit in _VALID_MODES:
+        if _is_valid_override(explicit):
             logger.info("auth_mode=%s (explicit via AUTH_MODE)", explicit)
-            return cast(AuthMode, explicit)
+            return explicit
         logger.warning(
             "auth_mode_unknown value=%r — ignoring, falling back to auto-detection",
             explicit,
@@ -424,47 +432,54 @@ def build_auth(config: ServerConfig) -> Any:
     # tools called in stdio/no-auth servers still get ``"local"``.
     set_current_auth_mode(mode)
 
-    if mode == "none":
-        return None
-    if mode in ("bearer-single", "bearer-mapped"):
-        return build_bearer_auth(config)
-    if mode == "oidc-proxy":
-        return build_oidc_proxy_auth(config)
-    if mode == "remote":
-        return build_remote_auth(config)
+    # ``match``-based dispatch with an explicit ``case _`` calling
+    # ``assert_never`` makes adding a new :data:`AuthMode` literal a
+    # mypy error rather than a silent fall-through.
+    match mode:
+        case "none":
+            return None
+        case "bearer-single" | "bearer-mapped":
+            return build_bearer_auth(config)
+        case "oidc-proxy":
+            return build_oidc_proxy_auth(config)
+        case "remote":
+            return build_remote_auth(config)
+        case "multi":
+            oidc_auth: OIDCProxy | RemoteAuthProvider | None = build_oidc_proxy_auth(
+                config
+            ) or build_remote_auth(config)
+            bearer_auth = build_bearer_auth(config)
 
-    # mode == "multi"
-    oidc_auth: OIDCProxy | RemoteAuthProvider | None = build_oidc_proxy_auth(
-        config
-    ) or build_remote_auth(config)
-    bearer_auth = build_bearer_auth(config)
+            if oidc_auth is None or bearer_auth is None:
+                # One of the two builders returned None despite
+                # ``resolve_auth_mode`` reporting "multi" (e.g. remote-auth
+                # discovery failed, or httpx missing).  Fall back to
+                # whichever one is available rather than silently dropping
+                # auth entirely.
+                logger.warning(
+                    "multi_auth_degraded oidc=%s bearer=%s — falling back to "
+                    "whichever auth provider succeeded",
+                    oidc_auth is not None,
+                    bearer_auth is not None,
+                )
+                return oidc_auth or bearer_auth
 
-    if oidc_auth is None or bearer_auth is None:
-        # One of the two builders returned None despite resolve_auth_mode
-        # reporting "multi" (e.g. remote-auth discovery failed, or httpx
-        # missing).  Fall back to whichever one is available rather than
-        # silently dropping auth entirely.
-        logger.warning(
-            "multi_auth_degraded oidc=%s bearer=%s — falling back to "
-            "whichever auth provider succeeded",
-            oidc_auth is not None,
-            bearer_auth is not None,
-        )
-        return oidc_auth or bearer_auth
+            from fastmcp.server.auth import MultiAuth
 
-    from fastmcp.server.auth import MultiAuth
-
-    # required_scopes=[] is load-bearing: without it, OIDC's ["openid"]
-    # scope propagates to FastMCP's RequireAuthMiddleware and rejects
-    # bearer tokens lacking "openid" with 403 insufficient_scope
-    # (MV PR #249).
-    #
-    # OIDCProxy / RemoteAuthProvider (both OAuthProvider subclasses) MUST
-    # go in server= — passing an OAuthProvider in verifiers= silently
-    # drops its OAuth routes because get_routes/get_well_known_routes
-    # only delegate to self.server.
-    return MultiAuth(
-        server=oidc_auth,
-        verifiers=[bearer_auth],
-        required_scopes=[],
-    )
+            # ``required_scopes=[]`` is load-bearing: without it, OIDC's
+            # ``["openid"]`` scope propagates to FastMCP's
+            # RequireAuthMiddleware and rejects bearer tokens lacking
+            # ``openid`` with 403 insufficient_scope (MV PR #249).
+            #
+            # OIDCProxy / RemoteAuthProvider (both OAuthProvider
+            # subclasses) MUST go in ``server=`` — passing an
+            # ``OAuthProvider`` in ``verifiers=`` silently drops its OAuth
+            # routes because ``get_routes`` / ``get_well_known_routes``
+            # only delegate to ``self.server``.
+            return MultiAuth(
+                server=oidc_auth,
+                verifiers=[bearer_auth],
+                required_scopes=[],
+            )
+        case _:
+            assert_never(mode)

--- a/src/fastmcp_pvl_core/_subject.py
+++ b/src/fastmcp_pvl_core/_subject.py
@@ -10,7 +10,14 @@ module is a thin extractor.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from fastmcp.server.dependencies import get_access_token
+
+if TYPE_CHECKING:
+    # Imported only for typing; runtime import would create a cycle
+    # (``_auth`` imports ``set_current_auth_mode`` from this module).
+    from fastmcp_pvl_core._auth import AuthMode
 
 # Process-global pointer to the auth mode resolved at server startup.
 # ``build_auth`` calls ``set_current_auth_mode``; the most recent value
@@ -20,10 +27,10 @@ from fastmcp.server.dependencies import get_access_token
 #
 # This is a process-global rather than a contextvar by design — auth
 # mode is resolved once at startup and is invariant across requests.
-_current_auth_mode: str | None = None
+_current_auth_mode: AuthMode | None = None
 
 
-def set_current_auth_mode(mode: str | None) -> None:
+def set_current_auth_mode(mode: AuthMode | None) -> None:
     """Record the auth mode resolved at server startup.
 
     Called by :func:`fastmcp_pvl_core.build_auth`. Tests that exercise

--- a/uv.lock
+++ b/uv.lock
@@ -605,12 +605,13 @@ wheels = [
 
 [[package]]
 name = "fastmcp-pvl-core"
-version = "1.2.0"
+version = "2.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 
 [package.optional-dependencies]
@@ -635,6 +636,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=3.2.4,<4" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.7" },
 ]
 provides-extras = ["remote-auth", "debug"]
 


### PR DESCRIPTION
## Summary

- **`build_auth` dispatch** refactored from `if` chain to `match`/`case` with `case _: assert_never(mode)`. Adding a new `AuthMode` literal now becomes a mypy `arg-type` error at the `assert_never` call instead of silently falling through into the multi branch (the prior shape's hidden bug).
- **`set_current_auth_mode(mode)`** narrowed from `str | None` to `AuthMode | None`. The runtime import cycle (`_auth` ↔ `_subject`) is broken via `TYPE_CHECKING`, leveraging the existing `from __future__ import annotations`.
- **`cast(AuthMode, explicit)`** in `resolve_auth_mode` replaced with a small `_is_valid_override` `TypeGuard` helper — the cast was bypassing the static-typing gap; the TypeGuard makes the narrowing explicit and checked.
- **`typing_extensions>=4.7`** added as a 3.10-only dep mirroring the existing `tomli` pattern (stdlib's `typing.assert_never` is 3.11+).

Closes #48.

## Behaviour change (intentional, defensive)

The pre-refactor `if`/`elif` chain silently routed any unforeseen `mode` value to the multi branch. The new dispatch raises `AssertionError` via `assert_never` on impossible-by-typing inputs. Since `resolve_auth_mode` is the only producer and returns one of six literals, valid runtime paths are unchanged — but the refactor converts a silent-misroute foot-gun into a loud failure.

## Local review

Both reviewers ran adversarial verification (built deliberate-to-fail mypy reproductions in `/tmp` to confirm `assert_never`, the or-pattern in `case`, and the `TYPE_CHECKING` cycle break behave as claimed):

- `pr-review-toolkit:code-reviewer`  ✅ (round 1 clean)
- `superpowers:code-reviewer`        ✅ (round 1 clean)

## Test plan

- [x] `uv sync --all-extras`
- [x] `uv run mypy src/` clean (also verified for `--python-version` 3.10/3.11/3.12/3.13 by reviewer)
- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [x] `uv run pytest -q` 448 passing
- [x] Existing tests cover both branches of the new `_is_valid_override` TypeGuard via `test_auth_mode.py` parametrised cases

Surfaced by the post-#40 forensic audit on 2026-05-04.