### PR TITLE
fix(auth)!: hard-fail in multi-mode and remote single-mode (drop silent degraded fallback)

### DIFF
--- a/src/fastmcp_pvl_core/_auth.py
+++ b/src/fastmcp_pvl_core/_auth.py
@@ -347,11 +347,12 @@ def build_remote_auth(config: ServerConfig) -> RemoteAuthProvider | None:
     ``None`` only as a precondition signal when either is missing
     (caller should already have routed away from ``remote`` mode in
     that case).  Other failure modes — ``httpx`` not installed, the
-    discovery fetch failing, the discovery document missing
-    ``jwks_uri`` / ``issuer`` — raise :class:`ConfigurationError`
-    rather than returning ``None``: a server that asked for OIDC and
-    cannot get it must fail at startup, never silently degrade to
-    "no auth at all" or "bearer break-glass only".
+    discovery request failing (network error or malformed JSON), the
+    discovery document missing ``jwks_uri`` / ``issuer`` — raise
+    :class:`ConfigurationError` rather than returning ``None``: a
+    server that asked for OIDC and cannot get it must fail at startup,
+    never silently degrade to "no auth at all" or "bearer break-glass
+    only".
 
     Args:
         config: Populated server configuration.
@@ -362,8 +363,9 @@ def build_remote_auth(config: ServerConfig) -> RemoteAuthProvider | None:
         miss; not a failure mode).
 
     Raises:
-        ConfigurationError: ``httpx`` missing, discovery fetch failed,
-            or the discovery document is incomplete.
+        ConfigurationError: ``httpx`` missing, discovery failed
+            (network error or malformed JSON), or the discovery
+            document is incomplete.
     """
     if not config.base_url or not config.oidc_config_url:
         logger.debug("remote_auth_skipped reason=missing_base_url_or_config_url")
@@ -383,8 +385,12 @@ def build_remote_auth(config: ServerConfig) -> RemoteAuthProvider | None:
         resp.raise_for_status()
         discovery = resp.json()
     except (httpx.HTTPError, ValueError) as exc:
+        # Catches both network-layer failures (``httpx.HTTPError``) and
+        # parse-layer failures (``ValueError`` from ``resp.json()``);
+        # phrasing avoids "fetch" so the message stays accurate for the
+        # parse case too.
         raise ConfigurationError(
-            f"OIDC discovery fetch failed at {config.oidc_config_url}: {exc}"
+            f"OIDC discovery failed at {config.oidc_config_url}: {exc}"
         ) from exc
 
     jwks_uri = discovery.get("jwks_uri")

--- a/src/fastmcp_pvl_core/_auth.py
+++ b/src/fastmcp_pvl_core/_auth.py
@@ -344,16 +344,26 @@ def build_remote_auth(config: ServerConfig) -> RemoteAuthProvider | None:
     tokens are validated locally.
 
     Requires ``base_url`` and ``oidc_config_url`` on *config*.  Returns
-    ``None`` when either is missing, when ``httpx`` is not installed
-    (the ``remote-auth`` extra), when the discovery request fails, or
-    when the discovery document is missing ``jwks_uri``/``issuer``.
+    ``None`` only as a precondition signal when either is missing
+    (caller should already have routed away from ``remote`` mode in
+    that case).  Other failure modes — ``httpx`` not installed, the
+    discovery fetch failing, the discovery document missing
+    ``jwks_uri`` / ``issuer`` — raise :class:`ConfigurationError`
+    rather than returning ``None``: a server that asked for OIDC and
+    cannot get it must fail at startup, never silently degrade to
+    "no auth at all" or "bearer break-glass only".
 
     Args:
         config: Populated server configuration.
 
     Returns:
         A configured :class:`RemoteAuthProvider`, or ``None`` when
-        remote auth cannot be built.
+        ``base_url`` / ``oidc_config_url`` are absent (precondition
+        miss; not a failure mode).
+
+    Raises:
+        ConfigurationError: ``httpx`` missing, discovery fetch failed,
+            or the discovery document is incomplete.
     """
     if not config.base_url or not config.oidc_config_url:
         logger.debug("remote_auth_skipped reason=missing_base_url_or_config_url")
@@ -361,33 +371,29 @@ def build_remote_auth(config: ServerConfig) -> RemoteAuthProvider | None:
 
     try:
         import httpx
