### PR TITLE
fix(auth): expand ~ in _load_bearer_tokens (single expansion site)

### DIFF
--- a/src/fastmcp_pvl_core/_auth.py
+++ b/src/fastmcp_pvl_core/_auth.py
@@ -124,10 +124,17 @@ def resolve_auth_mode(config: ServerConfig) -> AuthMode:
 def _load_bearer_tokens(path: Path) -> dict[str, str]:
     """Parse a bearer-token TOML file into a {token: subject} dict.
 
+    The path is normalised with :meth:`Path.expanduser` first.  This is
+    the single expansion site for both env-loaded configs (``from_env``
+    intentionally keeps a leading ``~`` literal) and direct-construction
+    configs (where ``Path("~/tokens.toml")`` also keeps the tilde
+    literal).  Both call sites converge on the same expanded path here.
+
     Raises:
         ConfigurationError: file missing, unparseable, schema-invalid, or
             containing empty/non-string values.
     """
+    path = path.expanduser()
     if not path.is_file():
         raise ConfigurationError(
             f"bearer tokens file not found or not a regular file: {path}"

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -84,9 +84,12 @@ class ServerConfig:
         )
 
         tokens_file_raw = env(env_prefix, "BEARER_TOKENS_FILE")
-        bearer_tokens_file = (
-            Path(tokens_file_raw).expanduser() if tokens_file_raw else None
-        )
+        # ``Path(...)`` keeps a leading ``~`` literal here.  Expansion is
+        # performed once, in :func:`fastmcp_pvl_core._auth._load_bearer_tokens`,
+        # so both this env-driven path and a directly-constructed
+        # ``ServerConfig(bearer_tokens_file=Path("~/tokens.toml"))`` resolve
+        # the tilde at the same call site.
+        bearer_tokens_file = Path(tokens_file_raw) if tokens_file_raw else None
         bearer_default_subject = env(
             env_prefix, "BEARER_DEFAULT_SUBJECT", "bearer-anon"
         )

--- a/tests/test_auth_bearer_tokens_file.py
+++ b/tests/test_auth_bearer_tokens_file.py
@@ -42,6 +42,27 @@ class TestBearerTokensFileLoader:
         with pytest.raises(ConfigurationError, match="not found"):
             build_bearer_auth(ServerConfig(bearer_tokens_file=tmp_path / "nope.toml"))
 
