### PR TITLE
impl: migrate capability builder to v0.3.0 source/sink shape (#86)

### DIFF
--- a/docs/superpowers/plans/2026-05-15-capability-builder-v030-migration.md
+++ b/docs/superpowers/plans/2026-05-15-capability-builder-v030-migration.md
@@ -1,0 +1,672 @@
+# Capability Builder v0.3.0 Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the file-exchange capability builder to emit the v0.3.0 `source`/`sink` `transfer_methods` shape, realign `SPEC_VERSION` to `"0.3"`, and delete the `legacy_capability_shape` override kwarg.
+
+**Architecture:** `_FileExchangeCapabilityBuilder` accumulates per-role tool contributions and `build()`s a `FileExchangeCapability`. The rework replaces the single `_download_tool` field (which collapsed producer and consumer into one slot) with separate `source`/`sink` tracking, emits `http` and `http_upload` as separate top-level method keys, and fixes the `register_file_exchange` call site so a produce-and-consume server advertises both `http` roles. The builder API change spans the builder class and both `register_*` call sites, so it lands as one atomic task.
+
+**Tech Stack:** Python 3.10–3.13, `uv`, `pytest`, `ruff`, `mypy`. Repo `/mnt/code/fastmcp-pvl-core`, branch `impl/capability-builder-v030-issue-86`.
+
+**Design doc:** `docs/superpowers/specs/2026-05-15-capability-builder-v030-migration-design.md` (issue #86).
+
+---
+
+## File Structure
+
+- `src/fastmcp_pvl_core/_file_exchange_protocol.py` — `SPEC_VERSION` constant; `_FileExchangeCapabilityBuilder` class. The builder gains the `source`/`sink` API and shape; loses the legacy branch.
+- `src/fastmcp_pvl_core/file_exchange.py` — `_get_or_create_builder` (drops `legacy_capability_shape`); `register_file_exchange` capability call site (the `if/elif` → `if/if` dual-role fix); `register_file_exchange_upload` (drops the `legacy_capability_shape` kwarg, switches to the new builder method).
+- `tests/test_file_exchange_capability_merge.py` — full rewrite to the v0.3.0 shape and new builder API.
+
+No new files. No production behaviour changes beyond capability emission and the dual-role advertisement fix.
+
+---
+
+## Task 1: Migrate the capability builder, call sites, and version
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange_protocol.py:36` (SPEC_VERSION) and `:449-550` (`_FileExchangeCapabilityBuilder`)
+- Modify: `src/fastmcp_pvl_core/file_exchange.py:136-214` (`_get_or_create_builder`), `:761-788` (`register_file_exchange` call site), `:1539-1789` (`register_file_exchange_upload`)
+- Test: `tests/test_file_exchange_capability_merge.py` (full rewrite)
+
+This is one atomic API change — the builder's method names change, so the builder class and both call sites must move together to keep `mypy`/tests green. Steps 3–7 leave the tree temporarily inconsistent; the gate is run at Step 8 and the commit at Step 9.
+
+- [ ] **Step 1: Rewrite the capability-merge test file**
+
+Replace the entire contents of `tests/test_file_exchange_capability_merge.py` with:
+
+```python
+"""Tests for capability-merge across the http / http_upload registrars.
+
+Capability declarations use the v0.3.0 ``source``/``sink`` role-keyed
+``transfer_methods`` shape (spec §"Transfer Methods").
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._file_exchange_protocol import (
+    _FileExchangeCapabilityBuilder,
+)
+
+
+def test_builder_http_source_only_emits_source_role() -> None:
+    b = _FileExchangeCapabilityBuilder(namespace="ns")
+    b.set_http_source(tool_name="create_download_link")
+    cap = b.build()
+    assert cap is not None
+    d = cap.to_capability_dict()
+    assert d["version"] == "0.3"
+    assert d["transfer_methods"]["http"] == {
+        "source": {"tool": "create_download_link"},
+    }
+
+
+def test_builder_http_sink_only_emits_sink_role() -> None:
+    b = _FileExchangeCapabilityBuilder(namespace="ns")
+    b.set_http_sink(tool_name="fetch_file")
+    cap = b.build()
+    assert cap is not None
+    d = cap.to_capability_dict()
+    assert d["transfer_methods"]["http"] == {"sink": {"tool": "fetch_file"}}
+
+
+def test_builder_http_both_roles_emits_source_and_sink() -> None:
+    """Dual-role guard: a producer-and-consumer server advertises both roles."""
+    b = _FileExchangeCapabilityBuilder(namespace="ns")
+    b.set_http_source(tool_name="create_download_link")
+    b.set_http_sink(tool_name="fetch_file")
+    cap = b.build()
+    assert cap is not None
+    http = cap.to_capability_dict()["transfer_methods"]["http"]
+    assert http == {
+        "source": {"tool": "create_download_link"},
+        "sink": {"tool": "fetch_file"},
+    }
+
+
+def test_builder_http_upload_sink_emits_under_own_method_key() -> None:
+    b = _FileExchangeCapabilityBuilder(namespace="ns")
+    b.set_http_upload_sink(
+        tool_name="create_upload_link",
+        max_bytes=10_000_000,
+        max_ttl_seconds=300,
+    )
+    cap = b.build()
+    assert cap is not None
+    d = cap.to_capability_dict()
+    assert "http" not in d["transfer_methods"]
+    assert d["transfer_methods"]["http_upload"] == {
+        "sink": {
+            "tool": "create_upload_link",
+            "max_bytes": 10_000_000,
+            "max_ttl_seconds": 300,
+        },
+    }
+
+
+def test_builder_http_upload_sink_includes_explicit_accepts() -> None:
+    b = _FileExchangeCapabilityBuilder(namespace="ns")
+    b.set_http_upload_sink(
+        tool_name="create_upload_link",
+        max_bytes=1000,
+        max_ttl_seconds=300,
+        accepts=("text/markdown", "application/octet-stream"),
+    )
+    cap = b.build()
+    assert cap is not None
+    sink = cap.to_capability_dict()["transfer_methods"]["http_upload"]["sink"]
+    assert sink["accepts"] == ["text/markdown", "application/octet-stream"]
+
+
+def test_builder_http_and_http_upload_are_separate_top_level_keys() -> None:
+    b = _FileExchangeCapabilityBuilder(namespace="ns")
+    b.set_http_source(tool_name="create_download_link")
+    b.set_http_upload_sink(
+        tool_name="create_upload_link",
+        max_bytes=10,
+        max_ttl_seconds=60,
+    )
+    cap = b.build()
+    assert cap is not None
+    tm = cap.to_capability_dict()["transfer_methods"]
+    assert tm["http"] == {"source": {"tool": "create_download_link"}}
+    assert tm["http_upload"]["sink"]["tool"] == "create_upload_link"
+
+
+def test_builder_with_no_method_returns_none() -> None:
+    b = _FileExchangeCapabilityBuilder(namespace="ns")
+    assert b.build() is None
+
+
+def test_builder_set_exchange_false_drops_exchange_method() -> None:
+    """``set_exchange(False)`` is the explicit no-op path (toggle off after on)."""
+    b = _FileExchangeCapabilityBuilder(namespace="ns")
+    b.set_exchange(True)
+    b.set_exchange(False)
+    # No http/http_upload either, so the builder produces nothing.
+    assert b.build() is None
+    # With a download tool added, exchange must be absent even though
+    # set_exchange was called once with True.
+    b.set_http_source(tool_name="create_download_link")
+    cap = b.build()
+    assert cap is not None
+    assert "exchange" not in cap.to_capability_dict()["transfer_methods"]
+
+
+def test_emit_capability_returns_none_when_no_builder_registered() -> None:
+    """``_emit_capability`` is idempotent on a FastMCP that has no builder."""
+    from fastmcp_pvl_core.file_exchange import _BUILDER_ATTR, _emit_capability
+
+    mcp = FastMCP(name="no-builder")
+    assert getattr(mcp, _BUILDER_ATTR, None) is None
+    assert _emit_capability(mcp) is None
+
+
+def test_builder_is_attached_per_instance_not_module_level() -> None:
+    """Capability builders live on the FastMCP instance, not in a global dict."""
+    from fastmcp_pvl_core.file_exchange import _BUILDER_ATTR, _get_or_create_builder
+
+    mcp_a = FastMCP(name="probe-a")
+    _get_or_create_builder(mcp_a, namespace="ns-a")
+    assert getattr(mcp_a, _BUILDER_ATTR, None) is not None
+    assert mcp_a._pvl_file_exchange_builder.namespace == "ns-a"  # type: ignore[attr-defined]
+
+    mcp_b = FastMCP(name="probe-b")
+    assert getattr(mcp_b, _BUILDER_ATTR, None) is None
+```
+
+- [ ] **Step 2: Run the test file to verify it fails**
+
+Run: `uv run pytest tests/test_file_exchange_capability_merge.py -q`
+Expected: FAIL — `AttributeError: '_FileExchangeCapabilityBuilder' object has no attribute 'set_http_source'` (the new builder API does not exist yet).
+
+- [ ] **Step 3: Bump `SPEC_VERSION`**
+
+In `src/fastmcp_pvl_core/_file_exchange_protocol.py`, change line 36:
+
+```python
+SPEC_VERSION = "0.4"
+```
+
+to:
+
+```python
+SPEC_VERSION = "0.3"
+```
+
+- [ ] **Step 4: Replace the `_FileExchangeCapabilityBuilder` class**
+
+In `src/fastmcp_pvl_core/_file_exchange_protocol.py`, replace the entire class (currently lines 449–550, from `@dataclass` / `class _FileExchangeCapabilityBuilder:` through the end of `_build_http_block`) with:
+
+```python
+@dataclass
+class _FileExchangeCapabilityBuilder:
+    """Accumulates per-role contributions into one capability dict.
+
+    Both ``register_file_exchange`` (the ``http`` download method) and
+    ``register_file_exchange_upload`` (the ``http_upload`` method) push
+    their entries into a shared per-server instance keyed by the FastMCP
+    instance; the capability dict is materialised by :meth:`build` once
+    every registrar has run.
+
+    Transfer methods are advertised in the v0.3.0 ``source``/``sink``
+    role-keyed shape (spec §"Transfer Methods"): ``http`` and
+    ``http_upload`` are separate top-level method keys, and each carries
+    whichever of the ``source`` / ``sink`` roles the server fills.
+
+    The builder is intentionally mutable (not frozen) — it accumulates
+    state across multiple registrar calls. The capability it produces
+    via :meth:`build` is the immutable :class:`FileExchangeCapability`.
+    """
+
+    namespace: str
+    exchange_id: str | None = None
+    produces: tuple[str, ...] = ()
+    consumes: tuple[str, ...] = ()
+    _exchange_present: bool = False
+    _http_source_tool: str | None = None
+    _http_sink_tool: str | None = None
+    _http_upload_sink_tool: str | None = None
+    _http_upload_max_bytes: int | None = None
+    _http_upload_max_ttl_seconds: int | None = None
+    _http_upload_accepts: tuple[str, ...] | None = None
+
+    def set_exchange(self, present: bool = True) -> None:
+        """Mark the ``exchange://`` shared-volume method as available."""
+        self._exchange_present = present
+
+    def set_http_source(self, *, tool_name: str) -> None:
+        """Record the ``http`` producer (``source``) tool — mints download URLs."""
+        self._http_source_tool = tool_name
+
+    def set_http_sink(self, *, tool_name: str) -> None:
+        """Record the ``http`` consumer (``sink``) tool — fetches from a URL."""
+        self._http_sink_tool = tool_name
+
+    def set_http_upload_sink(
+        self,
+        *,
+        tool_name: str,
+        max_bytes: int,
+        max_ttl_seconds: int,
+        accepts: tuple[str, ...] | None = None,
+    ) -> None:
+        """Record the ``http_upload`` receiver (``sink``) tool plus its
+        admission metadata (the body-size and TTL ceilings and the
+        accepted-``Content-Type`` filter)."""
+        self._http_upload_sink_tool = tool_name
+        self._http_upload_max_bytes = max_bytes
+        self._http_upload_max_ttl_seconds = max_ttl_seconds
+        self._http_upload_accepts = accepts
+
+    def build(self) -> FileExchangeCapability | None:
+        """Materialise the accumulated state into a FileExchangeCapability.
+
+        Returns:
+            ``None`` if no transfer method has been set (neither
+            exchange nor an ``http`` role nor an ``http_upload`` role).
+            Otherwise a frozen :class:`FileExchangeCapability` whose
+            ``transfer_methods`` uses the v0.3.0 ``source``/``sink`` shape.
+        """
+        transfer_methods: dict[str, dict[str, Any]] = {}
+        if self._exchange_present:
+            transfer_methods["exchange"] = {}
+        http_block = self._build_http_block()
+        if http_block is not None:
+            transfer_methods["http"] = http_block
+        http_upload_block = self._build_http_upload_block()
+        if http_upload_block is not None:
+            transfer_methods["http_upload"] = http_upload_block
+        if not transfer_methods:
+            return None
+        return FileExchangeCapability(
+            namespace=self.namespace,
+            exchange_id=self.exchange_id,
+            produces=self.produces,
+            consumes=self.consumes,
+            transfer_methods=transfer_methods,
+            version=SPEC_VERSION,
+        )
+
+    def _build_http_block(self) -> dict[str, Any] | None:
+        """Build ``transfer_methods.http`` with ``source`` / ``sink`` roles.
+
+        Returns ``None`` when the server fills neither ``http`` role.
+        """
+        block: dict[str, Any] = {}
+        if self._http_source_tool is not None:
+            block["source"] = {"tool": self._http_source_tool}
+        if self._http_sink_tool is not None:
+            block["sink"] = {"tool": self._http_sink_tool}
+        return block or None
+
+    def _build_http_upload_block(self) -> dict[str, Any] | None:
+        """Build ``transfer_methods.http_upload`` with the receiver ``sink`` block.
+
+        Returns ``None`` when no upload-receiver tool was registered.
+        """
+        if self._http_upload_sink_tool is None:
+            return None
+        sink: dict[str, Any] = {
+            "tool": self._http_upload_sink_tool,
+            "max_bytes": self._http_upload_max_bytes,
+            "max_ttl_seconds": self._http_upload_max_ttl_seconds,
+        }
+        if self._http_upload_accepts is not None:
+            sink["accepts"] = list(self._http_upload_accepts)
+        return {"sink": sink}
+```
+
+- [ ] **Step 5: Drop `legacy_capability_shape` from `_get_or_create_builder`**
+
+In `src/fastmcp_pvl_core/file_exchange.py`, the function `_get_or_create_builder` (lines 136–214) currently has a `legacy_capability_shape: bool = False` parameter, passes it to the builder constructor, and has a merge-mismatch warning block. Make three edits:
+
+(5a) Delete the parameter — change the signature from:
+
+```python
+def _get_or_create_builder(
+    mcp: FastMCP,
+    *,
+    namespace: str,
+    exchange_id: str | None = None,
+    produces: tuple[str, ...] = (),
+    consumes: tuple[str, ...] = (),
+    legacy_capability_shape: bool = False,
+) -> _FileExchangeCapabilityBuilder:
+```
+
+to:
+
+```python
+def _get_or_create_builder(
+    mcp: FastMCP,
+    *,
+    namespace: str,
+    exchange_id: str | None = None,
+    produces: tuple[str, ...] = (),
+    consumes: tuple[str, ...] = (),
+) -> _FileExchangeCapabilityBuilder:
+```
+
+(5b) Update the docstring paragraph about the merge contract — replace:
+
+```
+    Merge contract for the non-mergeable fields (``namespace``,
+    ``legacy_capability_shape``): first-caller-wins. A subsequent
+    caller passing a different value logs a WARNING and the original
+    value is retained — ``namespace`` always, and
+    ``legacy_capability_shape`` only when the second caller actively
+    tries to enable it (the common ``False`` default does not warn).
+    Likewise, ``exchange_id`` is set by the first caller that supplies
+    a non-``None`` value and not overwritten thereafter.
+```
+
+with:
+
+```
+    Merge contract for the non-mergeable field ``namespace``:
+    first-caller-wins. A subsequent caller passing a different
+    namespace logs a WARNING and the original value is retained.
+    Likewise, ``exchange_id`` is set by the first caller that supplies
+    a non-``None`` value and not overwritten thereafter.
+```
+
+(5c) Remove the constructor argument — change:
+
+```python
+        builder = _FileExchangeCapabilityBuilder(
+            namespace=namespace,
+            exchange_id=exchange_id,
+            produces=produces,
+            consumes=consumes,
+            legacy_capability_shape=legacy_capability_shape,
+        )
+```
+
+to:
+
+```python
+        builder = _FileExchangeCapabilityBuilder(
+            namespace=namespace,
+            exchange_id=exchange_id,
+            produces=produces,
+            consumes=consumes,
+        )
+```
+
+(5d) Delete the legacy mismatch-warning block entirely — remove these lines:
+
+```python
+        if (
+            legacy_capability_shape != builder.legacy_capability_shape
+            and legacy_capability_shape  # only warn if second caller TRIED to set True
+        ):
+            logger.warning(
+                "_get_or_create_builder: legacy_capability_shape mismatch "
+                "on FastMCP id=%d — first caller set %r, second tried "
+                "%r; first-caller-wins.",
+                id(mcp),
+                builder.legacy_capability_shape,
+                legacy_capability_shape,
+            )
+```
+
+The `namespace` mismatch warning immediately above it and the `builder.exchange_id = ...` / produces / consumes merge lines below it stay unchanged.
+
+- [ ] **Step 6: Fix the `register_file_exchange` capability call site (dual-role bug)**
+
+In `src/fastmcp_pvl_core/file_exchange.py`, the capability block of `register_file_exchange` (around lines 761–788) currently uses an `if/elif` that hides the consumer tool on a produce-and-consume server. Replace:
+
+```python
+    # --- Capability declaration ---
+    # Push contributions into the per-FastMCP builder so that an upload
+    # registrar on the same ``mcp`` can merge into one capability dict.
+    # The shape emitted is v0.4 (nested ``http.download`` / ``http.upload``);
+    # legacy v0.2 flat shape is no longer wired here.
+    capability: FileExchangeCapability | None = None
+    if enabled:
+        builder = _get_or_create_builder(
+            mcp,
+            namespace=namespace,
+            exchange_id=exchange.exchange_id if exchange is not None else None,
+            produces=tuple(produces) if produce else (),
+            consumes=tuple(consumes) if consume else (),
+        )
+        if exchange is not None and (produce or consume):
+            builder.set_exchange(True)
+        if produce and store is not None and store.has_base_url:
+            # Producer-side download: caller invokes ``create_download_link``
+            # to mint a one-time URL.
+            builder.set_download(tool_name=_DEFAULT_DOWNLOAD_TOOL)
+        elif consume:
+            # Consumer-side intake: the server's ``fetch_file`` tool pulls
+            # bytes when given a URL. Re-uses the ``download`` slot in the
+            # nested-http shape — both producer download-link minting and
+            # consumer fetch are "download-direction" from the spec's
+            # transfer-method perspective.
+            builder.set_download(tool_name=_DEFAULT_FETCH_TOOL)
+        capability = _emit_capability(mcp)
+```
+
+with:
+
+```python
+    # --- Capability declaration ---
+    # Push contributions into the per-FastMCP builder so that an upload
+    # registrar on the same ``mcp`` can merge into one capability dict.
+    # The shape emitted is the v0.3.0 ``source``/``sink`` role-keyed form.
+    capability: FileExchangeCapability | None = None
+    if enabled:
+        builder = _get_or_create_builder(
+            mcp,
+            namespace=namespace,
+            exchange_id=exchange.exchange_id if exchange is not None else None,
+            produces=tuple(produces) if produce else (),
+            consumes=tuple(consumes) if consume else (),
+        )
+        if exchange is not None and (produce or consume):
+            builder.set_exchange(True)
+        # The two http roles are independent — a server that both produces
+        # and consumes fills both. ``create_download_link`` is the producer
+        # (``source``) tool; ``fetch_file`` is the consumer (``sink``) tool.
+        if produce and store is not None and store.has_base_url:
+            builder.set_http_source(tool_name=_DEFAULT_DOWNLOAD_TOOL)
+        if consume:
+            builder.set_http_sink(tool_name=_DEFAULT_FETCH_TOOL)
+        capability = _emit_capability(mcp)
+```
+
+- [ ] **Step 7: Update `register_file_exchange_upload`**
+
+In `src/fastmcp_pvl_core/file_exchange.py`, three edits to `register_file_exchange_upload`:
+
+(7a) Remove the `legacy_capability_shape` parameter — delete this line from the signature (line 1554):
+
+```python
+    legacy_capability_shape: bool = False,
+```
+
+(7b) Remove the `legacy_capability_shape` entry from the docstring `Args` block. Delete exactly these five lines (around line 1633), leaving the `ttl_max:` entry above and the `Returns:` block below intact:
+
+```
+        legacy_capability_shape: Set to True during a migration window
+            to advertise the v0.2 flat ``transfer_methods.http: {tool: ...}``
+            shape instead of the v0.4 nested
+            ``{download: ..., upload: ...}`` shape. The upload entry is
+            dropped (with a logged warning) when legacy shape is selected.
+```
+
+(7c) Replace the builder wiring — change:
+
+```python
+    builder = _get_or_create_builder(
+        mcp,
+        namespace=namespace,
+        legacy_capability_shape=legacy_capability_shape,
+    )
+    builder.set_upload(
+        tool_name=upload_tool_name,
+        max_bytes=int(max_bytes_default),
+        max_ttl_seconds=int(ttl_max),
+        accepts=accepts,
+    )
+```
+
+to:
+
+```python
+    builder = _get_or_create_builder(mcp, namespace=namespace)
+    builder.set_http_upload_sink(
+        tool_name=upload_tool_name,
+        max_bytes=int(max_bytes_default),
+        max_ttl_seconds=int(ttl_max),
+        accepts=accepts,
+    )
+```
+
+- [ ] **Step 8: Run the capability-merge tests to verify they pass**
+
+Run: `uv run pytest tests/test_file_exchange_capability_merge.py -q`
+Expected: PASS — all tests in the rewritten file green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange_protocol.py src/fastmcp_pvl_core/file_exchange.py tests/test_file_exchange_capability_merge.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): emit v0.3.0 source/sink capability shape (refs #86)
+
+The capability builder advertised the pre-#83 nested
+http: {download, upload} shape and version "0.4". Migrate it to the
+v0.3.0 spec shape: http and http_upload are separate top-level
+transfer_methods keys, each carrying source/sink role sub-objects.
+
+_FileExchangeCapabilityBuilder gains set_http_source / set_http_sink
+/ set_http_upload_sink (replacing set_download / set_upload) and
+tracks the two http roles separately. register_file_exchange's
+if/elif is now two independent ifs, so a produce-and-consume server
+advertises both http.source and http.sink rather than hiding the
+consumer tool. SPEC_VERSION 0.4 -> 0.3. The legacy_capability_shape
+override kwarg is removed.
+
+Refs #86.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Verification sweep and quality gate
+
+**Files:** potentially any test under `tests/` that asserts the removed `http: {download, upload}` shape or `version: "0.4"`.
+
+- [ ] **Step 1: Sync dependencies and run the full test suite**
+
+Run:
+
+```bash
+uv sync --all-extras
+uv run pytest -q
+```
+
+Expected: most tests pass. Any failure should be a test that constructs `_FileExchangeCapabilityBuilder` with the old API (`set_download` / `set_upload` / `legacy_capability_shape`), or asserts the old `transfer_methods.http` shape (`download` / `upload` sub-keys), or asserts `version == "0.4"`, or calls `register_file_exchange_upload(..., legacy_capability_shape=...)`.
+
+- [ ] **Step 2: Fix any test asserting the removed shape**
+
+For each failing test, apply the mechanical transformation:
+
+- `builder.set_download(tool_name=X)` where `X` is the producer tool → `builder.set_http_source(tool_name=X)`; where `X` is the consumer/fetch tool → `builder.set_http_sink(tool_name=X)`.
+- `builder.set_upload(tool_name=X, max_bytes=..., max_ttl_seconds=..., accepts=...)` → `builder.set_http_upload_sink(tool_name=X, max_bytes=..., max_ttl_seconds=..., accepts=...)`.
+- An assertion `transfer_methods["http"] == {"download": {"tool": X}}` → `{"source": {"tool": X}}`.
+- An assertion `transfer_methods["http"] == {"upload": {...}}` → assert `transfer_methods["http_upload"] == {"sink": {...}}`.
+- An assertion `transfer_methods["http"]` has keys `{"download", "upload"}` → split: `transfer_methods["http"]` has `{"source"}` and/or `{"sink"}`, and `transfer_methods["http_upload"]` has `{"sink"}`.
+- `version == "0.4"` → `version == "0.3"`.
+- Any `register_file_exchange_upload(..., legacy_capability_shape=...)` call → drop the kwarg.
+- Any test that *only* exists to exercise `legacy_capability_shape` behaviour (the v0.2 flat shape) → delete it; the v0.2 flat shape is no longer emitted.
+
+Re-run `uv run pytest -q` until green.
+
+- [ ] **Step 3: Run the quality gate**
+
+Run:
+
+```bash
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
+```
+
+All three must pass clean. Fix any finding (e.g. an unused import left after deleting the legacy branch, or a `_DEFAULT_FETCH_TOOL` / `_DEFAULT_DOWNLOAD_TOOL` now-unused import — though both are still used by the Step 6 call site).
+
+- [ ] **Step 4: Commit**
+
+If Steps 2–3 changed any file:
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+test(file-exchange): update tests for v0.3.0 capability shape (refs #86)
+
+Sweep the suite for assertions on the removed http: {download, upload}
+shape, the "0.4" version, and the legacy_capability_shape kwarg;
+rewrite them against the v0.3.0 source/sink shape.
+
+Refs #86.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If Steps 2–3 changed nothing (the full suite was already green after Task 1 and the gate was clean), skip the commit — there is nothing to record.
+
+---
+
+## Summary
+
+Two tasks. Task 1 is the atomic builder + call-site + version migration with a fully rewritten capability-merge test file. Task 2 sweeps the rest of the suite and runs the quality gate.
+
+## What changes
+
+- `_FileExchangeCapabilityBuilder` — new `source`/`sink` API and v0.3.0 shape; `http` and `http_upload` separate keys.
+- `register_file_exchange` — `if/elif` → `if/if`: produce-and-consume servers advertise both `http` roles.
+- `SPEC_VERSION` — `"0.4"` → `"0.3"`.
+- `legacy_capability_shape` — removed from the builder, `_get_or_create_builder`, and `register_file_exchange_upload`.
+
+## What does NOT change
+
+- The `create_upload_link` tool contract, the POST upload route, the download-serving route — out of scope (→ #74, #87).
+- `register_file_exchange` / `register_file_exchange_upload` public behaviour apart from capability emission and the removed kwarg.
+- Token store, receiver callbacks, transport resolution.
+
+## Local review
+
+`preflight-circus` (five core lenses + `pr-review-toolkit:code-reviewer`) runs on the cumulative diff; clean at the ≥80 confidence bar before opening the draft PR.
+
+## Test plan
+
+- [ ] `uv run pytest` green on the full suite.
+- [ ] `uv run ruff format --check .` / `ruff check .` / `mypy src` clean.
+- [ ] Capability output: `http`/`http_upload` use `source`/`sink`; `exchange` stays `{}`; `version` is `"0.3"`.
+- [ ] A produce-and-consume server advertises both `http.source` and `http.sink` (the dual-role guard test).
+- [ ] `grep -rn 'legacy_capability_shape\|set_download\|set_upload\b' src/` returns nothing.
+- [ ] CI green.
+- [ ] Bot review clean.
+
+## Out of scope
+
+- The `create_upload_link` tool contract and POST route status codes — #74.
+- The sender-side `upload` tool — #85.
+- The `http`-direction tool/route conformance audit — #87.
+
+## Acceptance (from #86 / the design doc)
+
+- [ ] `transfer_methods` uses the v0.3.0 `source`/`sink` shape for `http` and `http_upload`; `exchange` stays `{}`.
+- [ ] A produce-and-consume server advertises both `http.source` and `http.sink`.
+- [ ] `SPEC_VERSION` and the capability `version` field are `"0.3"`.
+- [ ] `legacy_capability_shape` is gone from the codebase.
+- [ ] Capability tests assert the v0.3.0 shape, including the dual-role guard.

--- a/docs/superpowers/specs/2026-05-15-capability-builder-v030-migration-design.md
+++ b/docs/superpowers/specs/2026-05-15-capability-builder-v030-migration-design.md
@@ -1,0 +1,210 @@
+# Design: capability builder → v0.3.0 `source`/`sink` shape (issue #86)
+
+**Status**: approved (brainstorm 2026-05-15)
+**Issue**: [pvliesdonk/fastmcp-pvl-core#86](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/86)
+**Umbrella**: #75
+**Blocks**: #74 (the upload tool/route rebuild lands on the migrated builder)
+
+## Problem
+
+#83 (PR #84, merged) changed the file-exchange spec's capability declaration:
+tool-based transfer methods declare their tool(s) under `source` / `sink`
+role sub-objects, and `http` / `http_upload` are separate top-level method
+keys. The implementation has not caught up. Three concrete gaps:
+
+1. **Wrong capability shape.** `_FileExchangeCapabilityBuilder._build_http_block`
+   (`src/fastmcp_pvl_core/_file_exchange_protocol.py`) emits the pre-#83
+   v0.4-amendments shape — a single `transfer_methods["http"]` block with
+   nested `download` / `upload` sub-keys:
+
+   ```json
+   "http": {"download": {"tool": "..."}, "upload": {"tool": "...", "accepts": [...], "max_bytes": ..., "max_ttl_seconds": ...}}
+   ```
+
+   The v0.3.0 shape is two top-level keys, each role-keyed:
+
+   ```json
+   "http": {"source": {"tool": "..."}, "sink": {"tool": "..."}},
+   "http_upload": {"sink": {"tool": "...", "accepts": [...], "max_bytes": ..., "max_ttl_seconds": ...}}
+   ```
+
+2. **Stale version.** `SPEC_VERSION = "0.4"` (`_file_exchange_protocol.py:36`)
+   advertises a spec version that the spec doc itself now declares
+   permanently skipped. The published spec is `0.3`.
+
+3. **Dual-role collapse bug.** `register_file_exchange` registers the
+   producer tool (`create_download_link`) when `produce`, **else** the
+   consumer tool (`fetch_file`) when `consume` — an `if`/`elif`
+   (`file_exchange.py:777-787`). The builder stores whichever one in a
+   single `_download_tool` field. A server that both produces and consumes
+   only ever advertises the producer side; the consumer `fetch_file` tool
+   is never declared. This is the same dual-role gap #83 fixed at the spec
+   level — still live in the implementation.
+
+This is the precursor to #74: #74 rebuilds the `create_upload_link` tool
+contract and the POST route, and should land on a builder that already
+emits the correct capability shape.
+
+## The design
+
+### A. Capability builder rework (`_file_exchange_protocol.py`)
+
+Replace the single `_download_tool` field with separate role tracking, and
+emit `http_upload` as its own top-level method key.
+
+New builder API (internal — pvl-core owns it; no downstream surface):
+
+- `set_http_source(tool_name: str)` — records the `http` producer tool.
+- `set_http_sink(tool_name: str)` — records the `http` consumer tool.
+- `set_http_upload_sink(tool_name: str, max_bytes: int, max_ttl_seconds: int, accepts: tuple[str, ...] | None)`
+  — records the `http_upload` receiver tool plus its admission metadata.
+
+These replace the current `set_download` / `set_upload`. Backing fields
+become `_http_source_tool`, `_http_sink_tool`, `_http_upload_sink_tool`
+(plus the upload metadata fields, unchanged).
+
+`build()` materialises `transfer_methods` as:
+
+- `transfer_methods["exchange"] = {}` when the exchange method is present
+  (unchanged).
+- `transfer_methods["http"]` — a dict with `source` and/or `sink` sub-keys,
+  whichever role(s) were registered. Omitted entirely if neither.
+- `transfer_methods["http_upload"]` — `{"sink": {...}}` when the upload
+  receiver tool was registered. Omitted otherwise.
+
+`_build_http_block` is replaced by two private helpers
+(`_build_http_block` returning the `{source?, sink?}` dict, and
+`_build_http_upload_block` returning `{sink: {...}}`), or one helper that
+returns both — an implementation detail for the plan.
+
+### B. Call-site fix (`register_file_exchange`, `file_exchange.py:777-787`)
+
+Change the `if produce / elif consume` to two independent `if`s:
+
+```python
+if produce and store is not None and store.has_base_url:
+    builder.set_http_source(tool_name=_DEFAULT_DOWNLOAD_TOOL)
+if consume:
+    builder.set_http_sink(tool_name=_DEFAULT_FETCH_TOOL)
+```
+
+A produce-and-consume server now advertises both `http.source` and
+`http.sink`. The `register_file_exchange_upload` call site
+(`file_exchange.py:1783`) switches `set_upload(...)` → `set_http_upload_sink(...)`.
+
+### C. Version + dead kwarg
+
+- `SPEC_VERSION` `"0.4"` → `"0.3"` (`_file_exchange_protocol.py:36`). The
+  capability `version` field is `MAJOR.MINOR` per the spec, so `"0.3"` is
+  the correct wire value. `FileExchangeCapability.version` already defaults
+  to `SPEC_VERSION`.
+- Remove `legacy_capability_shape` entirely:
+  - the builder field (`_file_exchange_protocol.py:468`),
+  - the legacy branch in `_build_http_block` (`:526-536`),
+  - the `"0.2"`-vs-`SPEC_VERSION` version ternary in `build()` (`:515`),
+  - the kwarg on `register_file_exchange` (`file_exchange.py:143`) and
+    `register_file_exchange_upload` (`:1554`),
+  - the first-caller-wins mismatch logic in `_get_or_create_builder`
+    (`file_exchange.py:157-206`).
+
+  It is a shape-override kwarg — it fails the #72/#73 classification test
+  (pvl-core owns capability shape; downstream has no domain basis to pick a
+  different one). The v0.2 flat shape it served is retired: a v0.2 reader
+  meeting a v0.3 declaration is handled by the spec's own cross-version
+  compatibility rules, not by pvl-core emitting an old shape on request.
+
+### D. Tests
+
+`test_file_exchange_capability_merge.py` and any other test asserting the
+old `http: {download, upload}` shape or `version: "0.4"` are rewritten to
+assert the v0.3.0 shape. New assertions:
+
+- A produce-only server advertises `transfer_methods.http.source` and no
+  `http.sink`.
+- A consume-only server advertises `transfer_methods.http.sink` and no
+  `http.source`.
+- A **produce-and-consume** server advertises **both** `http.source` and
+  `http.sink` — the dual-role regression guard.
+- An upload receiver advertises `transfer_methods.http_upload.sink` with
+  `tool` / `accepts` / `max_bytes` / `max_ttl_seconds`, and no
+  `http.upload` key survives anywhere.
+- The capability `version` field is `"0.3"`.
+
+## Transfer-mechanism coverage
+
+The implementation surface for transfer mechanisms is a matrix: `exchange`
+has no tool roles; `http` and `http_upload` each have a `source` and a
+`sink` role — four role-implementations in total. This design records the
+matrix so the umbrella's remaining work is explicit and #74/#85 are not
+mistaken for the whole job.
+
+| Method / role | Tool(s) | pvl-core helper | Tool + route conformance | Capability shape |
+|---|---|---|---|---|
+| `exchange` | none (shared volume) | `register_file_exchange` | n/a — no tools | #86 (`{}`) |
+| `http.source` | `create_download_link` | `register_file_exchange` (produce) | **not audited** — see below | #86 |
+| `http.sink` | `fetch_file` | `register_file_exchange` (consume) | **not audited** — see below | #86 |
+| `http_upload.sink` | `create_upload_link` + POST route | `register_file_exchange_upload` | #74 (clean-slate rebuild) | #86 |
+| `http_upload.source` | `upload` | (new helper) | #85 | #86 (when the helper lands) |
+
+**#86 migrates the capability *shape* for every method/role at once** —
+that is its whole job, and it is complete for the shape axis.
+
+**The `http` row's tool-and-route conformance is not audited.** `http` is a
+v0.2.x method; v0.3.0 added `http_upload` and #83 changed only the
+capability shape — neither touched `http`'s tool contracts or route
+mechanics. So `create_download_link` / `fetch_file` and the download-serving
+route are *presumed* conformant. But "presumed" is not "verified": the
+download path was last substantially touched in the A11-amendments era, and
+this design's own discovery turned up loose ends (the upload POST route is
+the only `custom_route` in `_file_exchange_runtime.py` — where and how
+download bytes are served was not traced). #74 gives `http_upload` a
+clean-slate conformance rebuild; `http` has no equivalent.
+
+**Recommendation:** file an `http`-direction conformance-audit issue under
+#75 — verify `create_download_link` / `fetch_file` tool contracts and the
+download-serving route against the v0.3.0 spec, the same way #74 audits
+`http_upload`. It may close as "already conformant"; the point is to make
+that a verified outcome rather than an assumption. This design does not
+depend on the audit — #86 ships the shape migration regardless — but the
+umbrella is not complete until the `http` row is verified.
+
+## Backward compatibility
+
+- **No v0.3-flat or v0.4 peer to protect.** No deployed server advertises a
+  published `0.3`/`0.4` capability that this changes incompatibly — the
+  `"0.4"` constant was an internal stale value, never a released spec
+  version. The capability output simply becomes spec-conformant.
+- **v0.2.x peers** — a v0.2.x server emitting the flat `http: {tool}` shape,
+  or a v0.2.x reader meeting this server's v0.3.0 declaration, is covered by
+  the spec's §"Versioning and compatibility" cross-version rules (ignore
+  unrecognised fields, tolerate missing optional fields). pvl-core does not
+  emit an old shape on request; that is what removing `legacy_capability_shape`
+  finalises.
+
+## Out of scope
+
+- **The `create_upload_link` tool contract** — `target_id` → `origin_id` /
+  `destination`, the response field renames (`upload_url` → `url`,
+  `expires_in_seconds` → `ttl_seconds`, the mandatory `max_bytes`), the
+  `extra` parameter. → #74.
+- **The POST upload route** — `410` → `404` collapse, status-code classes.
+  → #74.
+- **The sender-side `upload` tool** (`http_upload.source`). → #85.
+- **The `http`-direction tool/route conformance audit.** → recommended new
+  issue (see "Transfer-mechanism coverage").
+
+#86 is the capability-declaration **shape and version** migration only.
+
+## Acceptance
+
+- [ ] `transfer_methods` is emitted in the v0.3.0 `source`/`sink` shape for
+  `http` and `http_upload`; `exchange` stays `{}`.
+- [ ] A produce-and-consume server advertises both `http.source` and
+  `http.sink`.
+- [ ] `SPEC_VERSION` is `"0.3"`; the capability `version` field is `"0.3"`.
+- [ ] `legacy_capability_shape` is gone from the codebase (builder, helpers,
+  merge logic).
+- [ ] Capability tests assert the v0.3.0 shape, including the dual-role
+  guard.
+- [ ] `register_file_exchange` / `register_file_exchange_upload` public
+  behaviour is otherwise unchanged — #86 touches capability emission only.

--- a/src/fastmcp_pvl_core/_file_exchange_protocol.py
+++ b/src/fastmcp_pvl_core/_file_exchange_protocol.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 #: field in the ``experimental.file_exchange`` capability declaration
 #: (spec §"Capability declaration"). Major.minor only — patch revisions
 #: are spec-internal.
-SPEC_VERSION = "0.4"
+SPEC_VERSION = "0.3"
 
 
 # ---------------------------------------------------------------------------
@@ -448,13 +448,18 @@ class FileExchangeCapability:
 
 @dataclass
 class _FileExchangeCapabilityBuilder:
-    """Accumulates per-direction contributions into one capability dict.
+    """Accumulates per-role contributions into one capability dict.
 
-    Both ``register_file_exchange`` (download) and
-    ``register_file_exchange_upload`` (upload) push their entries into a
-    shared per-server instance keyed by the FastMCP instance; the actual
-    capability dict is materialised by :meth:`build` once both
-    registrars have run.
+    Both ``register_file_exchange`` (the ``http`` download method) and
+    ``register_file_exchange_upload`` (the ``http_upload`` method) push
+    their entries into a shared per-server instance keyed by the FastMCP
+    instance; the capability dict is materialised by :meth:`build` once
+    every registrar has run.
+
+    Transfer methods are advertised in the v0.3.0 ``source``/``sink``
+    role-keyed shape (spec §"Transfer Methods"): ``http`` and
+    ``http_upload`` are separate top-level method keys, and each carries
+    whichever of the ``source`` / ``sink`` roles the server fills.
 
     The builder is intentionally mutable (not frozen) — it accumulates
     state across multiple registrar calls. The capability it produces
@@ -465,23 +470,27 @@ class _FileExchangeCapabilityBuilder:
     exchange_id: str | None = None
     produces: tuple[str, ...] = ()
     consumes: tuple[str, ...] = ()
-    legacy_capability_shape: bool = False
     _exchange_present: bool = False
-    _download_tool: str | None = None
-    _upload_tool: str | None = None
-    _upload_max_bytes: int | None = None
-    _upload_max_ttl_seconds: int | None = None
-    _upload_accepts: tuple[str, ...] | None = None
+    _http_source_tool: str | None = None
+    _http_sink_tool: str | None = None
+    _http_upload_sink_tool: str | None = None
+    _http_upload_max_bytes: int | None = None
+    _http_upload_max_ttl_seconds: int | None = None
+    _http_upload_accepts: tuple[str, ...] | None = None
 
     def set_exchange(self, present: bool = True) -> None:
         """Mark the ``exchange://`` shared-volume method as available."""
         self._exchange_present = present
 
-    def set_download(self, *, tool_name: str) -> None:
-        """Record the download-direction tool name."""
-        self._download_tool = tool_name
+    def set_http_source(self, *, tool_name: str) -> None:
+        """Record the ``http`` producer (``source``) tool — mints download URLs."""
+        self._http_source_tool = tool_name
 
-    def set_upload(
+    def set_http_sink(self, *, tool_name: str) -> None:
+        """Record the ``http`` consumer (``sink``) tool — fetches from a URL."""
+        self._http_sink_tool = tool_name
+
+    def set_http_upload_sink(
         self,
         *,
         tool_name: str,
@@ -489,20 +498,22 @@ class _FileExchangeCapabilityBuilder:
         max_ttl_seconds: int,
         accepts: tuple[str, ...] | None = None,
     ) -> None:
-        """Record the upload-direction tool name plus per-method knobs."""
-        self._upload_tool = tool_name
-        self._upload_max_bytes = max_bytes
-        self._upload_max_ttl_seconds = max_ttl_seconds
-        self._upload_accepts = accepts
+        """Record the ``http_upload`` receiver (``sink``) tool plus its
+        admission metadata (the body-size and TTL ceilings and the
+        accepted-``Content-Type`` filter)."""
+        self._http_upload_sink_tool = tool_name
+        self._http_upload_max_bytes = max_bytes
+        self._http_upload_max_ttl_seconds = max_ttl_seconds
+        self._http_upload_accepts = accepts
 
     def build(self) -> FileExchangeCapability | None:
         """Materialise the accumulated state into a FileExchangeCapability.
 
         Returns:
             ``None`` if no transfer method has been set (neither
-            exchange nor download nor upload). Otherwise a frozen
-            :class:`FileExchangeCapability` with ``version`` ``"0.2"``
-            (legacy shape) or ``"0.4"`` (nested-http shape).
+            exchange nor an ``http`` role nor an ``http_upload`` role).
+            Otherwise a frozen :class:`FileExchangeCapability` whose
+            ``transfer_methods`` uses the v0.3.0 ``source``/``sink`` shape.
         """
         transfer_methods: dict[str, dict[str, Any]] = {}
         if self._exchange_present:
@@ -510,44 +521,47 @@ class _FileExchangeCapabilityBuilder:
         http_block = self._build_http_block()
         if http_block is not None:
             transfer_methods["http"] = http_block
+        http_upload_block = self._build_http_upload_block()
+        if http_upload_block is not None:
+            transfer_methods["http_upload"] = http_upload_block
         if not transfer_methods:
             return None
-        version = "0.2" if self.legacy_capability_shape else SPEC_VERSION
         return FileExchangeCapability(
             namespace=self.namespace,
             exchange_id=self.exchange_id,
             produces=self.produces,
             consumes=self.consumes,
             transfer_methods=transfer_methods,
-            version=version,
+            version=SPEC_VERSION,
         )
 
     def _build_http_block(self) -> dict[str, Any] | None:
-        if self.legacy_capability_shape:
-            if self._upload_tool is not None:
-                logger.warning(
-                    "legacy_capability_shape=True drops the upload entry "
-                    "(no nested http.upload key in v0.2 spec); upgrade "
-                    "clients to v0.4 or unset legacy_capability_shape "
-                    "to advertise upload."
-                )
-            if self._download_tool is None:
-                return None
-            return {"tool": self._download_tool}
+        """Build ``transfer_methods.http`` with ``source`` / ``sink`` roles.
 
+        Returns ``None`` when the server fills neither ``http`` role.
+        """
         block: dict[str, Any] = {}
-        if self._download_tool is not None:
-            block["download"] = {"tool": self._download_tool}
-        if self._upload_tool is not None:
-            up: dict[str, Any] = {
-                "tool": self._upload_tool,
-                "max_bytes": self._upload_max_bytes,
-                "max_ttl_seconds": self._upload_max_ttl_seconds,
-            }
-            if self._upload_accepts is not None:
-                up["accepts"] = list(self._upload_accepts)
-            block["upload"] = up
+        if self._http_source_tool is not None:
+            block["source"] = {"tool": self._http_source_tool}
+        if self._http_sink_tool is not None:
+            block["sink"] = {"tool": self._http_sink_tool}
         return block or None
+
+    def _build_http_upload_block(self) -> dict[str, Any] | None:
+        """Build ``transfer_methods.http_upload`` with the receiver ``sink`` block.
+
+        Returns ``None`` when no upload-receiver tool was registered.
+        """
+        if self._http_upload_sink_tool is None:
+            return None
+        sink: dict[str, Any] = {
+            "tool": self._http_upload_sink_tool,
+            "max_bytes": self._http_upload_max_bytes,
+            "max_ttl_seconds": self._http_upload_max_ttl_seconds,
+        }
+        if self._http_upload_accepts is not None:
+            sink["accepts"] = list(self._http_upload_accepts)
+        return {"sink": sink}
 
 
 # ---------------------------------------------------------------------------

--- a/src/fastmcp_pvl_core/_file_exchange_protocol.py
+++ b/src/fastmcp_pvl_core/_file_exchange_protocol.py
@@ -498,9 +498,10 @@ class _FileExchangeCapabilityBuilder:
         max_ttl_seconds: int,
         accepts: tuple[str, ...] | None = None,
     ) -> None:
-        """Record the ``http_upload`` receiver (``sink``) tool plus its
-        admission metadata (the body-size and TTL ceilings and the
-        accepted-``Content-Type`` filter)."""
+        """Record the upload receiver (``sink``) tool and its admission metadata.
+
+        Stores body-size and TTL ceilings and the accepted-``Content-Type`` filter.
+        """
         self._http_upload_sink_tool = tool_name
         self._http_upload_max_bytes = max_bytes
         self._http_upload_max_ttl_seconds = max_ttl_seconds

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -1607,6 +1607,7 @@ def register_file_exchange_upload(
         ttl_max: Operator ceiling. Requested TTL is clamped; the
             effective value is returned to the caller.
             Operator-overridable via ``{PREFIX}_UPLOAD_TTL_MAX``.
+
     Returns:
         An :class:`UploadHandle`. Stash if you need ``create_link`` for
         advanced wrapping; otherwise discard — registration side-effects

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -1,17 +1,15 @@
 """MCP File Exchange — public facade.
 
 Single-entry-point wiring for downstream MCP servers that want to
-participate in the File Exchange convention (spec v0.2.5). Composes
+participate in the File Exchange convention (spec v0.3.0). Composes
 the artifact store, the protocol surface, and the exchange-volume
 runtime, and registers the spec-compliant ``create_download_link``
 and ``fetch_file`` MCP tools.
 
-Implementation note: the ``experimental.file_exchange`` capability
-this module advertises uses the nested ``http.{download, upload}``
-shape (a leftover from the proposed v0.4 amendments that PR #77
-reverted). The spec is back to v0.2.5 but the implementation has not
-yet realigned its capability shape; that realignment is tracked in
-#74 alongside the upload-helper rewrite.
+The ``experimental.file_exchange`` capability this module advertises
+uses the v0.3.0 ``transfer_methods`` shape: ``http`` and
+``http_upload`` are separate method keys, each carrying ``source`` /
+``sink`` role sub-objects for whichever role(s) the server fills.
 
 Downstream usage::
 
@@ -625,7 +623,7 @@ def register_file_exchange(
     consumes: Sequence[str] = (),
     consumer_sink: ConsumerSink | None = None,
 ) -> FileExchangeHandle:
-    """Wire MCP File Exchange (v0.2.5) onto ``mcp``.
+    """Wire MCP File Exchange (v0.3.0) onto ``mcp``.
 
     The kwarg surface is intentionally minimal — five domain hooks,
     no operator-config kwargs, no override seams. Operator config

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -140,7 +140,6 @@ def _get_or_create_builder(
     exchange_id: str | None = None,
     produces: tuple[str, ...] = (),
     consumes: tuple[str, ...] = (),
-    legacy_capability_shape: bool = False,
 ) -> _FileExchangeCapabilityBuilder:
     """Return (creating if needed) the per-FastMCP capability builder.
 
@@ -153,12 +152,9 @@ def _get_or_create_builder(
     additively extend ``produces`` / ``consumes`` (so download and
     upload registrations don't clobber each other's MIME lists).
 
-    Merge contract for the non-mergeable fields (``namespace``,
-    ``legacy_capability_shape``): first-caller-wins. A subsequent
-    caller passing a different value logs a WARNING and the original
-    value is retained — ``namespace`` always, and
-    ``legacy_capability_shape`` only when the second caller actively
-    tries to enable it (the common ``False`` default does not warn).
+    Merge contract for the non-mergeable field ``namespace``:
+    first-caller-wins. A subsequent caller passing a different
+    namespace logs a WARNING and the original value is retained.
     Likewise, ``exchange_id`` is set by the first caller that supplies
     a non-``None`` value and not overwritten thereafter.
     """
@@ -169,7 +165,6 @@ def _get_or_create_builder(
             exchange_id=exchange_id,
             produces=produces,
             consumes=consumes,
-            legacy_capability_shape=legacy_capability_shape,
         )
         # If FastMCP ever forbids dynamic attribute assignment (e.g. via
         # ``ConfigDict(extra="forbid")``) the AttributeError will surface
@@ -192,18 +187,6 @@ def _get_or_create_builder(
                 id(mcp),
                 builder.namespace,
                 namespace,
-            )
-        if (
-            legacy_capability_shape != builder.legacy_capability_shape
-            and legacy_capability_shape  # only warn if second caller TRIED to set True
-        ):
-            logger.warning(
-                "_get_or_create_builder: legacy_capability_shape mismatch "
-                "on FastMCP id=%d — first caller set %r, second tried "
-                "%r; first-caller-wins.",
-                id(mcp),
-                builder.legacy_capability_shape,
-                legacy_capability_shape,
             )
         builder.exchange_id = builder.exchange_id or exchange_id
         # Set-union the MIME lists; using ``set`` and back to tuple
@@ -761,8 +744,7 @@ def register_file_exchange(
     # --- Capability declaration ---
     # Push contributions into the per-FastMCP builder so that an upload
     # registrar on the same ``mcp`` can merge into one capability dict.
-    # The shape emitted is v0.4 (nested ``http.download`` / ``http.upload``);
-    # legacy v0.2 flat shape is no longer wired here.
+    # The shape emitted is the v0.3.0 ``source``/``sink`` role-keyed form.
     capability: FileExchangeCapability | None = None
     if enabled:
         builder = _get_or_create_builder(
@@ -774,17 +756,13 @@ def register_file_exchange(
         )
         if exchange is not None and (produce or consume):
             builder.set_exchange(True)
+        # The two http roles are independent — a server that both produces
+        # and consumes fills both. ``create_download_link`` is the producer
+        # (``source``) tool; ``fetch_file`` is the consumer (``sink``) tool.
         if produce and store is not None and store.has_base_url:
-            # Producer-side download: caller invokes ``create_download_link``
-            # to mint a one-time URL.
-            builder.set_download(tool_name=_DEFAULT_DOWNLOAD_TOOL)
-        elif consume:
-            # Consumer-side intake: the server's ``fetch_file`` tool pulls
-            # bytes when given a URL. Re-uses the ``download`` slot in the
-            # nested-http shape — both producer download-link minting and
-            # consumer fetch are "download-direction" from the spec's
-            # transfer-method perspective.
-            builder.set_download(tool_name=_DEFAULT_FETCH_TOOL)
+            builder.set_http_source(tool_name=_DEFAULT_DOWNLOAD_TOOL)
+        if consume:
+            builder.set_http_sink(tool_name=_DEFAULT_FETCH_TOOL)
         capability = _emit_capability(mcp)
 
     handle = FileExchangeHandle(
@@ -1551,7 +1529,6 @@ def register_file_exchange_upload(
     max_bytes_default: int = _DEFAULT_UPLOAD_MAX_BYTES,
     ttl_default: float = _DEFAULT_UPLOAD_TTL_SECONDS,
     ttl_max: float = _DEFAULT_UPLOAD_TTL_MAX_SECONDS,
-    legacy_capability_shape: bool = False,
 ) -> UploadHandle:
     """Wire MCP File Exchange upload direction onto ``mcp``.
 
@@ -1630,12 +1607,6 @@ def register_file_exchange_upload(
         ttl_max: Operator ceiling. Requested TTL is clamped; the
             effective value is returned to the caller.
             Operator-overridable via ``{PREFIX}_UPLOAD_TTL_MAX``.
-        legacy_capability_shape: Set to True during a migration window
-            to advertise the v0.2 flat ``transfer_methods.http: {tool: ...}``
-            shape instead of the v0.4 nested
-            ``{download: ..., upload: ...}`` shape. The upload entry is
-            dropped (with a logged warning) when legacy shape is selected.
-
     Returns:
         An :class:`UploadHandle`. Stash if you need ``create_link`` for
         advanced wrapping; otherwise discard — registration side-effects
@@ -1775,12 +1746,8 @@ def register_file_exchange_upload(
     # ``accepts`` would mislead clients into thinking only ``consumes``
     # types are accepted. Advertising ``["*/*"]`` explicitly keeps the
     # wire signal aligned with the route's actual permissiveness.
-    builder = _get_or_create_builder(
-        mcp,
-        namespace=namespace,
-        legacy_capability_shape=legacy_capability_shape,
-    )
-    builder.set_upload(
+    builder = _get_or_create_builder(mcp, namespace=namespace)
+    builder.set_http_upload_sink(
         tool_name=upload_tool_name,
         max_bytes=int(max_bytes_default),
         max_ttl_seconds=int(ttl_max),

--- a/tests/test_file_exchange_capability_merge.py
+++ b/tests/test_file_exchange_capability_merge.py
@@ -1,8 +1,11 @@
-"""Tests for capability-merge across download/upload registrars."""
+"""Tests for capability-merge across the http / http_upload registrars.
+
+Capability declarations use the v0.3.0 ``source``/``sink`` role-keyed
+``transfer_methods`` shape (spec §"Transfer Methods").
+"""
 
 from __future__ import annotations
 
-import pytest
 from fastmcp import FastMCP
 
 from fastmcp_pvl_core._file_exchange_protocol import (
@@ -10,34 +13,44 @@ from fastmcp_pvl_core._file_exchange_protocol import (
 )
 
 
-def test_builder_download_only_emits_flat_http_in_legacy_shape() -> None:
-    b = _FileExchangeCapabilityBuilder(
-        namespace="ns",
-        legacy_capability_shape=True,
-    )
-    b.set_download(tool_name="create_download_link")
-    cap = b.build()
-    assert cap is not None
-    d = cap.to_capability_dict()
-    assert d["version"] == "0.2"
-    assert d["transfer_methods"]["http"] == {"tool": "create_download_link"}
-
-
-def test_builder_download_only_emits_nested_http_in_v04_shape() -> None:
+def test_builder_http_source_only_emits_source_role() -> None:
     b = _FileExchangeCapabilityBuilder(namespace="ns")
-    b.set_download(tool_name="create_download_link")
+    b.set_http_source(tool_name="create_download_link")
     cap = b.build()
     assert cap is not None
     d = cap.to_capability_dict()
-    assert d["version"] == "0.4"
+    assert d["version"] == "0.3"
     assert d["transfer_methods"]["http"] == {
-        "download": {"tool": "create_download_link"},
+        "source": {"tool": "create_download_link"},
     }
 
 
-def test_builder_upload_only_emits_nested_http_with_upload_only() -> None:
+def test_builder_http_sink_only_emits_sink_role() -> None:
     b = _FileExchangeCapabilityBuilder(namespace="ns")
-    b.set_upload(
+    b.set_http_sink(tool_name="fetch_file")
+    cap = b.build()
+    assert cap is not None
+    d = cap.to_capability_dict()
+    assert d["transfer_methods"]["http"] == {"sink": {"tool": "fetch_file"}}
+
+
+def test_builder_http_both_roles_emits_source_and_sink() -> None:
+    """Dual-role guard: a producer-and-consumer server advertises both roles."""
+    b = _FileExchangeCapabilityBuilder(namespace="ns")
+    b.set_http_source(tool_name="create_download_link")
+    b.set_http_sink(tool_name="fetch_file")
+    cap = b.build()
+    assert cap is not None
+    http = cap.to_capability_dict()["transfer_methods"]["http"]
+    assert http == {
+        "source": {"tool": "create_download_link"},
+        "sink": {"tool": "fetch_file"},
+    }
+
+
+def test_builder_http_upload_sink_emits_under_own_method_key() -> None:
+    b = _FileExchangeCapabilityBuilder(namespace="ns")
+    b.set_http_upload_sink(
         tool_name="create_upload_link",
         max_bytes=10_000_000,
         max_ttl_seconds=300,
@@ -45,8 +58,9 @@ def test_builder_upload_only_emits_nested_http_with_upload_only() -> None:
     cap = b.build()
     assert cap is not None
     d = cap.to_capability_dict()
-    assert d["transfer_methods"]["http"] == {
-        "upload": {
+    assert "http" not in d["transfer_methods"]
+    assert d["transfer_methods"]["http_upload"] == {
+        "sink": {
             "tool": "create_upload_link",
             "max_bytes": 10_000_000,
             "max_ttl_seconds": 300,
@@ -54,71 +68,9 @@ def test_builder_upload_only_emits_nested_http_with_upload_only() -> None:
     }
 
 
-def test_builder_both_directions_merge_under_single_http_block() -> None:
+def test_builder_http_upload_sink_includes_explicit_accepts() -> None:
     b = _FileExchangeCapabilityBuilder(namespace="ns")
-    b.set_download(tool_name="create_download_link")
-    b.set_upload(tool_name="create_upload_link", max_bytes=10, max_ttl_seconds=60)
-    cap = b.build()
-    assert cap is not None
-    d = cap.to_capability_dict()
-    http = d["transfer_methods"]["http"]
-    assert set(http) == {"download", "upload"}
-    assert http["download"]["tool"] == "create_download_link"
-    assert http["upload"]["tool"] == "create_upload_link"
-
-
-def test_builder_both_directions_in_legacy_shape_keeps_only_download_http(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    import logging
-
-    b = _FileExchangeCapabilityBuilder(
-        namespace="ns",
-        legacy_capability_shape=True,
-    )
-    b.set_download(tool_name="create_download_link")
-    with caplog.at_level(logging.WARNING):
-        b.set_upload(tool_name="create_upload_link", max_bytes=10, max_ttl_seconds=60)
-        cap = b.build()
-    assert cap is not None
-    d = cap.to_capability_dict()
-    assert d["version"] == "0.2"
-    # In legacy shape, the http block is the flat tool: <name>; upload
-    # cannot ride along (there's no nested upload key in v0.2). The
-    # builder logs a warning but still emits a download-only flat shape.
-    assert d["transfer_methods"]["http"] == {"tool": "create_download_link"}
-    # The warning was emitted at some point during set_upload + build.
-    assert any(
-        "legacy" in r.getMessage().lower() or "v0.2" in r.getMessage()
-        for r in caplog.records
-    )
-
-
-def test_builder_with_neither_direction_returns_none() -> None:
-    b = _FileExchangeCapabilityBuilder(namespace="ns")
-    assert b.build() is None
-
-
-def test_builder_legacy_shape_no_download_tool_omits_http_block() -> None:
-    """Legacy v0.2 shape with only an upload (and no download) emits no http block.
-
-    Upload cannot ride the flat v0.2 shape (no nested ``http.upload`` key),
-    so without a download tool the http block is omitted entirely; the only
-    transfer methods left would be ``exchange``. With nothing else set, the
-    builder returns ``None``.
-    """
-    b = _FileExchangeCapabilityBuilder(
-        namespace="ns",
-        legacy_capability_shape=True,
-    )
-    b.set_upload(tool_name="create_upload_link", max_bytes=10, max_ttl_seconds=60)
-    assert b.build() is None
-
-
-def test_builder_upload_with_explicit_accepts_includes_accepts_in_capability() -> None:
-    """Non-default ``accepts`` is reflected in the upload capability dict."""
-    b = _FileExchangeCapabilityBuilder(namespace="ns")
-    b.set_upload(
+    b.set_http_upload_sink(
         tool_name="create_upload_link",
         max_bytes=1000,
         max_ttl_seconds=300,
@@ -126,27 +78,28 @@ def test_builder_upload_with_explicit_accepts_includes_accepts_in_capability() -
     )
     cap = b.build()
     assert cap is not None
-    upload = cap.to_capability_dict()["transfer_methods"]["http"]["upload"]
-    assert upload["accepts"] == ["text/markdown", "application/octet-stream"]
+    sink = cap.to_capability_dict()["transfer_methods"]["http_upload"]["sink"]
+    assert sink["accepts"] == ["text/markdown", "application/octet-stream"]
 
 
-def test_emit_capability_returns_none_when_no_builder_registered() -> None:
-    """``_emit_capability`` is idempotent on a FastMCP that has no builder.
-
-    Covers the early-out branch in ``_emit_capability``: a caller may
-    invoke it on a FastMCP instance no registrar has touched (e.g. a
-    transport-noop branch that still tries to publish), and the helper
-    must return ``None`` rather than raising.
-    """
-    from fastmcp_pvl_core.file_exchange import (
-        _BUILDER_ATTR,
-        _emit_capability,
+def test_builder_http_and_http_upload_are_separate_top_level_keys() -> None:
+    b = _FileExchangeCapabilityBuilder(namespace="ns")
+    b.set_http_source(tool_name="create_download_link")
+    b.set_http_upload_sink(
+        tool_name="create_upload_link",
+        max_bytes=10,
+        max_ttl_seconds=60,
     )
+    cap = b.build()
+    assert cap is not None
+    tm = cap.to_capability_dict()["transfer_methods"]
+    assert tm["http"] == {"source": {"tool": "create_download_link"}}
+    assert tm["http_upload"]["sink"]["tool"] == "create_upload_link"
 
-    mcp = FastMCP(name="no-builder")
-    # Sanity: builder is not yet attached to the instance.
-    assert getattr(mcp, _BUILDER_ATTR, None) is None
-    assert _emit_capability(mcp) is None
+
+def test_builder_with_no_method_returns_none() -> None:
+    b = _FileExchangeCapabilityBuilder(namespace="ns")
+    assert b.build() is None
 
 
 def test_builder_set_exchange_false_drops_exchange_method() -> None:
@@ -154,98 +107,33 @@ def test_builder_set_exchange_false_drops_exchange_method() -> None:
     b = _FileExchangeCapabilityBuilder(namespace="ns")
     b.set_exchange(True)
     b.set_exchange(False)
-    # No download/upload either, so the builder should produce nothing.
+    # No http/http_upload either, so the builder produces nothing.
     assert b.build() is None
-    # And with a download tool added, exchange must be absent from the
-    # transfer_methods even though set_exchange was called once with True.
-    b.set_download(tool_name="create_download_link")
+    # With a download tool added, exchange must be absent even though
+    # set_exchange was called once with True.
+    b.set_http_source(tool_name="create_download_link")
     cap = b.build()
     assert cap is not None
     assert "exchange" not in cap.to_capability_dict()["transfer_methods"]
 
 
+def test_emit_capability_returns_none_when_no_builder_registered() -> None:
+    """``_emit_capability`` is idempotent on a FastMCP that has no builder."""
+    from fastmcp_pvl_core.file_exchange import _BUILDER_ATTR, _emit_capability
+
+    mcp = FastMCP(name="no-builder")
+    assert getattr(mcp, _BUILDER_ATTR, None) is None
+    assert _emit_capability(mcp) is None
+
+
 def test_builder_is_attached_per_instance_not_module_level() -> None:
-    """Capability builders live on the FastMCP instance, not in a global dict.
-
-    The earlier implementation kept builders in a module-level
-    ``_capability_builders`` dict keyed by ``id(mcp)``; CPython is free
-    to reuse the id of a gc'd FastMCP for a future instance, which
-    would alias unrelated capability state across tests. The current
-    implementation stashes the builder as a private attribute on the
-    FastMCP itself, so the builder's lifetime is tied to the instance.
-
-    This test verifies (a) the attribute is set on the instance the
-    registrar acted on, and (b) a freshly-constructed FastMCP starts
-    out without the attribute — i.e. there is no shared global state
-    leaking across instances.
-    """
-    from fastmcp_pvl_core.file_exchange import (
-        _BUILDER_ATTR,
-        _get_or_create_builder,
-    )
+    """Capability builders live on the FastMCP instance, not in a global dict."""
+    from fastmcp_pvl_core.file_exchange import _BUILDER_ATTR, _get_or_create_builder
 
     mcp_a = FastMCP(name="probe-a")
     _get_or_create_builder(mcp_a, namespace="ns-a")
     assert getattr(mcp_a, _BUILDER_ATTR, None) is not None
     assert mcp_a._pvl_file_exchange_builder.namespace == "ns-a"  # type: ignore[attr-defined]
 
-    # A second, untouched FastMCP must not see ``mcp_a``'s state.
     mcp_b = FastMCP(name="probe-b")
     assert getattr(mcp_b, _BUILDER_ATTR, None) is None
-
-
-@pytest.mark.asyncio
-async def test_register_both_directions_emits_merged_http(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """End-to-end: both registrars on the same FastMCP merge into one capability.
-
-    Exercises the full public path — ``register_file_exchange`` (download
-    direction) followed by ``register_file_exchange_upload`` (upload
-    direction) on a shared :class:`FastMCP` instance — and confirms that
-    the per-id-of-mcp builder accumulates both contributions and emits a
-    single ``transfer_methods.http`` block carrying nested ``download``
-    and ``upload`` keys.
-    """
-    monkeypatch.setenv("TEST_DUAL_TRANSPORT", "http")
-    monkeypatch.setenv("TEST_DUAL_BASE_URL", "http://srv.test")
-    # ``MCP_EXCHANGE_DIR`` set-but-empty raises FileExchangeConfigError
-    # (see _file_exchange_runtime.FileExchange.from_env). Unset it so the
-    # test focuses on the http-direction merge.
-    monkeypatch.delenv("MCP_EXCHANGE_DIR", raising=False)
-
-    from fastmcp_pvl_core import (
-        register_file_exchange,
-        register_file_exchange_upload,
-    )
-
-    mcp = FastMCP(name="dual")
-    register_file_exchange(
-        mcp,
-        namespace="ns",
-        env_prefix="TEST_DUAL",
-        produces=["image/png"],
-    )
-    register_file_exchange_upload(
-        mcp,
-        namespace="ns",
-        env_prefix="TEST_DUAL",
-        receiver=lambda rec, body: {"ok": True},
-    )
-
-    builder = mcp._pvl_file_exchange_builder  # type: ignore[attr-defined]
-    cap = builder.build()
-    assert cap is not None
-    d = cap.to_capability_dict()
-
-    assert d["version"] == "0.4"
-    http = d["transfer_methods"]["http"]
-    assert "download" in http and http["download"]["tool"] == "create_download_link"
-    assert "upload" in http and http["upload"]["tool"] == "create_upload_link"
-    # ``accepts`` is advertised verbatim — including the default
-    # ``("*/*",)`` wildcard. Per Amendment 11 an absent ``accepts`` key
-    # means the route inherits the server-wide ``consumes`` list, so a
-    # wildcard route MUST advertise ``["*/*"]`` explicitly to avoid
-    # misleading clients into thinking only ``consumes`` types are
-    # accepted.
-    assert http["upload"]["accepts"] == ["*/*"]

--- a/tests/test_file_exchange_protocol.py
+++ b/tests/test_file_exchange_protocol.py
@@ -262,18 +262,18 @@ class TestFileExchangeCapability:
     def test_minimum_required_fields(self) -> None:
         cap = FileExchangeCapability(
             namespace="image-mcp",
-            transfer_methods={"http": {"tool": "create_download_link"}},
+            transfer_methods={"http": {"source": {"tool": "create_download_link"}}},
         )
         assert cap.to_capability_dict() == {
             "version": SPEC_VERSION,
             "namespace": "image-mcp",
             "produces": [],
             "consumes": [],
-            "transfer_methods": {"http": {"tool": "create_download_link"}},
+            "transfer_methods": {"http": {"source": {"tool": "create_download_link"}}},
         }
 
     def test_full_round_trip_matches_spec_3_9(self) -> None:
-        # Verbatim shape from spec §3.9 producer example.
+        # Verbatim shape from spec §3.9 producer example (v0.3.0 source/sink shape).
         cap = FileExchangeCapability(
             namespace="image-mcp",
             exchange_id="hades-01",
@@ -281,19 +281,19 @@ class TestFileExchangeCapability:
             consumes=(),
             transfer_methods={
                 "exchange": {},
-                "http": {"tool": "create_download_link"},
+                "http": {"source": {"tool": "create_download_link"}},
             },
         )
         d = cap.to_capability_dict()
         assert d == {
-            "version": "0.4",
+            "version": "0.3",
             "namespace": "image-mcp",
             "exchange_id": "hades-01",
             "produces": ["image/png", "image/webp", "image/jpeg"],
             "consumes": [],
             "transfer_methods": {
                 "exchange": {},
-                "http": {"tool": "create_download_link"},
+                "http": {"source": {"tool": "create_download_link"}},
             },
         }
 
@@ -301,12 +301,12 @@ class TestFileExchangeCapability:
         with pytest.raises(ExchangeURIError):
             FileExchangeCapability(
                 namespace="bad/namespace",
-                transfer_methods={"http": {"tool": "t"}},
+                transfer_methods={"http": {"source": {"tool": "t"}}},
             )
         with pytest.raises(ExchangeURIError, match="dot"):
             FileExchangeCapability(
                 namespace=".hidden",
-                transfer_methods={"http": {"tool": "t"}},
+                transfer_methods={"http": {"source": {"tool": "t"}}},
             )
 
     def test_invalid_exchange_id_rejected_at_construction(self) -> None:
@@ -314,13 +314,13 @@ class TestFileExchangeCapability:
             FileExchangeCapability(
                 namespace="ok",
                 exchange_id="bad/id",
-                transfer_methods={"http": {"tool": "t"}},
+                transfer_methods={"http": {"source": {"tool": "t"}}},
             )
 
     def test_list_inputs_are_normalised_to_tuples(self) -> None:
         cap = FileExchangeCapability(
             namespace="ok",
-            transfer_methods={"http": {"tool": "t"}},
+            transfer_methods={"http": {"source": {"tool": "t"}}},
             produces=["image/png"],  # type: ignore[arg-type]
         )
         assert cap.produces == ("image/png",)
@@ -336,7 +336,7 @@ class TestRegisterCapability:
         mcp = FastMCP("test")
         cap = FileExchangeCapability(
             namespace="vault-mcp",
-            transfer_methods={"http": {"tool": "fetch_file"}},
+            transfer_methods={"http": {"sink": {"tool": "fetch_file"}}},
         )
         before = len(mcp.middleware)
         register_file_exchange_capability(mcp, cap)
@@ -346,12 +346,12 @@ class TestRegisterCapability:
         mcp = FastMCP("test")
         cap1 = FileExchangeCapability(
             namespace="vault-mcp",
-            transfer_methods={"http": {"tool": "fetch_file"}},
+            transfer_methods={"http": {"sink": {"tool": "fetch_file"}}},
         )
         cap2 = FileExchangeCapability(
             namespace="vault-mcp",
             consumes=("image/png",),
-            transfer_methods={"http": {"tool": "fetch_file"}},
+            transfer_methods={"http": {"sink": {"tool": "fetch_file"}}},
         )
         register_file_exchange_capability(mcp, cap1)
         register_file_exchange_capability(mcp, cap2)
@@ -375,7 +375,7 @@ class TestRegisterCapability:
             consumes=("image/png", "application/pdf"),
             transfer_methods={
                 "exchange": {},
-                "http": {"tool": "fetch_file"},
+                "http": {"sink": {"tool": "fetch_file"}},
             },
         )
         register_file_exchange_capability(mcp, cap)


### PR DESCRIPTION
## Summary

Migrates the file-exchange **capability builder** to the v0.3.0 `transfer_methods` shape (the `source`/`sink` role sub-objects merged into the spec by #83/PR #84). Precursor to #74.

- `_FileExchangeCapabilityBuilder` now tracks the two `http` roles separately — `set_http_source` / `set_http_sink` / `set_http_upload_sink` replace `set_download` / `set_upload`. `build()` emits `http` and `http_upload` as **separate top-level method keys**, each carrying `source`/`sink` role sub-objects; `exchange` stays `{}`.
- **Dual-role bug fix:** `register_file_exchange` used `if produce / elif consume`, so a server that both produces and consumes only ever advertised the producer tool — the consumer `fetch_file` tool was hidden. It is now two independent `if`s; a produce-and-consume server advertises both `http.source` and `http.sink`.
- `SPEC_VERSION` `"0.4"` → `"0.3"` (the `"0.4"` was a stale value from the reverted amendments; the spec permanently skips `0.4`).
- The `legacy_capability_shape` override kwarg is removed entirely — builder field, `_get_or_create_builder` parameter + merge logic, and the `register_file_exchange_upload` kwarg. It was a shape-override kwarg (fails the #72/#73 classification test); the v0.2 flat shape it served is retired.

## Out of scope

- The `create_upload_link` tool contract and the POST upload route status codes — #74.
- The sender-side `upload` tool — #85.
- The `http`-direction tool/route conformance audit — #87.
- Stale "Amendment 11" comments in the upload tool body — noted on #74 (its clean-slate rebuild re-grounds them).

## Test plan

- [x] `uv run pytest` — 616 passed.
- [x] `uv run ruff format --check .` / `ruff check .` / `mypy src` — all clean.
- [x] `tests/test_file_exchange_capability_merge.py` rewritten to the v0.3.0 shape, including `test_builder_http_both_roles_emits_source_and_sink` (the dual-role guard).
- [x] `tests/test_file_exchange_protocol.py` realigned (`source`/`sink` payloads, `version` `"0.3"`).
- [ ] CI green.
- [ ] Bot review clean.

Follow-up: #88 tracks an end-to-end test for the produce-and-consume call site (needs `ConsumerSink` typing machinery the reviewers judged disproportionate here; the builder-level dual-role guard covers the emission).

Closes #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)