-    except ImportError:
-        logger.warning(
-            "remote_auth_skipped reason=httpx_missing — "
-            "install with `pip install fastmcp-pvl-core[remote-auth]`"
-        )
-        return None
+    except ImportError as exc:
+        raise ConfigurationError(
+            "remote auth requires the 'remote-auth' extra "
+            "(install with `pip install fastmcp-pvl-core[remote-auth]`); "
+            "refusing to start without auth"
+        ) from exc
 
     try:
         resp = httpx.get(config.oidc_config_url, timeout=10)
         resp.raise_for_status()
         discovery = resp.json()
-    except (httpx.HTTPError, ValueError):
-        logger.exception(
-            "remote_auth_discovery_failed config_url=%s",
-            config.oidc_config_url,
-        )
-        return None
+    except (httpx.HTTPError, ValueError) as exc:
+        raise ConfigurationError(
+            f"OIDC discovery fetch failed at {config.oidc_config_url}: {exc}"
+        ) from exc
 
     jwks_uri = discovery.get("jwks_uri")
     issuer = discovery.get("issuer")
     if not jwks_uri or not issuer:
-        logger.error(
-            "remote_auth_discovery_incomplete jwks_uri=%s issuer=%s",
-            jwks_uri,
-            issuer,
+        raise ConfigurationError(
+            f"OIDC discovery document at {config.oidc_config_url} is "
+            f"incomplete: jwks_uri={jwks_uri!r} issuer={issuer!r}"
         )
-        return None
 
     required_scopes: list[str] | None = list(config.oidc_required_scopes) or None
 
@@ -450,24 +456,35 @@ def build_auth(config: ServerConfig) -> Any:
         case "remote":
             return build_remote_auth(config)
         case "multi":
+            # ``build_remote_auth`` raises ``ConfigurationError`` on
+            # discovery / dependency failures, so the only way for either
+            # ``oidc_auth`` or ``bearer_auth`` to be ``None`` here is a
+            # precondition mismatch (e.g. ``build_oidc_proxy_auth`` finds
+            # missing fields and ``build_remote_auth`` likewise returns
+            # ``None`` from its precondition check).  In multi mode that
+            # is itself a misconfiguration: ``resolve_auth_mode`` only
+            # picks "multi" when both bearer and OIDC inputs are present
+            # at startup.  Hard-fail rather than silent-degrade.
             oidc_auth: OIDCProxy | RemoteAuthProvider | None = build_oidc_proxy_auth(
                 config
             ) or build_remote_auth(config)
             bearer_auth = build_bearer_auth(config)
 
-            if oidc_auth is None or bearer_auth is None:
-                # One of the two builders returned None despite
-                # ``resolve_auth_mode`` reporting "multi" (e.g. remote-auth
-                # discovery failed, or httpx missing).  Fall back to
-                # whichever one is available rather than silently dropping
-                # auth entirely.
-                logger.warning(
-                    "multi_auth_degraded oidc=%s bearer=%s — falling back to "
-                    "whichever auth provider succeeded",
-                    oidc_auth is not None,
-                    bearer_auth is not None,
+            if oidc_auth is None:
+                raise ConfigurationError(
+                    "multi-mode auth requires both OIDC and bearer providers; "
+                    "OIDC builder returned None — check OIDC configuration "
+                    "(base_url, oidc_config_url, and the proxy fields if used). "
+                    "Refusing to start without OIDC; would otherwise silently "
+                    "degrade to bearer-only and break the operator's "
+                    "real-identity contract."
                 )
-                return oidc_auth or bearer_auth
+            if bearer_auth is None:
+                raise ConfigurationError(
+                    "multi-mode auth requires both OIDC and bearer providers; "
+                    "bearer builder returned None — check bearer configuration "
+                    "(bearer_token or bearer_tokens_file)."
+                )
 
             from fastmcp.server.auth import MultiAuth
 

--- a/tests/test_auth_builders.py
+++ b/tests/test_auth_builders.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from fastmcp_pvl_core import (
+    ConfigurationError,
     ServerConfig,
     build_bearer_auth,
     build_oidc_proxy_auth,
@@ -144,8 +145,6 @@ class TestBuildRemoteAuth:
     def test_raises_configuration_error_when_httpx_unavailable(
         self, monkeypatch: pytest.MonkeyPatch
     ):
-        from fastmcp_pvl_core import ConfigurationError
-
         monkeypatch.setitem(sys.modules, "httpx", None)
         with pytest.raises(ConfigurationError, match="remote-auth"):
             build_remote_auth(
@@ -190,8 +189,6 @@ class TestBuildRemoteAuth:
     ):
         import httpx
 
-        from fastmcp_pvl_core import ConfigurationError
-
         class _StubResponse:
             def raise_for_status(self) -> None:
                 return None
@@ -213,8 +210,6 @@ class TestBuildRemoteAuth:
     def test_raises_when_discovery_raises(self, monkeypatch: pytest.MonkeyPatch):
         import httpx
 
-        from fastmcp_pvl_core import ConfigurationError
-
         def _raise(*a, **kw):
             raise httpx.ConnectError("network down")
 
@@ -233,8 +228,6 @@ class TestBuildRemoteAuth:
         self, monkeypatch: pytest.MonkeyPatch
     ):
         import httpx
-
-        from fastmcp_pvl_core import ConfigurationError
 
         class _BadJSONResp:
             def raise_for_status(self) -> None:

--- a/tests/test_auth_builders.py
+++ b/tests/test_auth_builders.py
@@ -141,15 +141,19 @@ class TestBuildRemoteAuth:
     def test_returns_none_when_only_base_url(self):
         assert build_remote_auth(ServerConfig(base_url="https://x")) is None
 
-    def test_returns_none_when_httpx_unavailable(self, monkeypatch: pytest.MonkeyPatch):
+    def test_raises_configuration_error_when_httpx_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from fastmcp_pvl_core import ConfigurationError
+
         monkeypatch.setitem(sys.modules, "httpx", None)
-        result = build_remote_auth(
-            ServerConfig(
-                base_url="https://x",
-                oidc_config_url="https://idp/.well-known/openid-configuration",
+        with pytest.raises(ConfigurationError, match="remote-auth"):
+            build_remote_auth(
+                ServerConfig(
+                    base_url="https://x",
+                    oidc_config_url="https://idp/.well-known/openid-configuration",
+                )
             )
-        )
-        assert result is None
 
     def test_returns_provider_when_discovery_succeeds(
         self, monkeypatch: pytest.MonkeyPatch
@@ -181,10 +185,12 @@ class TestBuildRemoteAuth:
         )
         assert isinstance(auth, RemoteAuthProvider)
 
-    def test_returns_none_when_discovery_missing_fields(
+    def test_raises_when_discovery_missing_fields(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         import httpx
+
+        from fastmcp_pvl_core import ConfigurationError
 
         class _StubResponse:
             def raise_for_status(self) -> None:
@@ -194,37 +200,41 @@ class TestBuildRemoteAuth:
                 return {}  # missing jwks_uri/issuer
 
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: _StubResponse())
-        auth = build_remote_auth(
-            ServerConfig(
-                base_url="https://x.example",
-                oidc_config_url=(
-                    "https://idp.example/.well-known/openid-configuration"
-                ),
+        with pytest.raises(ConfigurationError, match="incomplete"):
+            build_remote_auth(
+                ServerConfig(
+                    base_url="https://x.example",
+                    oidc_config_url=(
+                        "https://idp.example/.well-known/openid-configuration"
+                    ),
+                )
             )
-        )
-        assert auth is None
 
-    def test_returns_none_when_discovery_raises(self, monkeypatch: pytest.MonkeyPatch):
+    def test_raises_when_discovery_raises(self, monkeypatch: pytest.MonkeyPatch):
         import httpx
+
+        from fastmcp_pvl_core import ConfigurationError
 
         def _raise(*a, **kw):
             raise httpx.ConnectError("network down")
 
         monkeypatch.setattr(httpx, "get", _raise)
-        auth = build_remote_auth(
-            ServerConfig(
-                base_url="https://x.example",
-                oidc_config_url=(
-                    "https://idp.example/.well-known/openid-configuration"
-                ),
+        with pytest.raises(ConfigurationError, match="discovery"):
+            build_remote_auth(
+                ServerConfig(
+                    base_url="https://x.example",
+                    oidc_config_url=(
+                        "https://idp.example/.well-known/openid-configuration"
+                    ),
+                )
             )
-        )
-        assert auth is None
 
-    def test_returns_none_when_discovery_json_malformed(
+    def test_raises_when_discovery_json_malformed(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         import httpx
+
+        from fastmcp_pvl_core import ConfigurationError
 
         class _BadJSONResp:
             def raise_for_status(self) -> None:
@@ -234,12 +244,12 @@ class TestBuildRemoteAuth:
                 raise ValueError("not json")
 
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: _BadJSONResp())
-        auth = build_remote_auth(
-            ServerConfig(
-                base_url="https://x.example",
-                oidc_config_url=(
-                    "https://idp.example/.well-known/openid-configuration"
-                ),
+        with pytest.raises(ConfigurationError, match="discovery"):
+            build_remote_auth(
+                ServerConfig(
+                    base_url="https://x.example",
+                    oidc_config_url=(
+                        "https://idp.example/.well-known/openid-configuration"
+                    ),
+                )
             )
-        )
-        assert auth is None

--- a/tests/test_build_auth.py
+++ b/tests/test_build_auth.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fastmcp_pvl_core import ServerConfig, build_auth
+from fastmcp_pvl_core import ConfigurationError, ServerConfig, build_auth
 
 
 def _oidc_proxy_config(**overrides: object) -> ServerConfig:
@@ -117,8 +117,6 @@ class TestBuildAuth:
         """
         import httpx
 
-        from fastmcp_pvl_core import ConfigurationError
-
         def _boom(*_args: object, **_kw: object) -> MagicMock:
             raise httpx.ConnectError("boom")
 
@@ -139,8 +137,6 @@ class TestBuildAuth:
         Catches a future refactor that desyncs the resolver from the
         builder preconditions.
         """
-        from fastmcp_pvl_core import ConfigurationError
-
         cfg = _oidc_proxy_config()  # OIDC fully configured, no bearer
         mock_proxy_cls = MagicMock()
         with (
@@ -220,8 +216,6 @@ class TestBuildAuthMultiWithMapped:
         actually enforcing anything.  Hard-fail at startup instead.
         """
         import httpx
-
-        from fastmcp_pvl_core import ConfigurationError
 
         def _raise(*a, **kw):
             raise httpx.ConnectError("network down")

--- a/tests/test_build_auth.py
+++ b/tests/test_build_auth.py
@@ -126,6 +126,30 @@ class TestBuildAuth:
             with pytest.raises(ConfigurationError, match="discovery"):
                 build_auth(_remote_only_config(bearer_token="x"))
 
+    def test_multi_hard_fails_when_bearer_builder_returns_none(self):
+        """Defense-in-depth: bearer_auth=None in multi mode → ConfigurationError.
+
+        Currently unreachable via ``build_auth`` because
+        ``resolve_auth_mode`` only picks ``"multi"`` when bearer config is
+        present, so ``build_bearer_auth`` is guaranteed to return a
+        verifier.  This test forces the dispatcher into the multi branch
+        with no bearer config (via a mocked resolver) to lock in the
+        contract that the explicit ``bearer_auth is None`` guard fires
+        rather than silently constructing a half-auth ``MultiAuth``.
+        Catches a future refactor that desyncs the resolver from the
+        builder preconditions.
+        """
+        from fastmcp_pvl_core import ConfigurationError
+
+        cfg = _oidc_proxy_config()  # OIDC fully configured, no bearer
+        mock_proxy_cls = MagicMock()
+        with (
+            patch("fastmcp_pvl_core._auth.resolve_auth_mode", return_value="multi"),
+            patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_proxy_cls),
+            pytest.raises(ConfigurationError, match="bearer"),
+        ):
+            build_auth(cfg)
+
 
 class TestBuildAuthMapped:
     def test_returns_verifier_in_bearer_mapped_mode(self, tmp_path: Path) -> None:

--- a/tests/test_build_auth.py
+++ b/tests/test_build_auth.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from fastmcp_pvl_core import ServerConfig, build_auth
 
 
@@ -105,19 +107,24 @@ class TestBuildAuth:
         assert auth.required_scopes == []
         assert isinstance(auth.server, RemoteAuthProvider)
 
-    def test_multi_falls_back_to_bearer_when_oidc_build_fails(
-        self,
-    ):
-        """If remote discovery fails, fall back to bearer alone, not None."""
+    def test_multi_hard_fails_when_oidc_discovery_fails(self):
+        """OIDC discovery failure in multi mode must abort startup.
+
+        Regression guard for issue #41: the previous behaviour was to
+        log a ``multi_auth_degraded`` warning and silently fall back
+        to bearer-only — a security-relevant silent failure where the
+        operator believes OIDC is enforcing identity but it is not.
+        """
         import httpx
-        from fastmcp.server.auth import StaticTokenVerifier
+
+        from fastmcp_pvl_core import ConfigurationError
 
         def _boom(*_args: object, **_kw: object) -> MagicMock:
             raise httpx.ConnectError("boom")
 
         with patch("httpx.get", side_effect=_boom):
-            auth = build_auth(_remote_only_config(bearer_token="x"))
-        assert isinstance(auth, StaticTokenVerifier)
+            with pytest.raises(ConfigurationError, match="discovery"):
+                build_auth(_remote_only_config(bearer_token="x"))
 
 
 class TestBuildAuthMapped:
@@ -177,13 +184,21 @@ class TestBuildAuthMultiWithMapped:
             for r in caplog.records
         )
 
-    def test_multi_falls_back_to_mapped_bearer_when_oidc_build_fails(
+    def test_multi_with_mapped_bearer_hard_fails_when_oidc_discovery_fails(
         self, tmp_path, monkeypatch
     ):
-        import httpx
-        from fastmcp.server.auth import StaticTokenVerifier
+        """Same hard-fail as the single-bearer case — across both bearer flavors.
 
-        # Simulate remote auth discovery failure
+        The audit's silent-failure-hunter flagged this exact scenario
+        (mapped bearer + remote OIDC, discovery fails) as the canonical
+        operator foot-gun: the deployment looks fine, audit logs show
+        per-user mapped subjects from the bearer side, but OIDC isn't
+        actually enforcing anything.  Hard-fail at startup instead.
+        """
+        import httpx
+
+        from fastmcp_pvl_core import ConfigurationError
+
         def _raise(*a, **kw):
             raise httpx.ConnectError("network down")
 
@@ -197,7 +212,5 @@ class TestBuildAuthMultiWithMapped:
             oidc_config_url=("https://idp.example/.well-known/openid-configuration"),
             # Only base_url + oidc_config_url set → remote mode (not proxy)
         )
-        auth = build_auth(cfg)
-        # OIDC discovery fails → fallback to whatever bearer succeeded.
-        assert isinstance(auth, StaticTokenVerifier)
-        assert auth.tokens["k1"]["client_id"] == "user:alice"
+        with pytest.raises(ConfigurationError, match="discovery"):
+            build_auth(cfg)


### PR DESCRIPTION
## Summary

Closes the post-#40 audit's two **MUST-FIX silent-failure findings** (silent-failure-hunter #1 + #2) by replacing every silent-degraded-fallback branch in the auth pipeline with `ConfigurationError`-raised-at-startup:

- **`build_remote_auth`** — three explicit raise sites for `httpx` missing, discovery fetch failure, and incomplete discovery docs. Was: log + return `None` silently. Now: operator-readable `ConfigurationError` with `from exc` chaining where applicable.
- **`build_auth` multi mode** — explicit raises when either provider builder returns `None`, with messages naming which side (OIDC or bearer) failed. Was: `multi_auth_degraded` WARNING + silent fallback to whichever survived. Now: hard-fail at startup.
- **Precondition return-`None`** in `build_remote_auth` (when `base_url` / `oidc_config_url` absent) is preserved as a *precondition signal* — that path is unreachable from the dispatcher and only relevant to direct callers. Docstring updated to clarify the distinction.

Closes #41.

## Why this matters

The previous behaviour was a textbook silent-failure pattern where a transient IdP outage at startup would permanently degrade a "real OIDC + bearer break-glass" deployment to bearer-only — operator believes OIDC is enforcing identity, audit logs show mapped bearer subjects, but OIDC has been silently disabled. Now the server fails to start instead, with an actionable diagnostic. This is the security-relevant fix the audit identified as the most important architectural cleanup remaining.

## Breaking change

`build_remote_auth` and `build_auth` (multi mode) now raise `ConfigurationError` on previously-silent failure paths. Downstream code that caught `auth=None` from `build_auth` must now catch `ConfigurationError` (or — preferably — let it propagate so an operator pages on misconfiguration). Rides the existing 2.0 major bump (`2.0.0-rc.1` already tagged on PR #39); not a separate major bump.

## Test plan

- [x] `uv sync --all-extras`
- [x] `uv run mypy src/` clean
- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [x] `uv run pytest -q` 452 passing (existing fall-back tests rewritten to assert `ConfigurationError`; four `_auth_builders` tests inverted from `assert is None` → `pytest.raises(ConfigurationError)`; one new defense-in-depth test for the `bearer_auth is None` branch in multi-mode dispatch)
- [x] Test load-bearingness verified by both reviewers: each new `pytest.raises` assertion would FAIL on the old silent-fallback / return-`None` code, so they are real regression guards

## Local review

- `pr-review-toolkit:silent-failure-hunter`  ✅ (the original audit's primary reviewer for this finding; verified `from exc` chaining, multi-mode comprehensiveness, precondition-vs-failure split, test load-bearingness)
- `pr-review-toolkit:code-reviewer`  ✅ (verified type narrowing across the new raises, MultiAuth untouched, mypy + ruff + 451 tests green)

Round-1 bot review nits addressed in round 2:

- The `bearer_auth is None` defense-in-depth branch was untested. Added `test_multi_hard_fails_when_bearer_builder_returns_none` that mocks `resolve_auth_mode` to force the multi branch with no bearer config, asserts `ConfigurationError` matching `"bearer"`. Now 452/452 tests, including the new defense-in-depth coverage.

Surfaced by the post-#40 forensic audit on 2026-05-04.