### PR TITLE
feat(debug)!: require env_prefix on maybe_start_debugpy ({PREFIX}_DEBUG_PORT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,24 +130,27 @@ Resolution order:
 ### Remote debugging in containers
 
 Containerised consumers can opt into a remote Python debugger by calling
-`maybe_start_debugpy()` early in their CLI entrypoint:
+`maybe_start_debugpy(env_prefix)` early in their CLI entrypoint, passing
+the same per-app prefix the server uses for the rest of its config:
 
 ```python
 from fastmcp_pvl_core import configure_logging_from_env, maybe_start_debugpy
 
 def main() -> None:
     configure_logging_from_env()
-    maybe_start_debugpy()  # no-op unless DEBUG_PORT is set
+    maybe_start_debugpy("MY_APP")  # no-op unless MY_APP_DEBUG_PORT is set
     ...
 ```
 
-Environment contract:
+Environment contract (`{PREFIX}` matches the argument):
 
-- `DEBUG_PORT` — TCP port to listen on. Unset, blank, or any value that
-  parses to `0` is a silent no-op. Non-numeric or out-of-`1..65535`
-  values log a `WARNING` and the helper returns without raising.
-- `DEBUG_WAIT` — when truthy (`1`/`true`/`yes`/`on`, case-insensitive),
-  block startup until the IDE attaches. Default is non-blocking.
+- `{PREFIX}_DEBUG_PORT` — TCP port to listen on. Unset, blank, or any
+  value that parses to `0` is a silent no-op. Non-numeric or
+  out-of-`1..65535` values log a `WARNING` and the helper returns
+  without raising.
+- `{PREFIX}_DEBUG_WAIT` — when truthy (`1`/`true`/`yes`/`on`,
+  case-insensitive), block startup until the IDE attaches. Default is
+  non-blocking.
 - If `debugpy.listen()` itself fails (port in use, permission denied,
   debugpy-internal error), the helper logs a `WARNING` and continues —
   a debug-port problem must never crash the server.
@@ -166,10 +169,10 @@ so it is safe to ship in default scaffolds.
 > ⚠️ **Security:** the listener binds `0.0.0.0` and debugpy's DAP
 > protocol is **unauthenticated** — any peer that can reach the port
 > has arbitrary code execution as the server process. Only enable
-> `DEBUG_PORT` in environments where the port is reachable solely
-> from a trusted developer workstation, e.g. `kubectl port-forward`,
-> `docker run -p 127.0.0.1:5678:5678` (loopback bind), or an SSH
-> tunnel. Never publish the debug port on a public network.
+> `{PREFIX}_DEBUG_PORT` in environments where the port is reachable
+> solely from a trusted developer workstation, e.g. `kubectl
+> port-forward`, `docker run -p 127.0.0.1:5678:5678` (loopback bind),
+> or an SSH tunnel. Never publish the debug port on a public network.
 
 ## License
 

--- a/src/fastmcp_pvl_core/_debug.py
+++ b/src/fastmcp_pvl_core/_debug.py
@@ -4,16 +4,17 @@ Containerised consumers (image-generation-mcp, markdown-vault-mcp, ...)
 need a uniform way to attach a remote Python debugger without each one
 hand-rolling the ``debugpy`` bootstrap. Call :func:`maybe_start_debugpy`
 early in ``main()`` (after logging is configured, before argument
-parsing): it is a no-op unless ``DEBUG_PORT`` is set, so it is safe to
-ship in default scaffolds.
+parsing) with the same ``env_prefix`` the rest of the server uses for
+its config: it is a no-op unless ``{PREFIX}_DEBUG_PORT`` is set, so it
+is safe to ship in default scaffolds.
 
 Environment contract:
 
