### PR TITLE
refactor(config): single source of truth for bearer-anon; enforce non-blank invariant at construction

### DIFF
--- a/src/fastmcp_pvl_core/_auth.py
+++ b/src/fastmcp_pvl_core/_auth.py
@@ -226,16 +226,14 @@ def build_bearer_auth(config: ServerConfig) -> StaticTokenVerifier | None:
         logger.debug("bearer_auth_skipped reason=not_configured")
         return None
 
-    # ``env()`` already strips and falls back; this guard handles direct
-    # ``ServerConfig(bearer_default_subject="")`` construction where the
-    # empty value would otherwise produce a verifier with empty client_id.
-    default_subject = (config.bearer_default_subject or "").strip() or "bearer-anon"
-
+    # ``ServerConfig.__post_init__`` normalises blank/whitespace-only
+    # ``bearer_default_subject`` to the package default, so we can read
+    # the field directly without a defensive consumer-side fallback.
     logger.debug("bearer_auth_enabled token=<redacted>")
     return StaticTokenVerifier(
         tokens={
             token: {
-                "client_id": default_subject,
+                "client_id": config.bearer_default_subject,
                 "scopes": ["read", "write"],
             },
         },

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -16,6 +16,14 @@ from fastmcp_pvl_core._env import env, parse_bool, parse_scopes
 
 Transport = Literal["stdio", "http", "sse"]
 
+# Default subject string assigned to the single bearer-token mode (and
+# the bearer leg of ``multi`` mode when only ``bearer_token`` is set).
+# Mapped mode uses per-token subjects from the TOML file and ignores
+# this default. Referenced from the ``ServerConfig`` field default,
+# the env-loading fallback, and the ``__post_init__`` non-blank guard
+# below — three call sites, one source of truth.
+DEFAULT_BEARER_SUBJECT = "bearer-anon"
+
 
 @dataclass(frozen=True)
 class ServerConfig:
@@ -47,7 +55,31 @@ class ServerConfig:
     bearer_tokens_file: Path | None = None
     # Subject for the single-token bearer mode; ignored when
     # ``bearer_tokens_file`` is set (mapped mode uses per-token subjects).
-    bearer_default_subject: str = "bearer-anon"
+    bearer_default_subject: str = DEFAULT_BEARER_SUBJECT
+
+    def __post_init__(self) -> None:
+        """Enforce the non-blank ``bearer_default_subject`` invariant.
+
+        Blank / whitespace-only values are rewritten to
+        :data:`DEFAULT_BEARER_SUBJECT` rather than rejected, so that
+        direct construction (``ServerConfig(bearer_default_subject="")``)
+        stays permissive.  This guard exists specifically for the
+        direct-construction call site — the ``from_env`` path never
+        reaches it, because :func:`fastmcp_pvl_core._env.env` already
+        strips and falls back to its ``default`` argument before the
+        ``cls(...)`` call.
+
+        Without this guard, a downstream caller that constructs
+        ``ServerConfig`` directly with an empty string would otherwise
+        produce a ``StaticTokenVerifier`` entry with an empty
+        ``client_id`` — exactly the foot-gun the consumer-side
+        defensive fallback in ``_auth.py`` was previously papering over.
+        """
+        if not self.bearer_default_subject.strip():
+            # ``object.__setattr__`` bypasses the frozen-dataclass guard;
+            # this is the documented escape hatch for ``__post_init__``
+            # normalisation on a frozen dataclass.
+            object.__setattr__(self, "bearer_default_subject", DEFAULT_BEARER_SUBJECT)
 
     @classmethod
     def from_env(cls, env_prefix: str) -> ServerConfig:
@@ -88,7 +120,7 @@ class ServerConfig:
             Path(tokens_file_raw).expanduser() if tokens_file_raw else None
         )
         bearer_default_subject = env(
-            env_prefix, "BEARER_DEFAULT_SUBJECT", "bearer-anon"
+            env_prefix, "BEARER_DEFAULT_SUBJECT", DEFAULT_BEARER_SUBJECT
         )
 
         return cls(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,20 @@ class TestServerConfigDefaults:
     def test_bearer_default_subject_default(self):
         assert ServerConfig().bearer_default_subject == "bearer-anon"
 
+    def test_blank_bearer_default_subject_normalises_at_construction(self):
+        # The non-blank invariant lives on the dataclass (``__post_init__``),
+        # so direct construction with an empty / whitespace-only value
+        # must produce a config carrying the package default.  These
+        # assertions are observable on the construction surface itself,
+        # without relying on downstream consumers (``build_bearer_auth``)
+        # to paper over a blank subject.
+        assert ServerConfig(bearer_default_subject="").bearer_default_subject == (
+            "bearer-anon"
+        )
+        assert ServerConfig(bearer_default_subject="   ").bearer_default_subject == (
+            "bearer-anon"
+        )
+
 
 class TestServerConfigFromEnv:
     def test_reads_transport(self, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary

- **`DEFAULT_BEARER_SUBJECT`** module-level constant in `_config.py`, referenced from the field default and env fallback (one source of truth for the literal).
- **`__post_init__`** on `ServerConfig` normalises blank/whitespace-only `bearer_default_subject` to the package default via `object.__setattr__` (the documented frozen-dataclass escape hatch; same idiom already used in `_file_exchange_protocol.py`).
- **Drops** the consumer-side defensive `(config.bearer_default_subject or "").strip() or "bearer-anon"` in `build_bearer_auth`. The invariant lives at the dataclass layer now, not duplicated in every consumer.
- **New test** in `tests/test_config.py` asserts the construction-side invariant directly (not through the auth builder), since the SSOT moved onto the dataclass.

Closes #49.

Audit context: pre-existing `"bearer-anon"` literal was triple-duplicated across `_config.py:50`, `_config.py:91`, `_auth.py:232`, with the non-blank invariant enforced only by the consumer. Issue #49 spec called for SSOT + construction-time enforcement.

## Local review

- `pr-review-toolkit:code-reviewer`  ✅ (2 rounds — round 2 clean)
- `superpowers:code-reviewer`        ✅ (2 rounds — round 2 clean)

Round-1 second-opinion findings (both addressed in round 2):
1. `__post_init__` docstring claimed "matches `from_env` semantics" — inaccurate (env() strips at read-time so the from_env path never reaches the guard at all). Rewrote to state the guard is for the direct-construction call site only.
2. The construction-side invariant was only observable via the auth builder; added an explicit test on `ServerConfig` itself so the invariant is asserted at its true layer.

## Test plan

- [x] `uv sync --all-extras`
- [x] `uv run mypy src/` clean
- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [x] `uv run pytest -q` 449 passing (448 prior + 1 new construction-side invariant test)
- [x] Existing fall-back tests (`test_empty_default_subject_falls_back`, `test_whitespace_only_default_subject_falls_back` in `tests/test_auth_bearer_tokens_file.py`) still pass against the new architecture — they exercise the same end-to-end behaviour, just via a different invariant location.

Surfaced by the post-#40 forensic audit on 2026-05-04.