### PR TITLE
feat(authorization): opt-in submodule for downstream access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,62 @@ Resolution order:
 3. **No token, auth required:** returns `None` — caller decides whether
    to fall back or error.
 
+### Authorization (opt-in) — `AuthorizationMiddleware`
+
+Tools, resources, and prompts can opt into per-subject access control by
+setting `meta={"required_scope": "<scope>"}` at registration. A
+configured `AuthorizationMiddleware` enforces the static check and
+filters `list_*` responses to what the caller can use:
+
+```python
+from pathlib import Path
+from fastmcp_pvl_core import (
+    AuthorizationMiddleware, load_acl, make_acl_authorizer, check_authorization,
+)
+
+authorizer = make_acl_authorizer(load_acl(Path("/etc/my-app/acl.toml")))
+mcp.add_middleware(AuthorizationMiddleware(authorizer=authorizer))
+
+@mcp.tool(meta={"required_scope": "write"})
+async def edit_document(project_id: str, doc_id: str, body: str) -> None:
+    # Coarse "write" gate already passed at middleware. Per-project gate here:
+    check_authorization(f"write:{project_id}")
+    ...
+```
+
+ACL TOML schema (loaded by `load_acl`):
+
+```toml
+[subjects]
+"user:alice@example.com" = ["read", "write"]
+"user:admin@example.com" = ["*"]              # wildcard scope
+"service:ci-bot"         = ["read"]
+"local"                  = ["*"]              # stdio mode
+```
+
+Key properties:
+
+- **Opt-in per component.** Tools / resources / prompts without
+  `meta["required_scope"]` are unrestricted regardless of caller.
+- **`*` is the only library-treated special scope** ("any required
+  scope passes"). All other scopes are opaque strings; downstream chooses
+  the vocabulary.
+- **Subject-side wildcards (`*` as an ACL key) are rejected at load
+  time.**
+- **`load_acl` fails fast** with `ConfigurationError` on every malformed
+  condition — never silent denial.
+- **ACL is loaded once at startup.** Restart to pick up changes.
+- **Authorization scopes are application-level** and distinct from the
+  OAuth scopes carried in tokens.
+- **Subject is logged on every deny** at WARNING. The wire-side payload
+  *omits* the subject by default to limit cross-user info disclosure;
+  pass `AuthorizationMiddleware(..., expose_subject_in_error=True)` to
+  include it (e.g. for internal-only servers).
+
+For the full design rationale and deviations from the originating
+issue, see
+[`docs/specs/authorization-submodule.md`](docs/specs/authorization-submodule.md).
+
 ### Remote debugging in containers
 
 Containerised consumers can opt into a remote Python debugger by calling

--- a/docs/specs/auth-subject-authz.md
+++ b/docs/specs/auth-subject-authz.md
@@ -20,11 +20,11 @@ Once a real subject exists across all auth modes, downstream code wants a
 uniform `get_subject()` extractor so it stops poking at the auth context
 directly.
 
-A follow-on optional `authorization` submodule (subject + tenant + required
-scope → allow / deny middleware) is described separately in
-[`authorization-submodule.md`](authorization-submodule.md) — that work was
-attempted in 2026-05 and abandoned mid-implementation; issue #37 remains
-open.
+A follow-on optional `authorization` submodule (subject + scope →
+allow/deny middleware, ACL TOML loader, and `check_authorization`
+helper) is described separately in
+[`authorization-submodule.md`](authorization-submodule.md). The
+implementation closes [issue #37](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/37).
 
 ## Scope
 
@@ -275,12 +275,12 @@ PRs open as draft. Flip to ready only after CI green and bot LGTM bodies
 driver: needs per-user attribution for ACLs and audit metadata. Likely
 future consumers: any multi-tenant MCP server in the PVL ecosystem.
 
-The downstream `authorization` submodule (issue #37) — the deeper
-machinery for ACLs / admin tools / scope vocabulary — is described in
-[`authorization-submodule.md`](authorization-submodule.md). That spec
-is currently DRAFT and not implemented; treat it as forward design only.
+The downstream `authorization` submodule — the optional middleware /
+loader / `check_authorization` helper — is described in
+[`authorization-submodule.md`](authorization-submodule.md) and closes
+issue #37.
 
 ## See also
 
-- [`authorization-submodule.md`](authorization-submodule.md) — DRAFT
-  follow-on spec for the optional authorization submodule (issue #37).
+- [`authorization-submodule.md`](authorization-submodule.md) — the
+  optional authorization submodule design (issue #37).

--- a/docs/specs/authorization-submodule.md
+++ b/docs/specs/authorization-submodule.md
@@ -6,8 +6,11 @@ Date: 2026-05-06.
 
 ## Status
 
-Design accepted; implementation pending. Replaces the abandoned 2026-05
-draft (`docs/specs/authorization-submodule.md` at commit
+Implementation landed via PR
+[#61](https://github.com/pvliesdonk/fastmcp-pvl-core/pull/61); closes
+issue [#37](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/37).
+Replaces the abandoned 2026-05 draft (`docs/specs/authorization-submodule.md`
+at commit
 [9f79cfa](https://github.com/pvliesdonk/fastmcp-pvl-core/commit/9f79cfa)),
 which was deleted before this redesign started.
 

--- a/docs/specs/authorization-submodule.md
+++ b/docs/specs/authorization-submodule.md
@@ -427,6 +427,10 @@ in-process surface that exercises the full chain end-to-end.
 
 ### Verification list
 
+This is a design-time intent checklist; the corresponding tests are
+catalogued in the "Test files" / "Middleware test scenarios" tables
+above.
+
 Mapping the original issue's spirit to this design:
 
 - [ ] Tool with `required_scope` denies unmapped subject; allows mapped subject.

--- a/docs/specs/authorization-submodule.md
+++ b/docs/specs/authorization-submodule.md
@@ -1,0 +1,548 @@
+# Authorization submodule
+
+Design spec for [issue #37](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/37).
+
+Date: 2026-05-06.
+
+## Status
+
+Design accepted; implementation pending. Replaces the abandoned 2026-05
+draft (`docs/specs/authorization-submodule.md` at commit
+[9f79cfa](https://github.com/pvliesdonk/fastmcp-pvl-core/commit/9f79cfa)),
+which was deleted before this redesign started.
+
+## Problem
+
+The package today gives downstream MCP servers a working
+*identification* story: `get_subject()` returns "who is calling?" across
+every supported auth mode, and `bearer-mapped` plus the OIDC modes
+provide multi-user identification. What is still missing is
+*authorization*: turning "who is this?" into "are they allowed to do
+X?". Each consumer that needs per-user gating today reinvents the same
+small pieces — a middleware that reads tool metadata and short-circuits,
+a per-subject permission lookup, the structured deny error shape, list
+filtering for `tools/list` and `resources/list`. Moving those pieces
+upstream once is the goal of this spec.
+
+## Spirit
+
+The original issue body specified a heavyweight surface (middleware,
+tenant resolver protocol, ACL TOML loader, four admin tools that mutate
+the ACL via MCP, optional commit-to-git, fixed `read | write | admin`
+scope vocabulary). That shape was attempted in 2026-05 and abandoned
+mid-implementation. This spec is the redesign authored after the user
+explicitly asked for the *spirit* — "provide (multi-)user auth to
+downstream" — without inheriting the original shape.
+
+The redesign's scope is intentionally narrower than the issue body:
+
+| Original surface | Status in this spec |
+|---|---|
+| Enforcement middleware | **In** — `AuthorizationMiddleware`. |
+| Annotation convention for required scope | **In** — `meta["required_scope"]`. |
+| ACL TOML loader (read-only) | **In** — `load_acl`, plus `make_acl_authorizer` bridge. |
+| Tenant resolver protocol / tenant axis | **Out** — collapsed into open-ended scope strings (e.g. `read:project-foo`). Domain decides whether to namespace scopes by project / vault / workspace. |
+| Fixed `read \| write \| admin` scope vocabulary | **Out** — scopes are arbitrary domain-defined strings. The library only treats `*` specially (in `make_acl_authorizer`). |
+| Default `read` requirement when no annotation | **Out** — fully opt-in: tools without `meta["required_scope"]` are unrestricted. |
+| Admin tool helpers (`acl_grant`, `acl_revoke`, …) | **Out** — domain decides whether to expose ACL mutation; library does not ship admin tools. |
+| Commit-ACL-to-git integration | **Out**. |
+| ACL reload-on-change semantics | **Deferred** — load-once-at-startup in the initial implementation; restart to update. A future `make_reloading_acl_authorizer(path)` is purely additive. |
+
+## Design
+
+### Module layout and public API
+
+A single new private module `src/fastmcp_pvl_core/_authorization.py`
+following the package's leading-underscore convention. No subpackage;
+no per-component file split — the surface is small enough that one
+module is clearer than four.
+
+Re-exported from `fastmcp_pvl_core`:
+
+| Symbol | Kind | Purpose |
+|---|---|---|
+| `AuthorizationMiddleware` | class | The middleware. Subclasses `fastmcp.server.middleware.Middleware`. |
+| `AuthzDenied` | exception | Raised by `check_authorization`; middleware translates to per-operation MCP error. |
+| `check_authorization` | function | Imperative escape-hatch helper for fine-grained checks inside tool/resource bodies. |
+| `load_acl` | function | TOML loader. `load_acl(path) -> dict[str, frozenset[str]]`. |
+| `make_acl_authorizer` | function | Bridge: `Mapping[str, AbstractSet[str]] -> Authorizer`. Encodes the `*` wildcard scope semantics. |
+| `Authorizer` | type alias | `Callable[[str \| None, str], bool]`. Public name for the seam. |
+
+Six public symbols. `Authorizer` is a `TypeAlias`, not a `Protocol` —
+the Protocol upgrade across this and other Callable-typed seams in the
+package is tracked in
+[#60](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/60).
+
+The package uses the word *scope* throughout, despite the OAuth/OIDC
+collision. Documentation calls out that "authorization scopes" in this
+context are application-level identifiers chosen by the domain server
+operator, distinct from the OAuth scopes carried in tokens. The
+`Authorizer` callable's parameter is named `required_scope` to make
+the namespace explicit.
+
+### `AuthorizationMiddleware`
+
+```python
+class AuthorizationMiddleware(Middleware):
+    def __init__(
+        self,
+        *,
+        authorizer: Authorizer,
+        expose_subject_in_error: bool = False,
+    ) -> None: ...
+```
+
+One required keyword: the authorizer callable. One optional flag:
+whether the wire-side deny payload includes the subject string
+(`False` by default — see the error-shape section below).
+
+The middleware overrides hooks for the three component types,
+symmetrically:
+
+| Hook | Behavior |
+|---|---|
+| `on_call_tool` | Coarse static check based on `tool.meta.get("required_scope")`. Then `await call_next(context)` wrapped in `try/except AuthzDenied` so a `check_authorization` raised in the tool body becomes a `ToolError`. |
+| `on_read_resource` | Same pattern with `get_resource(uri)`; deny via `ResourceError`. |
+| `on_get_prompt` | Same pattern with `get_prompt(name)`; deny via `PromptError`. |
+| `on_list_tools` | Iterate tools returned from `call_next`, drop any whose `meta["required_scope"]` is set and `authorizer(subject, required) is False`. Tools without the meta key are always kept. |
+| `on_list_resources` | Same as `on_list_tools` for resources. |
+| `on_list_resource_templates` | Same for resource templates (kept symmetric even though it's niche). |
+| `on_list_prompts` | Same for prompts. |
+
+Subject lookup is internal: the middleware calls `get_subject()` at the
+top of each hook. The authorizer signature is therefore
+`(subject, required_scope) → bool`, not `(context, required_scope)` —
+which keeps the authorizer testable without spinning up a fastmcp
+context, and matches the existing ambient-`get_subject` pattern.
+
+The list-filtering hooks evaluate per-tool by calling
+`authorizer(subject, tool.meta["required_scope"])` once per tool that
+has the meta key. The middleware never asks "what scopes does this
+subject have?" — the authorizer's only obligation is yes/no per scope.
+This works for any backing implementation (dict-backed, DB-backed,
+IdP-group-backed) without forcing a "list scopes" capability into the
+seam.
+
+When the inner-component lookup
+(`fastmcp_context.fastmcp.get_tool/get_resource/get_prompt`) raises —
+mounted-server edge case, race during reload, transient internal state
+— the middleware logs a `WARNING` and falls through to `call_next`
+rather than denying. Deny-on-internal-error felt punitive when the
+operator's authz config is fine and the underlying issue is in fastmcp
+internals. Operators see the warning in logs.
+
+`call_next` is *not* called when the static-meta check denies. Per the
+fastmcp middleware docs (`servers/middleware`): denials raise per-
+operation exceptions before `call_next`; never return error values.
+
+The middleware also publishes the authorizer to a package-internal
+`_current_authorizer` `ContextVar` at `__init__` time, so
+`check_authorization` reads it ambient (see below). Same pattern as
+`_current_auth_mode` in `_subject.py`; same composition caveat (last
+writer wins across multiple `AuthorizationMiddleware` constructions in
+the same context — operators wishing to compose multiple authorizers
+must wrap each install in `contextvars.copy_context().run(...)`).
+
+### Annotation convention
+
+Tools, resources, and prompts opt in by setting
+`meta={"required_scope": "<scope>"}` at registration:
+
+```python
+@mcp.tool(meta={"required_scope": "write"})
+async def edit_document(...): ...
+```
+
+A single string per component. No list, no callable, no nested
+per-arg structure — the static annotation is intentionally coarse.
+For per-argument granularity (e.g. "user can write project-foo but
+not project-bar"), the tool body uses `check_authorization` (next
+section).
+
+Why `meta` and not `annotations`: fastmcp's `ToolAnnotations` is the
+MCP-standard set (`title`, `readOnlyHint`, `destructiveHint`,
+`idempotentHint`, `openWorldHint`). Free-form keys belong in `meta`
+(`dict[str, Any]`). The abandoned spec's
+`annotations={"requires_scope": "write"}` example was simply wrong
+against current fastmcp.
+
+No `requires_scope` decorator is shipped in the initial
+implementation: `meta={"required_scope": "..."}` is six characters
+more than `@requires_scope("...")` and orders-of-magnitude less
+likely to break across a fastmcp upgrade. Adding the decorator later
+is purely additive.
+
+### `check_authorization` and `AuthzDenied`
+
+```python
+def check_authorization(
+    required_scope: str,
+    *,
+    authorizer: Authorizer | None = None,
+    subject: str | None = None,
+) -> None: ...
+```
+
+Imperative form for use inside a tool/resource/prompt body. Raises
+`AuthzDenied` on deny; returns `None` on allow.
+
+When `authorizer` is omitted, the helper reads the
+`_current_authorizer` `ContextVar` set by `AuthorizationMiddleware.__init__`.
+If neither path supplies one, raises `RuntimeError` with an actionable
+message ("install AuthorizationMiddleware or pass authorizer=
+explicitly"). This makes the helper usable both inside and outside
+the middleware-installed context, while keeping the no-middleware path
+explicit rather than silent.
+
+When `subject` is omitted, the helper calls `get_subject()` — same
+extraction as the middleware, single source of truth for "who is
+calling?".
+
+```python
+class AuthzDenied(Exception):
+    subject: str | None
+    required_scope: str
+
+    def __init__(self, *, subject: str | None, required_scope: str) -> None: ...
+```
+
+Plain `Exception` subclass with two attributes. Inherits from
+`Exception`, *not* from `ToolError` / `ResourceError` / `PromptError`:
+the middleware catches `AuthzDenied` raised from any component body
+and re-raises it as the per-operation type appropriate to the active
+hook. The same `AuthzDenied` raised from a tool body becomes
+`ToolError`; raised from a resource handler becomes `ResourceError`;
+raised from a prompt handler becomes `PromptError`. This keeps a
+single domain-side exception type while the wire-shape varies per
+component.
+
+If a domain uses `check_authorization` *without* installing the
+middleware, `AuthzDenied` propagates as a plain `Exception` and
+surfaces as a generic MCP error. Documented as the cost of skipping
+the middleware.
+
+### Error shape
+
+The wire payload (the string passed to `ToolError(...)` /
+`ResourceError(...)` / `PromptError(...)`, JSON-encoded) defaults to:
+
+```json
+{"code": "authz_denied", "required_scope": "write"}
+```
+
+When `AuthorizationMiddleware(..., expose_subject_in_error=True)`:
+
+```json
+{"code": "authz_denied", "required_scope": "write", "subject": "user:alice@example.com"}
+```
+
+Subject identifiers are sensitive in multi-user deployments: leaking
+"user:bob@example.com was denied" across a connection can confirm
+account existence. Off by default; opt-in for deployments where the
+information is appropriate (e.g. internal tools, debugging).
+
+The subject is *always* logged at `WARNING` level on every deny,
+regardless of the wire-payload flag. Operators see the full picture
+in logs without exposing it to the client.
+
+### TOML loader and authorizer bridge
+
+```toml
+# acl.toml
+[subjects]
+"user:alice@example.com" = ["read", "write"]
+"user:admin@example.com" = ["*"]
+"service:ci-bot"         = ["read"]
+"local"                  = ["*"]
+```
+
+One flat `[subjects]` table. Keys are subject strings (opaque to the
+library; the `<kind>:<id>` convention from the bearer-tokens TOML is
+documentation only). Values are arrays of scope strings.
+
+The `*` scope is interpreted by `make_acl_authorizer` as "any required
+scope passes" — useful for admin grants. No subject-side wildcard
+(`*` as a key); rejected at load time because a global subject
+wildcard collapses the model.
+
+`load_acl(path: Path) -> dict[str, frozenset[str]]` is fail-fast.
+`ConfigurationError` (the existing package exception, already used by
+`_load_bearer_tokens`) on every malformed condition:
+
+- Path missing or not a regular file.
+- Unreadable or non-UTF-8.
+- Unparseable TOML.
+- Top-level `[subjects]` table missing or not a table.
+- Subject key blank or whitespace-only.
+- Subject key equals `"*"` (the rejected-wildcard case).
+- Subject value not an array.
+- Array contains a non-string entry, or an entry that is blank /
+  whitespace-only.
+
+Empty `[subjects]` (`[subjects] = {}`) is *permitted* — it represents
+an explicit "deny everyone" ACL, a valid state. The path is normalized
+with `Path.expanduser()` once inside the loader, mirroring the single-
+expansion-site pattern from `_load_bearer_tokens` (PR #55).
+
+`make_acl_authorizer(acl: Mapping[str, AbstractSet[str]]) -> Authorizer`
+returns:
+
+```python
+def authorize(subject: str | None, required_scope: str) -> bool:
+    if subject is None:
+        return False
+    granted = acl.get(subject)
+    if granted is None:
+        return False
+    return "*" in granted or required_scope in granted
+```
+
+`subject is None` denies. The `OIDC-required server with missing
+token` case is mostly handled by fastmcp 401-ing before the middleware
+runs, but the deny-by-default branch covers callers that invoke
+`check_authorization` from a code path without auth context.
+
+The ACL is captured by reference, not copied — a downstream that
+mutates the dict in place sees the change reflected by the closure.
+Documented; not a recommended pattern, but explicit so consumers know
+the semantics.
+
+No combined `load_and_make` helper. Consumers write
+`make_acl_authorizer(load_acl(path))` — one short line, no helper
+needed.
+
+### Wiring from a domain server
+
+```python
+import os
+from pathlib import Path
+from fastmcp import FastMCP
+from fastmcp_pvl_core import (
+    ServerConfig, build_auth, build_instructions,
+    wire_middleware_stack,
+    AuthorizationMiddleware, load_acl, make_acl_authorizer, check_authorization,
+)
+
+config = ServerConfig.from_env("MY_APP")
+mcp = FastMCP(
+    name="my-app",
+    instructions=build_instructions(
+        read_only=False, env_prefix="MY_APP", domain_line="…"
+    ),
+    auth=build_auth(config),
+)
+wire_middleware_stack(mcp)
+
+# Authz is opt-in. ACL path is a domain config concern, not on ServerConfig.
+acl_path_raw = os.environ.get("MY_APP_ACL_PATH")
+if acl_path_raw:
+    authorizer = make_acl_authorizer(load_acl(Path(acl_path_raw)))
+    mcp.add_middleware(AuthorizationMiddleware(authorizer=authorizer))
+
+@mcp.tool(meta={"required_scope": "write"})
+async def edit_document(project_id: str, doc_id: str, body: str) -> None:
+    # Coarse "write" gate already passed at middleware. Per-project gate here:
+    check_authorization(f"write:{project_id}")  # ambient authorizer
+    ...
+
+@mcp.tool                                       # no meta = unrestricted
+async def list_documents() -> list[str]: ...
+```
+
+Three points worth calling out:
+
+- The library does **not** add ACL fields to `ServerConfig`. Per the
+  composed-not-inherited pattern documented in `_config.py`, ACL
+  configuration belongs in the domain config (`MY_APP_ACL_PATH` in
+  the example).
+- `wire_middleware_stack(mcp)` is called *before*
+  `mcp.add_middleware(AuthorizationMiddleware(...))`, so middleware
+  order is: ErrorHandling → Timing → Logging → Authorization. Denied
+  requests *are* timed and logged — operationally desirable.
+- `check_authorization(f"write:{project_id}")` omits the `authorizer`
+  kwarg; the middleware install above has populated the
+  `_current_authorizer` `ContextVar`.
+
+## What this submodule does NOT do
+
+- No tenant axis or `TenantResolver` protocol. Multi-tenant deployments
+  encode the tenant into the scope string (`read:project-foo`).
+- No fixed scope vocabulary. `read`, `write`, `admin` are the
+  conventional choices but the library treats every scope as an
+  opaque string except `*`.
+- No default required scope. Tools without `meta["required_scope"]`
+  are unrestricted regardless of subject.
+- No subject-side wildcard. `*` as a subject key in the ACL TOML is
+  rejected at load time.
+- No admin tools (`acl_grant`, `acl_revoke`, …). Domain decides
+  whether and how to expose ACL mutation.
+- No commit-ACL-to-git integration.
+- No ACL reload-on-change semantics in the initial implementation.
+  Restart the server to pick up changes. Future
+  `make_reloading_acl_authorizer(path)` is purely additive.
+- No structured audit log of failed authz beyond standard middleware
+  logging (the per-deny `WARNING` already covers the basics).
+- No OIDC group-mapping. The authorizer is a callable, so a domain
+  that wants group-based authorization writes its own — no library
+  change needed.
+- No `requires_scope` decorator. `meta={"required_scope": "..."}` is
+  the documented form; sugar can be added later.
+
+## Testing
+
+mypy-strict and ruff are gates per `pyproject.toml`. Test files follow
+the existing one-concern-per-file convention from `test_auth_*.py` and
+`test_subject.py`. Integration tests against a real fastmcp server stay
+deferred for the same reason as
+[#44](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/44) and
+[#47](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/47):
+fastmcp's in-memory `FastMCPTransport` runs the low-level MCP server
+directly and bypasses the HTTP-layer auth middleware, so there is no
+in-process surface that exercises the full chain end-to-end.
+
+### Test files
+
+| File | Coverage |
+|---|---|
+| `tests/test_authorization_loader.py` | `load_acl`: happy path, missing file, non-file path, unreadable bytes, malformed TOML, missing or non-table `[subjects]`, blank/whitespace subject key, subject key literal `"*"` rejected, non-list value, list with non-string entry, blank scope string. Each error case asserts on `ConfigurationError` and a clear message. Empty `[subjects]` permitted. |
+| `tests/test_authorization_authorizer.py` | `make_acl_authorizer`: subject-in-ACL allow, subject-in-ACL deny (scope absent), unknown subject deny, `subject is None` deny, `"*"` scope wildcard. ACL captured by reference (mutating the dict reflects in the closure — explicit test). |
+| `tests/test_authorization_check.py` | `check_authorization`: ambient authorizer (set via test helper) found and used, explicit `authorizer=` overrides ambient, no authorizer in either path raises `RuntimeError` with actionable message, `subject=` kwarg overrides `get_subject()`, `AuthzDenied` raised on deny carries `subject` and `required_scope` attrs. |
+| `tests/test_authorization_middleware.py` | Middleware behaviors — see scenarios below. Patches `get_access_token` (per `test_subject.py`'s pattern) and a fake `MiddlewareContext` rather than spinning up a real fastmcp server. |
+| `tests/conftest.py` | Adds `_reset_authorizer` autouse fixture mirroring `_reset_auth_mode`. |
+
+### Middleware test scenarios
+
+- Tool call, no `required_scope` meta → passes through, `call_next` called once.
+- Tool call, `required_scope` set, authorizer returns `True` → passes through.
+- Tool call, `required_scope` set, authorizer returns `False` → `ToolError` raised, `call_next` *not* called.
+- Resource read with `required_scope`, denied → `ResourceError`.
+- Prompt get with `required_scope`, denied → `PromptError`.
+- Tool body raises `AuthzDenied` (via `check_authorization`) → middleware catches around `call_next`, converts to `ToolError`. Same for resource body → `ResourceError`, prompt body → `PromptError`.
+- `on_list_tools` filters out tools whose `required_scope` is denied; tools without the meta key are kept.
+- Same for `on_list_resources`, `on_list_resource_templates`, `on_list_prompts`.
+- `tool` / `resource` / `prompt` lookup raises (mounted-server edge case) → log warning, fall through to `call_next`.
+- Default error payload: `{"code": "authz_denied", "required_scope": "<scope>"}`. No `subject` key.
+- With `expose_subject_in_error=True`: payload includes `"subject": "<sub>"`.
+- Subject always logged at WARNING on deny regardless of `expose_subject_in_error`. Asserted via `caplog`.
+
+### Verification list
+
+Mapping the original issue's spirit to this design:
+
+- [ ] Tool with `required_scope` denies unmapped subject; allows mapped subject.
+- [ ] Tool without `required_scope` is unrestricted regardless of subject.
+- [ ] `*` scope wildcard lets a subject pass any required scope.
+- [ ] `subject is None` denies (default-deny in `make_acl_authorizer`).
+- [ ] `subject == "local"` works exactly like any other subject (no special casing in either middleware or bridge).
+- [ ] `tools/list`, `resources/list`, `resource_templates/list`, `prompts/list` are filtered to what the subject can use.
+- [ ] `AuthzDenied` from a tool/resource/prompt body becomes the matching `*Error` on the wire.
+- [ ] `check_authorization` works without explicit `authorizer=` when the middleware is installed; raises `RuntimeError` when neither ambient nor explicit is provided.
+- [ ] Subject not exposed in deny wire payload by default; opt-in flag turns it on.
+- [ ] Subject logged at WARNING on every deny regardless.
+- [ ] Bad ACL → `ConfigurationError` at startup; never silent denial.
+
+## Documentation
+
+The audience splits in two — handled in two repos.
+
+### Library-side (this repo)
+
+- API reference in `_authorization.py` docstrings (developer audience reading the library directly).
+- Terse "Authorization" section in `README.md`, after the existing "Identifying the caller" section: surface signatures + the minimal wiring example, link to this spec for the full picture.
+- This spec, plus updating `docs/specs/auth-subject-authz.md` to replace its broken "See also" pointer to the deleted authorization-submodule draft.
+
+### Template-side (`pvliesdonk/fastmcp-server-template`)
+
+Operator-facing walkthrough belongs in the template, not the library.
+Three stub issues to be filed against the template repo when
+implementation lands here, each with `Depends-on:` pointing at this
+issue:
+
+1. Commented `acl_path` config field in `config.py.jinja` (between the
+   `CONFIG-FIELDS-START`/`-END` block) plus the matching
+   `CONFIG-FROM-ENV-*` env reader stanza. Default commented-out so the
+   scaffold stays opt-in.
+2. Commented `AuthorizationMiddleware` wiring in `server.py.jinja`
+   immediately after the `wire_middleware_stack(mcp)` line, with the
+   load + bridge dance shown.
+3. Operator walkthrough section in `README.md.jinja`: ACL TOML schema,
+   the `<kind>:<id>` subject convention, the `*` scope wildcard,
+   opt-in posture, the load-once-at-startup-restart-to-update story,
+   and the bearer-mapped subject ↔ ACL key alignment (the same
+   string that's the value in the bearer-tokens TOML is the key in
+   the ACL TOML).
+
+Filed when implementation lands here, not before — the abandoned spec
+filed analogous template-repo issues prematurely (#94, #95, #96 in
+that repo) which then blocked on this work for months.
+
+## Implementation phasing
+
+Single PR is feasible — the surface is six symbols across one new
+module plus a `conftest.py` fixture and four new test files, with
+small README and existing-spec edits riding along. Splitting into
+loader + middleware sub-PRs would not provide useful intermediate
+states (the middleware can't be tested end-to-end without something
+producing an authorizer; the loader has nothing to be wired into
+without the middleware).
+
+The implementation PR opens against `main` after this design lands as
+its own commit/PR. Local review circus on each, per the standard PR
+workflow.
+
+Versioning is PSR-driven from conventional-commit subjects: this is a
+non-breaking feature add (no existing symbol changes shape, no
+existing behavior changes), so the implementation PR ships under a
+minor bump (`feat(authorization): …`).
+
+## Driving consumers
+
+`pvliesdonk/reqeng-mcp` Phase 2 (write-substrate) is the immediate
+driver: needs per-user attribution for ACLs and audit metadata.
+Likely future consumers: `markdown-vault-mcp` (per-vault scopes),
+`scholar-mcp` (read/write distinction), other multi-user MCP servers
+in the PVL ecosystem.
+
+## Local review discipline
+
+Per the global PR workflow, every PR runs the full circus before
+opening as draft:
+
+1. `pr-review-toolkit:code-reviewer` on the cumulative diff.
+2. `superpowers:code-reviewer` on the same diff.
+3. Targeted reviewers when the diff calls for them: `silent-failure-hunter`, `type-design-analyzer`, `pr-test-analyzer`, `comment-analyzer`.
+4. Bar: nothing flagged at any severity from either reviewer.
+5. Bot iteration after open capped at one round; escalate if a third would be needed.
+
+PRs open as draft. Flip to ready only after CI green and bot LGTM
+bodies (reading the body, not just the check status).
+
+## Deviations from issue #37
+
+The issue body specified a heavyweight surface that was attempted in
+2026-05 and abandoned. This redesign deviates as follows:
+
+| Issue body | This spec | Reason |
+|---|---|---|
+| Subject + tenant + scope as the access-control unit | Subject + scope only; tenants encoded into scope strings | User decision in design discussion: per-tenant grain felt wrong; namespaced scopes (`read:project-foo`) are the simpler primitive. |
+| Fixed `read \| write \| admin` vocabulary | Open-ended scope strings | Domain-specific scopes (`read:vault/personal`) need open-ended; the abandoned spec's `read < write < admin` ordering is a special case domains can encode in their own authorizer if they want. |
+| Default `read` scope when no annotation | No default; tools without `meta["required_scope"]` unrestricted | User decision: makes the system fully opt-in. Avoids deny-by-default-on-omission, which surprises consumers. |
+| `wire_middleware_stack(mcp, extra=[...])` install pattern | `mcp.add_middleware(AuthorizationMiddleware(...))` after `wire_middleware_stack(mcp)` | The `extra=` parameter does not exist in the shipped `wire_middleware_stack`. The previous session's implementation agent flagged this and was overridden — this design uses the actual fastmcp install API. |
+| `annotations={"requires_scope": "..."}` | `meta={"required_scope": "..."}` | `ToolAnnotations` is the MCP-standard set; free-form keys go in `meta`. The previous design's choice was wrong against current fastmcp. |
+| Admin tool helpers in the library | Out of scope | User decision: domain owns ACL mutation. Library does not ship tools that mutate library-loaded files. |
+| Commit-ACL-to-git | Out of scope | Same. |
+| Reload-on-each-request ACL semantics | Load-once-at-startup; future `make_reloading_acl_authorizer` is additive | Reload semantics are tricky (mtime-only? checksum? inode?) and were not justified by a concrete consumer need; deferring keeps the initial implementation predictable. |
+| `fastmcp_pvl_core.authorization/` subpackage with `_middleware.py`, `_store.py`, `_admin.py`, `_git.py` | Single `_authorization.py` module | Smaller scope means a single module is clearer; the four-file split was sized for the heavyweight design. |
+
+These are intentional deviations made during the redesign and accepted
+by the user. They are listed here so a future reader of the issue body
+sees exactly where this implementation parts ways with it.
+
+## See also
+
+- [`auth-subject-authz.md`](auth-subject-authz.md) — the design spec
+  for the shipped `get_subject` + bearer-mapped work this builds on.
+- [Issue #60](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/60)
+  — tracks the broader question of whether `Authorizer` and other
+  Callable-typed seams in the package should be Protocols. Low
+  priority; not blocking.

--- a/docs/superpowers/plans/2026-05-06-authorization-submodule.md
+++ b/docs/superpowers/plans/2026-05-06-authorization-submodule.md
@@ -1,0 +1,2293 @@
+# Authorization Submodule Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in authorization layer to `fastmcp-pvl-core` that gives downstream MCP servers a reusable `(subject, required_scope) → allow/deny` primitive — middleware + annotation convention + read-only ACL TOML loader — closing issue #37.
+
+**Architecture:** A single new private module `src/fastmcp_pvl_core/_authorization.py` exposing six public symbols re-exported from the package root. Per-component hooks (`on_call_tool`, `on_read_resource`, `on_get_prompt`) for enforcement; matching `on_list_*` hooks for list filtering. `check_authorization` reads an ambient `Authorizer` from a package-internal `ContextVar` set by the middleware at install time, mirroring the `_current_auth_mode` pattern in `_subject.py`. Tools opt in via `meta={"required_scope": "<scope>"}`; absence of the key means unrestricted.
+
+**Tech Stack:** Python 3.10+, fastmcp ≥3.2.4, `tomllib` (with `tomli` backport for 3.10), `contextvars.ContextVar`, pytest+pytest-asyncio (asyncio_mode=auto), mypy --strict, ruff (Google docstring convention).
+
+**Spec reference:** `docs/specs/authorization-submodule.md` (committed in this branch's first commit).
+
+---
+
+## File structure
+
+| File | Action | Purpose |
+|---|---|---|
+| `src/fastmcp_pvl_core/_authorization.py` | Create | All authz logic in one module — ~250 lines: `AuthzDenied`, `Authorizer` alias, `_current_authorizer` ContextVar + `set_current_authorizer`, `load_acl`, `make_acl_authorizer`, `check_authorization`, `AuthorizationMiddleware`. |
+| `src/fastmcp_pvl_core/__init__.py` | Modify | Add six public symbols to imports + `__all__`. |
+| `tests/conftest.py` | Modify | Add `_reset_authorizer` autouse fixture mirroring `_reset_auth_mode`. |
+| `tests/test_authorization_loader.py` | Create | `load_acl` happy path + every validation error. |
+| `tests/test_authorization_authorizer.py` | Create | `make_acl_authorizer` semantics. |
+| `tests/test_authorization_check.py` | Create | `check_authorization` + `AuthzDenied`. |
+| `tests/test_authorization_middleware.py` | Create | All middleware hook behaviors. |
+| `README.md` | Modify | New "Authorization" section after "Identifying the caller — `get_subject`". |
+| `docs/specs/auth-subject-authz.md` | Modify | Update broken "See also" pointer that the deleted-then-redrafted authorization-submodule.md created. |
+
+Existing `_authorization.py` precedents to follow:
+- **TOML loading + `Path.expanduser()` single-expansion-site pattern**: `src/fastmcp_pvl_core/_auth.py:_load_bearer_tokens` (lines 132-190).
+- **`ContextVar` plumbing + `set_current_*` helper**: `src/fastmcp_pvl_core/_subject.py` (lines 43-57).
+- **Tests that patch ambient context rather than spinning up fastmcp**: `tests/test_subject.py` (patches `fastmcp.server.dependencies.get_access_token`).
+- **`ConfigurationError` for fail-fast loader errors**: `src/fastmcp_pvl_core/_errors.py` + usage throughout `_auth.py`.
+
+---
+
+## Task 1: Module skeleton — `AuthzDenied`, `Authorizer`, ContextVar
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_authorization.py`
+- Test: `tests/test_authorization_check.py` (just for `AuthzDenied` here; full check_authorization tests come in Task 5)
+
+This task creates the module file with the type alias, exception, and ambient-context plumbing. No middleware, no loader, no helper yet — just the foundations everything else builds on.
+
+- [ ] **Step 1: Write the failing test for `AuthzDenied`**
+
+Create `tests/test_authorization_check.py`:
+
+```python
+"""Tests for AuthzDenied and check_authorization (added in later tasks)."""
+
+from __future__ import annotations
+
+import pytest
+
+from fastmcp_pvl_core._authorization import AuthzDenied
+
+
+def test_authz_denied_carries_subject_and_required_scope() -> None:
+    exc = AuthzDenied(subject="user:alice@example.com", required_scope="write")
+    assert exc.subject == "user:alice@example.com"
+    assert exc.required_scope == "write"
+
+
+def test_authz_denied_subject_can_be_none() -> None:
+    exc = AuthzDenied(subject=None, required_scope="read")
+    assert exc.subject is None
+    assert exc.required_scope == "read"
+
+
+def test_authz_denied_is_an_exception() -> None:
+    with pytest.raises(AuthzDenied):
+        raise AuthzDenied(subject="x", required_scope="y")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_authorization_check.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'fastmcp_pvl_core._authorization'`.
+
+- [ ] **Step 3: Write the module skeleton**
+
+Create `src/fastmcp_pvl_core/_authorization.py`:
+
+```python
+"""Authorization primitives: middleware, annotation convention, ACL loader.
+
+Downstream MCP servers that need to enforce per-subject access control
+on their tools, resources, or prompts can opt in by:
+
+1. Annotating components with ``meta={"required_scope": "<scope>"}``.
+2. Building an :data:`Authorizer` (typically via :func:`load_acl` +
+   :func:`make_acl_authorizer`).
+3. Installing :class:`AuthorizationMiddleware` after
+   :func:`fastmcp_pvl_core.wire_middleware_stack`.
+
+See ``docs/specs/authorization-submodule.md`` for the design rationale.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextvars import ContextVar
+from typing import TypeAlias
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+Authorizer: TypeAlias = Callable[[str | None, str], bool]
+"""Decision callable: ``(subject, required_scope) -> bool``.
+
+Returns ``True`` to allow, ``False`` to deny.  ``None`` subject means
+"no caller identity available" — typical authorizers deny that case.
+
+This is a :class:`TypeAlias`, not a ``Protocol``.  The Protocol upgrade
+across this and other Callable seams in the package is tracked in
+issue #60.
+"""
+
+
+# ---------------------------------------------------------------------------
+# AuthzDenied exception
+# ---------------------------------------------------------------------------
+
+
+class AuthzDenied(Exception):
+    """Raised by :func:`check_authorization` when the authorizer denies.
+
+    The :class:`AuthorizationMiddleware` catches this around
+    ``call_next`` and re-raises as the per-operation MCP error
+    (:class:`fastmcp.exceptions.ToolError` for a tool body,
+    :class:`~fastmcp.exceptions.ResourceError` for a resource handler,
+    :class:`~fastmcp.exceptions.PromptError` for a prompt handler).
+
+    If the middleware is *not* installed, this propagates as a plain
+    :class:`Exception` and surfaces as a generic MCP error.
+    """
+
+    subject: str | None
+    required_scope: str
+
+    def __init__(self, *, subject: str | None, required_scope: str) -> None:
+        super().__init__(
+            f"authorization denied: subject={subject!r} "
+            f"required_scope={required_scope!r}"
+        )
+        self.subject = subject
+        self.required_scope = required_scope
+
+
+# ---------------------------------------------------------------------------
+# Ambient authorizer (ContextVar plumbing)
+# ---------------------------------------------------------------------------
+
+
+_current_authorizer: ContextVar[Authorizer | None] = ContextVar(
+    "fastmcp_pvl_core_current_authorizer",
+    default=None,
+)
+"""Per-context pointer to the active authorizer.
+
+Set by :class:`AuthorizationMiddleware.__init__`; read by
+:func:`check_authorization` when its ``authorizer=`` kwarg is omitted.
+Same pattern as ``_current_auth_mode`` in :mod:`_subject`; same
+composition caveat (last writer wins; operators wishing to compose
+multiple :class:`AuthorizationMiddleware` instances on distinct
+contexts must wrap each install in
+``contextvars.copy_context().run(...)``).
+"""
+
+
+def set_current_authorizer(authorizer: Authorizer | None) -> None:
+    """Record the active authorizer for the current context.
+
+    Called by :class:`AuthorizationMiddleware.__init__`.  Tests that
+    exercise :func:`check_authorization` without going through the
+    middleware may call this directly.  Passing ``None`` resets the
+    pointer (useful between tests).
+    """
+    _current_authorizer.set(authorizer)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_authorization_check.py -v`
+Expected: PASS (3 tests passing).
+
+- [ ] **Step 5: Run mypy + ruff**
+
+Run: `uv run mypy src/fastmcp_pvl_core/_authorization.py && uv run ruff check src/fastmcp_pvl_core/_authorization.py`
+Expected: both pass with no findings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_authorization.py tests/test_authorization_check.py
+git commit -m "feat(authorization): add AuthzDenied + ambient authorizer plumbing (refs #37)"
+```
+
+---
+
+## Task 2: `load_acl` happy path
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_authorization.py` (add `load_acl`)
+- Create: `tests/test_authorization_loader.py`
+
+Minimal happy-path-only loader. Validation errors come in Task 3.
+
+- [ ] **Step 1: Write the failing happy-path test**
+
+Create `tests/test_authorization_loader.py`:
+
+```python
+"""Tests for the load_acl TOML loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fastmcp_pvl_core._authorization import load_acl
+
+
+def test_load_acl_happy_path(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text(
+        '''
+[subjects]
+"user:alice@example.com" = ["read", "write"]
+"user:admin@example.com" = ["*"]
+"service:ci-bot"         = ["read"]
+        ''',
+        encoding="utf-8",
+    )
+    acl = load_acl(p)
+    assert acl == {
+        "user:alice@example.com": frozenset({"read", "write"}),
+        "user:admin@example.com": frozenset({"*"}),
+        "service:ci-bot": frozenset({"read"}),
+    }
+    # Values are frozensets, not lists.
+    assert all(isinstance(v, frozenset) for v in acl.values())
+
+
+def test_load_acl_empty_subjects_table_permitted(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text("[subjects]\n", encoding="utf-8")
+    assert load_acl(p) == {}
+
+
+def test_load_acl_expands_user_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Create the file at a real location, then point HOME at tmp_path
+    # so that ``~/acl.toml`` resolves there.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    real = tmp_path / "acl.toml"
+    real.write_text('[subjects]\n"user:x" = ["read"]\n', encoding="utf-8")
+    acl = load_acl(Path("~/acl.toml"))
+    assert acl == {"user:x": frozenset({"read"})}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_authorization_loader.py -v`
+Expected: FAIL with `ImportError: cannot import name 'load_acl'`.
+
+- [ ] **Step 3: Add minimal `load_acl` to `_authorization.py`**
+
+Add the import block at the top of `_authorization.py` (extend the existing imports):
+
+```python
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Mapping, AbstractSet
+from contextvars import ContextVar
+from pathlib import Path
+from typing import TypeAlias
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - fallback for Python 3.10
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
+
+from fastmcp_pvl_core._errors import ConfigurationError
+```
+
+Then append the loader after the ContextVar block:
+
+```python
+# ---------------------------------------------------------------------------
+# ACL TOML loader
+# ---------------------------------------------------------------------------
+
+
+def load_acl(path: Path) -> dict[str, frozenset[str]]:
+    """Load an ACL TOML file into a ``{subject: frozenset[scope]}`` dict.
+
+    The path is normalised with :meth:`Path.expanduser` first.  This is
+    the single expansion site for both env-loaded paths (which keep a
+    leading ``~`` literal) and direct-construction paths.
+
+    Schema:
+
+    .. code-block:: toml
+
+        [subjects]
+        "user:alice@example.com" = ["read", "write"]
+        "user:admin@example.com" = ["*"]
+
+    The ``*`` scope is interpreted by :func:`make_acl_authorizer` as
+    "any required scope passes".  No subject-side wildcard.
+
+    Args:
+        path: Path to the ACL TOML file.
+
+    Returns:
+        A ``dict`` mapping each subject to a ``frozenset`` of granted
+        scope strings.
+
+    Raises:
+        ConfigurationError: file missing, unreadable, malformed,
+            schema-invalid, or containing an empty / whitespace /
+            ``"*"`` subject key.
+    """
+    path = path.expanduser()
+    if not path.is_file():
+        raise ConfigurationError(
+            f"ACL file not found or not a regular file: {path}"
+        )
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ConfigurationError(
+            f"ACL file at {path} could not be read: {exc}"
+        ) from exc
+    try:
+        data = tomllib.loads(raw)
+    except tomllib.TOMLDecodeError as exc:
+        raise ConfigurationError(
+            f"ACL file at {path} could not be parsed: {exc}"
+        ) from exc
+
+    subjects = data.get("subjects")
+    if not isinstance(subjects, dict):
+        raise ConfigurationError(
+            f"ACL file at {path} must define a [subjects] table"
+        )
+
+    result: dict[str, frozenset[str]] = {}
+    for subject, scopes in subjects.items():
+        result[subject] = frozenset(scopes)
+    return result
+```
+
+- [ ] **Step 4: Run tests to verify happy path passes**
+
+Run: `uv run pytest tests/test_authorization_loader.py -v`
+Expected: PASS (3 tests passing).
+
+- [ ] **Step 5: Run mypy + ruff**
+
+Run: `uv run mypy src/fastmcp_pvl_core/_authorization.py && uv run ruff check src/fastmcp_pvl_core/_authorization.py`
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_authorization.py tests/test_authorization_loader.py
+git commit -m "feat(authorization): add load_acl happy path (refs #37)"
+```
+
+---
+
+## Task 3: `load_acl` validation errors
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_authorization.py:load_acl` (add validation branches)
+- Modify: `tests/test_authorization_loader.py` (add error tests)
+
+Each validation rule from the spec gets a test + branch.
+
+- [ ] **Step 1: Write the failing validation tests**
+
+Append to `tests/test_authorization_loader.py`:
+
+```python
+def test_load_acl_missing_file(tmp_path: Path) -> None:
+    p = tmp_path / "nope.toml"
+    with pytest.raises(ConfigurationError, match="not found"):
+        load_acl(p)
+
+
+def test_load_acl_directory_not_file(tmp_path: Path) -> None:
+    with pytest.raises(ConfigurationError, match="not found or not a regular file"):
+        load_acl(tmp_path)  # a directory
+
+
+def test_load_acl_invalid_utf8(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_bytes(b"\xff\xfe\xfd not utf-8")
+    with pytest.raises(ConfigurationError, match="could not be read"):
+        load_acl(p)
+
+
+def test_load_acl_malformed_toml(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text("[subjects\nbroken =", encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="could not be parsed"):
+        load_acl(p)
+
+
+def test_load_acl_missing_subjects_table(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[other]\nkey = "val"\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match=r"\[subjects\] table"):
+        load_acl(p)
+
+
+def test_load_acl_subjects_not_a_table(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('subjects = "scalar"\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match=r"\[subjects\] table"):
+        load_acl(p)
+
+
+def test_load_acl_blank_subject_key_rejected(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"" = ["read"]\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="subject key is empty"):
+        load_acl(p)
+
+
+def test_load_acl_whitespace_subject_key_rejected(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"   " = ["read"]\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="subject key is empty"):
+        load_acl(p)
+
+
+def test_load_acl_subject_wildcard_rejected(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"*" = ["read"]\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match=r'"\*" as a subject key'):
+        load_acl(p)
+
+
+def test_load_acl_non_list_value(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"user:x" = "read"\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="must be an array"):
+        load_acl(p)
+
+
+def test_load_acl_non_string_scope(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"user:x" = ["read", 42]\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="scope must be a string"):
+        load_acl(p)
+
+
+def test_load_acl_blank_scope(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"user:x" = ["read", "  "]\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="scope is empty"):
+        load_acl(p)
+```
+
+Add the matching import to the top of the test file:
+
+```python
+from fastmcp_pvl_core._errors import ConfigurationError
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_authorization_loader.py -v`
+Expected: 12 new tests fail (the existing 3 happy-path tests still pass).
+
+- [ ] **Step 3: Add validation branches to `load_acl`**
+
+Replace the loop body in `load_acl` (the part starting at `for subject, scopes in subjects.items():`) with:
+
+```python
+    result: dict[str, frozenset[str]] = {}
+    for subject, scopes in subjects.items():
+        if not subject.strip():
+            raise ConfigurationError(
+                f"ACL file at {path}: subject key is empty or whitespace-only"
+            )
+        if subject == "*":
+            raise ConfigurationError(
+                f'ACL file at {path}: "*" as a subject key is not allowed '
+                "(global subject wildcards collapse the model)"
+            )
+        if not isinstance(scopes, list):
+            raise ConfigurationError(
+                f"ACL file at {path}: subject {subject!r} value must be an "
+                f"array of scope strings; got {type(scopes).__name__}"
+            )
+        cleaned: set[str] = set()
+        for scope in scopes:
+            if not isinstance(scope, str):
+                raise ConfigurationError(
+                    f"ACL file at {path}: subject {subject!r}: scope must "
+                    f"be a string; got {type(scope).__name__}"
+                )
+            if not scope.strip():
+                raise ConfigurationError(
+                    f"ACL file at {path}: subject {subject!r}: scope is "
+                    "empty or whitespace-only"
+                )
+            cleaned.add(scope)
+        result[subject] = frozenset(cleaned)
+    return result
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+Run: `uv run pytest tests/test_authorization_loader.py -v`
+Expected: 15 tests passing (12 new + 3 happy-path).
+
+- [ ] **Step 5: Run mypy + ruff**
+
+Run: `uv run mypy src/fastmcp_pvl_core/_authorization.py && uv run ruff check src/fastmcp_pvl_core/_authorization.py tests/test_authorization_loader.py`
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_authorization.py tests/test_authorization_loader.py
+git commit -m "feat(authorization): add load_acl validation (refs #37)"
+```
+
+---
+
+## Task 4: `make_acl_authorizer`
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_authorization.py` (add bridge)
+- Create: `tests/test_authorization_authorizer.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_authorization_authorizer.py`:
+
+```python
+"""Tests for make_acl_authorizer."""
+
+from __future__ import annotations
+
+from fastmcp_pvl_core._authorization import make_acl_authorizer
+
+
+def test_subject_in_acl_with_required_scope_allowed() -> None:
+    authorize = make_acl_authorizer(
+        {"user:alice": frozenset({"read", "write"})}
+    )
+    assert authorize("user:alice", "read") is True
+    assert authorize("user:alice", "write") is True
+
+
+def test_subject_in_acl_missing_required_scope_denied() -> None:
+    authorize = make_acl_authorizer({"user:alice": frozenset({"read"})})
+    assert authorize("user:alice", "write") is False
+
+
+def test_unknown_subject_denied() -> None:
+    authorize = make_acl_authorizer({"user:alice": frozenset({"read"})})
+    assert authorize("user:bob", "read") is False
+
+
+def test_subject_none_denied() -> None:
+    authorize = make_acl_authorizer({"user:alice": frozenset({"read"})})
+    assert authorize(None, "read") is False
+
+
+def test_wildcard_scope_grants_anything() -> None:
+    authorize = make_acl_authorizer({"user:admin": frozenset({"*"})})
+    assert authorize("user:admin", "read") is True
+    assert authorize("user:admin", "write") is True
+    assert authorize("user:admin", "anything:project-foo") is True
+
+
+def test_wildcard_alongside_specific_scopes() -> None:
+    authorize = make_acl_authorizer(
+        {"user:admin": frozenset({"*", "read"})}
+    )
+    assert authorize("user:admin", "anything") is True
+
+
+def test_acl_captured_by_reference_not_copied() -> None:
+    acl: dict[str, frozenset[str]] = {"user:alice": frozenset({"read"})}
+    authorize = make_acl_authorizer(acl)
+    assert authorize("user:bob", "read") is False
+    # Mutate the ACL after the bridge was created.
+    acl["user:bob"] = frozenset({"read"})
+    assert authorize("user:bob", "read") is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_authorization_authorizer.py -v`
+Expected: FAIL with `ImportError: cannot import name 'make_acl_authorizer'`.
+
+- [ ] **Step 3: Add `make_acl_authorizer` to `_authorization.py`**
+
+Append after `load_acl`:
+
+```python
+# ---------------------------------------------------------------------------
+# ACL → Authorizer bridge
+# ---------------------------------------------------------------------------
+
+
+def make_acl_authorizer(acl: Mapping[str, AbstractSet[str]]) -> Authorizer:
+    """Bridge a ``{subject: scopes}`` mapping to an :data:`Authorizer`.
+
+    Allow rules:
+
+    - ``subject is None`` → deny.
+    - Subject not in ``acl`` → deny.
+    - ``"*"`` in the subject's grants → allow any required scope.
+    - Otherwise → allow iff ``required_scope`` is in the grants.
+
+    The mapping is captured by reference, not copied.  A downstream that
+    mutates the dict in place sees the change reflected by the closure
+    (intentional; the recommended pattern is rebuild + reassign, but
+    reference-capture lets advanced consumers wire reload semantics
+    without changing this signature).
+
+    Args:
+        acl: Mapping from subject string to a set of granted scope strings.
+
+    Returns:
+        An :data:`Authorizer` callable.
+    """
+
+    def authorize(subject: str | None, required_scope: str) -> bool:
+        if subject is None:
+            return False
+        granted = acl.get(subject)
+        if granted is None:
+            return False
+        return "*" in granted or required_scope in granted
+
+    return authorize
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+Run: `uv run pytest tests/test_authorization_authorizer.py -v`
+Expected: 7 tests passing.
+
+- [ ] **Step 5: Run mypy + ruff**
+
+Run: `uv run mypy src/fastmcp_pvl_core/_authorization.py && uv run ruff check src/fastmcp_pvl_core/_authorization.py tests/test_authorization_authorizer.py`
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_authorization.py tests/test_authorization_authorizer.py
+git commit -m "feat(authorization): add make_acl_authorizer bridge (refs #37)"
+```
+
+---
+
+## Task 5: `check_authorization`
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_authorization.py` (add helper)
+- Modify: `tests/test_authorization_check.py` (add full-coverage tests)
+- Modify: `tests/conftest.py` (add `_reset_authorizer` autouse fixture)
+
+This task adds the ambient-or-explicit `check_authorization` helper *and* the conftest fixture that keeps test isolation working — the two are coupled because the helper reads the ContextVar and the fixture resets it.
+
+- [ ] **Step 1: Add the conftest fixture**
+
+Replace `tests/conftest.py` with:
+
+```python
+"""Shared pytest fixtures for fastmcp-pvl-core tests."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from fastmcp_pvl_core._authorization import set_current_authorizer
+from fastmcp_pvl_core._subject import set_current_auth_mode
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth_mode() -> Iterator[None]:
+    """Reset the auth-mode contextvar between tests.
+
+    ``set_current_auth_mode`` writes to a :class:`ContextVar` whose
+    visible value crosses test boundaries when tests share the same
+    asyncio task / module run.  Lifted suite-wide here so that any
+    test calling ``build_auth`` (which mutates the var as a startup
+    side effect) does not leak the resolved mode into the next test
+    that reads via ``get_subject``.
+    """
+    set_current_auth_mode(None)
+    yield
+    set_current_auth_mode(None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_authorizer() -> Iterator[None]:
+    """Reset the authorizer contextvar between tests.
+
+    Mirrors ``_reset_auth_mode``; same rationale.
+    """
+    set_current_authorizer(None)
+    yield
+    set_current_authorizer(None)
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Strip all env vars whose name starts with a common test prefix."""
+    prefixes = ("TEST_", "PVLCORE_TEST_")
+    for key in list(os.environ):
+        if key.startswith(prefixes):
+            monkeypatch.delenv(key, raising=False)
+    yield
+```
+
+- [ ] **Step 2: Add the failing `check_authorization` tests**
+
+Append to `tests/test_authorization_check.py`:
+
+```python
+from unittest.mock import patch
+
+from fastmcp_pvl_core._authorization import (
+    Authorizer,
+    check_authorization,
+    set_current_authorizer,
+)
+
+
+def _allow_all(_subject: str | None, _required_scope: str) -> bool:
+    return True
+
+
+def _deny_all(_subject: str | None, _required_scope: str) -> bool:
+    return False
+
+
+def test_check_authorization_uses_explicit_authorizer_allow() -> None:
+    # No subject lookup needed when the authorizer says yes.
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = check_authorization("read", authorizer=_allow_all)
+    assert result is None
+
+
+def test_check_authorization_uses_explicit_authorizer_deny() -> None:
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(AuthzDenied) as exc_info:
+            check_authorization("write", authorizer=_deny_all)
+    assert exc_info.value.subject == "user:alice"
+    assert exc_info.value.required_scope == "write"
+
+
+def test_check_authorization_reads_ambient_authorizer() -> None:
+    set_current_authorizer(_allow_all)
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        check_authorization("read")  # no authorizer kwarg
+
+
+def test_check_authorization_explicit_overrides_ambient() -> None:
+    # Ambient says allow, explicit says deny — explicit wins.
+    set_current_authorizer(_allow_all)
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(AuthzDenied):
+            check_authorization("read", authorizer=_deny_all)
+
+
+def test_check_authorization_no_authorizer_anywhere_raises_runtime_error() -> None:
+    # Both ambient and explicit absent.
+    with pytest.raises(RuntimeError, match="install AuthorizationMiddleware"):
+        check_authorization("read")
+
+
+def test_check_authorization_subject_kwarg_overrides_get_subject() -> None:
+    captured: dict[str, object] = {}
+
+    def authorize(subject: str | None, required_scope: str) -> bool:
+        captured["subject"] = subject
+        captured["required_scope"] = required_scope
+        return True
+
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:fromcontext"
+    ):
+        check_authorization("read", authorizer=authorize, subject="user:explicit")
+    assert captured == {"subject": "user:explicit", "required_scope": "read"}
+
+
+def test_check_authorization_omitted_subject_falls_through_to_get_subject() -> None:
+    """When ``subject`` is omitted (or None), ``get_subject()`` is consulted."""
+    captured: dict[str, object] = {}
+
+    def authorize(subject: str | None, required_scope: str) -> bool:
+        captured["subject"] = subject
+        return True
+
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:from_context"
+    ):
+        check_authorization("read", authorizer=authorize)
+    assert captured == {"subject": "user:from_context"}
+
+
+def test_check_authorization_get_subject_returning_none_denied_by_authorizer() -> None:
+    """When no ambient subject and the authorizer denies None, AuthzDenied carries None."""
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value=None
+    ):
+        with pytest.raises(AuthzDenied) as exc_info:
+            check_authorization("read", authorizer=_deny_all)
+    assert exc_info.value.subject is None
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_authorization_check.py -v`
+Expected: 7 new tests fail with `ImportError: cannot import name 'check_authorization'`. (The 3 `AuthzDenied` tests from Task 1 still pass.)
+
+- [ ] **Step 4: Add `check_authorization` to `_authorization.py`**
+
+Append after `make_acl_authorizer`:
+
+```python
+# ---------------------------------------------------------------------------
+# check_authorization (escape-hatch helper)
+# ---------------------------------------------------------------------------
+
+# Local import to keep ``_authorization`` importable from ``_subject`` if
+# that direction ever becomes needed; today the dependency is one-way.
+from fastmcp_pvl_core._subject import get_subject  # noqa: E402
+
+
+def check_authorization(
+    required_scope: str,
+    *,
+    authorizer: Authorizer | None = None,
+    subject: str | None = None,
+) -> None:
+    """Imperative authz check for use inside a tool / resource / prompt body.
+
+    Resolution order:
+
+    1. ``authorizer`` argument if given.
+    2. The ambient :data:`_current_authorizer` (set by
+       :class:`AuthorizationMiddleware.__init__`).
+    3. Otherwise raise :class:`RuntimeError`.
+
+    Subject resolution:
+
+    - ``subject`` used as-is when a non-``None`` value is passed.
+    - When omitted (or ``None``), :func:`fastmcp_pvl_core.get_subject`
+      is called.  ``get_subject`` itself may return ``None`` if no auth
+      context is available — that ``None`` is then forwarded to the
+      authorizer, which typically denies it.
+
+    Args:
+        required_scope: Scope string to require, e.g. ``"write"`` or
+            ``"read:project-foo"``.
+        authorizer: Override the ambient authorizer.  Useful when the
+            middleware isn't installed but a code path still wants the
+            check.
+        subject: Override the ``get_subject()`` lookup.  ``None``
+            (the default) means "look up via :func:`get_subject`".
+
+    Raises:
+        AuthzDenied: when the authorizer returns ``False``.
+        RuntimeError: when no authorizer is reachable (neither ambient
+            nor explicit).
+    """
+    if authorizer is None:
+        authorizer = _current_authorizer.get()
+        if authorizer is None:
+            raise RuntimeError(
+                "no authorizer in context; install AuthorizationMiddleware "
+                "or pass authorizer= explicitly to check_authorization()"
+            )
+
+    resolved_subject = subject if subject is not None else get_subject()
+
+    if not authorizer(resolved_subject, required_scope):
+        raise AuthzDenied(
+            subject=resolved_subject, required_scope=required_scope
+        )
+```
+
+- [ ] **Step 5: Run tests to verify all pass**
+
+Run: `uv run pytest tests/test_authorization_check.py -v`
+Expected: 10 tests passing (3 from Task 1 + 7 new).
+
+- [ ] **Step 6: Run full test suite to ensure no regression**
+
+Run: `uv run pytest -q`
+Expected: all existing tests + new authz tests pass.
+
+- [ ] **Step 7: Run mypy + ruff**
+
+Run: `uv run mypy src/fastmcp_pvl_core/_authorization.py tests/conftest.py && uv run ruff check src/fastmcp_pvl_core/_authorization.py tests/test_authorization_check.py tests/conftest.py`
+Expected: both pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_authorization.py tests/test_authorization_check.py tests/conftest.py
+git commit -m "feat(authorization): add check_authorization + reset fixture (refs #37)"
+```
+
+---
+
+## Task 6: `AuthorizationMiddleware` skeleton + `on_call_tool` static deny
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_authorization.py` (add middleware class)
+- Create: `tests/test_authorization_middleware.py`
+
+The middleware grows in four tasks (6, 7, 8, 9); this one creates the class and the tool-call hook with static-meta deny only. AuthzDenied catching, list filtering, and lookup-error tolerance come next.
+
+- [ ] **Step 1: Write the failing tool-call tests**
+
+Create `tests/test_authorization_middleware.py`:
+
+```python
+"""Tests for AuthorizationMiddleware."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from fastmcp_pvl_core._authorization import AuthorizationMiddleware
+
+
+def _make_context(
+    *,
+    tool_name: str = "do_thing",
+    tool_meta: dict[str, Any] | None = None,
+) -> MagicMock:
+    """Build a minimal MiddlewareContext-shaped mock for tool calls."""
+    tool = SimpleNamespace(meta=tool_meta or {})
+    fastmcp_obj = SimpleNamespace(get_tool=AsyncMock(return_value=tool))
+    fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
+    message = SimpleNamespace(name=tool_name, arguments={})
+    return MagicMock(
+        message=message,
+        fastmcp_context=fastmcp_context,
+    )
+
+
+def _allow_all(_subject: str | None, _required_scope: str) -> bool:
+    return True
+
+
+def _deny_all(_subject: str | None, _required_scope: str) -> bool:
+    return False
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_no_meta_passes_through() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_context(tool_meta={})  # no required_scope
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_call_tool(ctx, call_next)
+    assert result == "result"
+    call_next.assert_awaited_once_with(ctx)
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_with_meta_allowed_passes_through() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_allow_all)
+    ctx = _make_context(tool_meta={"required_scope": "write"})
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_call_tool(ctx, call_next)
+    assert result == "result"
+    call_next.assert_awaited_once_with(ctx)
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_with_meta_denied_raises_tool_error() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_context(tool_meta={"required_scope": "write"})
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, call_next)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {"code": "authz_denied", "required_scope": "write"}
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_publishes_authorizer_to_contextvar() -> None:
+    """__init__ sets the ambient authorizer so check_authorization works."""
+    from fastmcp_pvl_core._authorization import _current_authorizer
+
+    AuthorizationMiddleware(authorizer=_allow_all)
+    assert _current_authorizer.get() is _allow_all
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_authorization_middleware.py -v`
+Expected: FAIL with `ImportError: cannot import name 'AuthorizationMiddleware'`.
+
+- [ ] **Step 3: Add the middleware class to `_authorization.py`**
+
+Append after `check_authorization`:
+
+```python
+# ---------------------------------------------------------------------------
+# AuthorizationMiddleware
+# ---------------------------------------------------------------------------
+
+import json  # noqa: E402  (kept inline next to the deny-formatter)
+import logging  # noqa: E402
+
+from fastmcp.exceptions import ToolError  # noqa: E402
+from fastmcp.server.middleware import Middleware, MiddlewareContext  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+class AuthorizationMiddleware(Middleware):
+    """fastmcp middleware that enforces ``meta["required_scope"]`` on components.
+
+    Tools, resources, and prompts opt in by setting
+    ``meta={"required_scope": "<scope>"}`` at registration.  Components
+    without the meta key are unrestricted.
+
+    See ``docs/specs/authorization-submodule.md`` for the full design.
+    """
+
+    def __init__(
+        self,
+        *,
+        authorizer: Authorizer,
+        expose_subject_in_error: bool = False,
+    ) -> None:
+        """Construct the middleware and publish the authorizer ambient.
+
+        Args:
+            authorizer: Decision callable.  Saved on the instance and
+                also written to the package-internal
+                ``_current_authorizer`` :class:`ContextVar` so that
+                :func:`check_authorization` calls inside tool bodies
+                find it without an explicit ``authorizer=`` kwarg.
+            expose_subject_in_error: When ``True``, the wire-side deny
+                payload includes the ``subject`` key.  Defaults to
+                ``False`` (multi-user disclosure risk).  The subject is
+                always logged at WARNING regardless.
+        """
+        self._authorizer = authorizer
+        self._expose_subject = expose_subject_in_error
+        set_current_authorizer(authorizer)
+
+    # -------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------
+
+    def _format_deny_payload(
+        self, *, subject: str | None, required_scope: str
+    ) -> str:
+        """Render the JSON-encoded deny payload for the wire."""
+        body: dict[str, Any] = {
+            "code": "authz_denied",
+            "required_scope": required_scope,
+        }
+        if self._expose_subject:
+            body["subject"] = subject
+        return json.dumps(body)
+
+    def _log_deny(
+        self, *, kind: str, name: str, subject: str | None, required_scope: str
+    ) -> None:
+        """Log an authz denial at WARNING (subject always included in logs)."""
+        logger.warning(
+            "authz_denied kind=%s name=%s subject=%r required_scope=%r",
+            kind, name, subject, required_scope,
+        )
+
+    # -------------------------------------------------------------------
+    # Hooks (tool-call only in this task)
+    # -------------------------------------------------------------------
+
+    async def on_call_tool(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Enforce ``required_scope`` on tool calls."""
+        tool = await context.fastmcp_context.fastmcp.get_tool(
+            context.message.name
+        )
+        meta = getattr(tool, "meta", None) or {}
+        required = meta.get("required_scope")
+        if not isinstance(required, str) or not required.strip():
+            # No requirement: pass through.
+            return await call_next(context)
+
+        subject = get_subject()
+        if not self._authorizer(subject, required):
+            self._log_deny(
+                kind="tool",
+                name=context.message.name,
+                subject=subject,
+                required_scope=required,
+            )
+            raise ToolError(
+                self._format_deny_payload(
+                    subject=subject, required_scope=required
+                )
+            )
+        return await call_next(context)
+```
+
+Note on imports: the late `import` block (`json`, `logging`, fastmcp imports) is grouped with the middleware to keep the section self-contained. The `# noqa: E402` suppresses ruff's "module-level imports at top" rule for these specific lines; alternatively move them to the top of the file in a final cleanup pass.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_authorization_middleware.py -v`
+Expected: 4 tests passing.
+
+- [ ] **Step 5: Run mypy + ruff on the module**
+
+Run: `uv run mypy src/fastmcp_pvl_core/_authorization.py && uv run ruff check src/fastmcp_pvl_core/_authorization.py tests/test_authorization_middleware.py`
+Expected: both pass. If ruff complains about E402 even with the `# noqa`, hoist the imports to the top of the file (the per-section import comment is a stylistic preference, not a requirement).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_authorization.py tests/test_authorization_middleware.py
+git commit -m "feat(authorization): add AuthorizationMiddleware tool-call hook (refs #37)"
+```
+
+---
+
+## Task 7: `on_read_resource` and `on_get_prompt`
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_authorization.py` (add two parallel hooks)
+- Modify: `tests/test_authorization_middleware.py` (add resource and prompt tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_authorization_middleware.py`:
+
+```python
+from fastmcp.exceptions import PromptError, ResourceError
+
+
+def _make_resource_context(
+    *, uri: str = "vault://doc-1", resource_meta: dict[str, Any] | None = None
+) -> MagicMock:
+    resource = SimpleNamespace(meta=resource_meta or {})
+    fastmcp_obj = SimpleNamespace(get_resource=AsyncMock(return_value=resource))
+    fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
+    message = SimpleNamespace(uri=uri)
+    return MagicMock(message=message, fastmcp_context=fastmcp_context)
+
+
+def _make_prompt_context(
+    *, prompt_name: str = "the_prompt", prompt_meta: dict[str, Any] | None = None
+) -> MagicMock:
+    prompt = SimpleNamespace(meta=prompt_meta or {})
+    fastmcp_obj = SimpleNamespace(get_prompt=AsyncMock(return_value=prompt))
+    fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
+    message = SimpleNamespace(name=prompt_name, arguments={})
+    return MagicMock(message=message, fastmcp_context=fastmcp_context)
+
+
+@pytest.mark.asyncio
+async def test_on_read_resource_with_meta_denied_raises_resource_error() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_resource_context(resource_meta={"required_scope": "read"})
+    call_next = AsyncMock(return_value="contents")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ResourceError) as exc_info:
+            await middleware.on_read_resource(ctx, call_next)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {"code": "authz_denied", "required_scope": "read"}
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_read_resource_no_meta_passes_through() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_resource_context(resource_meta={})
+    call_next = AsyncMock(return_value="contents")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_read_resource(ctx, call_next)
+    assert result == "contents"
+
+
+@pytest.mark.asyncio
+async def test_on_get_prompt_with_meta_denied_raises_prompt_error() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_prompt_context(prompt_meta={"required_scope": "read"})
+    call_next = AsyncMock(return_value="messages")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(PromptError) as exc_info:
+            await middleware.on_get_prompt(ctx, call_next)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {"code": "authz_denied", "required_scope": "read"}
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_get_prompt_no_meta_passes_through() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_prompt_context(prompt_meta={})
+    call_next = AsyncMock(return_value="messages")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_get_prompt(ctx, call_next)
+    assert result == "messages"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_authorization_middleware.py -v`
+Expected: 4 new tests fail with `AttributeError: 'AuthorizationMiddleware' object has no attribute 'on_read_resource'`.
+
+- [ ] **Step 3: Add the parallel hooks**
+
+Add to `_authorization.py`'s import block (top of file or grouped near the existing fastmcp import):
+
+```python
+from fastmcp.exceptions import PromptError, ResourceError, ToolError  # noqa: E402
+```
+
+(Replacing the bare `from fastmcp.exceptions import ToolError` line.)
+
+Add the two methods to `AuthorizationMiddleware` after `on_call_tool`:
+
+```python
+    async def on_read_resource(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Enforce ``required_scope`` on resource reads."""
+        resource = await context.fastmcp_context.fastmcp.get_resource(
+            context.message.uri
+        )
+        meta = getattr(resource, "meta", None) or {}
+        required = meta.get("required_scope")
+        if not isinstance(required, str) or not required.strip():
+            return await call_next(context)
+
+        subject = get_subject()
+        if not self._authorizer(subject, required):
+            self._log_deny(
+                kind="resource",
+                name=str(context.message.uri),
+                subject=subject,
+                required_scope=required,
+            )
+            raise ResourceError(
+                self._format_deny_payload(
+                    subject=subject, required_scope=required
+                )
+            )
+        return await call_next(context)
+
+    async def on_get_prompt(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Enforce ``required_scope`` on prompt retrievals."""
+        prompt = await context.fastmcp_context.fastmcp.get_prompt(
+            context.message.name
+        )
+        meta = getattr(prompt, "meta", None) or {}
+        required = meta.get("required_scope")
+        if not isinstance(required, str) or not required.strip():
+            return await call_next(context)
+
+        subject = get_subject()
+        if not self._authorizer(subject, required):
+            self._log_deny(
+                kind="prompt",
+                name=context.message.name,
+                subject=subject,
+                required_scope=required,
+            )
+            raise PromptError(
+                self._format_deny_payload(
+                    subject=subject, required_scope=required
+                )
+            )
+        return await call_next(context)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_authorization_middleware.py -v`
+Expected: 8 tests passing.
+
+- [ ] **Step 5: Run mypy + ruff**
+
+Run: `uv run mypy src/fastmcp_pvl_core/_authorization.py && uv run ruff check src/fastmcp_pvl_core/_authorization.py tests/test_authorization_middleware.py`
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_authorization.py tests/test_authorization_middleware.py
+git commit -m "feat(authorization): add resource and prompt hooks (refs #37)"
+```
+
+---
+
+## Task 8: `AuthzDenied` translation in per-call hooks
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_authorization.py` (wrap `call_next` in try/except)
+- Modify: `tests/test_authorization_middleware.py` (add `AuthzDenied`-from-body tests)
+
+The middleware needs to catch `AuthzDenied` raised from inside a tool/resource/prompt body (via `check_authorization`) and convert it to the per-operation MCP error.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_authorization_middleware.py`:
+
+```python
+from fastmcp_pvl_core._authorization import AuthzDenied
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_body_authz_denied_becomes_tool_error() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_allow_all)
+    ctx = _make_context(tool_meta={})  # static check passes (no meta)
+
+    async def body_raises(_ctx: object) -> str:
+        raise AuthzDenied(subject="user:alice", required_scope="write:foo")
+
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, body_raises)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {"code": "authz_denied", "required_scope": "write:foo"}
+
+
+@pytest.mark.asyncio
+async def test_on_read_resource_body_authz_denied_becomes_resource_error() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_allow_all)
+    ctx = _make_resource_context(resource_meta={})
+
+    async def body_raises(_ctx: object) -> str:
+        raise AuthzDenied(subject="user:alice", required_scope="read:foo")
+
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ResourceError) as exc_info:
+            await middleware.on_read_resource(ctx, body_raises)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {"code": "authz_denied", "required_scope": "read:foo"}
+
+
+@pytest.mark.asyncio
+async def test_on_get_prompt_body_authz_denied_becomes_prompt_error() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_allow_all)
+    ctx = _make_prompt_context(prompt_meta={})
+
+    async def body_raises(_ctx: object) -> str:
+        raise AuthzDenied(subject="user:alice", required_scope="read:foo")
+
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(PromptError) as exc_info:
+            await middleware.on_get_prompt(ctx, body_raises)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {"code": "authz_denied", "required_scope": "read:foo"}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_authorization_middleware.py -v -k authz_denied_becomes`
+Expected: 3 tests fail (the bodies' `AuthzDenied` propagates as `Exception` rather than `ToolError`/`ResourceError`/`PromptError`).
+
+- [ ] **Step 3: Wrap each per-call hook's `call_next` in a try/except**
+
+In `_authorization.py`, modify `on_call_tool` so that the `return await call_next(context)` lines (both branches: with and without meta) become:
+
+```python
+        try:
+            return await call_next(context)
+        except AuthzDenied as exc:
+            self._log_deny(
+                kind="tool",
+                name=context.message.name,
+                subject=exc.subject,
+                required_scope=exc.required_scope,
+            )
+            raise ToolError(
+                self._format_deny_payload(
+                    subject=exc.subject, required_scope=exc.required_scope
+                )
+            ) from None
+```
+
+Apply the analogous pattern to `on_read_resource` (raising `ResourceError`, `kind="resource"`, `name=str(context.message.uri)`) and `on_get_prompt` (raising `PromptError`, `kind="prompt"`, `name=context.message.name`).
+
+The pattern collapses well into a small helper. Refactor `on_call_tool`'s body to:
+
+```python
+    async def on_call_tool(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        tool = await context.fastmcp_context.fastmcp.get_tool(
+            context.message.name
+        )
+        await self._enforce_static(
+            kind="tool",
+            name=context.message.name,
+            meta=getattr(tool, "meta", None) or {},
+            error_cls=ToolError,
+        )
+        return await self._call_with_authz_translation(
+            kind="tool",
+            name=context.message.name,
+            error_cls=ToolError,
+            call_next=call_next,
+            context=context,
+        )
+```
+
+And add the two helpers after `_log_deny`:
+
+```python
+    async def _enforce_static(
+        self,
+        *,
+        kind: str,
+        name: str,
+        meta: Mapping[str, Any],
+        error_cls: type[Exception],
+    ) -> None:
+        """Run the static `meta["required_scope"]` check.
+
+        Raises `error_cls` (constructed with the JSON deny payload) on
+        deny.  Does nothing when meta has no requirement.
+        """
+        required = meta.get("required_scope")
+        if not isinstance(required, str) or not required.strip():
+            return
+        subject = get_subject()
+        if not self._authorizer(subject, required):
+            self._log_deny(
+                kind=kind, name=name, subject=subject, required_scope=required
+            )
+            raise error_cls(
+                self._format_deny_payload(
+                    subject=subject, required_scope=required
+                )
+            )
+
+    async def _call_with_authz_translation(
+        self,
+        *,
+        kind: str,
+        name: str,
+        error_cls: type[Exception],
+        call_next: Any,
+        context: MiddlewareContext,
+    ) -> Any:
+        """Run ``call_next`` and translate AuthzDenied to ``error_cls``."""
+        try:
+            return await call_next(context)
+        except AuthzDenied as exc:
+            self._log_deny(
+                kind=kind, name=name,
+                subject=exc.subject, required_scope=exc.required_scope,
+            )
+            raise error_cls(
+                self._format_deny_payload(
+                    subject=exc.subject, required_scope=exc.required_scope,
+                )
+            ) from None
+```
+
+Then collapse `on_read_resource` and `on_get_prompt` to mirror `on_call_tool`'s shape. Final form:
+
+```python
+    async def on_read_resource(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        resource = await context.fastmcp_context.fastmcp.get_resource(
+            context.message.uri
+        )
+        await self._enforce_static(
+            kind="resource",
+            name=str(context.message.uri),
+            meta=getattr(resource, "meta", None) or {},
+            error_cls=ResourceError,
+        )
+        return await self._call_with_authz_translation(
+            kind="resource",
+            name=str(context.message.uri),
+            error_cls=ResourceError,
+            call_next=call_next,
+            context=context,
+        )
+
+    async def on_get_prompt(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        prompt = await context.fastmcp_context.fastmcp.get_prompt(
+            context.message.name
+        )
+        await self._enforce_static(
+            kind="prompt",
+            name=context.message.name,
+            meta=getattr(prompt, "meta", None) or {},
+            error_cls=PromptError,
+        )
+        return await self._call_with_authz_translation(
+            kind="prompt",
+            name=context.message.name,
+            error_cls=PromptError,
+            call_next=call_next,
+            context=context,
+        )
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+Run: `uv run pytest tests/test_authorization_middleware.py -v`
+Expected: 11 tests passing (8 prior + 3 new).
+
+- [ ] **Step 5: Run mypy + ruff**
+
+Run: `uv run mypy src/fastmcp_pvl_core/_authorization.py && uv run ruff check src/fastmcp_pvl_core/_authorization.py tests/test_authorization_middleware.py`
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_authorization.py tests/test_authorization_middleware.py
+git commit -m "feat(authorization): translate AuthzDenied from component bodies (refs #37)"
+```
+
+---
+
+## Task 9: Component-lookup error tolerance
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_authorization.py` (defensive try/except around `get_tool`/`get_resource`/`get_prompt`)
+- Modify: `tests/test_authorization_middleware.py` (add fall-through tests)
+
+When the inner-component lookup raises (mounted-server edge cases), the middleware logs a warning and falls through rather than denying.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_authorization_middleware.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_on_call_tool_get_tool_failure_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    fastmcp_obj = SimpleNamespace(
+        get_tool=AsyncMock(side_effect=KeyError("tool not found"))
+    )
+    fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
+    ctx = MagicMock(
+        message=SimpleNamespace(name="missing", arguments={}),
+        fastmcp_context=fastmcp_context,
+    )
+    call_next = AsyncMock(return_value="result")
+    caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_call_tool(ctx, call_next)
+    assert result == "result"
+    call_next.assert_awaited_once_with(ctx)
+    assert any("tool lookup failed" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_on_read_resource_get_resource_failure_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    fastmcp_obj = SimpleNamespace(
+        get_resource=AsyncMock(side_effect=KeyError("nope"))
+    )
+    fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
+    ctx = MagicMock(
+        message=SimpleNamespace(uri="vault://x"),
+        fastmcp_context=fastmcp_context,
+    )
+    call_next = AsyncMock(return_value="contents")
+    caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
+    result = await middleware.on_read_resource(ctx, call_next)
+    assert result == "contents"
+    assert any("resource lookup failed" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_on_get_prompt_get_prompt_failure_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    fastmcp_obj = SimpleNamespace(
+        get_prompt=AsyncMock(side_effect=KeyError("nope"))
+    )
+    fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
+    ctx = MagicMock(
+        message=SimpleNamespace(name="missing", arguments={}),
+        fastmcp_context=fastmcp_context,
+    )
+    call_next = AsyncMock(return_value="messages")
+    caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
+    result = await middleware.on_get_prompt(ctx, call_next)
+    assert result == "messages"
+    assert any("prompt lookup failed" in rec.message for rec in caplog.records)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_authorization_middleware.py -v -k lookup_failure`
+Expected: 3 tests fail (the `KeyError` propagates).
+
+- [ ] **Step 3: Wrap the lookups in defensive try/except**
+
+In `_authorization.py`, modify `on_call_tool` to wrap the `get_tool` call:
+
+```python
+    async def on_call_tool(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        try:
+            tool = await context.fastmcp_context.fastmcp.get_tool(
+                context.message.name
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive, logged
+            logger.warning(
+                "tool lookup failed during authz check; falling through "
+                "name=%s exc=%r",
+                context.message.name, exc,
+            )
+            return await self._call_with_authz_translation(
+                kind="tool",
+                name=context.message.name,
+                error_cls=ToolError,
+                call_next=call_next,
+                context=context,
+            )
+        await self._enforce_static(
+            kind="tool",
+            name=context.message.name,
+            meta=getattr(tool, "meta", None) or {},
+            error_cls=ToolError,
+        )
+        return await self._call_with_authz_translation(
+            kind="tool",
+            name=context.message.name,
+            error_cls=ToolError,
+            call_next=call_next,
+            context=context,
+        )
+```
+
+Apply the analogous wrap to `on_read_resource` (`get_resource`, `"resource lookup failed"`, `name=str(context.message.uri)`, `error_cls=ResourceError`) and `on_get_prompt` (`get_prompt`, `"prompt lookup failed"`, `name=context.message.name`, `error_cls=PromptError`).
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+Run: `uv run pytest tests/test_authorization_middleware.py -v`
+Expected: 14 tests passing.
+
+- [ ] **Step 5: Run mypy + ruff**
+
+Run: `uv run mypy src/fastmcp_pvl_core/_authorization.py && uv run ruff check src/fastmcp_pvl_core/_authorization.py tests/test_authorization_middleware.py`
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_authorization.py tests/test_authorization_middleware.py
+git commit -m "feat(authorization): tolerate component-lookup failures (refs #37)"
+```
+
+---
+
+## Task 10: List-filtering hooks
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_authorization.py` (add four `on_list_*` hooks)
+- Modify: `tests/test_authorization_middleware.py` (add list-filter tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_authorization_middleware.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_on_list_tools_filters_denied_tools() -> None:
+    """Tools with denied required_scope are dropped; unannotated kept."""
+    tool_open = SimpleNamespace(name="open_tool", meta={})
+    tool_write = SimpleNamespace(
+        name="write_tool", meta={"required_scope": "write"}
+    )
+    tool_read = SimpleNamespace(
+        name="read_tool", meta={"required_scope": "read"}
+    )
+
+    def authorize(_subject: str | None, required: str) -> bool:
+        return required == "read"  # only "read" passes
+
+    middleware = AuthorizationMiddleware(authorizer=authorize)
+    call_next = AsyncMock(return_value=[tool_open, tool_write, tool_read])
+    ctx = MagicMock()
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_list_tools(ctx, call_next)
+    assert result == [tool_open, tool_read]
+
+
+@pytest.mark.asyncio
+async def test_on_list_resources_filters_denied() -> None:
+    res_open = SimpleNamespace(uri="vault://1", meta={})
+    res_locked = SimpleNamespace(uri="vault://2", meta={"required_scope": "x"})
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    call_next = AsyncMock(return_value=[res_open, res_locked])
+    ctx = MagicMock()
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_list_resources(ctx, call_next)
+    assert result == [res_open]
+
+
+@pytest.mark.asyncio
+async def test_on_list_resource_templates_filters_denied() -> None:
+    tmpl_open = SimpleNamespace(uri="vault://{a}", meta={})
+    tmpl_locked = SimpleNamespace(
+        uri="vault://locked/{a}", meta={"required_scope": "x"}
+    )
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    call_next = AsyncMock(return_value=[tmpl_open, tmpl_locked])
+    ctx = MagicMock()
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_list_resource_templates(ctx, call_next)
+    assert result == [tmpl_open]
+
+
+@pytest.mark.asyncio
+async def test_on_list_prompts_filters_denied() -> None:
+    p_open = SimpleNamespace(name="open", meta={})
+    p_locked = SimpleNamespace(name="locked", meta={"required_scope": "x"})
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    call_next = AsyncMock(return_value=[p_open, p_locked])
+    ctx = MagicMock()
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_list_prompts(ctx, call_next)
+    assert result == [p_open]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_authorization_middleware.py -v -k on_list`
+Expected: 4 tests fail with `AttributeError: ... has no attribute 'on_list_tools'`.
+
+- [ ] **Step 3: Add the four list-filter hooks**
+
+In `_authorization.py`, add a private helper and the four hooks:
+
+```python
+    def _filter_components(
+        self, components: list[Any]
+    ) -> list[Any]:
+        """Drop components whose ``meta["required_scope"]`` denies the caller."""
+        subject = get_subject()
+        kept: list[Any] = []
+        for component in components:
+            meta = getattr(component, "meta", None) or {}
+            required = meta.get("required_scope")
+            if not isinstance(required, str) or not required.strip():
+                kept.append(component)
+                continue
+            if self._authorizer(subject, required):
+                kept.append(component)
+        return kept
+
+    async def on_list_tools(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Filter tool listings by what the caller can call."""
+        tools = await call_next(context)
+        return self._filter_components(tools)
+
+    async def on_list_resources(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Filter resource listings by what the caller can read."""
+        resources = await call_next(context)
+        return self._filter_components(resources)
+
+    async def on_list_resource_templates(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Filter resource template listings by what the caller can read."""
+        templates = await call_next(context)
+        return self._filter_components(templates)
+
+    async def on_list_prompts(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Filter prompt listings by what the caller can retrieve."""
+        prompts = await call_next(context)
+        return self._filter_components(prompts)
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+Run: `uv run pytest tests/test_authorization_middleware.py -v`
+Expected: 18 tests passing.
+
+- [ ] **Step 5: Run mypy + ruff**
+
+Run: `uv run mypy src/fastmcp_pvl_core/_authorization.py && uv run ruff check src/fastmcp_pvl_core/_authorization.py tests/test_authorization_middleware.py`
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_authorization.py tests/test_authorization_middleware.py
+git commit -m "feat(authorization): filter list-* responses by authz (refs #37)"
+```
+
+---
+
+## Task 11: `expose_subject_in_error` flag tests
+
+**Files:**
+- Modify: `tests/test_authorization_middleware.py` (add expose-subject tests)
+
+The flag and the WARNING-log behavior were already implemented in Tasks 6 and 8. This task locks them in with explicit assertions.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_authorization_middleware.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_default_payload_does_not_include_subject() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_context(tool_meta={"required_scope": "write"})
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, call_next)
+    payload = json.loads(str(exc_info.value))
+    assert "subject" not in payload
+
+
+@pytest.mark.asyncio
+async def test_expose_subject_in_error_includes_subject() -> None:
+    middleware = AuthorizationMiddleware(
+        authorizer=_deny_all, expose_subject_in_error=True
+    )
+    ctx = _make_context(tool_meta={"required_scope": "write"})
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, call_next)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {
+        "code": "authz_denied",
+        "required_scope": "write",
+        "subject": "user:alice",
+    }
+
+
+@pytest.mark.asyncio
+async def test_subject_always_logged_at_warning_regardless_of_flag(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Subject appears in WARNING log even when expose_subject_in_error=False."""
+    caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
+    middleware = AuthorizationMiddleware(
+        authorizer=_deny_all, expose_subject_in_error=False
+    )
+    ctx = _make_context(tool_meta={"required_scope": "write"})
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ToolError):
+            await middleware.on_call_tool(ctx, call_next)
+    assert any(
+        "user:alice" in rec.message and "authz_denied" in rec.message
+        for rec in caplog.records
+    )
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_authorization_middleware.py -v -k "expose_subject or default_payload or always_logged"`
+Expected: 3 tests passing (these behaviors were already implemented; the tests just lock them in).
+
+If a test fails, the implementation in Tasks 6 and 8 didn't match the assertions — go back and fix the implementation rather than weakening the test.
+
+- [ ] **Step 3: Run full middleware test suite**
+
+Run: `uv run pytest tests/test_authorization_middleware.py -v`
+Expected: 21 tests passing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_authorization_middleware.py
+git commit -m "test(authorization): lock in expose_subject_in_error + log behavior (refs #37)"
+```
+
+---
+
+## Task 12: Wire up package exports
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/__init__.py`
+
+- [ ] **Step 1: Add the imports**
+
+In `src/fastmcp_pvl_core/__init__.py`, after the existing `from fastmcp_pvl_core._auth import ...` block (around line 14-21), insert:
+
+```python
+from fastmcp_pvl_core._authorization import (
+    Authorizer,
+    AuthorizationMiddleware,
+    AuthzDenied,
+    check_authorization,
+    load_acl,
+    make_acl_authorizer,
+)
+```
+
+- [ ] **Step 2: Add to `__all__`**
+
+In the same file's `__all__` list, insert these entries (alphabetical placement; the list is sorted):
+
+```python
+    "AuthorizationMiddleware",
+    "Authorizer",
+    "AuthzDenied",
+    ...
+    "check_authorization",
+    ...
+    "load_acl",
+    ...
+    "make_acl_authorizer",
+```
+
+The exact insertion points depend on the alphabetical order; the existing `__all__` is sorted, so place each new symbol at the right spot. After editing, run a quick check that `__all__` stays sorted:
+
+Run: `python -c "import fastmcp_pvl_core; assert fastmcp_pvl_core.__all__ == sorted(fastmcp_pvl_core.__all__), 'unsorted'; print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 3: Smoke-test the public API**
+
+Run: `python -c "from fastmcp_pvl_core import AuthorizationMiddleware, AuthzDenied, Authorizer, check_authorization, load_acl, make_acl_authorizer; print('imports ok')"`
+Expected: `imports ok`.
+
+- [ ] **Step 4: Run full suite**
+
+Run: `uv run pytest -q && uv run mypy src tests && uv run ruff check src tests`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/__init__.py
+git commit -m "feat(authorization): export public symbols (refs #37)"
+```
+
+---
+
+## Task 13: README addition
+
+**Files:**
+- Modify: `README.md` (add an "Authorization" section after "Identifying the caller — `get_subject`")
+
+- [ ] **Step 1: Add the new section**
+
+In `README.md`, after the closing of the "Identifying the caller — `get_subject`" section (after the resolution-order block), and before the "Remote debugging in containers" section, insert:
+
+````markdown
+### Authorization (opt-in) — `AuthorizationMiddleware`
+
+Tools, resources, and prompts can opt into per-subject access control by
+setting `meta={"required_scope": "<scope>"}` at registration. A
+configured `AuthorizationMiddleware` enforces the static check and
+filters `list_*` responses to what the caller can use:
+
+```python
+from pathlib import Path
+from fastmcp_pvl_core import (
+    AuthorizationMiddleware, load_acl, make_acl_authorizer, check_authorization,
+)
+
+authorizer = make_acl_authorizer(load_acl(Path("/etc/my-app/acl.toml")))
+mcp.add_middleware(AuthorizationMiddleware(authorizer=authorizer))
+
+@mcp.tool(meta={"required_scope": "write"})
+async def edit_document(project_id: str, doc_id: str, body: str) -> None:
+    # Coarse "write" gate already passed at middleware. Per-project gate here:
+    check_authorization(f"write:{project_id}")
+    ...
+```
+
+ACL TOML schema (loaded by `load_acl`):
+
+```toml
+[subjects]
+"user:alice@example.com" = ["read", "write"]
+"user:admin@example.com" = ["*"]              # wildcard scope
+"service:ci-bot"         = ["read"]
+"local"                  = ["*"]              # stdio mode
+```
+
+Key properties:
+
+- **Opt-in per component.** Tools / resources / prompts without
+  `meta["required_scope"]` are unrestricted regardless of caller.
+- **`*` is the only library-treated special scope** ("any required
+  scope passes"). All other scopes are opaque strings; downstream chooses
+  the vocabulary.
+- **Subject-side wildcards (`*` as an ACL key) are rejected at load
+  time.**
+- **`load_acl` fails fast** with `ConfigurationError` on every malformed
+  condition — never silent denial.
+- **ACL is loaded once at startup.** Restart to pick up changes.
+- **Authorization scopes are application-level** and distinct from the
+  OAuth scopes carried in tokens.
+- **Subject is logged on every deny** at WARNING. The wire-side payload
+  *omits* the subject by default to limit cross-user info disclosure;
+  pass `AuthorizationMiddleware(..., expose_subject_in_error=True)` to
+  include it (e.g. for internal-only servers).
+
+For the full design rationale and deviations from the originating
+issue, see
+[`docs/specs/authorization-submodule.md`](docs/specs/authorization-submodule.md).
+````
+
+- [ ] **Step 2: Verify README still renders cleanly**
+
+Run: `python -c "import pathlib; t = pathlib.Path('README.md').read_text(); print('len=', len(t), 'has authz section=', 'AuthorizationMiddleware' in t)"`
+Expected: `len=...` (longer than before), `has authz section= True`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): add Authorization section (refs #37)"
+```
+
+---
+
+## Task 14: Cross-link cleanup in `auth-subject-authz.md`
+
+**Files:**
+- Modify: `docs/specs/auth-subject-authz.md` (the `## See also` block at the bottom + the "follow-on" paragraph in the Problem section)
+
+The existing spec has two stale references to the deleted authorization-submodule draft:
+
+- Lines 23-27 (Problem section): "A follow-on optional `authorization` submodule ... is described separately in `authorization-submodule.md` — that work was attempted in 2026-05 and abandoned mid-implementation; issue #37 remains open."
+- Lines 277-281 (Driving consumers): "The downstream `authorization` submodule (issue #37) ... is described in `authorization-submodule.md`. That spec is currently DRAFT and not implemented; treat it as forward design only."
+- Lines 283-286 (See also): the link annotated as DRAFT.
+
+Each of these now points at a real, implemented spec rather than a deleted draft.
+
+- [ ] **Step 1: Read the current state**
+
+Run: `grep -n "authorization-submodule" docs/specs/auth-subject-authz.md`
+Expected: 3 line numbers showing the references to update.
+
+- [ ] **Step 2: Update Problem-section paragraph**
+
+In `docs/specs/auth-subject-authz.md`, replace the paragraph that starts "A follow-on optional `authorization` submodule" with:
+
+```markdown
+A follow-on optional `authorization` submodule (subject + scope →
+allow/deny middleware, ACL TOML loader, and `check_authorization`
+helper) is described separately in
+[`authorization-submodule.md`](authorization-submodule.md). The
+implementation closes [issue #37](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/37).
+```
+
+- [ ] **Step 3: Update the Driving-consumers paragraph**
+
+Replace the paragraph that starts "The downstream `authorization` submodule (issue #37)" with:
+
+```markdown
+The downstream `authorization` submodule — the optional middleware /
+loader / `check_authorization` helper — is described in
+[`authorization-submodule.md`](authorization-submodule.md) and closes
+issue #37.
+```
+
+- [ ] **Step 4: Update the "See also" link annotation**
+
+Replace the `authorization-submodule.md` line in the `## See also` block with:
+
+```markdown
+- [`authorization-submodule.md`](authorization-submodule.md) — the
+  optional authorization submodule design (issue #37).
+```
+
+(Remove the "DRAFT and not implemented" suffix — it's no longer accurate.)
+
+- [ ] **Step 5: Verify no stale references remain**
+
+Run: `grep -n -E "(DRAFT|abandoned|not implemented)" docs/specs/auth-subject-authz.md`
+Expected: no output (or only output that's about something else, not authorization-submodule).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/specs/auth-subject-authz.md
+git commit -m "docs(spec): refresh auth-subject-authz cross-links to live authz spec (refs #37)"
+```
+
+---
+
+## Task 15: Verification sweep + final commit
+
+**Files:** none new — this task verifies everything works together.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `uv run pytest -q`
+Expected: all tests pass, no warnings about authz tests.
+
+- [ ] **Step 2: Run mypy in strict mode across the project**
+
+Run: `uv run mypy src tests`
+Expected: `Success: no issues found`.
+
+- [ ] **Step 3: Run ruff**
+
+Run: `uv run ruff check src tests`
+Expected: `All checks passed!`.
+
+- [ ] **Step 4: Smoke-test the public API end-to-end**
+
+Run:
+
+```bash
+python <<'EOF'
+from pathlib import Path
+import tempfile
+from fastmcp_pvl_core import (
+    AuthorizationMiddleware, AuthzDenied, Authorizer,
+    check_authorization, load_acl, make_acl_authorizer,
+)
+
+with tempfile.NamedTemporaryFile("w", suffix=".toml", delete=False) as f:
+    f.write('[subjects]\n"user:alice" = ["read", "write"]\n"user:bob" = ["read"]\n')
+    f.flush()
+    acl = load_acl(Path(f.name))
+
+authorize = make_acl_authorizer(acl)
+assert authorize("user:alice", "write") is True
+assert authorize("user:bob", "write") is False
+assert authorize(None, "read") is False
+
+mw = AuthorizationMiddleware(authorizer=authorize)
+
+try:
+    check_authorization("write", subject="user:bob")
+    raise AssertionError("expected AuthzDenied")
+except AuthzDenied as exc:
+    assert exc.subject == "user:bob"
+    assert exc.required_scope == "write"
+
+print("smoke ok")
+EOF
+```
+
+Expected: `smoke ok`.
+
+- [ ] **Step 5: Verify git history is clean**
+
+Run: `git log --oneline origin/main..HEAD`
+Expected: ~14 commits (one per task plus the initial spec commit), each with a `(refs #37)` trailer.
+
+- [ ] **Step 6: Map verification list from spec**
+
+Open `docs/specs/authorization-submodule.md` "Verification list" section. For each `[ ]` checkbox, point to the test that covers it. Update the spec's list to `[x]` only via a follow-up commit if the user wants — otherwise leave the spec's list as the design-time intent.
+
+- [ ] **Step 7: Final review preparation**
+
+The branch is now ready for the local review circus:
+
+1. Dispatch `pr-review-toolkit:code-reviewer` on the cumulative diff against `main`.
+2. Dispatch `superpowers:code-reviewer` on the same diff.
+3. Targeted reviewers: `silent-failure-hunter` (the middleware has try/except / fall-through paths), `type-design-analyzer` (the `Authorizer` alias + the `subject: ... = ...` sentinel), `pr-test-analyzer` (asserts the test list against the spec's verification matrix), `comment-analyzer` (the spec is a long doc that the comment-analyzer should sanity-check).
+
+After both primary reviewers return *nothing flagged at any severity*, open the PR as draft against `main` with body that explicitly closes #37.
+
+After CI green and bot LGTM bodies (read the bodies, not just the check status), flip ready.
+
+- [ ] **Step 8: Post-merge follow-up**
+
+The spec's "Documentation → Template-side" section lists three stub issues to file against `pvliesdonk/fastmcp-server-template`. File these *after* this PR merges, each with a `Depends-on:` pointer back to issue #37 / this PR, per the spec.
+
+---
+
+## Self-review
+
+**Spec coverage check:** every section of `docs/specs/authorization-submodule.md` maps to one or more tasks above:
+
+| Spec section | Covered by |
+|---|---|
+| Module layout and public API | Tasks 1, 12 |
+| `AuthorizationMiddleware` (per-call hooks, list filtering, ContextVar publish, lookup error tolerance) | Tasks 6, 7, 8, 9, 10 |
+| Annotation convention | Tasks 6, 7, 13 (docs) |
+| `check_authorization` and `AuthzDenied` | Tasks 1, 5 |
+| Error shape (default + `expose_subject_in_error`, log on deny) | Tasks 6, 11 |
+| TOML loader + bridge | Tasks 2, 3, 4 |
+| Wiring example | Task 13 |
+| What this submodule does NOT do | Implicit — anything not implemented in Tasks 1-14 isn't shipped |
+| Testing (file-by-file, scenarios, verification list) | Tasks 2-11 + 15 |
+| Documentation (library-side) | Tasks 13, 14 |
+| Documentation (template-side) | Task 15 step 8 (post-merge follow-up) |
+| Implementation phasing | This whole plan + the "single PR" framing in Task 15 |
+| Driving consumers | Mentioned in spec; nothing to implement here |
+| Local review discipline | Task 15 step 7 |
+| Deviations from issue #37 | Spec section; nothing to implement |
+
+**Placeholder scan:** none. Each step has the actual code, the actual command, the actual expected output.
+
+**Type consistency:** the `Authorizer` alias is defined in Task 1 and used identically in Tasks 4, 5, 6, 7, 8, 10, 11, 12. `AuthzDenied`'s constructor signature (`subject=`, `required_scope=`) is consistent across Tasks 1, 5, 8. The middleware's `_format_deny_payload` and `_log_deny` helper signatures are consistent across all per-call hooks (Tasks 6-9). The `_enforce_static` and `_call_with_authz_translation` helpers introduced in Task 8 are reused unchanged in Task 9.
+
+---
+
+**End of plan.**

--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -19,6 +19,14 @@ from fastmcp_pvl_core._auth import (
     build_remote_auth,
     resolve_auth_mode,
 )
+from fastmcp_pvl_core._authorization import (
+    AuthorizationMiddleware,
+    Authorizer,
+    AuthzDenied,
+    check_authorization,
+    load_acl,
+    make_acl_authorizer,
+)
 from fastmcp_pvl_core._cli import make_serve_parser, normalise_http_path
 from fastmcp_pvl_core._config import ServerConfig, Transport
 from fastmcp_pvl_core._debug import maybe_start_debugpy
@@ -65,14 +73,17 @@ from fastmcp_pvl_core.file_exchange import (
 __version__ = "2.0.0-rc.1"  # PSR overrides at build time
 
 __all__ = [
-    "FILE_EXCHANGE_SPEC_VERSION",
     "ArtifactStore",
     "AuthMode",
+    "AuthorizationMiddleware",
+    "Authorizer",
+    "AuthzDenied",
     "ConfigurationError",
     "ConsumerSink",
     "ExchangeGroupMismatch",
     "ExchangeURI",
     "ExchangeURIError",
+    "FILE_EXCHANGE_SPEC_VERSION",
     "FetchContext",
     "FetchResult",
     "FileExchange",
@@ -94,11 +105,14 @@ __all__ = [
     "build_instructions",
     "build_oidc_proxy_auth",
     "build_remote_auth",
+    "check_authorization",
     "compute_app_domain",
     "configure_logging_from_env",
     "env",
     "get_artifact_store",
     "get_subject",
+    "load_acl",
+    "make_acl_authorizer",
     "make_icon",
     "make_serve_parser",
     "maybe_start_debugpy",

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -167,5 +167,32 @@ def load_acl(path: Path) -> dict[str, frozenset[str]]:
 
     result: dict[str, frozenset[str]] = {}
     for subject, scopes in subjects.items():
-        result[subject] = frozenset(scopes)
+        if not subject.strip():
+            raise ConfigurationError(
+                f"ACL file at {path}: subject key is empty or whitespace-only"
+            )
+        if subject == "*":
+            raise ConfigurationError(
+                f'ACL file at {path}: "*" as a subject key is not allowed '
+                "(global subject wildcards collapse the model)"
+            )
+        if not isinstance(scopes, list):
+            raise ConfigurationError(
+                f"ACL file at {path}: subject {subject!r} value must be an "
+                f"array of scope strings; got {type(scopes).__name__}"
+            )
+        cleaned: set[str] = set()
+        for scope in scopes:
+            if not isinstance(scope, str):
+                raise ConfigurationError(
+                    f"ACL file at {path}: subject {subject!r}: scope must "
+                    f"be a string; got {type(scope).__name__}"
+                )
+            if not scope.strip():
+                raise ConfigurationError(
+                    f"ACL file at {path}: subject {subject!r}: scope is "
+                    "empty or whitespace-only"
+                )
+            cleaned.add(scope)
+        result[subject] = frozenset(cleaned)
     return result

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -396,7 +396,7 @@ class AuthorizationMiddleware(Middleware):
         required = meta.get("required_scope")
         if required is None:
             return
-        if not isinstance(required, str):
+        if not isinstance(required, str) or not required.strip():
             logger.warning(
                 "authz_meta_invalid kind=%s name=%s required_scope=%r — "
                 "expected non-empty string; treating as unrestricted",
@@ -406,8 +406,6 @@ class AuthorizationMiddleware(Middleware):
             )
             return
         required = required.strip()
-        if not required:
-            return
         subject = get_subject()
         if not self._authorizer(subject, required):
             self._log_deny(
@@ -453,7 +451,7 @@ class AuthorizationMiddleware(Middleware):
             if required is None:
                 kept.append(component)
                 continue
-            if not isinstance(required, str):
+            if not isinstance(required, str) or not required.strip():
                 logger.warning(
                     "authz_meta_invalid component=%r required_scope=%r — "
                     "expected non-empty string; treating as unrestricted",
@@ -463,9 +461,6 @@ class AuthorizationMiddleware(Middleware):
                 kept.append(component)
                 continue
             required = required.strip()
-            if not required:
-                kept.append(component)
-                continue
             if self._authorizer(subject, required):
                 kept.append(component)
         return kept

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -1,0 +1,82 @@
+"""Authorization primitives: middleware, annotation convention, ACL loader.
+
+Downstream MCP servers that need to enforce per-subject access control
+on their tools, resources, or prompts can opt in by:
+
+1. Annotating components with ``meta={"required_scope": "<scope>"}``.
+2. Building an :data:`Authorizer` (typically via :func:`load_acl` +
+   :func:`make_acl_authorizer`).
+3. Installing :class:`AuthorizationMiddleware` after
+   :func:`fastmcp_pvl_core.wire_middleware_stack`.
+
+See ``docs/specs/authorization-submodule.md`` for the design rationale.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextvars import ContextVar
+from typing import TypeAlias
+
+Authorizer: TypeAlias = Callable[[str | None, str], bool]
+"""Decision callable: ``(subject, required_scope) -> bool``.
+
+Returns ``True`` to allow, ``False`` to deny.  ``None`` subject means
+"no caller identity available" — typical authorizers deny that case.
+
+This is a :class:`TypeAlias`, not a ``Protocol``.  The Protocol upgrade
+across this and other Callable seams in the package is tracked in
+issue #60.
+"""
+
+
+class AuthzDenied(Exception):  # noqa: N818
+    """Raised by :func:`check_authorization` when the authorizer denies.
+
+    The :class:`AuthorizationMiddleware` catches this around
+    ``call_next`` and re-raises as the per-operation MCP error
+    (:class:`fastmcp.exceptions.ToolError` for a tool body,
+    :class:`~fastmcp.exceptions.ResourceError` for a resource handler,
+    :class:`~fastmcp.exceptions.PromptError` for a prompt handler).
+
+    If the middleware is *not* installed, this propagates as a plain
+    :class:`Exception` and surfaces as a generic MCP error.
+    """
+
+    subject: str | None
+    required_scope: str
+
+    def __init__(self, *, subject: str | None, required_scope: str) -> None:
+        super().__init__(
+            f"authorization denied: subject={subject!r} "
+            f"required_scope={required_scope!r}"
+        )
+        self.subject = subject
+        self.required_scope = required_scope
+
+
+_current_authorizer: ContextVar[Authorizer | None] = ContextVar(
+    "fastmcp_pvl_core_current_authorizer",
+    default=None,
+)
+"""Per-context pointer to the active authorizer.
+
+Set by :class:`AuthorizationMiddleware.__init__`; read by
+:func:`check_authorization` when its ``authorizer=`` kwarg is omitted.
+Same pattern as ``_current_auth_mode`` in :mod:`_subject`; same
+composition caveat (last writer wins; operators wishing to compose
+multiple :class:`AuthorizationMiddleware` instances on distinct
+contexts must wrap each install in
+``contextvars.copy_context().run(...)``).
+"""
+
+
+def set_current_authorizer(authorizer: Authorizer | None) -> None:
+    """Record the active authorizer for the current context.
+
+    Called by :class:`AuthorizationMiddleware.__init__`.  Tests that
+    exercise :func:`check_authorization` without going through the
+    middleware may call this directly.  Passing ``None`` resets the
+    pointer (useful between tests).
+    """
+    _current_authorizer.set(authorizer)

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -14,9 +14,21 @@ See ``docs/specs/authorization-submodule.md`` for the design rationale.
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 from contextvars import ContextVar
+from pathlib import Path
 from typing import TypeAlias
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - fallback for Python 3.10
+    # ``import-not-found`` covers CI rows where ``tomli`` is excluded by
+    # the marker (3.11+); ``unused-ignore`` covers local 3.10 envs where
+    # ``tomli`` is installed and the ignore would otherwise be flagged.
+    import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
+
+from fastmcp_pvl_core._errors import ConfigurationError
 
 # ---------------------------------------------------------------------------
 # Public types
@@ -92,3 +104,68 @@ def set_current_authorizer(authorizer: Authorizer | None) -> None:
     pointer (useful between tests).
     """
     _current_authorizer.set(authorizer)
+
+
+# ---------------------------------------------------------------------------
+# ACL TOML loader
+# ---------------------------------------------------------------------------
+
+
+def load_acl(path: Path) -> dict[str, frozenset[str]]:
+    """Load an ACL TOML file into a ``{subject: frozenset[scope]}`` dict.
+
+    The path is normalised with :meth:`Path.expanduser` first.  This is
+    the single expansion site for both env-loaded paths (which keep a
+    leading ``~`` literal) and direct-construction paths.
+
+    Schema:
+
+    .. code-block:: toml
+
+        [subjects]
+        "user:alice@example.com" = ["read", "write"]
+        "user:admin@example.com" = ["*"]
+
+    The ``*`` scope is interpreted by :func:`make_acl_authorizer` as
+    "any required scope passes".  No subject-side wildcard.
+
+    Args:
+        path: Path to the ACL TOML file.
+
+    Returns:
+        A ``dict`` mapping each subject to a ``frozenset`` of granted
+        scope strings.
+
+    Raises:
+        ConfigurationError: file missing, unreadable, malformed,
+            schema-invalid, or containing an empty / whitespace /
+            ``"*"`` subject key.
+    """
+    path = path.expanduser()
+    if not path.is_file():
+        raise ConfigurationError(
+            f"ACL file not found or not a regular file: {path}"
+        )
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ConfigurationError(
+            f"ACL file at {path} could not be read: {exc}"
+        ) from exc
+    try:
+        data = tomllib.loads(raw)
+    except tomllib.TOMLDecodeError as exc:
+        raise ConfigurationError(
+            f"ACL file at {path} could not be parsed: {exc}"
+        ) from exc
+
+    subjects = data.get("subjects")
+    if not isinstance(subjects, dict):
+        raise ConfigurationError(
+            f"ACL file at {path} must define a [subjects] table"
+        )
+
+    result: dict[str, frozenset[str]] = {}
+    for subject, scopes in subjects.items():
+        result[subject] = frozenset(scopes)
+    return result

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -30,6 +30,7 @@ else:  # pragma: no cover - fallback for Python 3.10
     import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
 
 from fastmcp_pvl_core._errors import ConfigurationError
+from fastmcp_pvl_core._subject import get_subject
 
 # ---------------------------------------------------------------------------
 # Public types
@@ -236,3 +237,61 @@ def make_acl_authorizer(acl: Mapping[str, AbstractSet[str]]) -> Authorizer:
         return "*" in granted or required_scope in granted
 
     return authorize
+
+
+# ---------------------------------------------------------------------------
+# check_authorization (escape-hatch helper)
+# ---------------------------------------------------------------------------
+
+
+def check_authorization(
+    required_scope: str,
+    *,
+    authorizer: Authorizer | None = None,
+    subject: str | None = None,
+) -> None:
+    """Imperative authz check for use inside a tool / resource / prompt body.
+
+    Resolution order:
+
+    1. ``authorizer`` argument if given.
+    2. The ambient :data:`_current_authorizer` (set by
+       :class:`AuthorizationMiddleware.__init__`).
+    3. Otherwise raise :class:`RuntimeError`.
+
+    Subject resolution:
+
+    - ``subject`` used as-is when a non-``None`` value is passed.
+    - When omitted (or ``None``), :func:`fastmcp_pvl_core.get_subject`
+      is called.  ``get_subject`` itself may return ``None`` if no auth
+      context is available — that ``None`` is then forwarded to the
+      authorizer, which typically denies it.
+
+    Args:
+        required_scope: Scope string to require, e.g. ``"write"`` or
+            ``"read:project-foo"``.
+        authorizer: Override the ambient authorizer.  Useful when the
+            middleware isn't installed but a code path still wants the
+            check.
+        subject: Override the ``get_subject()`` lookup.  ``None``
+            (the default) means "look up via :func:`get_subject`".
+
+    Raises:
+        AuthzDenied: when the authorizer returns ``False``.
+        RuntimeError: when no authorizer is reachable (neither ambient
+            nor explicit).
+    """
+    if authorizer is None:
+        authorizer = _current_authorizer.get()
+        if authorizer is None:
+            raise RuntimeError(
+                "no authorizer in context; install AuthorizationMiddleware "
+                "or pass authorizer= explicitly to check_authorization()"
+            )
+
+    resolved_subject = subject if subject is not None else get_subject()
+
+    if not authorizer(resolved_subject, required_scope):
+        raise AuthzDenied(
+            subject=resolved_subject, required_scope=required_scope
+        )

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -14,12 +14,17 @@ See ``docs/specs/authorization-submodule.md`` for the design rationale.
 
 from __future__ import annotations
 
+import json
+import logging
 import sys
 from collections.abc import Callable, Mapping
 from collections.abc import Set as AbstractSet
 from contextvars import ContextVar
 from pathlib import Path
-from typing import TypeAlias
+from typing import Any, TypeAlias
+
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -295,3 +300,99 @@ def check_authorization(
         raise AuthzDenied(
             subject=resolved_subject, required_scope=required_scope
         )
+
+
+# ---------------------------------------------------------------------------
+# AuthorizationMiddleware
+# ---------------------------------------------------------------------------
+
+
+logger = logging.getLogger(__name__)
+
+
+class AuthorizationMiddleware(Middleware):
+    """fastmcp middleware that enforces ``meta["required_scope"]`` on components.
+
+    Tools, resources, and prompts opt in by setting
+    ``meta={"required_scope": "<scope>"}`` at registration.  Components
+    without the meta key are unrestricted.
+
+    See ``docs/specs/authorization-submodule.md`` for the full design.
+    """
+
+    def __init__(
+        self,
+        *,
+        authorizer: Authorizer,
+        expose_subject_in_error: bool = False,
+    ) -> None:
+        """Construct the middleware and publish the authorizer ambient.
+
+        Args:
+            authorizer: Decision callable.  Saved on the instance and
+                also written to the package-internal
+                ``_current_authorizer`` :class:`ContextVar` so that
+                :func:`check_authorization` calls inside tool bodies
+                find it without an explicit ``authorizer=`` kwarg.
+            expose_subject_in_error: When ``True``, the wire-side deny
+                payload includes the ``subject`` key.  Defaults to
+                ``False`` (multi-user disclosure risk).  The subject is
+                always logged at WARNING regardless.
+        """
+        self._authorizer = authorizer
+        self._expose_subject = expose_subject_in_error
+        set_current_authorizer(authorizer)
+
+    def _format_deny_payload(
+        self, *, subject: str | None, required_scope: str
+    ) -> str:
+        """Render the JSON-encoded deny payload for the wire."""
+        body: dict[str, Any] = {
+            "code": "authz_denied",
+            "required_scope": required_scope,
+        }
+        if self._expose_subject:
+            body["subject"] = subject
+        return json.dumps(body)
+
+    def _log_deny(
+        self, *, kind: str, name: str, subject: str | None, required_scope: str
+    ) -> None:
+        """Log an authz denial at WARNING (subject always included in logs)."""
+        logger.warning(
+            "authz_denied kind=%s name=%s subject=%r required_scope=%r",
+            kind,
+            name,
+            subject,
+            required_scope,
+        )
+
+    async def on_call_tool(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Enforce ``required_scope`` on tool calls."""
+        assert context.fastmcp_context is not None, (
+            "on_call_tool invoked without a fastmcp_context"
+        )
+        tool = await context.fastmcp_context.fastmcp.get_tool(
+            context.message.name
+        )
+        meta = getattr(tool, "meta", None) or {}
+        required = meta.get("required_scope")
+        if not isinstance(required, str) or not required.strip():
+            return await call_next(context)
+
+        subject = get_subject()
+        if not self._authorizer(subject, required):
+            self._log_deny(
+                kind="tool",
+                name=context.message.name,
+                subject=subject,
+                required_scope=required,
+            )
+            raise ToolError(
+                self._format_deny_payload(
+                    subject=subject, required_scope=required
+                )
+            )
+        return await call_next(context)

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -394,7 +394,16 @@ class AuthorizationMiddleware(Middleware):
         deny.  Does nothing when meta has no requirement.
         """
         required = meta.get("required_scope")
+        if required is None:
+            return
         if not isinstance(required, str):
+            logger.warning(
+                "authz_meta_invalid kind=%s name=%s required_scope=%r — "
+                "expected non-empty string; treating as unrestricted",
+                kind,
+                name,
+                required,
+            )
             return
         required = required.strip()
         if not required:
@@ -441,7 +450,16 @@ class AuthorizationMiddleware(Middleware):
         for component in components:
             meta = getattr(component, "meta", None) or {}
             required = meta.get("required_scope")
+            if required is None:
+                kept.append(component)
+                continue
             if not isinstance(required, str):
+                logger.warning(
+                    "authz_meta_invalid component=%r required_scope=%r — "
+                    "expected non-empty string; treating as unrestricted",
+                    component,
+                    required,
+                )
                 kept.append(component)
                 continue
             required = required.strip()

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -367,35 +367,77 @@ class AuthorizationMiddleware(Middleware):
             required_scope,
         )
 
-    async def on_call_tool(
-        self, context: MiddlewareContext, call_next: Any
-    ) -> Any:
-        """Enforce ``required_scope`` on tool calls."""
-        assert context.fastmcp_context is not None, (
-            "on_call_tool invoked without a fastmcp_context"
-        )
-        tool = await context.fastmcp_context.fastmcp.get_tool(
-            context.message.name
-        )
-        meta = getattr(tool, "meta", None) or {}
+    async def _enforce_static(
+        self,
+        *,
+        kind: str,
+        name: str,
+        meta: Mapping[str, Any],
+        error_cls: type[Exception],
+    ) -> None:
+        """Run the static ``meta["required_scope"]`` check.
+
+        Raises ``error_cls`` (constructed with the JSON deny payload) on
+        deny.  Does nothing when meta has no requirement.
+        """
         required = meta.get("required_scope")
         if not isinstance(required, str) or not required.strip():
-            return await call_next(context)
-
+            return
         subject = get_subject()
         if not self._authorizer(subject, required):
             self._log_deny(
-                kind="tool",
-                name=context.message.name,
-                subject=subject,
-                required_scope=required,
+                kind=kind, name=name, subject=subject, required_scope=required
             )
-            raise ToolError(
+            raise error_cls(
                 self._format_deny_payload(
                     subject=subject, required_scope=required
                 )
             )
-        return await call_next(context)
+
+    async def _call_with_authz_translation(
+        self,
+        *,
+        kind: str,
+        name: str,
+        error_cls: type[Exception],
+        call_next: Any,
+        context: MiddlewareContext,
+    ) -> Any:
+        """Run ``call_next`` and translate AuthzDenied to ``error_cls``."""
+        try:
+            return await call_next(context)
+        except AuthzDenied as exc:
+            self._log_deny(
+                kind=kind, name=name,
+                subject=exc.subject, required_scope=exc.required_scope,
+            )
+            raise error_cls(
+                self._format_deny_payload(
+                    subject=exc.subject, required_scope=exc.required_scope,
+                )
+            ) from None
+
+    async def on_call_tool(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Enforce ``required_scope`` on tool calls."""
+        assert context.fastmcp_context is not None
+        tool = await context.fastmcp_context.fastmcp.get_tool(
+            context.message.name
+        )
+        await self._enforce_static(
+            kind="tool",
+            name=context.message.name,
+            meta=getattr(tool, "meta", None) or {},
+            error_cls=ToolError,
+        )
+        return await self._call_with_authz_translation(
+            kind="tool",
+            name=context.message.name,
+            error_cls=ToolError,
+            call_next=call_next,
+            context=context,
+        )
 
     async def on_read_resource(
         self, context: MiddlewareContext, call_next: Any
@@ -405,25 +447,19 @@ class AuthorizationMiddleware(Middleware):
         resource = await context.fastmcp_context.fastmcp.get_resource(
             context.message.uri
         )
-        meta = getattr(resource, "meta", None) or {}
-        required = meta.get("required_scope")
-        if not isinstance(required, str) or not required.strip():
-            return await call_next(context)
-
-        subject = get_subject()
-        if not self._authorizer(subject, required):
-            self._log_deny(
-                kind="resource",
-                name=str(context.message.uri),
-                subject=subject,
-                required_scope=required,
-            )
-            raise ResourceError(
-                self._format_deny_payload(
-                    subject=subject, required_scope=required
-                )
-            )
-        return await call_next(context)
+        await self._enforce_static(
+            kind="resource",
+            name=str(context.message.uri),
+            meta=getattr(resource, "meta", None) or {},
+            error_cls=ResourceError,
+        )
+        return await self._call_with_authz_translation(
+            kind="resource",
+            name=str(context.message.uri),
+            error_cls=ResourceError,
+            call_next=call_next,
+            context=context,
+        )
 
     async def on_get_prompt(
         self, context: MiddlewareContext, call_next: Any
@@ -433,22 +469,16 @@ class AuthorizationMiddleware(Middleware):
         prompt = await context.fastmcp_context.fastmcp.get_prompt(
             context.message.name
         )
-        meta = getattr(prompt, "meta", None) or {}
-        required = meta.get("required_scope")
-        if not isinstance(required, str) or not required.strip():
-            return await call_next(context)
-
-        subject = get_subject()
-        if not self._authorizer(subject, required):
-            self._log_deny(
-                kind="prompt",
-                name=context.message.name,
-                subject=subject,
-                required_scope=required,
-            )
-            raise PromptError(
-                self._format_deny_payload(
-                    subject=subject, required_scope=required
-                )
-            )
-        return await call_next(context)
+        await self._enforce_static(
+            kind="prompt",
+            name=context.message.name,
+            meta=getattr(prompt, "meta", None) or {},
+            error_cls=PromptError,
+        )
+        return await self._call_with_authz_translation(
+            kind="prompt",
+            name=context.message.name,
+            error_cls=PromptError,
+            call_next=call_next,
+            context=context,
+        )

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -57,6 +57,7 @@ issue #60.
 # AuthzDenied exception
 # ---------------------------------------------------------------------------
 
+
 class AuthzDenied(Exception):  # noqa: N818
     """Raised by :func:`check_authorization` when the authorizer denies.
 
@@ -150,9 +151,7 @@ def load_acl(path: Path) -> dict[str, frozenset[str]]:
     """
     path = path.expanduser()
     if not path.is_file():
-        raise ConfigurationError(
-            f"ACL file not found or not a regular file: {path}"
-        )
+        raise ConfigurationError(f"ACL file not found or not a regular file: {path}")
     try:
         raw = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
@@ -168,9 +167,7 @@ def load_acl(path: Path) -> dict[str, frozenset[str]]:
 
     subjects = data.get("subjects")
     if not isinstance(subjects, dict):
-        raise ConfigurationError(
-            f"ACL file at {path} must define a [subjects] table"
-        )
+        raise ConfigurationError(f"ACL file at {path} must define a [subjects] table")
 
     result: dict[str, frozenset[str]] = {}
     for subject, scopes in subjects.items():
@@ -200,7 +197,7 @@ def load_acl(path: Path) -> dict[str, frozenset[str]]:
                     f"ACL file at {path}: subject {subject!r}: scope is "
                     "empty or whitespace-only"
                 )
-            cleaned.add(scope)
+            cleaned.add(scope.strip())
         result[subject] = frozenset(cleaned)
     return result
 
@@ -278,8 +275,12 @@ def check_authorization(
         authorizer: Override the ambient authorizer.  Useful when the
             middleware isn't installed but a code path still wants the
             check.
-        subject: Override the ``get_subject()`` lookup.  ``None``
-            (the default) means "look up via :func:`get_subject`".
+        subject: Override the ``get_subject()`` lookup.  Both omitting
+            the argument and explicitly passing ``None`` trigger
+            :func:`get_subject`; to force ``None`` to the authorizer (the
+            "no auth context" test case), patch :func:`get_subject` directly
+            or use :func:`make_acl_authorizer` (which returns ``False`` on
+            ``None`` subject) and call it directly.
 
     Raises:
         AuthzDenied: when the authorizer returns ``False``.
@@ -297,9 +298,7 @@ def check_authorization(
     resolved_subject = subject if subject is not None else get_subject()
 
     if not authorizer(resolved_subject, required_scope):
-        raise AuthzDenied(
-            subject=resolved_subject, required_scope=required_scope
-        )
+        raise AuthzDenied(subject=resolved_subject, required_scope=required_scope)
 
 
 # ---------------------------------------------------------------------------
@@ -343,9 +342,7 @@ class AuthorizationMiddleware(Middleware):
         self._expose_subject = expose_subject_in_error
         set_current_authorizer(authorizer)
 
-    def _format_deny_payload(
-        self, *, subject: str | None, required_scope: str
-    ) -> str:
+    def _format_deny_payload(self, *, subject: str | None, required_scope: str) -> str:
         """Render the JSON-encoded deny payload for the wire.
 
         When ``expose_subject_in_error`` is ``True`` and the subject is
@@ -358,7 +355,7 @@ class AuthorizationMiddleware(Middleware):
         }
         if self._expose_subject:
             body["subject"] = subject
-        return json.dumps(body)
+        return json.dumps(body, separators=(",", ":"))
 
     def _log_deny(
         self, *, kind: str, name: str, subject: str | None, required_scope: str
@@ -386,7 +383,10 @@ class AuthorizationMiddleware(Middleware):
         deny.  Does nothing when meta has no requirement.
         """
         required = meta.get("required_scope")
-        if not isinstance(required, str) or not required.strip():
+        if not isinstance(required, str):
+            return
+        required = required.strip()
+        if not required:
             return
         subject = get_subject()
         if not self._authorizer(subject, required):
@@ -394,9 +394,7 @@ class AuthorizationMiddleware(Middleware):
                 kind=kind, name=name, subject=subject, required_scope=required
             )
             raise error_cls(
-                self._format_deny_payload(
-                    subject=subject, required_scope=required
-                )
+                self._format_deny_payload(subject=subject, required_scope=required)
             )
 
     async def _call_with_authz_translation(
@@ -413,49 +411,53 @@ class AuthorizationMiddleware(Middleware):
             return await call_next(context)
         except AuthzDenied as exc:
             self._log_deny(
-                kind=kind, name=name,
-                subject=exc.subject, required_scope=exc.required_scope,
+                kind=kind,
+                name=name,
+                subject=exc.subject,
+                required_scope=exc.required_scope,
             )
             raise error_cls(
                 self._format_deny_payload(
-                    subject=exc.subject, required_scope=exc.required_scope,
+                    subject=exc.subject,
+                    required_scope=exc.required_scope,
                 )
             ) from None
 
-    def _filter_components(
-        self, components: list[Any]
-    ) -> list[Any]:
+    def _filter_components(self, components: list[Any]) -> list[Any]:
         """Drop components whose ``meta["required_scope"]`` denies the caller."""
         subject = get_subject()
         kept: list[Any] = []
         for component in components:
             meta = getattr(component, "meta", None) or {}
             required = meta.get("required_scope")
-            if not isinstance(required, str) or not required.strip():
+            if not isinstance(required, str):
+                kept.append(component)
+                continue
+            required = required.strip()
+            if not required:
                 kept.append(component)
                 continue
             if self._authorizer(subject, required):
                 kept.append(component)
         return kept
 
-    async def on_call_tool(
-        self, context: MiddlewareContext, call_next: Any
-    ) -> Any:
+    async def on_call_tool(self, context: MiddlewareContext, call_next: Any) -> Any:
         """Enforce ``required_scope`` on tool calls."""
         if context.fastmcp_context is None:
             raise RuntimeError(
                 "AuthorizationMiddleware.on_call_tool: fastmcp_context is None; "
                 "ensure the middleware is installed on a FastMCP server"
             )
+        # NOTE: lookup failure path skips the static meta check. See
+        # docs/specs/authorization-submodule.md (AuthorizationMiddleware
+        # section, "When the inner-component lookup ... raises").
         try:
-            tool = await context.fastmcp_context.fastmcp.get_tool(
-                context.message.name
-            )
+            tool = await context.fastmcp_context.fastmcp.get_tool(context.message.name)
         except Exception as exc:  # noqa: BLE001 — defensive, logged
             logger.warning(
-                "tool lookup failed during authz check; falling through "
-                "name=%s exc=%r",
-                context.message.name, exc,
+                "tool lookup failed during authz check; falling through name=%s exc=%r",
+                context.message.name,
+                exc,
             )
             return await self._call_with_authz_translation(
                 kind="tool",
@@ -478,15 +480,16 @@ class AuthorizationMiddleware(Middleware):
             context=context,
         )
 
-    async def on_read_resource(
-        self, context: MiddlewareContext, call_next: Any
-    ) -> Any:
+    async def on_read_resource(self, context: MiddlewareContext, call_next: Any) -> Any:
         """Enforce ``required_scope`` on resource reads."""
         if context.fastmcp_context is None:
             raise RuntimeError(
                 "AuthorizationMiddleware.on_read_resource: fastmcp_context is None; "
                 "ensure the middleware is installed on a FastMCP server"
             )
+        # NOTE: lookup failure path skips the static meta check. See
+        # docs/specs/authorization-submodule.md (AuthorizationMiddleware
+        # section, "When the inner-component lookup ... raises").
         try:
             resource = await context.fastmcp_context.fastmcp.get_resource(
                 context.message.uri
@@ -495,7 +498,8 @@ class AuthorizationMiddleware(Middleware):
             logger.warning(
                 "resource lookup failed during authz check; falling through "
                 "uri=%s exc=%r",
-                context.message.uri, exc,
+                context.message.uri,
+                exc,
             )
             return await self._call_with_authz_translation(
                 kind="resource",
@@ -518,15 +522,16 @@ class AuthorizationMiddleware(Middleware):
             context=context,
         )
 
-    async def on_get_prompt(
-        self, context: MiddlewareContext, call_next: Any
-    ) -> Any:
+    async def on_get_prompt(self, context: MiddlewareContext, call_next: Any) -> Any:
         """Enforce ``required_scope`` on prompt retrievals."""
         if context.fastmcp_context is None:
             raise RuntimeError(
                 "AuthorizationMiddleware.on_get_prompt: fastmcp_context is None; "
                 "ensure the middleware is installed on a FastMCP server"
             )
+        # NOTE: lookup failure path skips the static meta check. See
+        # docs/specs/authorization-submodule.md (AuthorizationMiddleware
+        # section, "When the inner-component lookup ... raises").
         try:
             prompt = await context.fastmcp_context.fastmcp.get_prompt(
                 context.message.name
@@ -535,7 +540,8 @@ class AuthorizationMiddleware(Middleware):
             logger.warning(
                 "prompt lookup failed during authz check; falling through "
                 "name=%s exc=%r",
-                context.message.name, exc,
+                context.message.name,
+                exc,
             )
             return await self._call_with_authz_translation(
                 kind="prompt",
@@ -558,9 +564,7 @@ class AuthorizationMiddleware(Middleware):
             context=context,
         )
 
-    async def on_list_tools(
-        self, context: MiddlewareContext, call_next: Any
-    ) -> Any:
+    async def on_list_tools(self, context: MiddlewareContext, call_next: Any) -> Any:
         """Filter tool listings by what the caller can call."""
         tools = await call_next(context)
         return self._filter_components(tools)
@@ -579,9 +583,7 @@ class AuthorizationMiddleware(Middleware):
         templates = await call_next(context)
         return self._filter_components(templates)
 
-    async def on_list_prompts(
-        self, context: MiddlewareContext, call_next: Any
-    ) -> Any:
+    async def on_list_prompts(self, context: MiddlewareContext, call_next: Any) -> Any:
         """Filter prompt listings by what the caller can retrieve."""
         prompts = await call_next(context)
         return self._filter_components(prompts)

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -15,7 +15,8 @@ See ``docs/specs/authorization-submodule.md`` for the design rationale.
 from __future__ import annotations
 
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from collections.abc import Set as AbstractSet
 from contextvars import ContextVar
 from pathlib import Path
 from typing import TypeAlias
@@ -196,3 +197,42 @@ def load_acl(path: Path) -> dict[str, frozenset[str]]:
             cleaned.add(scope)
         result[subject] = frozenset(cleaned)
     return result
+
+
+# ---------------------------------------------------------------------------
+# ACL → Authorizer bridge
+# ---------------------------------------------------------------------------
+
+
+def make_acl_authorizer(acl: Mapping[str, AbstractSet[str]]) -> Authorizer:
+    """Bridge a ``{subject: scopes}`` mapping to an :data:`Authorizer`.
+
+    Allow rules:
+
+    - ``subject is None`` → deny.
+    - Subject not in ``acl`` → deny.
+    - ``"*"`` in the subject's grants → allow any required scope.
+    - Otherwise → allow iff ``required_scope`` is in the grants.
+
+    The mapping is captured by reference, not copied.  A downstream that
+    mutates the dict in place sees the change reflected by the closure
+    (intentional; the recommended pattern is rebuild + reassign, but
+    reference-capture lets advanced consumers wire reload semantics
+    without changing this signature).
+
+    Args:
+        acl: Mapping from subject string to a set of granted scope strings.
+
+    Returns:
+        An :data:`Authorizer` callable.
+    """
+
+    def authorize(subject: str | None, required_scope: str) -> bool:
+        if subject is None:
+            return False
+        granted = acl.get(subject)
+        if granted is None:
+            return False
+        return "*" in granted or required_scope in granted
+
+    return authorize

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -417,6 +417,22 @@ class AuthorizationMiddleware(Middleware):
                 )
             ) from None
 
+    def _filter_components(
+        self, components: list[Any]
+    ) -> list[Any]:
+        """Drop components whose ``meta["required_scope"]`` denies the caller."""
+        subject = get_subject()
+        kept: list[Any] = []
+        for component in components:
+            meta = getattr(component, "meta", None) or {}
+            required = meta.get("required_scope")
+            if not isinstance(required, str) or not required.strip():
+                kept.append(component)
+                continue
+            if self._authorizer(subject, required):
+                kept.append(component)
+        return kept
+
     async def on_call_tool(
         self, context: MiddlewareContext, call_next: Any
     ) -> Any:
@@ -524,3 +540,31 @@ class AuthorizationMiddleware(Middleware):
             call_next=call_next,
             context=context,
         )
+
+    async def on_list_tools(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Filter tool listings by what the caller can call."""
+        tools = await call_next(context)
+        return self._filter_components(tools)
+
+    async def on_list_resources(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Filter resource listings by what the caller can read."""
+        resources = await call_next(context)
+        return self._filter_components(resources)
+
+    async def on_list_resource_templates(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Filter resource template listings by what the caller can read."""
+        templates = await call_next(context)
+        return self._filter_components(templates)
+
+    async def on_list_prompts(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Filter prompt listings by what the caller can retrieve."""
+        prompts = await call_next(context)
+        return self._filter_components(prompts)

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -23,7 +23,7 @@ from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, TypeAlias
 
-from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import PromptError, ResourceError, ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 if sys.version_info >= (3, 11):
@@ -391,6 +391,62 @@ class AuthorizationMiddleware(Middleware):
                 required_scope=required,
             )
             raise ToolError(
+                self._format_deny_payload(
+                    subject=subject, required_scope=required
+                )
+            )
+        return await call_next(context)
+
+    async def on_read_resource(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Enforce ``required_scope`` on resource reads."""
+        assert context.fastmcp_context is not None
+        resource = await context.fastmcp_context.fastmcp.get_resource(
+            context.message.uri
+        )
+        meta = getattr(resource, "meta", None) or {}
+        required = meta.get("required_scope")
+        if not isinstance(required, str) or not required.strip():
+            return await call_next(context)
+
+        subject = get_subject()
+        if not self._authorizer(subject, required):
+            self._log_deny(
+                kind="resource",
+                name=str(context.message.uri),
+                subject=subject,
+                required_scope=required,
+            )
+            raise ResourceError(
+                self._format_deny_payload(
+                    subject=subject, required_scope=required
+                )
+            )
+        return await call_next(context)
+
+    async def on_get_prompt(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        """Enforce ``required_scope`` on prompt retrievals."""
+        assert context.fastmcp_context is not None
+        prompt = await context.fastmcp_context.fastmcp.get_prompt(
+            context.message.name
+        )
+        meta = getattr(prompt, "meta", None) or {}
+        required = meta.get("required_scope")
+        if not isinstance(required, str) or not required.strip():
+            return await call_next(context)
+
+        subject = get_subject()
+        if not self._authorizer(subject, required):
+            self._log_deny(
+                kind="prompt",
+                name=context.message.name,
+                subject=subject,
+                required_scope=required,
+            )
+            raise PromptError(
                 self._format_deny_payload(
                     subject=subject, required_scope=required
                 )

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -422,9 +422,23 @@ class AuthorizationMiddleware(Middleware):
     ) -> Any:
         """Enforce ``required_scope`` on tool calls."""
         assert context.fastmcp_context is not None
-        tool = await context.fastmcp_context.fastmcp.get_tool(
-            context.message.name
-        )
+        try:
+            tool = await context.fastmcp_context.fastmcp.get_tool(
+                context.message.name
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive, logged
+            logger.warning(
+                "tool lookup failed during authz check; falling through "
+                "name=%s exc=%r",
+                context.message.name, exc,
+            )
+            return await self._call_with_authz_translation(
+                kind="tool",
+                name=context.message.name,
+                error_cls=ToolError,
+                call_next=call_next,
+                context=context,
+            )
         await self._enforce_static(
             kind="tool",
             name=context.message.name,
@@ -444,9 +458,23 @@ class AuthorizationMiddleware(Middleware):
     ) -> Any:
         """Enforce ``required_scope`` on resource reads."""
         assert context.fastmcp_context is not None
-        resource = await context.fastmcp_context.fastmcp.get_resource(
-            context.message.uri
-        )
+        try:
+            resource = await context.fastmcp_context.fastmcp.get_resource(
+                context.message.uri
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive, logged
+            logger.warning(
+                "resource lookup failed during authz check; falling through "
+                "uri=%s exc=%r",
+                context.message.uri, exc,
+            )
+            return await self._call_with_authz_translation(
+                kind="resource",
+                name=str(context.message.uri),
+                error_cls=ResourceError,
+                call_next=call_next,
+                context=context,
+            )
         await self._enforce_static(
             kind="resource",
             name=str(context.message.uri),
@@ -466,9 +494,23 @@ class AuthorizationMiddleware(Middleware):
     ) -> Any:
         """Enforce ``required_scope`` on prompt retrievals."""
         assert context.fastmcp_context is not None
-        prompt = await context.fastmcp_context.fastmcp.get_prompt(
-            context.message.name
-        )
+        try:
+            prompt = await context.fastmcp_context.fastmcp.get_prompt(
+                context.message.name
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive, logged
+            logger.warning(
+                "prompt lookup failed during authz check; falling through "
+                "name=%s exc=%r",
+                context.message.name, exc,
+            )
+            return await self._call_with_authz_translation(
+                kind="prompt",
+                name=context.message.name,
+                error_cls=PromptError,
+                call_next=call_next,
+                context=context,
+            )
         await self._enforce_static(
             kind="prompt",
             name=context.message.name,

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -294,6 +294,10 @@ def check_authorization(
             nor explicit).
         ValueError: when ``required_scope`` is empty or whitespace-only.
     """
+    required_scope = required_scope.strip()
+    if not required_scope:
+        raise ValueError("required_scope must be a non-empty string")
+
     if authorizer is None:
         authorizer = _current_authorizer.get()
         if authorizer is None:
@@ -301,10 +305,6 @@ def check_authorization(
                 "no authorizer in context; install AuthorizationMiddleware "
                 "or pass authorizer= explicitly to check_authorization()"
             )
-
-    required_scope = required_scope.strip()
-    if not required_scope:
-        raise ValueError("required_scope must be a non-empty string")
 
     resolved_subject = subject if subject is not None else get_subject()
 

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -346,7 +346,12 @@ class AuthorizationMiddleware(Middleware):
     def _format_deny_payload(
         self, *, subject: str | None, required_scope: str
     ) -> str:
-        """Render the JSON-encoded deny payload for the wire."""
+        """Render the JSON-encoded deny payload for the wire.
+
+        When ``expose_subject_in_error`` is ``True`` and the subject is
+        ``None``, the payload includes ``"subject": null``.  Downstream code
+        that consumes the payload should defend against this case.
+        """
         body: dict[str, Any] = {
             "code": "authz_denied",
             "required_scope": required_scope,
@@ -367,7 +372,7 @@ class AuthorizationMiddleware(Middleware):
             required_scope,
         )
 
-    async def _enforce_static(
+    def _enforce_static(
         self,
         *,
         kind: str,
@@ -437,7 +442,11 @@ class AuthorizationMiddleware(Middleware):
         self, context: MiddlewareContext, call_next: Any
     ) -> Any:
         """Enforce ``required_scope`` on tool calls."""
-        assert context.fastmcp_context is not None
+        if context.fastmcp_context is None:
+            raise RuntimeError(
+                "AuthorizationMiddleware.on_call_tool: fastmcp_context is None; "
+                "ensure the middleware is installed on a FastMCP server"
+            )
         try:
             tool = await context.fastmcp_context.fastmcp.get_tool(
                 context.message.name
@@ -455,7 +464,7 @@ class AuthorizationMiddleware(Middleware):
                 call_next=call_next,
                 context=context,
             )
-        await self._enforce_static(
+        self._enforce_static(
             kind="tool",
             name=context.message.name,
             meta=getattr(tool, "meta", None) or {},
@@ -473,7 +482,11 @@ class AuthorizationMiddleware(Middleware):
         self, context: MiddlewareContext, call_next: Any
     ) -> Any:
         """Enforce ``required_scope`` on resource reads."""
-        assert context.fastmcp_context is not None
+        if context.fastmcp_context is None:
+            raise RuntimeError(
+                "AuthorizationMiddleware.on_read_resource: fastmcp_context is None; "
+                "ensure the middleware is installed on a FastMCP server"
+            )
         try:
             resource = await context.fastmcp_context.fastmcp.get_resource(
                 context.message.uri
@@ -491,7 +504,7 @@ class AuthorizationMiddleware(Middleware):
                 call_next=call_next,
                 context=context,
             )
-        await self._enforce_static(
+        self._enforce_static(
             kind="resource",
             name=str(context.message.uri),
             meta=getattr(resource, "meta", None) or {},
@@ -509,7 +522,11 @@ class AuthorizationMiddleware(Middleware):
         self, context: MiddlewareContext, call_next: Any
     ) -> Any:
         """Enforce ``required_scope`` on prompt retrievals."""
-        assert context.fastmcp_context is not None
+        if context.fastmcp_context is None:
+            raise RuntimeError(
+                "AuthorizationMiddleware.on_get_prompt: fastmcp_context is None; "
+                "ensure the middleware is installed on a FastMCP server"
+            )
         try:
             prompt = await context.fastmcp_context.fastmcp.get_prompt(
                 context.message.name
@@ -527,7 +544,7 @@ class AuthorizationMiddleware(Middleware):
                 call_next=call_next,
                 context=context,
             )
-        await self._enforce_static(
+        self._enforce_static(
             kind="prompt",
             name=context.message.name,
             meta=getattr(prompt, "meta", None) or {},

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -18,6 +18,10 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from typing import TypeAlias
 
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
 Authorizer: TypeAlias = Callable[[str | None, str], bool]
 """Decision callable: ``(subject, required_scope) -> bool``.
 
@@ -29,6 +33,10 @@ across this and other Callable seams in the package is tracked in
 issue #60.
 """
 
+
+# ---------------------------------------------------------------------------
+# AuthzDenied exception
+# ---------------------------------------------------------------------------
 
 class AuthzDenied(Exception):  # noqa: N818
     """Raised by :func:`check_authorization` when the authorizer denies.
@@ -54,6 +62,10 @@ class AuthzDenied(Exception):  # noqa: N818
         self.subject = subject
         self.required_scope = required_scope
 
+
+# ---------------------------------------------------------------------------
+# Ambient authorizer (ContextVar plumbing)
+# ---------------------------------------------------------------------------
 
 _current_authorizer: ContextVar[Authorizer | None] = ContextVar(
     "fastmcp_pvl_core_current_authorizer",

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -269,6 +269,12 @@ def check_authorization(
       context is available — that ``None`` is then forwarded to the
       authorizer, which typically denies it.
 
+    Scope normalisation:
+
+    The ``required_scope`` is stripped of surrounding whitespace before
+    the authorizer is called.  Passing an empty or whitespace-only scope
+    raises :class:`ValueError`.
+
     Args:
         required_scope: Scope string to require, e.g. ``"write"`` or
             ``"read:project-foo"``.
@@ -286,6 +292,7 @@ def check_authorization(
         AuthzDenied: when the authorizer returns ``False``.
         RuntimeError: when no authorizer is reachable (neither ambient
             nor explicit).
+        ValueError: when ``required_scope`` is empty or whitespace-only.
     """
     if authorizer is None:
         authorizer = _current_authorizer.get()
@@ -294,6 +301,10 @@ def check_authorization(
                 "no authorizer in context; install AuthorizationMiddleware "
                 "or pass authorizer= explicitly to check_authorization()"
             )
+
+    required_scope = required_scope.strip()
+    if not required_scope:
+        raise ValueError("required_scope must be a non-empty string")
 
     resolved_subject = subject if subject is not None else get_subject()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 
 import pytest
 
+from fastmcp_pvl_core._authorization import set_current_authorizer
 from fastmcp_pvl_core._subject import set_current_auth_mode
 
 
@@ -24,6 +25,17 @@ def _reset_auth_mode() -> Iterator[None]:
     set_current_auth_mode(None)
     yield
     set_current_auth_mode(None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_authorizer() -> Iterator[None]:
+    """Reset the authorizer contextvar between tests.
+
+    Mirrors ``_reset_auth_mode``; same rationale.
+    """
+    set_current_authorizer(None)
+    yield
+    set_current_authorizer(None)
 
 
 @pytest.fixture

--- a/tests/test_authorization_authorizer.py
+++ b/tests/test_authorization_authorizer.py
@@ -6,9 +6,7 @@ from fastmcp_pvl_core._authorization import make_acl_authorizer
 
 
 def test_subject_in_acl_with_required_scope_allowed() -> None:
-    authorize = make_acl_authorizer(
-        {"user:alice": frozenset({"read", "write"})}
-    )
+    authorize = make_acl_authorizer({"user:alice": frozenset({"read", "write"})})
     assert authorize("user:alice", "read") is True
     assert authorize("user:alice", "write") is True
 
@@ -36,9 +34,7 @@ def test_wildcard_scope_grants_anything() -> None:
 
 
 def test_wildcard_alongside_specific_scopes() -> None:
-    authorize = make_acl_authorizer(
-        {"user:admin": frozenset({"*", "read"})}
-    )
+    authorize = make_acl_authorizer({"user:admin": frozenset({"*", "read"})})
     assert authorize("user:admin", "anything") is True
 
 

--- a/tests/test_authorization_authorizer.py
+++ b/tests/test_authorization_authorizer.py
@@ -1,0 +1,50 @@
+"""Tests for make_acl_authorizer."""
+
+from __future__ import annotations
+
+from fastmcp_pvl_core._authorization import make_acl_authorizer
+
+
+def test_subject_in_acl_with_required_scope_allowed() -> None:
+    authorize = make_acl_authorizer(
+        {"user:alice": frozenset({"read", "write"})}
+    )
+    assert authorize("user:alice", "read") is True
+    assert authorize("user:alice", "write") is True
+
+
+def test_subject_in_acl_missing_required_scope_denied() -> None:
+    authorize = make_acl_authorizer({"user:alice": frozenset({"read"})})
+    assert authorize("user:alice", "write") is False
+
+
+def test_unknown_subject_denied() -> None:
+    authorize = make_acl_authorizer({"user:alice": frozenset({"read"})})
+    assert authorize("user:bob", "read") is False
+
+
+def test_subject_none_denied() -> None:
+    authorize = make_acl_authorizer({"user:alice": frozenset({"read"})})
+    assert authorize(None, "read") is False
+
+
+def test_wildcard_scope_grants_anything() -> None:
+    authorize = make_acl_authorizer({"user:admin": frozenset({"*"})})
+    assert authorize("user:admin", "read") is True
+    assert authorize("user:admin", "write") is True
+    assert authorize("user:admin", "anything:project-foo") is True
+
+
+def test_wildcard_alongside_specific_scopes() -> None:
+    authorize = make_acl_authorizer(
+        {"user:admin": frozenset({"*", "read"})}
+    )
+    assert authorize("user:admin", "anything") is True
+
+
+def test_acl_captured_by_reference_not_copied() -> None:
+    acl: dict[str, frozenset[str]] = {"user:alice": frozenset({"read"})}
+    authorize = make_acl_authorizer(acl)
+    assert authorize("user:bob", "read") is False
+    acl["user:bob"] = frozenset({"read"})
+    assert authorize("user:bob", "read") is True

--- a/tests/test_authorization_authorizer.py
+++ b/tests/test_authorization_authorizer.py
@@ -48,3 +48,14 @@ def test_acl_captured_by_reference_not_copied() -> None:
     assert authorize("user:bob", "read") is False
     acl["user:bob"] = frozenset({"read"})
     assert authorize("user:bob", "read") is True
+
+
+def test_local_subject_treated_as_normal_subject() -> None:
+    """Spec checklist: ``"local"`` works exactly like any other subject."""
+    authorize = make_acl_authorizer({"local": frozenset({"read", "write"})})
+    assert authorize("local", "read") is True
+    assert authorize("local", "write") is True
+    assert authorize("local", "admin") is False
+    # And not in ACL → denied like any unknown subject.
+    other = make_acl_authorizer({"user:alice": frozenset({"read"})})
+    assert other("local", "read") is False

--- a/tests/test_authorization_check.py
+++ b/tests/test_authorization_check.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
-from fastmcp_pvl_core._authorization import AuthzDenied
+from fastmcp_pvl_core._authorization import (
+    AuthzDenied,
+    check_authorization,
+    set_current_authorizer,
+)
 
 
 def test_authz_denied_carries_subject_and_required_scope() -> None:
@@ -31,14 +37,6 @@ def test_authz_denied_is_an_exception() -> None:
         raise AuthzDenied(subject="x", required_scope="y")
 
 
-from unittest.mock import patch  # noqa: E402
-
-from fastmcp_pvl_core._authorization import (  # noqa: E402
-    check_authorization,
-    set_current_authorizer,
-)
-
-
 def _allow_all(_subject: str | None, _required_scope: str) -> bool:
     return True
 
@@ -51,8 +49,7 @@ def test_check_authorization_uses_explicit_authorizer_allow() -> None:
     with patch(
         "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
     ):
-        result = check_authorization("read", authorizer=_allow_all)
-    assert result is None
+        check_authorization("read", authorizer=_allow_all)
 
 
 def test_check_authorization_uses_explicit_authorizer_deny() -> None:

--- a/tests/test_authorization_check.py
+++ b/tests/test_authorization_check.py
@@ -113,6 +113,43 @@ def test_check_authorization_omitted_subject_falls_through_to_get_subject() -> N
     assert captured == {"subject": "user:from_context"}
 
 
+def test_check_authorization_explicit_subject_none_uses_get_subject() -> None:
+    """Explicit ``subject=None`` is equivalent to omitting the kwarg."""
+    captured: dict[str, object] = {}
+
+    def authorize(subject: str | None, required_scope: str) -> bool:
+        captured["subject"] = subject
+        return True
+
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:from_context"
+    ):
+        check_authorization("read", authorizer=authorize, subject=None)
+    assert captured == {"subject": "user:from_context"}
+
+
+def test_check_authorization_strips_required_scope() -> None:
+    captured: dict[str, object] = {}
+
+    def authorize(_subject: str | None, required_scope: str) -> bool:
+        captured["required_scope"] = required_scope
+        return True
+
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        check_authorization("  write  ", authorizer=authorize)
+    assert captured == {"required_scope": "write"}
+
+
+def test_check_authorization_empty_required_scope_raises_value_error() -> None:
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ValueError, match="non-empty"):
+            check_authorization("   ", authorizer=_allow_all)
+
+
 def test_check_authorization_get_subject_returning_none_denied_by_authorizer() -> None:
     with patch("fastmcp_pvl_core._authorization.get_subject", return_value=None):
         with pytest.raises(AuthzDenied) as exc_info:

--- a/tests/test_authorization_check.py
+++ b/tests/test_authorization_check.py
@@ -114,9 +114,7 @@ def test_check_authorization_omitted_subject_falls_through_to_get_subject() -> N
 
 
 def test_check_authorization_get_subject_returning_none_denied_by_authorizer() -> None:
-    with patch(
-        "fastmcp_pvl_core._authorization.get_subject", return_value=None
-    ):
+    with patch("fastmcp_pvl_core._authorization.get_subject", return_value=None):
         with pytest.raises(AuthzDenied) as exc_info:
             check_authorization("read", authorizer=_deny_all)
     assert exc_info.value.subject is None

--- a/tests/test_authorization_check.py
+++ b/tests/test_authorization_check.py
@@ -1,0 +1,24 @@
+"""Tests for AuthzDenied and check_authorization (added in later tasks)."""
+
+from __future__ import annotations
+
+import pytest
+
+from fastmcp_pvl_core._authorization import AuthzDenied
+
+
+def test_authz_denied_carries_subject_and_required_scope() -> None:
+    exc = AuthzDenied(subject="user:alice@example.com", required_scope="write")
+    assert exc.subject == "user:alice@example.com"
+    assert exc.required_scope == "write"
+
+
+def test_authz_denied_subject_can_be_none() -> None:
+    exc = AuthzDenied(subject=None, required_scope="read")
+    assert exc.subject is None
+    assert exc.required_scope == "read"
+
+
+def test_authz_denied_is_an_exception() -> None:
+    with pytest.raises(AuthzDenied):
+        raise AuthzDenied(subject="x", required_scope="y")

--- a/tests/test_authorization_check.py
+++ b/tests/test_authorization_check.py
@@ -19,6 +19,13 @@ def test_authz_denied_subject_can_be_none() -> None:
     assert exc.required_scope == "read"
 
 
+def test_authz_denied_message_contains_subject_and_scope() -> None:
+    exc = AuthzDenied(subject="user:alice@example.com", required_scope="write")
+    msg = str(exc)
+    assert "user:alice@example.com" in msg
+    assert "write" in msg
+
+
 def test_authz_denied_is_an_exception() -> None:
     with pytest.raises(AuthzDenied):
         raise AuthzDenied(subject="x", required_scope="y")

--- a/tests/test_authorization_check.py
+++ b/tests/test_authorization_check.py
@@ -29,3 +29,97 @@ def test_authz_denied_message_contains_subject_and_scope() -> None:
 def test_authz_denied_is_an_exception() -> None:
     with pytest.raises(AuthzDenied):
         raise AuthzDenied(subject="x", required_scope="y")
+
+
+from unittest.mock import patch  # noqa: E402
+
+from fastmcp_pvl_core._authorization import (  # noqa: E402
+    check_authorization,
+    set_current_authorizer,
+)
+
+
+def _allow_all(_subject: str | None, _required_scope: str) -> bool:
+    return True
+
+
+def _deny_all(_subject: str | None, _required_scope: str) -> bool:
+    return False
+
+
+def test_check_authorization_uses_explicit_authorizer_allow() -> None:
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = check_authorization("read", authorizer=_allow_all)
+    assert result is None
+
+
+def test_check_authorization_uses_explicit_authorizer_deny() -> None:
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(AuthzDenied) as exc_info:
+            check_authorization("write", authorizer=_deny_all)
+    assert exc_info.value.subject == "user:alice"
+    assert exc_info.value.required_scope == "write"
+
+
+def test_check_authorization_reads_ambient_authorizer() -> None:
+    set_current_authorizer(_allow_all)
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        check_authorization("read")
+
+
+def test_check_authorization_explicit_overrides_ambient() -> None:
+    set_current_authorizer(_allow_all)
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(AuthzDenied):
+            check_authorization("read", authorizer=_deny_all)
+
+
+def test_check_authorization_no_authorizer_anywhere_raises_runtime_error() -> None:
+    with pytest.raises(RuntimeError, match="install AuthorizationMiddleware"):
+        check_authorization("read")
+
+
+def test_check_authorization_subject_kwarg_overrides_get_subject() -> None:
+    captured: dict[str, object] = {}
+
+    def authorize(subject: str | None, required_scope: str) -> bool:
+        captured["subject"] = subject
+        captured["required_scope"] = required_scope
+        return True
+
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:fromcontext"
+    ):
+        check_authorization("read", authorizer=authorize, subject="user:explicit")
+    assert captured == {"subject": "user:explicit", "required_scope": "read"}
+
+
+def test_check_authorization_omitted_subject_falls_through_to_get_subject() -> None:
+    captured: dict[str, object] = {}
+
+    def authorize(subject: str | None, required_scope: str) -> bool:
+        captured["subject"] = subject
+        return True
+
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:from_context"
+    ):
+        check_authorization("read", authorizer=authorize)
+    assert captured == {"subject": "user:from_context"}
+
+
+def test_check_authorization_get_subject_returning_none_denied_by_authorizer() -> None:
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value=None
+    ):
+        with pytest.raises(AuthzDenied) as exc_info:
+            check_authorization("read", authorizer=_deny_all)
+    assert exc_info.value.subject is None

--- a/tests/test_authorization_check.py
+++ b/tests/test_authorization_check.py
@@ -143,11 +143,15 @@ def test_check_authorization_strips_required_scope() -> None:
 
 
 def test_check_authorization_empty_required_scope_raises_value_error() -> None:
-    with patch(
-        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
-    ):
-        with pytest.raises(ValueError, match="non-empty"):
-            check_authorization("   ", authorizer=_allow_all)
+    with pytest.raises(ValueError, match="non-empty"):
+        check_authorization("   ", authorizer=_allow_all)
+
+
+def test_check_authorization_empty_scope_raises_before_authorizer_resolution() -> None:
+    """Empty scope is a programmer bug; ``ValueError`` fires regardless of context."""
+    set_current_authorizer(None)
+    with pytest.raises(ValueError, match="non-empty"):
+        check_authorization("   ")  # no ambient, no explicit — but scope check wins
 
 
 def test_check_authorization_get_subject_returning_none_denied_by_authorizer() -> None:

--- a/tests/test_authorization_loader.py
+++ b/tests/test_authorization_loader.py
@@ -13,12 +13,12 @@ from fastmcp_pvl_core._errors import ConfigurationError
 def test_load_acl_happy_path(tmp_path: Path) -> None:
     p = tmp_path / "acl.toml"
     p.write_text(
-        '''
+        """
 [subjects]
 "user:alice@example.com" = ["read", "write"]
 "user:admin@example.com" = ["*"]
 "service:ci-bot"         = ["read"]
-        ''',
+        """,
         encoding="utf-8",
     )
     acl = load_acl(p)

--- a/tests/test_authorization_loader.py
+++ b/tests/test_authorization_loader.py
@@ -46,6 +46,14 @@ def test_load_acl_expands_user_home(
     assert acl == {"user:x": frozenset({"read"})}
 
 
+def test_load_acl_strips_padded_scopes(tmp_path: Path) -> None:
+    """Scopes with surrounding whitespace are stored in canonical form."""
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"user:x" = ["  read  ", " write"]\n', encoding="utf-8")
+    acl = load_acl(p)
+    assert acl == {"user:x": frozenset({"read", "write"})}
+
+
 def test_load_acl_missing_file(tmp_path: Path) -> None:
     p = tmp_path / "nope.toml"
     with pytest.raises(ConfigurationError, match="not found"):

--- a/tests/test_authorization_loader.py
+++ b/tests/test_authorization_loader.py
@@ -1,0 +1,45 @@
+"""Tests for the load_acl TOML loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fastmcp_pvl_core._authorization import load_acl
+
+
+def test_load_acl_happy_path(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text(
+        '''
+[subjects]
+"user:alice@example.com" = ["read", "write"]
+"user:admin@example.com" = ["*"]
+"service:ci-bot"         = ["read"]
+        ''',
+        encoding="utf-8",
+    )
+    acl = load_acl(p)
+    assert acl == {
+        "user:alice@example.com": frozenset({"read", "write"}),
+        "user:admin@example.com": frozenset({"*"}),
+        "service:ci-bot": frozenset({"read"}),
+    }
+    assert all(isinstance(v, frozenset) for v in acl.values())
+
+
+def test_load_acl_empty_subjects_table_permitted(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text("[subjects]\n", encoding="utf-8")
+    assert load_acl(p) == {}
+
+
+def test_load_acl_expands_user_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    real = tmp_path / "acl.toml"
+    real.write_text('[subjects]\n"user:x" = ["read"]\n', encoding="utf-8")
+    acl = load_acl(Path("~/acl.toml"))
+    assert acl == {"user:x": frozenset({"read"})}

--- a/tests/test_authorization_loader.py
+++ b/tests/test_authorization_loader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from fastmcp_pvl_core._authorization import load_acl
+from fastmcp_pvl_core._errors import ConfigurationError
 
 
 def test_load_acl_happy_path(tmp_path: Path) -> None:
@@ -43,3 +44,84 @@ def test_load_acl_expands_user_home(
     real.write_text('[subjects]\n"user:x" = ["read"]\n', encoding="utf-8")
     acl = load_acl(Path("~/acl.toml"))
     assert acl == {"user:x": frozenset({"read"})}
+
+
+def test_load_acl_missing_file(tmp_path: Path) -> None:
+    p = tmp_path / "nope.toml"
+    with pytest.raises(ConfigurationError, match="not found"):
+        load_acl(p)
+
+
+def test_load_acl_directory_not_file(tmp_path: Path) -> None:
+    with pytest.raises(ConfigurationError, match="not found or not a regular file"):
+        load_acl(tmp_path)
+
+
+def test_load_acl_invalid_utf8(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_bytes(b"\xff\xfe\xfd not utf-8")
+    with pytest.raises(ConfigurationError, match="could not be read"):
+        load_acl(p)
+
+
+def test_load_acl_malformed_toml(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text("[subjects\nbroken =", encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="could not be parsed"):
+        load_acl(p)
+
+
+def test_load_acl_missing_subjects_table(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[other]\nkey = "val"\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match=r"\[subjects\] table"):
+        load_acl(p)
+
+
+def test_load_acl_subjects_not_a_table(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('subjects = "scalar"\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match=r"\[subjects\] table"):
+        load_acl(p)
+
+
+def test_load_acl_blank_subject_key_rejected(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"" = ["read"]\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="subject key is empty"):
+        load_acl(p)
+
+
+def test_load_acl_whitespace_subject_key_rejected(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"   " = ["read"]\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="subject key is empty"):
+        load_acl(p)
+
+
+def test_load_acl_subject_wildcard_rejected(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"*" = ["read"]\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match=r'"\*" as a subject key'):
+        load_acl(p)
+
+
+def test_load_acl_non_list_value(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"user:x" = "read"\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="must be an array"):
+        load_acl(p)
+
+
+def test_load_acl_non_string_scope(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"user:x" = ["read", 42]\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="scope must be a string"):
+        load_acl(p)
+
+
+def test_load_acl_blank_scope(tmp_path: Path) -> None:
+    p = tmp_path / "acl.toml"
+    p.write_text('[subjects]\n"user:x" = ["read", "  "]\n', encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="scope is empty"):
+        load_acl(p)

--- a/tests/test_authorization_middleware.py
+++ b/tests/test_authorization_middleware.py
@@ -78,10 +78,21 @@ async def test_on_call_tool_with_meta_denied_raises_tool_error() -> None:
     call_next.assert_not_awaited()
 
 
-@pytest.mark.asyncio
-async def test_on_call_tool_publishes_authorizer_to_contextvar() -> None:
-    """__init__ sets the ambient authorizer so check_authorization works."""
-    from fastmcp_pvl_core._authorization import _current_authorizer
+def test_init_publishes_authorizer_for_ambient_check_authorization() -> None:
+    """__init__ makes the authorizer available to check_authorization without kwarg."""
+    from fastmcp_pvl_core._authorization import (
+        AuthzDenied,
+        check_authorization,
+    )
 
-    AuthorizationMiddleware(authorizer=_allow_all)
-    assert _current_authorizer.get() is _allow_all
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        AuthorizationMiddleware(authorizer=_allow_all)
+        check_authorization("any_scope")  # ambient authorizer found, allows
+
+        AuthorizationMiddleware(authorizer=_deny_all)
+        with pytest.raises(AuthzDenied) as exc_info:
+            check_authorization("any_scope")
+    assert exc_info.value.subject == "user:alice"
+    assert exc_info.value.required_scope == "any_scope"

--- a/tests/test_authorization_middleware.py
+++ b/tests/test_authorization_middleware.py
@@ -221,3 +221,67 @@ async def test_on_get_prompt_body_authz_denied_becomes_prompt_error() -> None:
             await middleware.on_get_prompt(ctx, body_raises)
     payload = json.loads(str(exc_info.value))
     assert payload == {"code": "authz_denied", "required_scope": "read:foo"}
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_get_tool_failure_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    fastmcp_obj = SimpleNamespace(
+        get_tool=AsyncMock(side_effect=KeyError("tool not found"))
+    )
+    fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
+    ctx = MagicMock(
+        message=SimpleNamespace(name="missing", arguments={}),
+        fastmcp_context=fastmcp_context,
+    )
+    call_next = AsyncMock(return_value="result")
+    caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_call_tool(ctx, call_next)
+    assert result == "result"
+    call_next.assert_awaited_once_with(ctx)
+    assert any("tool lookup failed" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_on_read_resource_get_resource_failure_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    fastmcp_obj = SimpleNamespace(
+        get_resource=AsyncMock(side_effect=KeyError("nope"))
+    )
+    fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
+    ctx = MagicMock(
+        message=SimpleNamespace(uri="vault://x"),
+        fastmcp_context=fastmcp_context,
+    )
+    call_next = AsyncMock(return_value="contents")
+    caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
+    result = await middleware.on_read_resource(ctx, call_next)
+    assert result == "contents"
+    assert any("resource lookup failed" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_on_get_prompt_get_prompt_failure_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    fastmcp_obj = SimpleNamespace(
+        get_prompt=AsyncMock(side_effect=KeyError("nope"))
+    )
+    fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
+    ctx = MagicMock(
+        message=SimpleNamespace(name="missing", arguments={}),
+        fastmcp_context=fastmcp_context,
+    )
+    call_next = AsyncMock(return_value="messages")
+    caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
+    result = await middleware.on_get_prompt(ctx, call_next)
+    assert result == "messages"
+    assert any("prompt lookup failed" in rec.message for rec in caplog.records)

--- a/tests/test_authorization_middleware.py
+++ b/tests/test_authorization_middleware.py
@@ -8,7 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import PromptError, ResourceError, ToolError
 
 from fastmcp_pvl_core._authorization import AuthorizationMiddleware
 
@@ -96,3 +96,77 @@ def test_init_publishes_authorizer_for_ambient_check_authorization() -> None:
             check_authorization("any_scope")
     assert exc_info.value.subject == "user:alice"
     assert exc_info.value.required_scope == "any_scope"
+
+
+def _make_resource_context(
+    *, uri: str = "vault://doc-1", resource_meta: dict[str, Any] | None = None
+) -> MagicMock:
+    resource = SimpleNamespace(meta=resource_meta or {})
+    fastmcp_obj = SimpleNamespace(get_resource=AsyncMock(return_value=resource))
+    fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
+    message = SimpleNamespace(uri=uri)
+    return MagicMock(message=message, fastmcp_context=fastmcp_context)
+
+
+def _make_prompt_context(
+    *, prompt_name: str = "the_prompt", prompt_meta: dict[str, Any] | None = None
+) -> MagicMock:
+    prompt = SimpleNamespace(meta=prompt_meta or {})
+    fastmcp_obj = SimpleNamespace(get_prompt=AsyncMock(return_value=prompt))
+    fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
+    message = SimpleNamespace(name=prompt_name, arguments={})
+    return MagicMock(message=message, fastmcp_context=fastmcp_context)
+
+
+@pytest.mark.asyncio
+async def test_on_read_resource_with_meta_denied_raises_resource_error() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_resource_context(resource_meta={"required_scope": "read"})
+    call_next = AsyncMock(return_value="contents")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ResourceError) as exc_info:
+            await middleware.on_read_resource(ctx, call_next)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {"code": "authz_denied", "required_scope": "read"}
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_read_resource_no_meta_passes_through() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_resource_context(resource_meta={})
+    call_next = AsyncMock(return_value="contents")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_read_resource(ctx, call_next)
+    assert result == "contents"
+
+
+@pytest.mark.asyncio
+async def test_on_get_prompt_with_meta_denied_raises_prompt_error() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_prompt_context(prompt_meta={"required_scope": "read"})
+    call_next = AsyncMock(return_value="messages")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(PromptError) as exc_info:
+            await middleware.on_get_prompt(ctx, call_next)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {"code": "authz_denied", "required_scope": "read"}
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_get_prompt_no_meta_passes_through() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_prompt_context(prompt_meta={})
+    call_next = AsyncMock(return_value="messages")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_get_prompt(ctx, call_next)
+    assert result == "messages"

--- a/tests/test_authorization_middleware.py
+++ b/tests/test_authorization_middleware.py
@@ -353,3 +353,59 @@ async def test_on_list_prompts_filters_denied() -> None:
     ):
         result = await middleware.on_list_prompts(ctx, call_next)
     assert result == [p_open]
+
+
+@pytest.mark.asyncio
+async def test_default_payload_does_not_include_subject() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_context(tool_meta={"required_scope": "write"})
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, call_next)
+    payload = json.loads(str(exc_info.value))
+    assert "subject" not in payload
+
+
+@pytest.mark.asyncio
+async def test_expose_subject_in_error_includes_subject() -> None:
+    middleware = AuthorizationMiddleware(
+        authorizer=_deny_all, expose_subject_in_error=True
+    )
+    ctx = _make_context(tool_meta={"required_scope": "write"})
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, call_next)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {
+        "code": "authz_denied",
+        "required_scope": "write",
+        "subject": "user:alice",
+    }
+
+
+@pytest.mark.asyncio
+async def test_subject_always_logged_at_warning_regardless_of_flag(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Subject appears in WARNING log even when expose_subject_in_error=False."""
+    caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
+    middleware = AuthorizationMiddleware(
+        authorizer=_deny_all, expose_subject_in_error=False
+    )
+    ctx = _make_context(tool_meta={"required_scope": "write"})
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ToolError):
+            await middleware.on_call_tool(ctx, call_next)
+    assert any(
+        "user:alice" in rec.message and "authz_denied" in rec.message
+        for rec in caplog.records
+    )

--- a/tests/test_authorization_middleware.py
+++ b/tests/test_authorization_middleware.py
@@ -451,6 +451,28 @@ async def test_expose_subject_in_error_renders_null_when_subject_is_none() -> No
 
 
 @pytest.mark.asyncio
+async def test_on_call_tool_strips_padded_required_scope() -> None:
+    """Whitespace-padded required_scope is stripped before authorizer + payload."""
+    captured: list[str] = []
+
+    def authorize(_subject: str | None, required_scope: str) -> bool:
+        captured.append(required_scope)
+        return False  # deny so we can assert the payload
+
+    middleware = AuthorizationMiddleware(authorizer=authorize)
+    ctx = _make_context(tool_meta={"required_scope": "  write  "})
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, call_next)
+    assert captured == ["write"]
+    payload = json.loads(str(exc_info.value))
+    assert payload["required_scope"] == "write"
+
+
+@pytest.mark.asyncio
 async def test_subject_always_logged_at_warning_regardless_of_flag(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_authorization_middleware.py
+++ b/tests/test_authorization_middleware.py
@@ -280,9 +280,7 @@ async def test_on_read_resource_get_resource_failure_falls_through(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     middleware = AuthorizationMiddleware(authorizer=_deny_all)
-    fastmcp_obj = SimpleNamespace(
-        get_resource=AsyncMock(side_effect=KeyError("nope"))
-    )
+    fastmcp_obj = SimpleNamespace(get_resource=AsyncMock(side_effect=KeyError("nope")))
     fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
     ctx = MagicMock(
         message=SimpleNamespace(uri="vault://x"),
@@ -301,9 +299,7 @@ async def test_on_get_prompt_get_prompt_failure_falls_through(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     middleware = AuthorizationMiddleware(authorizer=_deny_all)
-    fastmcp_obj = SimpleNamespace(
-        get_prompt=AsyncMock(side_effect=KeyError("nope"))
-    )
+    fastmcp_obj = SimpleNamespace(get_prompt=AsyncMock(side_effect=KeyError("nope")))
     fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
     ctx = MagicMock(
         message=SimpleNamespace(name="missing", arguments={}),
@@ -321,12 +317,8 @@ async def test_on_get_prompt_get_prompt_failure_falls_through(
 async def test_on_list_tools_filters_denied_tools() -> None:
     """Tools with denied required_scope are dropped; unannotated kept."""
     tool_open = SimpleNamespace(name="open_tool", meta={})
-    tool_write = SimpleNamespace(
-        name="write_tool", meta={"required_scope": "write"}
-    )
-    tool_read = SimpleNamespace(
-        name="read_tool", meta={"required_scope": "read"}
-    )
+    tool_write = SimpleNamespace(name="write_tool", meta={"required_scope": "write"})
+    tool_read = SimpleNamespace(name="read_tool", meta={"required_scope": "read"})
 
     def authorize(_subject: str | None, required: str) -> bool:
         return required == "read"
@@ -416,6 +408,45 @@ async def test_expose_subject_in_error_includes_subject() -> None:
         "code": "authz_denied",
         "required_scope": "write",
         "subject": "user:alice",
+    }
+
+
+@pytest.mark.parametrize(
+    ("method_name", "message_kwarg"),
+    [
+        ("on_call_tool", {"name": "x", "arguments": {}}),
+        ("on_read_resource", {"uri": "x"}),
+        ("on_get_prompt", {"name": "x", "arguments": {}}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_hook_raises_runtime_error_when_fastmcp_context_is_none(
+    method_name: str, message_kwarg: dict[str, Any]
+) -> None:
+    middleware = AuthorizationMiddleware(authorizer=_allow_all)
+    ctx = MagicMock(
+        fastmcp_context=None,
+        message=SimpleNamespace(**message_kwarg),
+    )
+    with pytest.raises(RuntimeError, match="fastmcp_context is None"):
+        await getattr(middleware, method_name)(ctx, AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_expose_subject_in_error_renders_null_when_subject_is_none() -> None:
+    middleware = AuthorizationMiddleware(
+        authorizer=_deny_all, expose_subject_in_error=True
+    )
+    ctx = _make_context(tool_meta={"required_scope": "write"})
+    call_next = AsyncMock(return_value="result")
+    with patch("fastmcp_pvl_core._authorization.get_subject", return_value=None):
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, call_next)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {
+        "code": "authz_denied",
+        "required_scope": "write",
+        "subject": None,
     }
 
 

--- a/tests/test_authorization_middleware.py
+++ b/tests/test_authorization_middleware.py
@@ -285,3 +285,71 @@ async def test_on_get_prompt_get_prompt_failure_falls_through(
     result = await middleware.on_get_prompt(ctx, call_next)
     assert result == "messages"
     assert any("prompt lookup failed" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_on_list_tools_filters_denied_tools() -> None:
+    """Tools with denied required_scope are dropped; unannotated kept."""
+    tool_open = SimpleNamespace(name="open_tool", meta={})
+    tool_write = SimpleNamespace(
+        name="write_tool", meta={"required_scope": "write"}
+    )
+    tool_read = SimpleNamespace(
+        name="read_tool", meta={"required_scope": "read"}
+    )
+
+    def authorize(_subject: str | None, required: str) -> bool:
+        return required == "read"
+
+    middleware = AuthorizationMiddleware(authorizer=authorize)
+    call_next = AsyncMock(return_value=[tool_open, tool_write, tool_read])
+    ctx = MagicMock()
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_list_tools(ctx, call_next)
+    assert result == [tool_open, tool_read]
+
+
+@pytest.mark.asyncio
+async def test_on_list_resources_filters_denied() -> None:
+    res_open = SimpleNamespace(uri="vault://1", meta={})
+    res_locked = SimpleNamespace(uri="vault://2", meta={"required_scope": "x"})
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    call_next = AsyncMock(return_value=[res_open, res_locked])
+    ctx = MagicMock()
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_list_resources(ctx, call_next)
+    assert result == [res_open]
+
+
+@pytest.mark.asyncio
+async def test_on_list_resource_templates_filters_denied() -> None:
+    tmpl_open = SimpleNamespace(uri="vault://{a}", meta={})
+    tmpl_locked = SimpleNamespace(
+        uri="vault://locked/{a}", meta={"required_scope": "x"}
+    )
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    call_next = AsyncMock(return_value=[tmpl_open, tmpl_locked])
+    ctx = MagicMock()
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_list_resource_templates(ctx, call_next)
+    assert result == [tmpl_open]
+
+
+@pytest.mark.asyncio
+async def test_on_list_prompts_filters_denied() -> None:
+    p_open = SimpleNamespace(name="open", meta={})
+    p_locked = SimpleNamespace(name="locked", meta={"required_scope": "x"})
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    call_next = AsyncMock(return_value=[p_open, p_locked])
+    ctx = MagicMock()
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_list_prompts(ctx, call_next)
+    assert result == [p_open]

--- a/tests/test_authorization_middleware.py
+++ b/tests/test_authorization_middleware.py
@@ -1,0 +1,87 @@
+"""Tests for AuthorizationMiddleware."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from fastmcp_pvl_core._authorization import AuthorizationMiddleware
+
+
+def _make_context(
+    *,
+    tool_name: str = "do_thing",
+    tool_meta: dict[str, Any] | None = None,
+) -> MagicMock:
+    """Build a minimal MiddlewareContext-shaped mock for tool calls."""
+    tool = SimpleNamespace(meta=tool_meta or {})
+    fastmcp_obj = SimpleNamespace(get_tool=AsyncMock(return_value=tool))
+    fastmcp_context = SimpleNamespace(fastmcp=fastmcp_obj)
+    message = SimpleNamespace(name=tool_name, arguments={})
+    return MagicMock(
+        message=message,
+        fastmcp_context=fastmcp_context,
+    )
+
+
+def _allow_all(_subject: str | None, _required_scope: str) -> bool:
+    return True
+
+
+def _deny_all(_subject: str | None, _required_scope: str) -> bool:
+    return False
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_no_meta_passes_through() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_context(tool_meta={})
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_call_tool(ctx, call_next)
+    assert result == "result"
+    call_next.assert_awaited_once_with(ctx)
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_with_meta_allowed_passes_through() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_allow_all)
+    ctx = _make_context(tool_meta={"required_scope": "write"})
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_call_tool(ctx, call_next)
+    assert result == "result"
+    call_next.assert_awaited_once_with(ctx)
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_with_meta_denied_raises_tool_error() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_context(tool_meta={"required_scope": "write"})
+    call_next = AsyncMock(return_value="result")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, call_next)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {"code": "authz_denied", "required_scope": "write"}
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_publishes_authorizer_to_contextvar() -> None:
+    """__init__ sets the ambient authorizer so check_authorization works."""
+    from fastmcp_pvl_core._authorization import _current_authorizer
+
+    AuthorizationMiddleware(authorizer=_allow_all)
+    assert _current_authorizer.get() is _allow_all

--- a/tests/test_authorization_middleware.py
+++ b/tests/test_authorization_middleware.py
@@ -91,6 +91,33 @@ async def test_on_list_tools_non_string_required_scope_logs_warning_and_keeps(
 
 
 @pytest.mark.asyncio
+async def test_on_call_tool_blank_string_required_scope_logs_warning_and_passes(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Empty / whitespace-only ``required_scope`` falls open *and* warns.
+
+    Symmetric with the non-string case: an operator typo (e.g.
+    ``meta={"required_scope": ""}``) is more likely a misconfiguration
+    than a deliberate "no restriction" signal (the documented way to
+    express that is to omit the key entirely).
+    """
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_context(tool_meta={"required_scope": "   "})
+    call_next = AsyncMock(return_value="result")
+    caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_call_tool(ctx, call_next)
+    assert result == "result"
+    call_next.assert_awaited_once_with(ctx)
+    assert any(
+        "authz_meta_invalid" in rec.message and "kind=tool" in rec.message
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
 async def test_on_call_tool_with_meta_allowed_passes_through() -> None:
     middleware = AuthorizationMiddleware(authorizer=_allow_all)
     ctx = _make_context(tool_meta={"required_scope": "write"})

--- a/tests/test_authorization_middleware.py
+++ b/tests/test_authorization_middleware.py
@@ -51,6 +51,46 @@ async def test_on_call_tool_no_meta_passes_through() -> None:
 
 
 @pytest.mark.asyncio
+async def test_on_call_tool_non_string_required_scope_logs_warning_and_passes(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-string ``required_scope`` falls open but logs a WARNING."""
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    ctx = _make_context(tool_meta={"required_scope": ["read", "write"]})
+    call_next = AsyncMock(return_value="result")
+    caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_call_tool(ctx, call_next)
+    assert result == "result"
+    call_next.assert_awaited_once_with(ctx)
+    assert any(
+        "authz_meta_invalid" in rec.message and "kind=tool" in rec.message
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_list_tools_non_string_required_scope_logs_warning_and_keeps(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-string ``required_scope`` in a listed component falls open but warns."""
+    bad_tool = SimpleNamespace(name="bad", meta={"required_scope": 42})
+    good_tool = SimpleNamespace(name="good", meta={})
+    middleware = AuthorizationMiddleware(authorizer=_deny_all)
+    call_next = AsyncMock(return_value=[bad_tool, good_tool])
+    ctx = MagicMock()
+    caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_list_tools(ctx, call_next)
+    assert result == [bad_tool, good_tool]
+    assert any("authz_meta_invalid" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_on_call_tool_with_meta_allowed_passes_through() -> None:
     middleware = AuthorizationMiddleware(authorizer=_allow_all)
     ctx = _make_context(tool_meta={"required_scope": "write"})

--- a/tests/test_authorization_middleware.py
+++ b/tests/test_authorization_middleware.py
@@ -143,6 +143,20 @@ async def test_on_read_resource_no_meta_passes_through() -> None:
     ):
         result = await middleware.on_read_resource(ctx, call_next)
     assert result == "contents"
+    call_next.assert_awaited_once_with(ctx)
+
+
+@pytest.mark.asyncio
+async def test_on_read_resource_with_meta_allowed_passes_through() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_allow_all)
+    ctx = _make_resource_context(resource_meta={"required_scope": "read"})
+    call_next = AsyncMock(return_value="contents")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_read_resource(ctx, call_next)
+    assert result == "contents"
+    call_next.assert_awaited_once_with(ctx)
 
 
 @pytest.mark.asyncio
@@ -170,6 +184,20 @@ async def test_on_get_prompt_no_meta_passes_through() -> None:
     ):
         result = await middleware.on_get_prompt(ctx, call_next)
     assert result == "messages"
+    call_next.assert_awaited_once_with(ctx)
+
+
+@pytest.mark.asyncio
+async def test_on_get_prompt_with_meta_allowed_passes_through() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_allow_all)
+    ctx = _make_prompt_context(prompt_meta={"required_scope": "read"})
+    call_next = AsyncMock(return_value="messages")
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        result = await middleware.on_get_prompt(ctx, call_next)
+    assert result == "messages"
+    call_next.assert_awaited_once_with(ctx)
 
 
 @pytest.mark.asyncio
@@ -264,6 +292,7 @@ async def test_on_read_resource_get_resource_failure_falls_through(
     caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
     result = await middleware.on_read_resource(ctx, call_next)
     assert result == "contents"
+    call_next.assert_awaited_once_with(ctx)
     assert any("resource lookup failed" in rec.message for rec in caplog.records)
 
 
@@ -284,6 +313,7 @@ async def test_on_get_prompt_get_prompt_failure_falls_through(
     caplog.set_level("WARNING", logger="fastmcp_pvl_core._authorization")
     result = await middleware.on_get_prompt(ctx, call_next)
     assert result == "messages"
+    call_next.assert_awaited_once_with(ctx)
     assert any("prompt lookup failed" in rec.message for rec in caplog.records)
 
 

--- a/tests/test_authorization_middleware.py
+++ b/tests/test_authorization_middleware.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp.exceptions import PromptError, ResourceError, ToolError
 
-from fastmcp_pvl_core._authorization import AuthorizationMiddleware
+from fastmcp_pvl_core._authorization import AuthorizationMiddleware, AuthzDenied
 
 
 def _make_context(
@@ -170,3 +170,54 @@ async def test_on_get_prompt_no_meta_passes_through() -> None:
     ):
         result = await middleware.on_get_prompt(ctx, call_next)
     assert result == "messages"
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_body_authz_denied_becomes_tool_error() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_allow_all)
+    ctx = _make_context(tool_meta={})  # static check passes (no meta)
+
+    async def body_raises(_ctx: object) -> str:
+        raise AuthzDenied(subject="user:alice", required_scope="write:foo")
+
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, body_raises)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {"code": "authz_denied", "required_scope": "write:foo"}
+
+
+@pytest.mark.asyncio
+async def test_on_read_resource_body_authz_denied_becomes_resource_error() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_allow_all)
+    ctx = _make_resource_context(resource_meta={})
+
+    async def body_raises(_ctx: object) -> str:
+        raise AuthzDenied(subject="user:alice", required_scope="read:foo")
+
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(ResourceError) as exc_info:
+            await middleware.on_read_resource(ctx, body_raises)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {"code": "authz_denied", "required_scope": "read:foo"}
+
+
+@pytest.mark.asyncio
+async def test_on_get_prompt_body_authz_denied_becomes_prompt_error() -> None:
+    middleware = AuthorizationMiddleware(authorizer=_allow_all)
+    ctx = _make_prompt_context(prompt_meta={})
+
+    async def body_raises(_ctx: object) -> str:
+        raise AuthzDenied(subject="user:alice", required_scope="read:foo")
+
+    with patch(
+        "fastmcp_pvl_core._authorization.get_subject", return_value="user:alice"
+    ):
+        with pytest.raises(PromptError) as exc_info:
+            await middleware.on_get_prompt(ctx, body_raises)
+    payload = json.loads(str(exc_info.value))
+    assert payload == {"code": "authz_denied", "required_scope": "read:foo"}


### PR DESCRIPTION
## Summary

- New optional `fastmcp_pvl_core` authorization layer: `AuthorizationMiddleware` enforces `meta["required_scope"]` on tools/resources/prompts, filters `list_*` responses, and translates `AuthzDenied` raised inside component bodies into the matching per-operation MCP error.
- Public surface: `AuthorizationMiddleware`, `AuthzDenied`, `Authorizer` (TypeAlias), `check_authorization`, `load_acl`, `make_acl_authorizer`. Six symbols re-exported from package root; opt-in per server and per component.
- Spec at `docs/specs/authorization-submodule.md` is the design contract; "Deviations from issue #37" table documents where the redesign parts ways from the originating issue body.

Closes #37.

## Test plan

- [ ] CI: `pytest -q` passes (513 tests locally, +56 from new files).
- [ ] CI: `mypy src/fastmcp_pvl_core` clean under strict mode.
- [ ] CI: `ruff check src tests` clean.
- [ ] Smoke-test the public API end-to-end: `load_acl` → `make_acl_authorizer` → `AuthorizationMiddleware` → `check_authorization`.
- [ ] README example renders and the imports it shows are real public exports.
- [ ] `claude-review` body returns LGTM.
- [ ] `gemini-code-assist` body returns LGTM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)