-* ``DEBUG_PORT`` — TCP port to listen on. Unset, blank, or any value
-  that parses to ``0`` disables the helper silently. Non-numeric or
-  out-of-``1..65535`` values log a ``WARNING`` and the helper returns
-  without raising. Surrounding whitespace is ignored.
-* ``DEBUG_WAIT`` — when truthy (``1``/``true``/``yes``/``on``,
+* ``{PREFIX}_DEBUG_PORT`` — TCP port to listen on. Unset, blank, or any
+  value that parses to ``0`` disables the helper silently. Non-numeric
+  or out-of-``1..65535`` values log a ``WARNING`` and the helper
+  returns without raising. Surrounding whitespace is ignored.
+* ``{PREFIX}_DEBUG_WAIT`` — when truthy (``1``/``true``/``yes``/``on``,
   case-insensitive — see ``parse_bool`` in ``_env.py``), block startup
   until the IDE attaches. Default is non-blocking so missing-attach
   doesn't deadlock production containers that were accidentally built
@@ -31,18 +32,18 @@ to call unconditionally in the default scaffold.
    outside the container — this is intentional for the developer
    workflow, but **debugpy's DAP protocol is unauthenticated**: any
    peer that can reach the port has arbitrary code execution as the
-   server process. Only enable ``DEBUG_PORT`` in environments where
-   the port is reachable solely from a trusted developer workstation
-   (e.g. ``kubectl port-forward``, ``docker run -p 127.0.0.1:5678:5678``,
-   an SSH tunnel). Never publish the debug port on a public network.
+   server process. Only enable ``{PREFIX}_DEBUG_PORT`` in environments
+   where the port is reachable solely from a trusted developer
+   workstation (e.g. ``kubectl port-forward``,
+   ``docker run -p 127.0.0.1:5678:5678``, an SSH tunnel). Never publish
+   the debug port on a public network.
 """
 
 from __future__ import annotations
 
 import logging
-import os
 
-from fastmcp_pvl_core._env import parse_bool
+from fastmcp_pvl_core._env import env, parse_bool
 
 logger = logging.getLogger(__name__)
 
@@ -56,14 +57,14 @@ logger = logging.getLogger(__name__)
 _started = False
 
 
-def maybe_start_debugpy() -> None:
-    """Start a debugpy listener if ``DEBUG_PORT`` is set.
+def maybe_start_debugpy(env_prefix: str) -> None:
+    """Start a debugpy listener if ``{env_prefix}_DEBUG_PORT`` is set.
 
-    Reads ``DEBUG_PORT`` from the environment. Unset, blank, or any
-    value that parses to ``0`` is a silent no-op. Non-numeric or
-    out-of-``1..65535`` values log a ``WARNING`` so misconfiguration
-    is visible. Otherwise imports :mod:`debugpy` lazily and binds
-    ``("0.0.0.0", port)``.
+    Reads ``{env_prefix}_DEBUG_PORT`` from the environment. Unset,
+    blank, or any value that parses to ``0`` is a silent no-op.
+    Non-numeric or out-of-``1..65535`` values log a ``WARNING`` so
+    misconfiguration is visible. Otherwise imports :mod:`debugpy`
+    lazily and binds ``("0.0.0.0", port)``.
 
     A failed import logs a ``WARNING`` pointing at the ``debug`` extra
     and returns. A failure inside :func:`debugpy.listen` (port in use,
@@ -71,8 +72,8 @@ def maybe_start_debugpy() -> None:
     ``WARNING`` and returns — a debug-port problem must never crash
     the server.
 
-    When ``DEBUG_WAIT`` is truthy the helper blocks until the IDE
-    attaches (``debugpy.wait_for_client()``); otherwise startup
+    When ``{env_prefix}_DEBUG_WAIT`` is truthy the helper blocks until
+    the IDE attaches (``debugpy.wait_for_client()``); otherwise startup
     continues immediately. A failure inside ``wait_for_client`` (e.g.
     debugpy-internal error, transport hiccup) likewise logs a
     ``WARNING`` and returns — the listener is still up, so the IDE can
@@ -84,6 +85,12 @@ def maybe_start_debugpy() -> None:
     a ``wait_for_client`` failure a re-call short-circuits silently:
     the listener is up, there is nothing more to do.
 
+    Args:
+        env_prefix: The same per-app prefix the server uses for its
+            other env vars (e.g. ``"MY_APP"`` produces
+            ``MY_APP_DEBUG_PORT`` / ``MY_APP_DEBUG_WAIT``). Trailing
+            underscore optional, matching ``_env.env``'s convention.
+
     Security note: the listener binds ``0.0.0.0`` and debugpy's DAP
     protocol is unauthenticated. Only expose the port to a trusted
     developer workstation (port-forward, loopback bind, SSH tunnel).
@@ -93,15 +100,17 @@ def maybe_start_debugpy() -> None:
     if _started:
         return
 
-    raw = os.environ.get("DEBUG_PORT", "").strip()
-    if not raw:
+    port_var = f"{env_prefix.rstrip('_')}_DEBUG_PORT"
+    raw = env(env_prefix, "DEBUG_PORT")
+    if raw is None:
         return
 
     try:
         port = int(raw)
     except ValueError:
         logger.warning(
-            "DEBUG_PORT=%r is not a valid integer; debugpy listener not started.",
+            "%s=%r is not a valid integer; debugpy listener not started.",
+            port_var,
             raw,
         )
         return
@@ -113,7 +122,8 @@ def maybe_start_debugpy() -> None:
 
     if not 1 <= port <= 65535:
         logger.warning(
-            "DEBUG_PORT=%d is outside 1..65535; debugpy listener not started.",
+            "%s=%d is outside 1..65535; debugpy listener not started.",
+            port_var,
             port,
         )
         return
@@ -125,9 +135,10 @@ def maybe_start_debugpy() -> None:
         import debugpy  # type: ignore[import-not-found, unused-ignore]
     except ImportError:
         logger.warning(
-            "DEBUG_PORT=%d set but debugpy is not installed. "
+            "%s=%d set but debugpy is not installed. "
             "Install with `pip install 'fastmcp-pvl-core[debug]'` "
             "or `uv add debugpy`.",
+            port_var,
             port,
         )
         return
@@ -145,8 +156,9 @@ def maybe_start_debugpy() -> None:
     _started = True
     logger.info("debugpy listening on 0.0.0.0:%d", port)
 
-    if parse_bool(os.environ.get("DEBUG_WAIT", "")):
-        logger.info("DEBUG_WAIT=true — blocking until debugger attaches...")
+    if parse_bool(env(env_prefix, "DEBUG_WAIT", "")):
+        wait_var = f"{env_prefix.rstrip('_')}_DEBUG_WAIT"
+        logger.info("%s=true — blocking until debugger attaches...", wait_var)
         try:
             debugpy.wait_for_client()
         except KeyboardInterrupt:

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -12,13 +12,21 @@ import pytest
 from fastmcp_pvl_core import _debug as debug_mod
 from fastmcp_pvl_core import maybe_start_debugpy
 
+# All tests use a stable per-app prefix so the env-var spelling is
+# consistent.  Mirrors the pattern downstream consumers will use:
+# every server picks an ``env_prefix`` and the debug helper reads
+# ``{PREFIX}_DEBUG_PORT`` / ``{PREFIX}_DEBUG_WAIT`` from there.
+# Underscore form (``MY_APP``) matches the README and the rest of the
+# project's examples (``ServerConfig.from_env("MY_APP")`` etc.).
+_PREFIX = "MY_APP"
+
 
 @pytest.fixture(autouse=True)
 def _reset_state(monkeypatch: pytest.MonkeyPatch) -> None:
     """Each test starts with the helper's idempotency latch reset."""
     monkeypatch.setattr(debug_mod, "_started", False)
-    monkeypatch.delenv("DEBUG_PORT", raising=False)
-    monkeypatch.delenv("DEBUG_WAIT", raising=False)
+    monkeypatch.delenv(f"{_PREFIX}_DEBUG_PORT", raising=False)
+    monkeypatch.delenv(f"{_PREFIX}_DEBUG_WAIT", raising=False)
 
 
 def _install_fake_debugpy(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespace:
@@ -41,7 +49,7 @@ def _install_fake_debugpy(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamesp
 
 def test_no_op_when_debug_port_unset() -> None:
     # No env, no fake debugpy installed — must not raise.
-    maybe_start_debugpy()
+    maybe_start_debugpy(_PREFIX)
 
 
 @pytest.mark.parametrize("raw", ["0", "00", "+0", "-0", " 0 "])
@@ -52,15 +60,15 @@ def test_no_op_when_debug_port_parses_to_zero(
 ) -> None:
     # All forms that parse to 0 are the documented "disable" form and
     # must be silent — not the out-of-range WARNING that "70000" triggers.
-    monkeypatch.setenv("DEBUG_PORT", raw)
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", raw)
     fake = _install_fake_debugpy(monkeypatch)
 
     with caplog.at_level(logging.DEBUG, logger="fastmcp_pvl_core._debug"):
-        maybe_start_debugpy()
+        maybe_start_debugpy(_PREFIX)
 
     assert fake.calls == []
     assert caplog.records == [], (
-        f"DEBUG_PORT={raw!r} should be a silent no-op, but logged: "
+        f"{_PREFIX}_DEBUG_PORT={raw!r} should be a silent no-op, but logged: "
         f"{[r.getMessage() for r in caplog.records]}"
     )
 
@@ -69,15 +77,15 @@ def test_no_op_when_debug_port_blank(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.setenv("DEBUG_PORT", "   ")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "   ")
     fake = _install_fake_debugpy(monkeypatch)
 
     with caplog.at_level(logging.DEBUG, logger="fastmcp_pvl_core._debug"):
-        maybe_start_debugpy()
+        maybe_start_debugpy(_PREFIX)
 
     assert fake.calls == []
     assert caplog.records == [], (
-        "blank DEBUG_PORT must be a silent no-op, but logged: "
+        f"blank {_PREFIX}_DEBUG_PORT must be a silent no-op, but logged: "
         f"{[r.getMessage() for r in caplog.records]}"
     )
 
@@ -86,15 +94,15 @@ def test_invalid_port_logs_warning_and_no_ops(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.setenv("DEBUG_PORT", "not-a-number")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "not-a-number")
     fake = _install_fake_debugpy(monkeypatch)
 
     with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
-        maybe_start_debugpy()
+        maybe_start_debugpy(_PREFIX)
 
     assert fake.calls == []
     assert any(
-        "DEBUG_PORT" in rec.message and rec.levelno == logging.WARNING
+        f"{_PREFIX}_DEBUG_PORT" in rec.message and rec.levelno == logging.WARNING
         for rec in caplog.records
     )
 
@@ -103,11 +111,11 @@ def test_out_of_range_port_logs_warning_and_no_ops(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.setenv("DEBUG_PORT", "70000")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "70000")
     fake = _install_fake_debugpy(monkeypatch)
 
     with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
-        maybe_start_debugpy()
+        maybe_start_debugpy(_PREFIX)
 
     assert fake.calls == []
     assert any(rec.levelno == logging.WARNING for rec in caplog.records)
@@ -117,11 +125,11 @@ def test_negative_port_logs_warning_and_no_ops(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.setenv("DEBUG_PORT", "-1")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "-1")
     fake = _install_fake_debugpy(monkeypatch)
 
     with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
-        maybe_start_debugpy()
+        maybe_start_debugpy(_PREFIX)
 
     assert fake.calls == []
     assert any(rec.levelno == logging.WARNING for rec in caplog.records)
@@ -131,12 +139,12 @@ def test_debugpy_missing_logs_warning(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.setenv("DEBUG_PORT", "5678")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "5678")
     # Force ImportError when the helper tries to import debugpy.
     monkeypatch.setitem(sys.modules, "debugpy", None)
 
     with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
-        maybe_start_debugpy()
+        maybe_start_debugpy(_PREFIX)
 
     msgs = " ".join(rec.message for rec in caplog.records)
     assert "debugpy" in msgs
@@ -148,11 +156,11 @@ def test_happy_path_calls_listen(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.setenv("DEBUG_PORT", "5678")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "5678")
     fake = _install_fake_debugpy(monkeypatch)
 
     with caplog.at_level(logging.INFO, logger="fastmcp_pvl_core._debug"):
-        maybe_start_debugpy()
+        maybe_start_debugpy(_PREFIX)
 
     assert fake.calls == [("listen", ("0.0.0.0", 5678))]
     assert any(
@@ -163,11 +171,11 @@ def test_happy_path_calls_listen(
 def test_debug_wait_triggers_wait_for_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("DEBUG_PORT", "5678")
-    monkeypatch.setenv("DEBUG_WAIT", "true")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "5678")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_WAIT", "true")
     fake = _install_fake_debugpy(monkeypatch)
 
-    maybe_start_debugpy()
+    maybe_start_debugpy(_PREFIX)
 
     assert ("listen", ("0.0.0.0", 5678)) in fake.calls
     assert ("wait", None) in fake.calls
@@ -193,8 +201,8 @@ def test_wait_for_client_failure_logs_warning_and_continues(
     # must not crash startup. The latch is correctly already True at this
     # point (listen succeeded), so subsequent calls short-circuit — but
     # the *current* call must continue, not raise.
-    monkeypatch.setenv("DEBUG_PORT", "5678")
-    monkeypatch.setenv("DEBUG_WAIT", "true")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "5678")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_WAIT", "true")
 
     def listen(_: tuple[str, int]) -> None:
         return None
@@ -208,7 +216,7 @@ def test_wait_for_client_failure_logs_warning_and_continues(
     monkeypatch.setitem(sys.modules, "debugpy", fake)
 
     with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
-        maybe_start_debugpy()  # must not raise
+        maybe_start_debugpy(_PREFIX)  # must not raise
 
     assert any(
         rec.levelno == logging.WARNING
@@ -227,8 +235,8 @@ def test_wait_for_client_keyboard_interrupt_propagates(
 ) -> None:
     # Ctrl-C during wait must propagate so the operator can abort —
     # swallowing it would prevent process shutdown via SIGINT.
-    monkeypatch.setenv("DEBUG_PORT", "5678")
-    monkeypatch.setenv("DEBUG_WAIT", "true")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "5678")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_WAIT", "true")
 
     def listen(_: tuple[str, int]) -> None:
         return None
@@ -242,26 +250,26 @@ def test_wait_for_client_keyboard_interrupt_propagates(
     monkeypatch.setitem(sys.modules, "debugpy", fake)
 
     with pytest.raises(KeyboardInterrupt):
-        maybe_start_debugpy()
+        maybe_start_debugpy(_PREFIX)
 
 
 def test_debug_wait_false_skips_wait(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("DEBUG_PORT", "5678")
-    monkeypatch.setenv("DEBUG_WAIT", "false")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "5678")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_WAIT", "false")
     fake = _install_fake_debugpy(monkeypatch)
 
-    maybe_start_debugpy()
+    maybe_start_debugpy(_PREFIX)
 
     assert ("listen", ("0.0.0.0", 5678)) in fake.calls
     assert ("wait", None) not in fake.calls
 
 
 def test_idempotent_on_second_call(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("DEBUG_PORT", "5678")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "5678")
     fake = _install_fake_debugpy(monkeypatch)
 
-    maybe_start_debugpy()
-    maybe_start_debugpy()
+    maybe_start_debugpy(_PREFIX)
+    maybe_start_debugpy(_PREFIX)
 
     # listen runs exactly once even though the helper was called twice.
     assert [c for c in fake.calls if c[0] == "listen"] == [
@@ -285,7 +293,7 @@ def test_listen_failure_logs_warning_and_continues(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.setenv("DEBUG_PORT", "5678")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "5678")
 
     def boom(_: tuple[str, int]) -> None:
         raise exc
@@ -296,7 +304,7 @@ def test_listen_failure_logs_warning_and_continues(
     monkeypatch.setitem(sys.modules, "debugpy", fake)
 
     with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
-        maybe_start_debugpy()  # must not raise
+        maybe_start_debugpy(_PREFIX)  # must not raise
 
     assert any(
         rec.levelno == logging.WARNING and str(exc) in rec.message
@@ -311,7 +319,7 @@ def test_failed_listen_does_not_latch(
     # latch must NOT be set — a subsequent call (e.g. after the operator
     # frees the port and re-runs) is allowed to retry. Regression guard
     # for the "set _started after success" ordering in _debug.py.
-    monkeypatch.setenv("DEBUG_PORT", "5678")
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "5678")
     attempts: list[tuple[str, int]] = []
     raise_once = {"left": True}
 
@@ -326,8 +334,56 @@ def test_failed_listen_does_not_latch(
     fake.wait_for_client = lambda: None  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "debugpy", fake)
 
-    maybe_start_debugpy()  # first attempt fails
-    maybe_start_debugpy()  # retry must reach listen() again
+    maybe_start_debugpy(_PREFIX)  # first attempt fails
+    maybe_start_debugpy(_PREFIX)  # retry must reach listen() again
 
     assert attempts == [("0.0.0.0", 5678), ("0.0.0.0", 5678)]
     assert debug_mod._started is True  # latched only after the successful attempt
+
+
+def test_trailing_underscore_prefix_normalised(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Caller may pass ``"MY_APP_"`` (with trailing underscore) — env
+    # lookup AND log var-name must agree on the canonical
+    # ``MY_APP_DEBUG_PORT`` form, not produce ``MY_APP__DEBUG_PORT``.
+    # Regression guard against drift between ``_env.env``'s
+    # ``rstrip('_')`` normalisation and the ``port_var`` /
+    # ``wait_var`` constructions in ``_debug.py``.
+    monkeypatch.setenv(f"{_PREFIX}_DEBUG_PORT", "not-a-number")
+    fake = _install_fake_debugpy(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._debug"):
+        maybe_start_debugpy(f"{_PREFIX}_")
+
+    assert fake.calls == []
+    msgs = [rec.message for rec in caplog.records]
+    assert any(
+        f"{_PREFIX}_DEBUG_PORT" in m and f"{_PREFIX}__DEBUG_PORT" not in m for m in msgs
+    ), f"Expected single underscore in log var-name, got: {msgs}"
+
+
+def test_unprefixed_env_vars_no_longer_honored(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Regression guard for the 2.0.0-rc.2 breaking change: the legacy
+    # unprefixed ``DEBUG_PORT`` / ``DEBUG_WAIT`` env vars are no longer
+    # honored.  Setting them with no matching ``{PREFIX}_DEBUG_PORT``
+    # must produce a silent no-op (no listener bound, no warning), so
+    # an operator who has the legacy vars in their environment for
+    # other tools doesn't accidentally fire up an unauthenticated
+    # debugger on a server that hasn't opted in.
+    monkeypatch.setenv("DEBUG_PORT", "5678")
+    monkeypatch.setenv("DEBUG_WAIT", "true")
+    fake = _install_fake_debugpy(monkeypatch)
+
+    with caplog.at_level(logging.DEBUG, logger="fastmcp_pvl_core._debug"):
+        maybe_start_debugpy(_PREFIX)
+
+    assert fake.calls == []
+    assert caplog.records == [], (
+        "Legacy unprefixed DEBUG_PORT must be a silent no-op, but logged: "
+        f"{[r.getMessage() for r in caplog.records]}"
+    )


### PR DESCRIPTION
## Summary

Closes #51 — the audit's last paper-trail item. `maybe_start_debugpy()` now requires an `env_prefix: str` argument and reads `{env_prefix}_DEBUG_PORT` / `{env_prefix}_DEBUG_WAIT` (was unprefixed `DEBUG_PORT` / `DEBUG_WAIT`).

## Why path C (required arg) over #51's path A or B

Issue #51 listed two paths. This PR takes a third option — required `env_prefix: str` (breaking) — for these reasons:

1. **rc cycle is for breaking changes.** We're in 2.0.0-rc.x; the user explicitly authorised breaking changes inside the rc.
2. **Path B's `Optional[str]` with fallback would perpetuate the security smell.** The audit identified the unprefixed lookup as the root issue: a stray `DEBUG_PORT=5678` left in an operator's shell from another tool could fire up an unauthenticated debugger on a server that hadn't opted in. A backward-compatible fallback would keep that foot-gun intact.
3. **Required-arg tells the type-checker.** mypy / pyright catch zero-arg callers at static time; no runtime compat-shim.

## Surface change

- `maybe_start_debugpy(env_prefix: str)` — required positional.
- Reads `{env_prefix}_DEBUG_PORT` and `{env_prefix}_DEBUG_WAIT` via the existing `_env.env(prefix, name)` helper (matches `ServerConfig.from_env` convention; trailing underscore tolerated identically).
- Log messages compute the real env-var name so misconfigurations report what the operator should grep for.
- README example updated to `maybe_start_debugpy("MY_APP")` with `{PREFIX}_*` placeholders.

## Migration impact (downstream consumers)

Two known zero-arg callers will get `TypeError: maybe_start_debugpy() missing 1 required positional argument: 'env_prefix'` on upgrade:

- `pvliesdonk/image-generation-mcp`
- `pvliesdonk/markdown-vault-mcp`

They will be updated in lockstep with the 2.0.0-rc.2 bump.

## Test plan

- [x] `uv sync --all-extras`
- [x] `uv run mypy src/` clean
- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [x] `uv run pytest -q` 455 passing (453 prior + 2 new regression guards):
  - `test_unprefixed_env_vars_no_longer_honored` — legacy unprefixed `DEBUG_PORT` / `DEBUG_WAIT` produce a silent no-op.
  - `test_trailing_underscore_prefix_normalised` — caller passing `"MY_APP_"` (trailing underscore) sees canonical `MY_APP_DEBUG_PORT` in both env lookup and log var-name; catches drift between `_env.env`'s `rstrip('_')` and the `_debug.py` log-string constructions.

## Local review

- `pr-review-toolkit:code-reviewer`  ✅ (clean — verified `env_prefix` typing, `rstrip('_')` consistency, regression-guard load-bearingness)
- `superpowers:code-reviewer`  ✅ (clean — same plus migration callout and trailing-underscore test)

Reviewer findings, all addressed:
- Test prefix renamed `"MYAPP"` → `"MY_APP"` to match the README and the rest of the project's examples.
- Trailing-underscore regression test added.

CHANGELOG.md `Unreleased` left untouched — pre-existing project-wide gap (#38, #39, #40 also skipped it). Backfill in a separate cleanup before tagging 2.0.0 final.

Surfaced by the post-#40 forensic audit on 2026-05-04.