### PR TITLE
docs(spec): strip abandoned PR #37 sections from auth-subject-authz; rewrite ctx_or_request paragraph

### DIFF
--- a/docs/specs/auth-subject-authz.md
+++ b/docs/specs/auth-subject-authz.md
@@ -1,11 +1,11 @@
-# Auth subject extraction & optional authorization submodule
+# Auth subject extraction
 
 Design spec for issues
-[#35](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/35),
-[#36](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/36),
-[#37](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/37).
+[#35](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/35) and
+[#36](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/36).
 
-Date: 2026-05-03.
+Date: 2026-05-04 (revised post-implementation; supersedes the
+2026-05-03 draft).
 
 ## Problem
 
@@ -16,31 +16,40 @@ ACLs, request metadata). OIDC already produces a real subject from the `sub`
 claim; the bearer surface needs a comparable affordance for deployments that
 prefer pre-shared tokens (CI bots, service-to-service, small teams, no IdP).
 
-Once a real subject exists across all auth modes, the next two layers can land:
-a uniform `get_subject()` extractor so downstream code stops poking at
-the auth context directly, and an optional `authorization` submodule providing
-the `subject + tenant + required_scope → allow/deny` middleware that several
-consuming servers will otherwise reinvent.
+Once a real subject exists across all auth modes, downstream code wants a
+uniform `get_subject()` extractor so it stops poking at the auth context
+directly.
+
+A follow-on optional `authorization` submodule (subject + tenant + required
+scope → allow / deny middleware) is described separately in
+[`authorization-submodule.md`](authorization-submodule.md) — that work was
+attempted in 2026-05 and abandoned mid-implementation; issue #37 remains
+open.
 
 ## Scope
 
-This spec covers three sequential pull requests, one per issue:
+This spec covers the two issues whose work shipped:
 
-1. **PR #35** — `{PREFIX}_BEARER_TOKENS_FILE` + bearer-mapped auth mode.
-2. **PR #36** — `get_subject()` helper with unified extraction logic.
-3. **PR #37** — optional `fastmcp_pvl_core.authorization` submodule (middleware,
-   ACL store, scope vocabulary, admin tools, optional git-commit integration).
+1. **Issue #35**, shipped as
+   [PR #39](https://github.com/pvliesdonk/fastmcp-pvl-core/pull/39) —
+   `{PREFIX}_BEARER_TOKENS_FILE` + bearer-mapped auth mode.
+2. **Issue #36**, shipped as
+   [PR #40](https://github.com/pvliesdonk/fastmcp-pvl-core/pull/40) —
+   `get_subject()` helper with unified extraction logic.
 
-PR #35 is a breaking change (renames the `AuthMode` literal `"bearer"` to
-`"bearer-single"`) and triggers a major version bump (1.x → 2.0). PR #36 and
-#37 are additive and ship as `2.1.0` / `2.2.0` respectively under the existing
-PSR + conventional-commits flow.
+Issue #35's implementation (PR #39) is a breaking change — it renames
+the `AuthMode` literal `"bearer"` to `"bearer-single"` and changes the
+single-token `client_id` from the literal `"bearer"` to a configurable
+default subject. The originating issue framed itself as
+backward-compatible; the breaking-change framing here was a scope
+expansion accepted during implementation. See
+[#45](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/45) for the
+discrepancy resolution. Together with PR #40 the work shipped under
+the 2.0 major bump (`2.0.0-rc.1`).
 
 ## Design
 
-### Subject extraction (PR #35 + #36)
-
-#### `ServerConfig` additions
+### `ServerConfig` additions
 
 Two new fields on `ServerConfig`, populated by `from_env`:
 
@@ -53,7 +62,7 @@ The per-app prefix is intentional: it matches the existing
 `{PREFIX}_BEARER_TOKEN` convention and lets multi-tenant hosts run several
 servers with separate token files.
 
-#### Token file format
+### Token file format
 
 ```toml
 # bearer-tokens.toml
@@ -65,14 +74,14 @@ servers with separate token files.
 Subject strings are opaque to the library. The `<kind>:<id>` convention
 (`user:`, `service:`, `token:`) is documentation only.
 
-#### Builder behavior
+### Builder behavior
 
-`build_bearer_auth(config)` is rewritten to handle three cases:
+`build_bearer_auth(config)` handles three cases:
 
 1. `bearer_tokens_file` is set:
    - Parse the file at startup. Malformed TOML, missing file, blank file, or
-     schema-invalid contents raise a new `ConfigurationError` exception
-     (fail-fast — never silent denial).
+     schema-invalid contents raise `ConfigurationError` (fail-fast — never
+     silent denial).
    - Build `StaticTokenVerifier(tokens={token: {"client_id": <subject>,
      "scopes": ["read", "write"]}})`. The per-token `client_id` carries the
      subject all the way to `access_token.client_id` at request time.
@@ -84,27 +93,28 @@ Subject strings are opaque to the library. The `<kind>:<id>` convention
    literal string `"bearer"`).
 3. Neither is set: returns `None` (unchanged).
 
-#### `AuthMode` literal — breaking change
+### `AuthMode` literal — breaking change
 
 `AuthMode` becomes `none | bearer-single | bearer-mapped | remote | oidc-proxy
 | multi`. `resolve_auth_mode` distinguishes the two bearer flavors by
 `bearer_tokens_file` presence; `multi` continues to mean "any bearer flavor +
 any OIDC". This is a breaking change for any consumer that switches on the
-literal `"bearer"`; it lands together with PR #35 and drives the 2.0 major
-bump.
+literal `"bearer"`; it lands together with issue #35 and drives the 2.0
+major bump.
 
 A second observable change rides along: the per-token `client_id` in
 `StaticTokenVerifier` was previously the literal `"bearer"` and becomes
 `bearer_default_subject` (`"bearer-anon"` by default) in single-token mode, or
-the per-token mapped subject in mapped mode. Code that read `access_token.
-client_id` to gate behavior on the literal `"bearer"` will need to update;
-this is documented in the PR #35 release notes.
+the per-token mapped subject in mapped mode. Code that read
+`access_token.client_id` to gate behavior on the literal `"bearer"` will
+need to update; this is documented in the PR #39 release notes.
 
-#### `get_subject() -> str | None` (PR #36)
+### `get_subject() -> str | None` (issue #36 / PR #40)
 
-New module `_subject.py`, exported from the package root. Implementation is
-mode-agnostic at runtime — the per-mode logic was already pushed into the
-builders:
+New module `_subject.py`, exported from the package root. The signature
+takes no arguments — the function reads the auth context via FastMCP's
+ambient `get_access_token()` dependency and the package-internal
+auth-mode pointer set by `build_auth`.
 
 ```python
 def get_subject() -> str | None:
@@ -125,252 +135,104 @@ def get_subject() -> str | None:
     return None
 ```
 
-`_current_auth_mode` is a process-global pointer set at server startup by a
-module-level `set_current_auth_mode(mode)` that `build_auth` calls before
-returning.
+`_current_auth_mode` is a process-global pointer set at server startup by
+a module-level `set_current_auth_mode(mode)` that `build_auth` calls
+after resolving the mode and before any early return — so
+`get_subject()` returns `"local"` even in stdio/no-auth servers where
+`build_auth` itself returns `None`.
 
-A previous draft of this spec proposed an optional positional `ctx_or_request`
-parameter for forward-compat, but local code review concluded the parameter
-was a future-evolution trap (a leading-underscore positional on a public-API
-symbol is non-standard, `object` typing offers no IDE help, downstream
-consumers passing a context would silently have it ignored). The v1
-implementation drops the parameter; a future version that needs explicit
-context will add it as a named parameter or a separate overload — both are
-non-breaking additions on a no-arg signature.
+The architectural questions raised by this design — the module-global
+mutable state (which doesn't survive concurrent `build_auth` calls in a
+multi-server-in-one-process setup), the typed contract on
+`set_current_auth_mode`, missing end-to-end integration tests for tool /
+middleware / resource surfaces — are tracked separately in
+[#42](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/42),
+[#48](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/48), and
+[#44](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/44).
 
-#### README drift fix (PR #35)
+### README drift fix (PR #39)
 
-The README example currently shows `auth=build_auth("MY_APP", config)`; the
-real signature is `build_auth(config)`. PR #35 corrects this in the same diff.
-
-### Authorization submodule (PR #37)
-
-#### Module layout
-
-New package directory `src/fastmcp_pvl_core/authorization/`:
-
-| File | Purpose |
-|---|---|
-| `__init__.py` | Public exports |
-| `_middleware.py` | `AuthorizationMiddleware`, `AuthzDenied` |
-| `_store.py` | TOML loader, schema validation, in-memory `ACL` model |
-| `_admin.py` | `register_acl_admin_tools` + the four admin tool implementations |
-| `_git.py` | Internal helper for `commit_acl_to_git` |
-
-Re-exported from `fastmcp_pvl_core`: `AuthorizationMiddleware`,
-`register_acl_admin_tools`, `TenantResolver` (Protocol), `AuthzDenied`,
-`build_authorization_middleware`.
-
-#### `AuthorizationMiddleware`
-
-Installed via the existing `wire_middleware_stack(mcp, extra=[...])`
-extension point. Hooks:
-
-- **Tool call:** `subject = get_subject()`;
-  `tenant = tenant_resolver(request)`;
-  `required = annotation.get("requires_scope", "read")`;
-  ACL lookup → continue or raise `AuthzDenied`.
-- **Resource read:** same flow, but tenant comes from the resource's
-  `requires_tenant` annotation. **Permissive default: resources without the
-  annotation pass through unfiltered**, so existing downstream resources keep
-  working when authz is enabled until they opt in.
-- **`resources/list`:** filter the listing using the same per-resource logic;
-  resources without `requires_tenant` always included.
-
-`AuthzDenied` returns the structured error
-`{code: "authz_denied", subject, tenant, missing_scope}`.
-
-#### `TenantResolver`
-
-```python
-class TenantResolver(Protocol):
-    def __call__(self, request: object) -> str | None: ...
-```
-
-Domain code provides the callable. For tool calls, typically extracts
-`tenant_id` (or domain-specific name like `project_id`) from tool args; may
-fall back to a configured default. Returns `None` for tenant-less operations
-— the middleware then checks the wildcard tenant `*` only.
-
-#### Resource `requires_tenant` annotation
-
-Annotation value is one of:
-
-- `str` — static tenant ID, applies to the whole resource.
-- `Callable[[str, dict], str | None]` — given the resolved URI and any
-  URI-template match groups, return the tenant. Domain owns the logic; the
-  helper for the common templated case (`vault://{tenant_id}/...`) is just
-  `lambda uri, params: params.get("tenant_id")`.
-
-#### Scope vocabulary
-
-Three flat scopes, ordered: `read < write < admin`. Tool annotation
-`requires_scope`, default `"read"` for unannotated tools. An internal helper
-`_satisfies(granted: set[str], required: str) -> bool` encodes the ordering.
-
-#### ACL TOML store
-
-```toml
-[subjects."user:alice@example.com".tenants]
-"*" = ["read", "write", "admin"]
-
-[subjects."service:ci-bot".tenants]
-"*" = ["read"]
-
-[default]
-tenants = {}
-```
-
-- Wildcard `*` allowed on the tenant side only; subject-side wildcard rejected
-  at load time with a clear `ConfigurationError`.
-- Reload-on-each-request: file mtime checked, re-parsed on change. Cheap;
-  filesystem watch is out of scope for v1.
-- ACL absent: log `WARNING` once per process, default-deny.
-- Schema-invalid: load fails the request with `authz_denied` carrying a clear
-  reason — never silent allow.
-
-#### Admin tools
-
-`register_acl_admin_tools(mcp)` registers four tools, all annotated
-`requires_scope: "admin"`:
-
-| Tool | Behavior |
-|---|---|
-| `acl_list_subjects()` | Returns ACL filtered to tenants the caller admins. Caller with admin on `*` sees the full ACL. |
-| `acl_grant(subject, tenant, scopes, intent)` | Adds/extends grants. `intent` is a free-form audit string, **required**, written to the git commit message when `commit_acl_to_git=True`. |
-| `acl_revoke(subject, tenant, scopes, intent)` | Removes grants. |
-| `acl_set_default(scopes, intent)` | Replaces `[default].tenants["*"]`. |
-
-#### Mutation flow
-
-Single function path used by all three mutating tools:
-
-1. Load current ACL from disk.
-2. Apply mutation in memory.
-3. Validate the result against the schema (defense-in-depth).
-4. Write back atomically (temp-file + `os.replace`).
-5. If `commit_acl_to_git`: invoke `_git.commit_acl(path, intent, subject)` —
-   runs `git -C <repo> add <path>` then `git commit -m "acl: <intent>" --author
-   "<subject>"`. Surface git failures as a tool error *after* the file write
-   succeeded (i.e. the ACL is updated; the operator is told the commit didn't
-   happen).
-
-#### Configuration
-
-The library does not add fields to `ServerConfig` for authz; the submodule is
-opt-in per server. Domain code declares its own config fields:
-
-| Field | Default | Meaning |
-|---|---|---|
-| `enabled: bool` | `False` | Master switch. |
-| `acl_path: Path` | (required when enabled) | Path to the ACL TOML. |
-| `tenant_resolver: TenantResolver` | (required when enabled) | Callable to extract tenant from request. |
-| `commit_acl_to_git: bool` | `False` | Commit ACL mutations to git. |
-
-Helper `build_authorization_middleware(config) -> AuthorizationMiddleware |
-None` returns `None` when `enabled=False`; downstream code uses
-`wire_middleware_stack(mcp, extra=[m] if (m := build_authorization_middleware(
-config)) else [])`.
-
-#### Out of scope (v1)
-
-Verbatim from issue #37:
-
-- Per-document/per-node ACLs (tenant-grain only).
-- Role hierarchy beyond the three flat scopes.
-- OIDC group-mapping (subject-string-only ACLs); group-based extension is
-  additive — middleware lookup function changes, surface doesn't.
-- Structured audit log of failed authz beyond standard middleware logging.
+The README example previously showed `auth=build_auth("MY_APP", config)`;
+the real signature is `build_auth(config)`. PR #39 corrected this in
+the same diff.
 
 ## Testing
 
-Each PR ships its own tests. mypy-strict and ruff are gates per pyproject.toml.
+mypy-strict and ruff are gates per `pyproject.toml`. Each PR shipped
+its own tests.
 
-### PR #35
+### Issue #35 / PR #39
 
 - `test_auth_bearer_tokens_file.py` — TOML load happy path; malformed TOML →
   `ConfigurationError`; missing file → `ConfigurationError`; blank file →
-  `ConfigurationError`; both env vars set → WARNING + file wins; mapped token
-  → request succeeds with the mapped subject visible on
-  `access_token.client_id`; unmapped token → 401.
+  `ConfigurationError`; both env vars set → WARNING + file wins; mapped
+  token → request succeeds with the mapped subject visible on
+  `access_token.client_id`. The "unmapped token → 401" assertion was
+  delegated to fastmcp's `StaticTokenVerifier` and is being added as a
+  direct test in [#47](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/47).
 - `test_auth_mode.py` extended — `bearer-single` vs `bearer-mapped`
   resolution; `multi` mode with mapped bearer.
 - `test_config.py` extended — `bearer_tokens_file` and
   `bearer_default_subject` populate from env.
 
-### PR #36
+### Issue #36 / PR #40
 
 - `test_subject.py` — unit tests covering each branch of `get_subject`'s
   resolution order: `auth_mode=="none"` returns `"local"`, bearer-single
   uses the default subject from `client_id`, bearer-mapped uses the
   mapped subject, OIDC prefers `claims["sub"]` and falls back to
-  `client_id` when `sub` is absent, and missing-token-with-auth-required
-  returns `None`. Implementation reads FastMCP's ambient context via
-  `get_access_token`; tests patch that single call site rather than
-  spinning up a full FastMCP server.
-
-### PR #37
-
-- `test_authz_store.py` — schema validation; wildcard expansion; default-deny;
-  reload-on-mtime-change; subject-wildcard rejected.
-- `test_authz_middleware.py` — tool denial; scope ordering; tenant-less
-  operation (global wildcard); permissive default for resources without
-  `requires_tenant`; structured `authz_denied` shape.
-- `test_authz_admin.py` — non-admin caller refused; grant/revoke/set_default
-  flows; `intent` required; atomic write under simulated crash;
-  `commit_acl_to_git` happy path + git failure surfaces tool error post-write.
-- `test_authz_resource_filtering.py` — `resources/list` filtered correctly with
-  mixed annotated and unannotated resources.
+  `client_id` when `sub` is absent or empty, and missing-token-with-
+  auth-required returns `None`. Implementation reads FastMCP's ambient
+  context via `get_access_token`; tests patch that single call site
+  rather than spinning up a full FastMCP server.
+- The originating issue's "works equally from inside a tool body, a
+  middleware, and a resource handler" verification is *not* covered by
+  these unit tests; integration tests against a real FastMCP server are
+  tracked in [#44](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/44).
 
 ## PR-by-PR breakdown
 
-### PR #35 — `feat(auth)!: support {PREFIX}_BEARER_TOKENS_FILE for token→subject mapping`
+### Issue #35 / PR #39 — `feat(auth)!: support {PREFIX}_BEARER_TOKENS_FILE for token→subject mapping`
 
-- `closes #35`
-- Triggers the 2.0 major bump (rename of the `AuthMode` literal).
-- Files: `_auth.py`, `_config.py`, new `_errors.py` for `ConfigurationError`,
-  new tests, `__init__.py` exports, README drift fix.
-- Verification list (from issue #35):
+- Closes
+  [issue #35](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/35).
+- Triggered the 2.0 major bump (rename of the `AuthMode` literal +
+  `client_id` default change).
+- Files: `_auth.py`, `_config.py`, new `_errors.py` for
+  `ConfigurationError`, new tests, `__init__.py` exports, README drift
+  fix.
+- Issue verification list:
   - `{PREFIX}_BEARER_TOKENS_FILE=<path>` loads and a request with a mapped
     token reports the correct subject via the auth context.
   - `{PREFIX}_BEARER_TOKEN=<token>` (single) continues to work; subject is
     `bearer_default_subject` (default `"bearer-anon"`).
   - Both env vars set → WARNING logged and file mode active.
-  - Unmapped token → 401.
+  - Unmapped token → 401 (delegated to `StaticTokenVerifier`; direct test
+    pending — see issue #47).
   - Malformed/missing file → fail-fast at startup with a clear
     `ConfigurationError`.
 
-### PR #36 — `feat(auth): get_subject helper for uniform subject extraction`
+### Issue #36 / PR #40 — `feat(auth): get_subject helper for uniform subject extraction`
 
-- `closes #36`
-- Branched from `main` after #35 lands.
-- Files: new `_subject.py`; `__init__.py` exports `get_subject`; new tests;
-  README adds a short "Identifying the caller" section pointing at
-  `get_subject`.
-- Verification list (from issue #36): each auth mode returns the expected
-  subject shape; `get_subject` works equally from inside tool bodies,
-  middleware, and resource handlers; `auth_mode` reporting in startup logs
-  aligns with the values the function returns.
-
-### PR #37 — `feat(authorization): optional fastmcp_pvl_core.authorization submodule`
-
-- `closes #37`
-- Branched from `main` after #36 lands.
-- Files: new `authorization/` package (5 files); top-level `__init__.py`
-  exports; new tests; README adds an "Authorization (optional)" section with
-  the wiring example; `pyproject.toml` adds an `authorization` extra
-  (currently empty — reserved so a future `pygit2` switch doesn't bloat the
-  default install).
-- Verification list (from issue #37): default deny; wildcard expansion; scope
-  ordering; admin tools refuse non-admin callers; ACL disabled → middleware
-  is a no-op; `resources/list` filtering correct.
+- Closes
+  [issue #36](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/36).
+- Branched from `main` after PR #39 landed.
+- Files: new `_subject.py`; `__init__.py` exports `get_subject`; new
+  unit tests; README adds a short "Identifying the caller" section
+  pointing at `get_subject`.
+- Issue verification list: each auth mode returns the expected subject
+  shape; `auth_mode` reporting in startup logs aligns with the values
+  the function returns.  The "from inside tool / middleware / resource"
+  AC remains unverified at the integration level — see issue #44.
 
 ## Versioning
 
-PSR (semantic-release) drives versions from conventional-commit subject lines.
-PR #35's commit footer carries `BREAKING CHANGE: bearer auth-mode literal
-renamed from "bearer" to "bearer-single"` to trigger 2.0. PR #36 and #37 ship
-as `feat:` minors (2.1, 2.2). `CHANGELOG.md` is PSR-managed.
+PSR (semantic-release) drives versions from conventional-commit subject
+lines. PR #39's commit footer carries `BREAKING CHANGE:` markers for
+both observable breaks (the `AuthMode` rename and the `client_id`
+default change). PR #39 + PR #40 shipped together as `2.0.0-rc.1`;
+subsequent fixes (the post-#40 audit cleanup cluster, issues #41–#51)
+ride future PSR-determined minors. `CHANGELOG.md` is PSR-managed.
 
 ## Local review discipline
 
@@ -379,10 +241,8 @@ draft:
 
 1. `pr-review-toolkit:code-reviewer` on the cumulative diff.
 2. `superpowers:code-reviewer` on the same diff.
-3. Targeted reviewers when the diff calls for them: `silent-failure-hunter`
-   (PR #37 — error/fallback logic in mutation flow), `type-design-analyzer`
-   (PR #37 — new `TenantResolver` protocol, `ACL` model), `pr-test-analyzer`
-   (all three PRs).
+3. Targeted reviewers when the diff calls for them: `silent-failure-hunter`,
+   `type-design-analyzer`, `pr-test-analyzer`, `comment-analyzer`.
 4. Bar: nothing flagged at any severity from either reviewer.
 5. Bot iteration after open capped at one round; escalate if a third would be
    needed.
@@ -392,31 +252,16 @@ PRs open as draft. Flip to ready only after CI green and bot LGTM bodies
 
 ## Driving consumers
 
-`pvliesdonk/reqeng-mcp` Phase 2 (write-substrate) is the immediate driver:
-needs per-user attribution for ACLs and audit metadata, and the authz
-submodule directly. Likely future consumers: any multi-tenant MCP server in
-the PVL ecosystem.
+`pvliesdonk/reqeng-mcp` Phase 2 (write-substrate) is the immediate
+driver: needs per-user attribution for ACLs and audit metadata. Likely
+future consumers: any multi-tenant MCP server in the PVL ecosystem.
 
-Once PR #37 lands, `pvliesdonk/fastmcp-server-template` needs three matching
-scaffold-side stanzas. Stub issues already filed against the template repo,
-each with a `Depends-on:` pointer back to upstream:
+The downstream `authorization` submodule (issue #37) — the deeper
+machinery for ACLs / admin tools / scope vocabulary — is described in
+[`authorization-submodule.md`](authorization-submodule.md). That spec
+is currently DRAFT and not implemented; treat it as forward design only.
 
-- [`pvliesdonk/fastmcp-server-template#94`](https://github.com/pvliesdonk/fastmcp-server-template/issues/94)
-  — commented `acl_enabled` field in the `CONFIG-FIELDS-START`/`-END` block
-  of `config.py.jinja`, plus the matching `CONFIG-FROM-ENV-*` env reader.
-- [`pvliesdonk/fastmcp-server-template#95`](https://github.com/pvliesdonk/fastmcp-server-template/issues/95)
-  — commented `AuthorizationMiddleware` + `register_acl_admin_tools` wiring
-  in `server.py.jinja` after `wire_middleware_stack(mcp)`.
-- [`pvliesdonk/fastmcp-server-template#96`](https://github.com/pvliesdonk/fastmcp-server-template/issues/96)
-  — multi-tenant deployment section in `README.md.jinja` (ACL TOML format,
-  admin tool walkthrough, deployment matrix, pointer to upstream reference
-  docs). Also depends on PR #35 because the deployment matrix includes the
-  bearer-mapped flavor.
+## See also
 
-The template-side surface stays in sync with this upstream spec. When the
-submodule's API names or env var conventions settle here, the three template
-PRs land with exactly the matching strings — no drift between
-`fastmcp_pvl_core` and the template scaffold. As implementation lands in this
-repo, the corresponding template PR is the natural follow-up; tracking via
-the issues above. Not in scope for this spec, but called out so the
-cross-repo coupling is explicit.
+- [`authorization-submodule.md`](authorization-submodule.md) — DRAFT
+  follow-on spec for the optional authorization submodule (issue #37).

--- a/docs/specs/authorization-submodule.md
+++ b/docs/specs/authorization-submodule.md
@@ -1,0 +1,206 @@
+# Authorization submodule — DRAFT
+
+> **Status: DRAFT — not implemented.** The work described here was
+> attempted in 2026-05 and abandoned mid-implementation. The
+> originating issue [#37](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/37)
+> is still **open**; pick up here when work resumes. Nothing in this
+> document corresponds to shipped code: there is no
+> `fastmcp_pvl_core.authorization` package on `main`, and the symbols
+> referenced below (`AuthorizationMiddleware`, `register_acl_admin_tools`,
+> `TenantResolver`, etc.) do not exist.
+
+## Problem
+
+A growing set of MCP servers in this ecosystem (`pvliesdonk/reqeng-mcp`
+first, future multi-tenant servers next) need fine-grained per-tenant
+per-subject access control distinct from connection-level auth. The
+pattern is uniform: subject (from auth) + tenant (from request) +
+required scope (per-tool annotation) → allow / deny.
+
+Doing this per-server reinvents the same middleware, ACL file format,
+admin tools, and tenant resolver protocol every time. This spec moves
+the machinery upstream as an optional submodule.
+
+Depends on issues #35 (bearer subject mapping — shipped as PR #39) and
+#36 (`get_subject` helper — shipped as PR #40); see
+[`auth-subject-authz.md`](auth-subject-authz.md) for those.
+
+## Module layout
+
+New package directory `src/fastmcp_pvl_core/authorization/`:
+
+| File | Purpose |
+|---|---|
+| `__init__.py` | Public exports |
+| `_middleware.py` | `AuthorizationMiddleware`, `AuthzDenied` |
+| `_store.py` | TOML loader, schema validation, in-memory `ACL` model |
+| `_admin.py` | `register_acl_admin_tools` + the four admin tool implementations |
+| `_git.py` | Internal helper for `commit_acl_to_git` |
+
+Re-exported from `fastmcp_pvl_core`: `AuthorizationMiddleware`,
+`register_acl_admin_tools`, `TenantResolver` (Protocol), `AuthzDenied`,
+`build_authorization_middleware`.
+
+## `AuthorizationMiddleware`
+
+Installed via the existing `wire_middleware_stack(mcp, extra=[...])`
+extension point. Hooks:
+
+- **Tool call:** `subject = get_subject()`;
+  `tenant = tenant_resolver(request)`;
+  `required = annotation.get("requires_scope", "read")`;
+  ACL lookup → continue or raise `AuthzDenied`.
+- **Resource read:** same flow, but tenant comes from the resource's
+  `requires_tenant` annotation. **Permissive default: resources without the
+  annotation pass through unfiltered**, so existing downstream resources keep
+  working when authz is enabled until they opt in.
+- **`resources/list`:** filter the listing using the same per-resource logic;
+  resources without `requires_tenant` always included.
+
+`AuthzDenied` returns the structured error
+`{code: "authz_denied", subject, tenant, missing_scope}`.
+
+## `TenantResolver`
+
+```python
+class TenantResolver(Protocol):
+    def __call__(self, request: object) -> str | None: ...
+```
+
+Domain code provides the callable. For tool calls, typically extracts
+`tenant_id` (or domain-specific name like `project_id`) from tool args; may
+fall back to a configured default. Returns `None` for tenant-less operations
+— the middleware then checks the wildcard tenant `*` only.
+
+## Resource `requires_tenant` annotation
+
+Annotation value is one of:
+
+- `str` — static tenant ID, applies to the whole resource.
+- `Callable[[str, dict], str | None]` — given the resolved URI and any
+  URI-template match groups, return the tenant. Domain owns the logic; the
+  helper for the common templated case (`vault://{tenant_id}/...`) is just
+  `lambda uri, params: params.get("tenant_id")`.
+
+## Scope vocabulary
+
+Three flat scopes, ordered: `read < write < admin`. Tool annotation
+`requires_scope`, default `"read"` for unannotated tools. An internal helper
+`_satisfies(granted: set[str], required: str) -> bool` encodes the ordering.
+
+## ACL TOML store
+
+```toml
+[subjects."user:alice@example.com".tenants]
+"*" = ["read", "write", "admin"]
+
+[subjects."service:ci-bot".tenants]
+"*" = ["read"]
+
+[default]
+tenants = {}
+```
+
+- Wildcard `*` allowed on the tenant side only; subject-side wildcard rejected
+  at load time with a clear `ConfigurationError`.
+- Reload-on-each-request: file mtime checked, re-parsed on change. Cheap;
+  filesystem watch is out of scope for v1.
+- ACL absent: log `WARNING` once per process, default-deny.
+- Schema-invalid: load fails the request with `authz_denied` carrying a clear
+  reason — never silent allow.
+
+## Admin tools
+
+`register_acl_admin_tools(mcp)` registers four tools, all annotated
+`requires_scope: "admin"`:
+
+| Tool | Behavior |
+|---|---|
+| `acl_list_subjects()` | Returns ACL filtered to tenants the caller admins. Caller with admin on `*` sees the full ACL. |
+| `acl_grant(subject, tenant, scopes, intent)` | Adds/extends grants. `intent` is a free-form audit string, **required**, written to the git commit message when `commit_acl_to_git=True`. |
+| `acl_revoke(subject, tenant, scopes, intent)` | Removes grants. |
+| `acl_set_default(scopes, intent)` | Replaces `[default].tenants["*"]`. |
+
+## Mutation flow
+
+Single function path used by all three mutating tools:
+
+1. Load current ACL from disk.
+2. Apply mutation in memory.
+3. Validate the result against the schema (defense-in-depth).
+4. Write back atomically (temp-file + `os.replace`).
+5. If `commit_acl_to_git`: invoke `_git.commit_acl(path, intent, subject)` —
+   runs `git -C <repo> add <path>` then `git commit -m "acl: <intent>" --author
+   "<subject>"`. Surface git failures as a tool error *after* the file write
+   succeeded (i.e. the ACL is updated; the operator is told the commit didn't
+   happen).
+
+## Configuration
+
+The library does not add fields to `ServerConfig` for authz; the submodule is
+opt-in per server. Domain code declares its own config fields:
+
+| Field | Default | Meaning |
+|---|---|---|
+| `enabled: bool` | `False` | Master switch. |
+| `acl_path: Path` | (required when enabled) | Path to the ACL TOML. |
+| `tenant_resolver: TenantResolver` | (required when enabled) | Callable to extract tenant from request. |
+| `commit_acl_to_git: bool` | `False` | Commit ACL mutations to git. |
+
+Helper `build_authorization_middleware(config) -> AuthorizationMiddleware |
+None` returns `None` when `enabled=False`; downstream code uses
+`wire_middleware_stack(mcp, extra=[m] if (m := build_authorization_middleware(
+config)) else [])`.
+
+## Out of scope (v1)
+
+Verbatim from issue #37:
+
+- Per-document/per-node ACLs (tenant-grain only).
+- Role hierarchy beyond the three flat scopes.
+- OIDC group-mapping (subject-string-only ACLs); group-based extension is
+  additive — middleware lookup function changes, surface doesn't.
+- Structured audit log of failed authz beyond standard middleware logging.
+
+## Testing (planned)
+
+- `test_authz_store.py` — schema validation; wildcard expansion; default-deny;
+  reload-on-mtime-change; subject-wildcard rejected.
+- `test_authz_middleware.py` — tool denial; scope ordering; tenant-less
+  operation (global wildcard); permissive default for resources without
+  `requires_tenant`; structured `authz_denied` shape.
+- `test_authz_admin.py` — non-admin caller refused; grant/revoke/set_default
+  flows; `intent` required; atomic write under simulated crash;
+  `commit_acl_to_git` happy path + git failure surfaces tool error post-write.
+- `test_authz_resource_filtering.py` — `resources/list` filtered correctly with
+  mixed annotated and unannotated resources.
+
+## Driving consumers
+
+`pvliesdonk/reqeng-mcp` Phase 2 (write-substrate) is the immediate driver:
+needs per-user attribution for ACLs and audit metadata, and the authz
+submodule directly. Likely future consumers: any multi-tenant MCP server in
+the PVL ecosystem.
+
+When this submodule lands, `pvliesdonk/fastmcp-server-template` needs three
+matching scaffold-side stanzas. Stub issues already filed against the
+template repo, each with a `Depends-on:` pointer back to upstream:
+
+- [`pvliesdonk/fastmcp-server-template#94`](https://github.com/pvliesdonk/fastmcp-server-template/issues/94)
+  — commented `acl_enabled` field in the `CONFIG-FIELDS-START`/`-END` block
+  of `config.py.jinja`, plus the matching `CONFIG-FROM-ENV-*` env reader.
+- [`pvliesdonk/fastmcp-server-template#95`](https://github.com/pvliesdonk/fastmcp-server-template/issues/95)
+  — commented `AuthorizationMiddleware` + `register_acl_admin_tools` wiring
+  in `server.py.jinja` after `wire_middleware_stack(mcp)`.
+- [`pvliesdonk/fastmcp-server-template#96`](https://github.com/pvliesdonk/fastmcp-server-template/issues/96)
+  — multi-tenant deployment section in `README.md.jinja` (ACL TOML format,
+  admin tool walkthrough, deployment matrix, pointer to upstream reference
+  docs). Also depends on issue #35 because the deployment matrix includes
+  the bearer-mapped flavor.
+
+## When work resumes
+
+The previous attempt (2026-05) ran into severe-enough issues mid-flight to
+warrant abandonment. Picking this up should start by re-validating the
+design against the now-shipped `get_subject()` and bearer-mapped surface,
+not from this document alone.


### PR DESCRIPTION
## Summary

Two-file docs cleanup addressing the post-#40 audit findings on `docs/specs/auth-subject-authz.md`:

- **Abandoned-#37 design** (~150 lines describing `fastmcp_pvl_core.authorization`, a package that doesn't exist on `main`) moved into a new file `docs/specs/authorization-submodule.md` with a prominent `DRAFT — not implemented` banner that explicitly names the symbols absent from the codebase. Issue #37 itself is still OPEN; this preserves design notes for when work resumes without misleading readers in the meantime.
- **`auth-subject-authz.md` rewritten** to cover only the work that shipped (issue #35 → PR #39 and issue #36 → PR #40). Drops the apologetic `ctx_or_request` paragraph (commit `c48366a`'s post-hoc spec rewrite); the `get_subject() -> str | None` section now describes the no-arg signature directly.
- Honest cross-references added to the audit follow-up issues (#42, #44, #45, #47, #48) so the spec doesn't pretend the work is fully verified.
- PR-vs-issue numbering disambiguated throughout (section headers `### Issue #35 / PR #39 — …`; `grep` for `PR #35\|PR #36\|PR #37` returns zero).
- Removed implementation-coupled "must run before the early-return for `mode == 'none'`" parenthetical on the `set_current_auth_mode` paragraph; replaced with a contract statement that survives the eventual `ContextVar` refactor (issue #42).

Closes #43.

## Test plan

Doc-only PR; no code changes. 448 tests still pass.

- [x] `uv run pytest -q` clean
- [x] `grep -nE "PR #(35|36|37)" docs/specs/` returns 0 hits
- [x] DRAFT banner names every symbol that would mislead a future reader
- [x] All issue / PR numeric references resolve to real artifacts

## Local review

- `pr-review-toolkit:code-reviewer`    ✅ (rounds 1 + 2; round 2 clean)
- `pr-review-toolkit:comment-analyzer` ✅ (rounds 1 + 2; round 2 clean)

Round-1 findings (both addressed in round 2):

1. PR-vs-issue numbering conflation throughout the rewrite. Section headers like `### PR #35` (where #35 is actually the issue) renamed to `### Issue #35 / PR #39 — …`. Disambiguation patterns now consistent across both spec files.
2. The `set_current_auth_mode` paragraph referenced an implementation detail (early-return for `mode == "none"`) that would become stale when issue #42 lands. Replaced with a contract statement.

Round-1 also confirmed: DRAFT banner is unambiguous, the PR #45 callout reads as transparent acknowledgement (not apologia), and the testing-section deltas honestly link follow-up issues.

Surfaced by the post-#40 forensic audit on 2026-05-04.