### PR TITLE
refactor(subject): replace _current_auth_mode module-global with ContextVar

### DIFF
--- a/docs/specs/auth-subject-authz.md
+++ b/docs/specs/auth-subject-authz.md
@@ -123,7 +123,7 @@ def get_subject() -> str | None:
         # No auth context. Local stdio with auth_mode == "none" returns
         # the constant "local"; anything else returns None and lets the
         # caller decide whether to fall back or error.
-        return "local" if _current_auth_mode == "none" else None
+        return "local" if _current_auth_mode.get() == "none" else None
     raw_claims = getattr(access_token, "claims", None)
     claims = raw_claims if isinstance(raw_claims, dict) else {}
     sub = claims.get("sub")
@@ -135,20 +135,27 @@ def get_subject() -> str | None:
     return None
 ```
 
-`_current_auth_mode` is a process-global pointer set at server startup by
-a module-level `set_current_auth_mode(mode)` that `build_auth` calls
-after resolving the mode and before any early return — so
-`get_subject()` returns `"local"` even in stdio/no-auth servers where
-`build_auth` itself returns `None`.
+`_current_auth_mode` captures the resolved auth mode during server
+initialisation (via `set_current_auth_mode`) so that `get_subject()`
+can correctly distinguish between an unauthenticated local caller
+(returning `"local"`) and a missing token in an authenticated session
+(returning `None`).
 
-The architectural questions raised by this design — the module-global
-mutable state (which doesn't survive concurrent `build_auth` calls in a
-multi-server-in-one-process setup), the typed contract on
-`set_current_auth_mode`, missing end-to-end integration tests for tool /
-middleware / resource surfaces — are tracked separately in
-[#42](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/42),
-[#48](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/48), and
-[#44](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/44).
+The pointer is implemented as a `contextvars.ContextVar`. The primary
+benefit over a module global is **test isolation**, achieved via the
+suite-wide autouse fixture `_reset_auth_mode` in `tests/conftest.py`
+(pytest itself does not auto-reset `ContextVar` values across tests —
+the fixture is what makes the isolation work; without it, a `set()`
+in one test would leak to the next). Explicit harnesses that wrap
+each `build_auth` call in its own `contextvars.copy_context().run(...)`
+get scope-local isolation the same way. In the natural single-context
+production pattern (two `build_auth` calls in the same `main()`)
+last-writer-wins — a caller wishing to compose multiple `FastMCP`
+instances with distinct auth modes must do so via
+`copy_context().run(...)` per instance. asyncio task contexts inherit
+from the spawning context at task-creation time, so a
+server-startup-then-serve pattern propagates the startup-set value to
+every per-request task uniformly.
 
 ### README drift fix (PR #39)
 
@@ -167,9 +174,12 @@ its own tests.
   `ConfigurationError`; missing file → `ConfigurationError`; blank file →
   `ConfigurationError`; both env vars set → WARNING + file wins; mapped
   token → request succeeds with the mapped subject visible on
-  `access_token.client_id`. The "unmapped token → 401" assertion was
-  delegated to fastmcp's `StaticTokenVerifier` and is being added as a
-  direct test in [#47](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/47).
+  `access_token.client_id`. The "unmapped token → 401" assertion is
+  delegated to fastmcp's `StaticTokenVerifier`; a direct integration
+  test was considered in
+  [#47](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/47) and
+  closed-as-deferred for the same fastmcp in-memory-transport reason
+  as #44.
 - `test_auth_mode.py` extended — `bearer-single` vs `bearer-mapped`
   resolution; `multi` mode with mapped bearer.
 - `test_config.py` extended — `bearer_tokens_file` and
@@ -187,8 +197,14 @@ its own tests.
   rather than spinning up a full FastMCP server.
 - The originating issue's "works equally from inside a tool body, a
   middleware, and a resource handler" verification is *not* covered by
-  these unit tests; integration tests against a real FastMCP server are
-  tracked in [#44](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/44).
+  these unit tests. Integration tests against a real FastMCP server
+  were considered in
+  [#44](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/44) and
+  deferred: fastmcp's in-memory `FastMCPTransport` runs the low-level
+  MCP server directly and bypasses the HTTP-layer auth middleware, so
+  there is no in-process integration surface today that exercises the
+  auth chain end-to-end. The issue is closed-as-deferred with reopen
+  conditions documented inline.
 
 ## PR-by-PR breakdown
 
@@ -207,8 +223,10 @@ its own tests.
   - `{PREFIX}_BEARER_TOKEN=<token>` (single) continues to work; subject is
     `bearer_default_subject` (default `"bearer-anon"`).
   - Both env vars set → WARNING logged and file mode active.
-  - Unmapped token → 401 (delegated to `StaticTokenVerifier`; direct test
-    pending — see issue #47).
+  - Unmapped token → 401 (delegated to `StaticTokenVerifier`; a direct
+    integration test was considered in
+    [#47](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/47) and
+    deferred for the same fastmcp in-memory-transport reason as #44).
   - Malformed/missing file → fail-fast at startup with a clear
     `ConfigurationError`.
 
@@ -222,8 +240,9 @@ its own tests.
   pointing at `get_subject`.
 - Issue verification list: each auth mode returns the expected subject
   shape; `auth_mode` reporting in startup logs aligns with the values
-  the function returns.  The "from inside tool / middleware / resource"
-  AC remains unverified at the integration level — see issue #44.
+  the function returns. The "from inside tool / middleware / resource"
+  AC remains unverified at the integration level — see #44 (closed as
+  deferred) for the architectural reason and the reopen conditions.
 
 ## Versioning
 

--- a/src/fastmcp_pvl_core/_subject.py
+++ b/src/fastmcp_pvl_core/_subject.py
@@ -10,6 +10,7 @@ module is a thin extractor.
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
 from fastmcp.server.dependencies import get_access_token
@@ -19,15 +20,30 @@ if TYPE_CHECKING:
     # (``_auth`` imports ``set_current_auth_mode`` from this module).
     from fastmcp_pvl_core._auth import AuthMode
 
-# Process-global pointer to the auth mode resolved at server startup.
-# ``build_auth`` calls ``set_current_auth_mode``; the most recent value
-# is in effect. ``get_subject`` reads it to decide whether the absence
-# of an access token means "stdio/no-auth" (returns "local") or "auth
+# Per-context pointer to the auth mode resolved at server startup.
+# ``build_auth`` calls ``set_current_auth_mode`` once after resolving
+# the mode; ``get_subject`` reads it to decide whether the absence of
+# an access token means "stdio/no-auth" (returns "local") or "auth
 # configured but no valid token" (returns None).
 #
-# This is a process-global rather than a contextvar by design — auth
-# mode is resolved once at startup and is invariant across requests.
-_current_auth_mode: AuthMode | None = None
+# Implemented as a :class:`ContextVar` rather than a module global so
+# that the suite-wide autouse fixture in ``tests/conftest.py``
+# (``_reset_auth_mode``, which calls ``set_current_auth_mode(None)``
+# before/after every test) and explicitly-isolated harnesses
+# (``contextvars.copy_context().run(...)``) can reset / scope the
+# value cleanly.  Note: pytest does not auto-reset ``ContextVar``
+# values between tests on its own; the autouse fixture is what makes
+# isolation work.  In the natural single-context production pattern
+# (two ``build_auth`` calls in the same ``main()`` body) last-writer
+# still wins — caller code wishing to compose multiple ``FastMCP``
+# instances with distinct auth modes must wrap each ``build_auth`` in
+# its own ``copy_context().run(...)``.  In standard server-startup-
+# then-serve deployments, asyncio's task context inherits the
+# startup value uniformly across requests.
+_current_auth_mode: ContextVar[AuthMode | None] = ContextVar(
+    "fastmcp_pvl_core_current_auth_mode",
+    default=None,
+)
 
 
 def set_current_auth_mode(mode: AuthMode | None) -> None:
@@ -38,8 +54,7 @@ def set_current_auth_mode(mode: AuthMode | None) -> None:
     this directly. Passing ``None`` resets the pointer (useful between
     tests).
     """
-    global _current_auth_mode
-    _current_auth_mode = mode
+    _current_auth_mode.set(mode)
 
 
 def get_subject() -> str | None:
@@ -60,7 +75,7 @@ def get_subject() -> str | None:
     """
     access_token = get_access_token()
     if access_token is None:
-        return "local" if _current_auth_mode == "none" else None
+        return "local" if _current_auth_mode.get() == "none" else None
     raw_claims = getattr(access_token, "claims", None)
     claims = raw_claims if isinstance(raw_claims, dict) else {}
     sub = claims.get("sub")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,24 @@ from collections.abc import Iterator
 
 import pytest
 
+from fastmcp_pvl_core._subject import set_current_auth_mode
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth_mode() -> Iterator[None]:
+    """Reset the auth-mode contextvar between tests.
+
+    ``set_current_auth_mode`` writes to a :class:`ContextVar` whose
+    visible value crosses test boundaries when tests share the same
+    asyncio task / module run.  Lifted suite-wide here so that any
+    test calling ``build_auth`` (which mutates the var as a startup
+    side effect) does not leak the resolved mode into the next test
+    that reads via ``get_subject``.
+    """
+    set_current_auth_mode(None)
+    yield
+    set_current_auth_mode(None)
+
 
 @pytest.fixture
 def clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from typing import Any
 from unittest.mock import patch
@@ -14,20 +14,6 @@ from fastmcp_pvl_core import (
     build_auth,
     get_subject,
 )
-from fastmcp_pvl_core._subject import set_current_auth_mode
-
-
-@pytest.fixture(autouse=True)
-def _reset_auth_mode() -> Iterator[None]:
-    """Reset the process-global auth-mode pointer between tests.
-
-    Without this, a test that doesn't call ``build_auth`` would observe
-    the mode set by whichever earlier test ran last — order-dependent
-    flakes are easy to introduce as the suite grows.
-    """
-    set_current_auth_mode(None)
-    yield
-    set_current_auth_mode(None)
 
 
 class _FakeAccessToken:
@@ -130,6 +116,71 @@ class TestGetSubjectMissing:
         build_auth(ServerConfig(bearer_token="t"))
         with patch_get_access_token(None):
             assert get_subject() is None
+
+
+class TestExplicitContextIsolation:
+    def test_two_build_auth_calls_in_separate_contexts_dont_clobber(
+        self, patch_get_access_token
+    ):
+        """Per-context isolation regression guard.
+
+        Exercises the explicit ``contextvars.copy_context().run(...)``
+        isolation pattern — each context gets its own resolved mode
+        and a later ``build_auth`` in a sibling context does NOT
+        bleed into a prior context's reads.
+
+        With the old module-global storage this test FAILED at the
+        first assertion (``observed["a"] == "local"``): ``write_b``
+        would clobber the global to ``"bearer-single"``, and ``read_a``
+        would observe that value, returning ``None`` instead of
+        ``"local"``.  Under the ContextVar each context retains its own
+        value.  The test does **all writes first, then all reads** so a
+        within-context happy path (write-then-immediately-read) cannot
+        mask the bug.
+
+        Note: this protects test isolation and explicitly-isolated
+        harnesses.  Two ``build_auth`` calls in the *same* context
+        (e.g. sequential calls in the same ``main()``) still see
+        last-writer-wins — see the module docstring on ``_subject.py``
+        for caller guidance.
+        """
+        import contextvars
+
+        # Two independent contexts: each will call ``build_auth`` with
+        # a different config, then both will be read after both writes
+        # have happened.
+        ctx_a = contextvars.copy_context()
+        ctx_b = contextvars.copy_context()
+
+        observed: dict[str, str | None] = {}
+
+        def write_a() -> None:
+            build_auth(ServerConfig())  # mode == "none"
+
+        def write_b() -> None:
+            build_auth(ServerConfig(bearer_token="t"))  # mode == "bearer-single"
+
+        def read_a() -> None:
+            with patch_get_access_token(None):
+                observed["a"] = get_subject()
+
+        def read_b() -> None:
+            with patch_get_access_token(None):
+                observed["b"] = get_subject()
+
+        # All writes first — under module-global, ``write_b`` would
+        # clobber ``write_a``.  Under ContextVar, each context retains
+        # its own value.
+        ctx_a.run(write_a)
+        ctx_b.run(write_b)
+
+        # Now the reads: ``ctx_a`` must still see ``"none"`` even though
+        # ``ctx_b`` last set ``"bearer-single"``.
+        ctx_a.run(read_a)
+        ctx_b.run(read_b)
+
+        assert observed["a"] == "local"
+        assert observed["b"] is None
 
 
 # Note: ``multi`` mode is not exercised here. When a token is present,

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextvars
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from typing import Any
@@ -144,8 +145,6 @@ class TestExplicitContextIsolation:
         last-writer-wins — see the module docstring on ``_subject.py``
         for caller guidance.
         """
-        import contextvars
-
         # Two independent contexts: each will call ``build_auth`` with
         # a different config, then both will be read after both writes
         # have happened.


### PR DESCRIPTION
## Summary

- `_current_auth_mode` migrated from module global to `ContextVar[AuthMode | None]`. Public API of `get_subject()` and `set_current_auth_mode()` unchanged.
- Lifted the `_reset_auth_mode` autouse fixture into `tests/conftest.py` suite-wide — this is what actually provides test isolation (pytest does not auto-reset `ContextVar` values).
- New `TestExplicitContextIsolation` regression guard with `[write_a, write_b, read_a, read_b]` ordering across two `copy_context().run(...)` contexts. The all-writes-then-all-reads structure defeats a within-context happy-path mask: under the old module-global, `read_a` would see `write_b`'s clobbered value and the test fails.
- Spec doc updated: code sample uses `.get()`; prose honestly attributes test isolation to the autouse fixture, documents the same-context last-writer-wins caveat for two `build_auth` calls in one `main()`, and reframes references to closed follow-ups (#44, #47, #48) as "considered and closed-as-deferred" with the fastmcp in-memory-transport reason cited inline.

Closes #42.

## Honest scope

The audit framing of #42 implied the fix would let two `FastMCP` instances coexist in one process without clobbering. The ContextVar refactor only delivers that when each `build_auth` is wrapped in its own `contextvars.copy_context().run(...)`; in the natural single-context production pattern (two `build_auth` calls in one `main()`) last-writer-wins still applies. The PR's actual deliverables are: (1) test isolation via the suite-wide autouse fixture, (2) typed contract on `set_current_auth_mode` (already shipped via #48 / PR #53), (3) honest documentation of the same-context limitation. Multi-server callers wishing to compose distinct auth modes must use `copy_context().run()` per instance — documented in module docstring + spec.

## Test plan

- [x] `uv sync --all-extras`
- [x] `uv run mypy src/` clean
- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [x] `uv run pytest -q` 452 passing (451 prior + 1 new isolation test)
- [x] New test verified to FAIL under the old module-global storage (mental execution + reviewer empirical verification)

## Local review

- `pr-review-toolkit:code-reviewer`  ✅ (rounds 1+3+4 clean; round 2 was clean from this reviewer)
- `superpowers:code-reviewer`        ✅ (4 rounds — found regression-test ineffective, overclaimed multi-server fix, stale closed-issue references, factually-wrong pytest claim, "test harnesses already use" overclaim; all addressed)

This PR took 4 review rounds because each fix surfaced new claims the reviewers verified empirically. The discipline value is high: every claim in the final docstring/spec was tested by the reviewers (e.g. `pytest does NOT auto-scope ContextVar between tests` confirmed by a 6-line experiment).

Surfaced by the post-#40 forensic audit on 2026-05-04.