+    def test_tilde_path_expands_at_load_time(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Direct construction with a ``~``-prefixed path keeps the tilde
+        # literal on the dataclass; the loader normalises it via
+        # ``Path.expanduser`` so the file is found.
+        _write_tokens(tmp_path, '[tokens]\n"k1" = "user:alice"\n')
+        monkeypatch.setenv("HOME", str(tmp_path))
+        cfg = ServerConfig(bearer_tokens_file=Path("~/tokens.toml"))
+        # Field stays literal — the loader is the expansion site.
+        assert cfg.bearer_tokens_file is not None
+        assert str(cfg.bearer_tokens_file) == "~/tokens.toml"
+        # ``expanduser`` against the patched ``$HOME`` resolves to the
+        # same file the loader will touch.  This is the meaningful
+        # regression guard: removing ``expanduser`` from the loader
+        # would make ``build_bearer_auth`` raise "file not found".
+        assert cfg.bearer_tokens_file.expanduser() == tmp_path / "tokens.toml"
+        auth = build_bearer_auth(cfg)
+        assert auth is not None
+        assert auth.tokens["k1"]["client_id"] == "user:alice"
+
     def test_path_is_directory_raises_configuration_error(self, tmp_path: Path):
         directory = tmp_path / "tokens.toml"
         directory.mkdir()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from fastmcp_pvl_core import ServerConfig
+from fastmcp_pvl_core import ServerConfig, build_bearer_auth
 
 
 class TestServerConfigDefaults:
@@ -133,6 +133,12 @@ class TestServerConfigFromEnv:
         # actual file the loader will touch.
         assert config.bearer_tokens_file is not None
         assert config.bearer_tokens_file.expanduser() == token_file
+        # End-to-end: the loader resolves the tilde and returns a verifier
+        # carrying the mapped subject.  Symmetric with the loader-side test
+        # in ``test_auth_bearer_tokens_file.py::test_tilde_path_expands_at_load_time``.
+        auth = build_bearer_auth(config)
+        assert auth is not None
+        assert auth.tokens["k1"]["client_id"] == "user:alice"
 
     def test_reads_bearer_default_subject(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("MYAPP_BEARER_DEFAULT_SUBJECT", "service:bot")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from fastmcp_pvl_core import ServerConfig
@@ -112,6 +114,25 @@ class TestServerConfigFromEnv:
         monkeypatch.setenv("MYAPP_BEARER_TOKENS_FILE", str(token_file))
         config = ServerConfig.from_env("MYAPP")
         assert config.bearer_tokens_file == token_file
+
+    def test_bearer_tokens_file_keeps_tilde_literal(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        # ``from_env`` no longer expands ``~`` — the loader is the single
+        # expansion site.  Verifies the load-bearing change in this PR:
+        # the env-driven path stays literal on the dataclass and only
+        # resolves to the on-disk file when it reaches the loader.
+        token_file = tmp_path / "tokens.toml"
+        token_file.write_text('[tokens]\n"k1" = "user:alice"\n', encoding="utf-8")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("MYAPP_BEARER_TOKENS_FILE", "~/tokens.toml")
+        config = ServerConfig.from_env("MYAPP")
+        # Field is the literal ``~/tokens.toml`` — not expanded yet.
+        assert str(config.bearer_tokens_file) == "~/tokens.toml"
+        # Expanding by hand (with the patched ``$HOME``) lands on the
+        # actual file the loader will touch.
+        assert config.bearer_tokens_file is not None
+        assert config.bearer_tokens_file.expanduser() == token_file
 
     def test_reads_bearer_default_subject(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("MYAPP_BEARER_DEFAULT_SUBJECT", "service:bot")


### PR DESCRIPTION
## Summary

- **Single expansion site** — `_load_bearer_tokens` now calls `Path.expanduser` first.
- **`from_env` no longer expands** — the dataclass holds the literal tilde-prefixed path; the loader resolves it.
- Both call sites (env-driven and direct construction) now converge on the same expanded path at the loader.
- Two new tests cover both code paths.

Closes #46.

Audit context: pre-existing behaviour was inconsistent — `from_env` expanded `~`, but direct construction `ServerConfig(bearer_tokens_file=Path('~/tokens.toml'))` did not, leading to a confusing "file not found" diagnostic for the second case. Issue #46 spec called for unifying expansion at the loader.

## Test plan

- [x] `uv sync --all-extras`
- [x] `uv run mypy src/` clean
- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [x] `uv run pytest -q` 450 passing (448 prior + 2 new tilde tests)
- [x] New direct-construction test: `tests/test_auth_bearer_tokens_file.py::test_tilde_path_expands_at_load_time`
- [x] New env-loaded test: `tests/test_config.py::test_bearer_tokens_file_keeps_tilde_literal`

## Local review

- `pr-review-toolkit:code-reviewer`  ✅ (2 rounds — round 2 clean)
- `superpowers:code-reviewer`        ✅ (2 rounds — round 2 clean)

Round-1 findings (all addressed in round 2):
1. Loader docstring claimed "env helper already resolves a tilde via filesystem semantics" — wrong on both counts. Rewrote.
2. `samefile` assertion in the direct-construction test was tautological. Replaced with a meaningful `expanduser() ==` check.
3. The env-loaded-with-tilde path had zero direct test coverage. Added a symmetric test in `tests/test_config.py`.

Surfaced by the post-#40 forensic audit on 2026-05-04.