### PR TITLE
docs: pvl-core is the opinionated shared implementation (closes #73)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,139 @@
+# fastmcp-pvl-core — contributor guidance
+
+Repo-specific rules for contributors (human and AI) working on
+`fastmcp-pvl-core` itself. Personal/global agent rules (PR workflow,
+bot reviewers, memory) live elsewhere; this file is for cross-cutting
+rules that apply to *this* repo regardless of who is contributing.
+
+## What this repo is
+
+`fastmcp-pvl-core` is the **opinionated shared implementation** for
+the `pvliesdonk/*-mcp` server family (`markdown-vault-mcp`,
+`scholar-mcp`, `image-generation-mcp`, and future siblings). It is
+consumed transitively by downstream servers via the
+[`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template)
+copier template (`copier update` propagation).
+
+It is **not a buffet of helpers** downstream picks from à la carte.
+It is the load-bearing layer that fixes the shape of cross-cutting
+concerns so the server family stays coherent as it grows.
+
+## The framing principle
+
+Shape decisions live in pvl-core. Downstream contributes
+domain-specific logic only. Four facets in detail.
+
+### Shape decisions live in pvl-core
+
+Tool names, parameter shapes, route structures, capability
+declarations, error envelopes, environment-variable contracts —
+pvl-core picks one shape and downstream conforms. If two downstream
+servers would each prefer a different shape, the resolution is for
+pvl-core to pick one and migrate the others to it, **not** for
+pvl-core to grow an override kwarg.
+
+### Hooks expose domain-specific behaviour only
+
+A hook like *"where in my storage model do these bytes go?"* is
+appropriate — pvl-core cannot know the answer for a particular
+downstream. A hook like *"what should this tool be called?"* or
+*"what HTTP status code should an oversize body return?"* is not —
+those are shape decisions pvl-core owns and downstream must accept.
+
+**Classification test** for a proposed new keyword argument on a
+`register_*` helper, `Build*` factory, or middleware constructor:
+
+- Is the caller supplying a value pvl-core could not reasonably know
+  on its own? → **domain hook** — accept the kwarg.
+- Is the caller asking to override a decision pvl-core has already
+  made (or should make)? → **reject**. Keep the decision in pvl-core;
+  if downstream genuinely needs different behaviour, pvl-core changes
+  shape and *all* downstreams follow.
+- Is the caller supplying a deployer-side value (TTL ceiling, max body
+  size, listening port, debug flag)? → **operator configuration**
+  — expose via environment variable, not kwarg.
+
+If a proposed kwarg mixes categories — a legitimate hook bundled
+with an override of shape — split it: keep the hook component, drop
+the override component. Reviewers reject PRs that grow override
+kwargs disguised as hooks.
+
+### Spec docs are protocol extensions, not design docs
+
+Files under `docs/specs/` describe **wire format and behaviour
+requirements between independently developed servers** — what bytes
+move between systems and under what rules. They are read by anyone
+implementing the same protocol, not just pvl-core.
+
+Implementation choices that pvl-core happens to make (lazy
+materialisation, route mechanics, framework-specific helpers,
+downstream tool naming and registration mechanics, default values
+that pvl-core picks for its own use) belong in pvl-core's own
+implementor docs or code comments, **not** in a spec doc.
+
+Real spec gaps are resolved through a proper spec evolution: a new
+release with the version field bumped per the spec's own
+versioning-and-compatibility section. Inline amendments to a
+published version are not a valid spec-evolution mechanism. The
+opening of `docs/specs/file-exchange.md` is the worked example.
+
+### Pre-existing downstream conflicts resolve by migration
+
+If a downstream server has already shipped a different *shape* (a
+differently named tool, a divergent parameter, a custom error
+envelope), the resolution is for the **downstream** to migrate.
+pvl-core does not grow a compatibility shim to spare downstream the
+migration cost, even when the migration is large. If the migration
+cannot land immediately, file a tracked downstream issue and ship
+the breaking change in pvl-core anyway — the umbrella tracker
+coordinates the cutover.
+
+This applies to *shape* divergence (the things owned by pvl-core).
+Domain-specific divergence between downstreams is expected and does
+not require any migration — downstreams are supposed to differ in
+domain logic.
+
+## Practical consequences
+
+- **Adding a new `register_*` helper or `Build*` factory**: every
+  kwarg passes the classification test above. Document each kwarg's
+  category (hook / config / shape) in the docstring. Existing
+  helpers (notably `register_file_exchange` / `register_file_exchange_upload`)
+  predate this rule and are being audited in
+  [#72](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/72);
+  new kwargs added to existing helpers still pass the test and carry
+  the annotation.
+- **Adding a new spec under `docs/specs/`**: it documents wire format
+  for interop, not pvl-core's implementation. Implementation
+  decisions are out of scope of the spec file.
+- **Adopting a downstream-suggested rename or shape change**: if it
+  changes a shared shape, the change ships in pvl-core and downstream
+  follows; if it changes only domain-specific behaviour, it does not
+  belong in pvl-core at all.
+
+## Local checks before pushing
+
+Before declaring local checks clean:
+
+```bash
+uv sync --all-extras   # match CI's dependency state
+uv run pytest          # unit + integration tests
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
+```
+
+CI runs the same checks on Python 3.10 through 3.13.
+
+## Related
+
+- [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template)
+  — copier template downstream consumers `copier update` from.
+  Template-side equivalents of these principles are tracked in
+  [fastmcp-server-template#131](https://github.com/pvliesdonk/fastmcp-server-template/issues/131).
+- `docs/specs/` — wire-format specs (what goes between systems).
+  Read these to understand the protocol; do not put pvl-core's
+  implementation choices in here.
+- README.md — `## Design principles` section carries the same
+  framing in user-facing voice; this file is the contributor-facing
+  voice. Keep them aligned when one changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,8 @@ Real spec gaps are resolved through a proper spec evolution: a new
 release with the version field bumped per the spec's own
 versioning-and-compatibility section. Inline amendments to a
 published version are not a valid spec-evolution mechanism. The
-opening of `docs/specs/file-exchange.md` is the worked example.
+opening of [`docs/specs/file-exchange.md`](docs/specs/file-exchange.md)
+is the worked example.
 
 ### Pre-existing downstream conflicts resolve by migration
 
@@ -134,6 +135,7 @@ CI runs the same checks on Python 3.10 through 3.13.
 - `docs/specs/` — wire-format specs (what goes between systems).
   Read these to understand the protocol; do not put pvl-core's
   implementation choices in here.
-- README.md — `## Design principles` section carries the same
-  framing in user-facing voice; this file is the contributor-facing
-  voice. Keep them aligned when one changes.
+- [README.md](README.md#design-principles) — `## Design principles`
+  section carries the same framing in user-facing voice; this file
+  is the contributor-facing voice. Keep them aligned when one
+  changes.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # fastmcp-pvl-core
 
-Shared FastMCP infrastructure for the `pvliesdonk/*-mcp` server family:
-auth, middleware, logging, config helpers, server-factory building blocks.
+The opinionated shared implementation for the `pvliesdonk/*-mcp`
+server family. `fastmcp-pvl-core` owns the shape of cross-cutting
+concerns — auth, middleware, logging, config, server-factory builders,
+the file-exchange wire surface — and exposes narrow hooks to
+downstream servers for domain-specific behaviour. Downstream conforms
+to the shape; pvl-core does not adapt to downstream preferences. See
+[Design principles](#design-principles) for the rationale and the
+classification test that follows from it.
 
 ## Ecosystem
 
@@ -15,6 +21,83 @@ auth, middleware, logging, config helpers, server-factory building blocks.
   `copier update` runs against the template.
 - See the template's README for the update flow and the expected project
   shape.
+
+## Design principles
+
+`fastmcp-pvl-core` is not a buffet of helpers downstream picks from
+à la carte. It is the load-bearing layer that fixes the shape of
+cross-cutting concerns across the server family so the family stays
+coherent as it grows. Four principles follow from that role.
+
+### Shape decisions live in pvl-core
+
+Tool names, parameter shapes, route structures, capability
+declarations, error envelopes, environment-variable contracts —
+pvl-core picks one shape and downstream conforms. If two downstream
+servers would each prefer a different shape, the resolution is for
+pvl-core to pick one and migrate the others to it, not for pvl-core
+to grow an override kwarg.
+
+### Hooks expose domain-specific behaviour only
+
+A hook like *"where in my storage model do these bytes go?"* is
+appropriate — pvl-core cannot know the answer for a particular
+downstream. A hook like *"what should this tool be called?"* or
+*"what HTTP status code should an oversize body return?"* is not —
+those are shape decisions pvl-core owns, and downstream accepts them.
+
+Classification test for a proposed new keyword argument on a
+`register_*` helper, `Build*` factory, or middleware constructor:
+
+- The caller is supplying a value pvl-core could not reasonably know
+  on its own (a callback to its own storage, a per-instance label
+  visible only to the deployer) — **domain hook**, accept.
+- The caller is asking to override a decision pvl-core has already
+  made or should make (rename a tool, change a parameter shape,
+  swap a status code) — **reject**. If downstream genuinely needs
+  different behaviour, pvl-core changes shape and *all* downstreams
+  follow.
+- The caller is supplying a deployer-side value (TTL ceiling, max
+  body size, listening port, debug flag) — **operator
+  configuration**: expose via environment variable, not kwarg.
+
+If a proposed kwarg mixes categories — a legitimate hook bundled
+with an override of shape — split it: keep the hook, drop the
+override. PRs that grow override kwargs disguised as hooks are
+rejected.
+
+### Spec docs are protocol extensions, not design docs
+
+Files under `docs/specs/` describe the wire format and behaviour
+requirements between independently developed servers — what bytes
+move between systems and under what rules. Implementation choices
+that pvl-core happens to make (lazy materialisation strategies, route
+mechanics, framework-specific helpers, downstream tool naming and
+registration mechanics) do not belong in a spec doc; they belong in
+pvl-core's own implementor docs and code comments. Real spec gaps are
+resolved through a proper spec evolution — a new release with the
+version field bumped — not through inline amendments to a published
+version. The opening of
+[`docs/specs/file-exchange.md`](docs/specs/file-exchange.md) is the
+worked example of this distinction.
+
+### Pre-existing downstream conflicts resolve by migration
+
+If a downstream server has already shipped a different *shape* (a
+differently named tool, a divergent parameter, a custom error
+envelope), the resolution is for the downstream to migrate.
+pvl-core does not grow a compatibility shim to spare downstream the
+migration cost, even when the migration is large. If the migration
+cannot land immediately, file a tracked downstream issue and ship
+the breaking change in pvl-core anyway — the umbrella tracker
+coordinates the cutover and the
+[`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template)
+scaffold updates carry the new shape forward to fresh consumers.
+
+This applies to *shape* divergence (the things owned by pvl-core).
+Domain-specific divergence between downstreams is expected and does
+not require any migration — downstreams are *supposed* to differ in
+domain logic.
 
 ## API stability
 


### PR DESCRIPTION
Closes #73. Refs #75 (umbrella), #72 (hook-surface audit).

## Summary

Documents `fastmcp-pvl-core`'s role explicitly: it is the **opinionated shared implementation** for the `pvliesdonk/*-mcp` server family, not a buffet of helpers downstream picks from à la carte. pvl-core owns the shape of cross-cutting concerns (auth, middleware, logging, config, server-factory builders, the file-exchange wire surface) and exposes narrow hooks for downstream domain-specific behaviour. Downstream conforms to the shape; pvl-core does not adapt to downstream preferences.

## Changes

Two files. Both encode the same four-facet principle from #73 in two different voices — the user explicitly chose duplication over linking.

### `README.md`

- **Reframed opening** (lines 1–10): from feature-list ("Shared FastMCP infrastructure ... auth, middleware, logging, ...") to principle-first description of the opinionated-shared-implementation role.
- **New `## Design principles` section** (after Ecosystem, before API stability) carrying the four facets:
  1. Shape decisions live in pvl-core.
  2. Hooks expose domain-specific behaviour only — with the three-way classification test (domain hook / override / operator config) and a split-mixed-kwargs rule.
  3. Spec docs are protocol extensions, not design docs (`docs/specs/file-exchange.md` post-#77 is the worked example).
  4. Pre-existing downstream conflicts resolve by migration; pvl-core does not grow compatibility shims even when migration is large. Domain-specific divergence is fine.

### `CLAUDE.md` (new)

Self-contained contributor guide in directive voice carrying the same four facets, plus:

- **Practical consequences** — enumerates what the principle implies for adding a new `register_*` helper, adding a new spec under `docs/specs/`, and adopting downstream-suggested renames.
- **Local checks** — codifies the `uv sync --all-extras` / pytest / ruff / mypy commands CI runs.
- **Related** — names the README↔CLAUDE.md alignment obligation so the next contributor editing one mirrors to the other.
- A pointer to #72 (file-exchange hook-surface audit) so a contributor running the classification test on existing code (`register_file_exchange`, `register_file_exchange_upload`) sees that the existing override-shaped kwargs are tracked, not untracked debt.

## What's not changed

- **`fastmcp-server-template#131`** — the template-side rollout of these principles is an explicit acceptance item from #73, tracked there. Out of scope here.
- **Existing `register_file_exchange*` kwargs** — the classification test the new docs introduce surfaces several pre-existing override-shaped kwargs (tool names, transport forcing, legacy capability shape, operator-config-as-kwarg). These are #72's audit fodder, not this PR's scope.
- **Stale "v0.4 amendments" ref in README** — the README's File Exchange section (lines ~267–269) points at a removed spec section. Tracked separately as #79; would have stretched this PR past the framing principle.

## Local review

Two-subagent local review circus run on the cumulative diff:

- **Primary** (`pr-review-toolkit:code-reviewer`): initially flagged three should-fix items (asymmetric normative weight between README/CLAUDE.md, mixed-kwargs edge case missing from facet 2, loophole wording in facet 4). All three addressed before push; re-review pass returned clean.
- **Second-opinion** (`feature-dev:code-reviewer`, codebase-grounded): walked the classification test against every kwarg of `register_file_exchange`, `register_file_exchange_upload`, `build_instructions`, `wire_middleware_stack`, and `build_auth`. Confirmed the test produces unambiguous verdicts on real signatures. Flagged that future contributors running the test on existing code would hit override kwargs without an issue pointer — closed by the #72 pointer in CLAUDE.md's Practical Consequences section.

Both reviewers returned clean on the final diff.

## Test plan

- [x] No new code; tests unaffected.
- [x] No new spec doc claims.
- [x] `## Design principles` section sits between Ecosystem and API stability, both in-page anchor (`#design-principles` referenced from the opening) and ToC-by-headings work.
- [x] CLAUDE.md cross-references README's `## Design principles` section by name.
- [x] Worked-example link in facet 3 points to `docs/specs/file-exchange.md`, whose opening post-#77 does the framing the docs claim.
- [ ] CI green.
- [ ] Bot review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)