### PR TITLE
impl: re-implement http_upload receiver primitive against v0.3.0 spec (#74)

### DIFF
--- a/docs/superpowers/plans/2026-05-15-upload-primitive-v030.md
+++ b/docs/superpowers/plans/2026-05-15-upload-primitive-v030.md
@@ -1,0 +1,642 @@
+# http_upload Receiver Primitive — v0.3.0 Re-implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-implement the receiver/`sink`-side `http_upload` primitive — `register_file_exchange_upload`, the `create_upload_link` tool, the POST route, and `UploadRecord` — to be 100% conformant with the v0.3.0 file-exchange spec.
+
+**Architecture:** The `http_upload` receiver is one tightly-coupled unit spanning three files: `_token_store.py` (`UploadRecord` / `UploadStore`), `_file_exchange_runtime.py` (the POST route), and `file_exchange.py` (the helper + tool + `UploadHandle`). The tool's parameter/return shape, the route's status codes, and the record's fields all change together — the call graph (`create_upload_link` → `UploadHandle.create_link` → `UploadStore.reserve`; route → `UploadStore.consume`) does not survive a partial migration with `mypy` green. Task 1 therefore rebuilds all three files plus rewrites the upload tests in one atomic, test-first commit. Task 2 is the full-suite sweep + quality gate.
+
+**Tech Stack:** Python 3.10–3.13, `uv`, `pytest`, `ruff`, `mypy`. Repo `/mnt/code/fastmcp-pvl-core`, branch `impl/upload-primitive-v030-issue-74`.
+
+**Design doc:** `docs/superpowers/specs/2026-05-15-upload-primitive-v030-design.md` (issue #74).
+
+---
+
+## File Structure
+
+- `src/fastmcp_pvl_core/_token_store.py` — `UploadRecord` gains `origin_id`/`destination`/`content_type`, drops `target_id`/`extra`. `UploadStore.reserve` parameters change; `consume_or_status` is deleted (`consume` stays).
+- `src/fastmcp_pvl_core/_file_exchange_runtime.py` — `_upload_handler` drops the `410` branch (uses `consume`, not `consume_or_status`).
+- `src/fastmcp_pvl_core/file_exchange.py` — `PreLinkValidator` signature; `UploadHandle` / `create_link`; `register_file_exchange_upload` kwarg surface; the `create_upload_link` tool body and return; a new `_upload_transfer_failed` envelope helper.
+- `tests/test_uploads.py`, `tests/test_file_exchange_upload_facade.py`, `tests/test_file_exchange_upload_route.py` — rewritten to the v0.3.0 contract.
+
+No new files. The token-store *mechanics* (UUID4 token, atomic consume, lazy TTL purge, the `_bounded_chunks` streaming generator, sync/async receiver dispatch, `413`/`415`/`5xx` handling) are spec-conformant and preserved.
+
+---
+
+## The v0.3.0 target contract (reference for every task)
+
+**`create_upload_link` tool parameters:** `origin_id: str` (required), `destination: str | None = None`, `content_type: str | None = None`, `ttl_seconds: int | None = None`, `max_bytes: int | None = None`.
+
+**`create_upload_link` return (success):** exactly `{"url": str, "ttl_seconds": int, "max_bytes": int}` — effective post-clamp values.
+
+**`create_upload_link` return (in-band rejection):** the `transfer_failed` envelope `{"error": "transfer_failed", "method": "http_upload", "receiver_server": <namespace>, "origin_id": <origin_id>, "message": <str>}`.
+
+**POST route status classes:** `2xx` success; `404` for unknown/expired/consumed (indistinguishable, empty body, **no `410`**); `413` oversize; `415` content-type mismatch; other `4xx` domain rejection with `transfer_failed` body; `5xx` server error, generic body.
+
+**`UploadRecord` fields:** `origin_id: str`, `destination: str | None`, `content_type: str | None`, `max_bytes: int`, `expires_at: float`.
+
+**Hook signatures:** `PreLinkValidator = Callable[[str, str | None], None | Awaitable[None]]` (`origin_id`, `destination`); `BufferedReceiver` / `StreamReceiver` unchanged in shape (`(UploadRecord, bytes)` / `(UploadRecord, AsyncIterator[bytes])`).
+
+---
+
+## Task 1: Rebuild the http_upload receiver primitive
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_token_store.py` (`UploadRecord` ~407-441; `UploadStore.reserve` ~469-506; `consume`/`consume_or_status` ~508-545)
+- Modify: `src/fastmcp_pvl_core/_file_exchange_runtime.py` (`_upload_handler` ~706-723)
+- Modify: `src/fastmcp_pvl_core/file_exchange.py` (`PreLinkValidator` ~1376-1379; `UploadHandle`/`create_link` ~1382-1488; `_disabled_upload_handle` ~1490-1512; `register_file_exchange_upload` ~1515-1843; add `_upload_transfer_failed` near `_transfer_failed` ~922)
+- Test: `tests/test_uploads.py`, `tests/test_file_exchange_upload_facade.py`, `tests/test_file_exchange_upload_route.py`
+
+Steps 3–11 leave the tree temporarily `mypy`-inconsistent; the gate runs at Step 12. Do **not** run `pytest`/`mypy` between Steps 3 and 11; do not commit before Step 12 passes.
+
+- [ ] **Step 1: Rewrite the three upload test files to the v0.3.0 contract**
+
+Read all three files. They test the pre-v0.3.0 contract. Rewrite each to the target contract above. Apply these mechanical transformations everywhere they appear:
+
+- `target_id=` / `target_id` → `origin_id=` / `origin_id` (the tool param, `UploadRecord` field, `UploadStore.reserve` arg, `create_link` arg).
+- Tool return `"upload_url"` → `"url"`; `"expires_in_seconds"` → `"ttl_seconds"`; the return no longer contains `target_id`; it now also contains `"max_bytes"`.
+- Any `extra=` argument to the tool / `create_link` / `reserve`, and any `UploadRecord.extra` / `record.extra` access → removed.
+- `UploadRecord(target_id=..., max_bytes=..., extra=..., expires_at=...)` constructions → `UploadRecord(origin_id=..., destination=..., content_type=..., max_bytes=..., expires_at=...)`.
+- `store.consume_or_status(token)` calls → `store.consume(token)` (now returns `UploadRecord | None`, no status tuple).
+- Any test asserting a `410` response from the upload route → assert `404` instead.
+- `register_file_exchange_upload(..., upload_tool_name=X)` / `tool_tags=X` / `transport=X` / `max_bytes_default=X` / `ttl_default=X` / `ttl_max=X` → remove the kwarg; for the operator-config ones, set the corresponding env var (`{PREFIX}_UPLOAD_MAX_BYTES`, `{PREFIX}_UPLOAD_TTL`, `{PREFIX}_UPLOAD_TTL_MAX`, transport env) via `monkeypatch.setenv` if the test needs that value.
+
+Then ensure these v0.3.0 behaviours each have an explicit test (add them where missing — full code, not a sketch):
+
+```python
+# In test_file_exchange_upload_route.py — the anti-leak guard.
+@pytest.mark.asyncio
+async def test_upload_route_expired_token_returns_404_not_410(...):
+    """An expired token is indistinguishable from unknown/consumed: 404, never 410."""
+    # reserve a token with a tiny TTL, let it expire, POST to it,
+    # assert response.status_code == 404 (NOT 410).
+
+@pytest.mark.asyncio
+async def test_upload_route_unknown_and_consumed_and_expired_all_404(...):
+    """All three token-unusable conditions return an identical 404."""
+    # POST to a never-minted token -> 404
+    # POST twice to the same token -> second POST 404
+    # POST to an expired token -> 404
+    # assert all three responses are byte-identical (same status, same body).
+```
+
+```python
+# In test_file_exchange_upload_facade.py — the in-band transfer_failed envelope.
+@pytest.mark.asyncio
+async def test_create_upload_link_rejection_returns_transfer_failed_envelope(...):
+    """A pre_link_validator ValueError makes the tool return the transfer_failed envelope."""
+    # register with a pre_link_validator that raises ValueError("bad destination")
+    # call create_upload_link(origin_id="x", destination="../etc")
+    # assert the result == {"error": "transfer_failed", "method": "http_upload",
+    #                       "receiver_server": <namespace>, "origin_id": "x",
+    #                       "message": "bad destination"}
+
+@pytest.mark.asyncio
+async def test_create_upload_link_content_type_mismatch_returns_transfer_failed(...):
+    """A content_type hint outside the accepts list is rejected in-band."""
+    # register with accepts=("text/markdown",)
+    # call create_upload_link(origin_id="x", content_type="image/png")
+    # assert result["error"] == "transfer_failed" and result["method"] == "http_upload"
+    # assert result["receiver_server"] == <namespace> and result["origin_id"] == "x"
+
+@pytest.mark.asyncio
+async def test_create_upload_link_success_returns_url_ttl_maxbytes(...):
+    """Success return has exactly url / ttl_seconds / max_bytes."""
+    # call create_upload_link(origin_id="x")
+    # assert set(result) == {"url", "ttl_seconds", "max_bytes"}
+    # assert result["max_bytes"] == <effective ceiling>
+
+@pytest.mark.asyncio
+async def test_create_upload_link_clamps_ttl_and_max_bytes_to_ceilings(...):
+    """ttl_seconds and max_bytes in the return are the clamped effective values."""
+    # set {PREFIX}_UPLOAD_TTL_MAX and {PREFIX}_UPLOAD_MAX_BYTES low via env
+    # call create_upload_link(origin_id="x", ttl_seconds=99999, max_bytes=99999999)
+    # assert result["ttl_seconds"] == ceiling and result["max_bytes"] == ceiling
+```
+
+```python
+# In test_uploads.py — UploadRecord carries the WHAT/WHERE split to the receiver.
+def test_upload_record_carries_origin_id_destination_content_type():
+    rec = UploadRecord(origin_id="a", destination="d/x.md",
+                       content_type="text/markdown", max_bytes=10, expires_at=time.time()+60)
+    assert rec.origin_id == "a"
+    assert rec.destination == "d/x.md"
+    assert rec.content_type == "text/markdown"
+    assert not hasattr(rec, "target_id")
+    assert not hasattr(rec, "extra")
+```
+
+Keep all still-relevant existing coverage (token entropy, atomic one-time consume, `413` pre-declared + mid-stream, `415`, sync/async receiver dispatch, the disabled-handle paths) — only the contract-specific assertions change.
+
+- [ ] **Step 2: Run the upload tests to verify they fail**
+
+Run: `uv run pytest tests/test_uploads.py tests/test_file_exchange_upload_facade.py tests/test_file_exchange_upload_route.py -q`
+Expected: FAIL — the tests reference the new contract (`origin_id`, `consume`, the envelope) that the source does not yet implement.
+
+- [ ] **Step 3: Restructure `UploadRecord`**
+
+In `src/fastmcp_pvl_core/_token_store.py`, replace the `UploadRecord` dataclass (fields and docstring) with:
+
+```python
+@dataclass(frozen=True)
+class UploadRecord:
+    """A reservation slot for an in-flight upload (intake direction).
+
+    An ``UploadRecord`` does not carry bytes — bytes arrive over the wire
+    when a client ``POST``s to ``/<ns>/uploads/{token}``. The record
+    carries the metadata the receiver needs to commit the bytes, modelling
+    the v0.3.0 spec's WHAT/WHERE split, plus the runtime guards.
+
+    Attributes:
+        origin_id: The sender's opaque stable handle for the bytes (the
+            *what*). Validated against the spec's segment grammar — see
+            ``docs/specs/file-exchange.md`` §"Security and Path
+            Resolution".
+        destination: The sender's destination instruction (the *where*),
+            or ``None`` if the sender gave none. The receiver validates
+            and interprets it per its own domain rules.
+        content_type: The sender's hint of the ``Content-Type`` the POST
+            will declare, or ``None``.
+        max_bytes: Hard size cap for the POST body, enforced at the HTTP
+            route before dispatch.
+        expires_at: Unix timestamp after which the reservation is
+            invalid; consumed reservations are removed atomically by
+            ``UploadStore.consume``.
+    """
+
+    origin_id: str
+    destination: str | None
+    content_type: str | None
+    max_bytes: int
+    expires_at: float
+```
+
+- [ ] **Step 4: Update `UploadStore.reserve`**
+
+In `_token_store.py`, replace the `reserve` method with:
+
+```python
+    def reserve(
+        self,
+        *,
+        origin_id: str,
+        max_bytes: int,
+        ttl_seconds: float | None = None,
+        destination: str | None = None,
+        content_type: str | None = None,
+    ) -> str:
+        """Mint a token reserving a one-shot upload slot.
+
+        Validation note: ``max_bytes`` / ``origin_id`` / ``destination``
+        are stored verbatim; no validation runs at this layer. Higher-level
+        callers (``register_file_exchange_upload`` and its
+        ``pre_link_validator``) validate before reserving.
+        """
+        self._purge_expired()
+        token = self._mint_token()
+        ttl = self._ttl if ttl_seconds is None else float(ttl_seconds)
+        self._records[token] = UploadRecord(
+            origin_id=origin_id,
+            destination=destination,
+            content_type=content_type,
+            max_bytes=int(max_bytes),
+            expires_at=time.time() + ttl,
+        )
+        logger.debug(
+            "upload_reserve token_prefix=%s origin_id=%s max_bytes=%d ttl=%.1fs",
+            token[:8],
+            origin_id,
+            max_bytes,
+            ttl,
+        )
+        return token
+```
+
+- [ ] **Step 5: Delete `consume_or_status`, keep `consume`**
+
+In `_token_store.py`, delete the entire `consume_or_status` method. Update the `consume` method's docstring to drop the reference to `consume_or_status`:
+
+```python
+    def consume(self, token: str) -> UploadRecord | None:
+        """Atomic consume; returns the record, or ``None`` for an
+        unusable token — unknown, expired, or already consumed are
+        indistinguishable, per the spec's anti-leak rule for the
+        ``http_upload`` POST route.
+        """
+        return self._atomic_consume(token)
+```
+
+If `Literal` is now unused in `_token_store.py`, remove it from the imports. The `_peek_for_tests`, `has_base_url`, `build_url` methods are unchanged.
+
+- [ ] **Step 6: Update the POST route — `consume`, drop the `410` branch**
+
+In `src/fastmcp_pvl_core/_file_exchange_runtime.py`, in `_upload_handler`, replace the token-lookup block:
+
+```python
+        token = request.path_params.get("token", "")
+        record, status = store.consume_or_status(token)
+        if status == "expired":
+            logger.info("upload_handler_expired token_prefix=%s", token[:8])
+            return Response(content="Gone", status_code=410)
+        if record is None:
+            logger.debug("upload_handler_miss token_prefix=%s", (token or "")[:8])
+            return Response(content="Not Found", status_code=404)
+```
+
+with:
+
+```python
+        token = request.path_params.get("token", "")
+        record = store.consume(token)
+        if record is None:
+            # 404 covers all three token-unusable conditions — unknown,
+            # expired, already-consumed — indistinguishably (spec
+            # §"http_upload / POST contract": anti-leak, no 410).
+            logger.debug("upload_handler_miss token_prefix=%s", (token or "")[:8])
+            return Response(content="Not Found", status_code=404)
+```
+
+Then update `register_upload_route`'s docstring: remove the `410 Gone` bullet, and change the `404` bullet to "if the token is unknown, expired, or already consumed (indistinguishable, to avoid leaking token state to a probing caller)".
+
+- [ ] **Step 7: Update the `PreLinkValidator` type**
+
+In `src/fastmcp_pvl_core/file_exchange.py`, replace the `PreLinkValidator` alias:
+
+```python
+PreLinkValidator = Callable[
+    [str, "str | None"],
+    "None | Awaitable[None]",
+]
+```
+
+The two positional parameters are now `origin_id: str` and `destination: str | None`.
+
+- [ ] **Step 8: Add the `_upload_transfer_failed` envelope helper**
+
+In `file_exchange.py`, immediately after the existing `_transfer_failed` function (~line 940), add:
+
+```python
+def _upload_transfer_failed(
+    *,
+    receiver_server: str,
+    origin_id: str,
+    message: str,
+) -> dict[str, Any]:
+    """Build an ``http_upload`` in-band ``transfer_failed`` envelope.
+
+    The upload direction identifies the responding server as
+    ``receiver_server`` (not ``origin_server``): no file has been
+    produced, so the server is the receiver of an attempted upload.
+    See spec §"Transfer Methods / http_upload".
+    """
+    return {
+        "error": "transfer_failed",
+        "method": "http_upload",
+        "receiver_server": receiver_server,
+        "origin_id": origin_id,
+        "message": message,
+    }
+```
+
+- [ ] **Step 9: Update `UploadHandle` and `create_link`**
+
+In `file_exchange.py`, `UploadHandle` keeps its fields (`namespace`, `tool_name`, `enabled`, `upload_store`, `ttl_default`, `ttl_max`, `max_bytes_default`) and `__post_init__` unchanged — `ttl_default`/`ttl_max`/`max_bytes_default` remain handle fields (they are resolved values, populated from env/defaults). Replace only the `create_link` method:
+
+```python
+    def create_link(
+        self,
+        *,
+        origin_id: str,
+        ttl_seconds: float | None = None,
+        max_bytes: int | None = None,
+        destination: str | None = None,
+        content_type: str | None = None,
+    ) -> tuple[str, float, int]:
+        """Mint an upload reservation directly. Escape valve for advanced wraps.
+
+        Returns:
+            ``(upload_url, effective_ttl_seconds, effective_max_bytes)``.
+
+        Raises:
+            RuntimeError: if upload is not enabled (transport is stdio,
+                ``{PREFIX}_BASE_URL`` unset, or upload disabled by env).
+        """
+        if self.upload_store is None:
+            raise RuntimeError(
+                "upload not enabled (transport=stdio, missing BASE_URL, or disabled)"
+            )
+        if ttl_seconds is None or ttl_seconds <= 0:
+            ttl = float(self.ttl_default)
+        else:
+            ttl = float(ttl_seconds)
+        ttl = min(ttl, self.ttl_max)
+        if max_bytes is None or max_bytes <= 0:
+            cap = int(self.max_bytes_default)
+        else:
+            cap = min(int(max_bytes), int(self.max_bytes_default))
+        token = self.upload_store.reserve(
+            origin_id=origin_id,
+            max_bytes=cap,
+            ttl_seconds=ttl,
+            destination=destination,
+            content_type=content_type,
+        )
+        return self.upload_store.build_url(token), ttl, cap
+```
+
+Note two deliberate changes beyond the rename: `create_link` now returns the effective `max_bytes` as a third tuple element (the tool MUST return it), and a caller-supplied `max_bytes` is clamped *down* to `max_bytes_default` (the operator ceiling) rather than only floored — so the returned `max_bytes` is a true effective ceiling.
+
+- [ ] **Step 10: Update `_disabled_upload_handle` and the `register_file_exchange_upload` signature**
+
+In `file_exchange.py`, `_disabled_upload_handle` — drop the `upload_tool_name` parameter; the handle's `tool_name` is fixed:
+
+```python
+def _disabled_upload_handle(
+    *,
+    namespace: str,
+    ttl_default: float,
+    ttl_max: float,
+    max_bytes_default: int,
+) -> UploadHandle:
+    """Return a no-op UploadHandle for the upload-disabled path."""
+    return UploadHandle(
+        namespace=namespace,
+        tool_name=_DEFAULT_UPLOAD_TOOL,
+        enabled=False,
+        upload_store=None,
+        ttl_default=ttl_default,
+        ttl_max=ttl_max,
+        max_bytes_default=max_bytes_default,
+    )
+```
+
+Replace the `register_file_exchange_upload` signature:
+
+```python
+def register_file_exchange_upload(
+    mcp: FastMCP,
+    *,
+    namespace: str,
+    env_prefix: str,
+    receiver: BufferedReceiver | None = None,
+    stream_receiver: StreamReceiver | None = None,
+    pre_link_validator: PreLinkValidator | None = None,
+    accepts: tuple[str, ...] = ("*/*",),
+) -> UploadHandle:
+```
+
+Inside the body: `transport` is no longer a parameter — the `_resolve_transport(env_prefix, transport)` call becomes `_resolve_transport(env_prefix)` (its second parameter already defaults to `"auto"` — verify and rely on that default; if it has no default, pass `"auto"` explicitly). `max_bytes_default` / `ttl_default` / `ttl_max` are no longer parameters — initialise them as locals from the module defaults before the env-override block:
+
+```python
+    max_bytes_default = _DEFAULT_UPLOAD_MAX_BYTES
+    ttl_default = _DEFAULT_UPLOAD_TTL_SECONDS
+    ttl_max = _DEFAULT_UPLOAD_TTL_MAX_SECONDS
+```
+
+The existing env-override block (`{PREFIX}_UPLOAD_MAX_BYTES` / `_TTL` / `_TTL_MAX`, with `ConfigurationError` on malformed values) stays as-is and now writes those locals. The two `_disabled_upload_handle(...)` call sites drop the `upload_tool_name=` argument. The `register_upload_route(...)` call stays as-is. `UploadHandle(...)` construction: `tool_name=_DEFAULT_UPLOAD_TOOL` (was `upload_tool_name`). The `builder.set_http_upload_sink(tool_name=_DEFAULT_UPLOAD_TOOL, ...)` call uses the fixed name. Update the helper's docstring `Args:` block — remove `transport`, `upload_tool_name`, `tool_tags`, `max_bytes_default`, `ttl_default`, `ttl_max`; keep `mcp`/`namespace`/`env_prefix`/`receiver`/`stream_receiver`/`pre_link_validator`/`accepts`; rewrite `pre_link_validator`'s entry for the `(origin_id, destination)` signature. Re-ground the stale "Amendment 11" comment in the helper body (the `accepts`-verbatim comment) against spec §"Transfer Methods / http_upload" instead.
+
+- [ ] **Step 11: Rebuild the `create_upload_link` tool**
+
+In `file_exchange.py`, replace the `create_upload_link` tool definition (the `@mcp.tool(...)` decorator and the whole `async def create_upload_link` body) with — note the tool name and tags are now fixed, not kwargs:
+
+```python
+    @mcp.tool(name=_DEFAULT_UPLOAD_TOOL, tags={"write"})
+    async def create_upload_link(
+        origin_id: str,
+        destination: str | None = None,
+        content_type: str | None = None,
+        ttl_seconds: int | None = None,
+        max_bytes: int | None = None,
+    ) -> dict[str, Any]:
+        r"""Mint a one-time HTTPS POST URL for an inbound upload.
+
+        Args:
+            origin_id: The sender's opaque stable handle for the bytes
+                (the *what*). Validated against the spec's segment rules
+                (§"Security and Path Resolution"): no ``/``, ``\``, ``.``,
+                ``..``, control bytes, leading/trailing whitespace.
+            destination: Optional destination instruction (the *where*).
+                Only null bytes, control characters, and leading/trailing
+                whitespace are rejected at the spec level; the receiver
+                validates the rest per its own domain rules via
+                ``pre_link_validator``.
+            content_type: Optional hint of the ``Content-Type`` the POST
+                will declare; pre-filtered against the receiver's
+                ``accepts`` list.
+            ttl_seconds: Optional requested lifetime in seconds; clamped
+                to the server's TTL ceiling.
+            max_bytes: Optional requested body cap; clamped to the
+                server's ``max_bytes`` ceiling.
+
+        Returns:
+            On success, ``{url, ttl_seconds, max_bytes}`` — the effective
+            (post-clamp) values. On in-band rejection, a ``transfer_failed``
+            envelope.
+        """
+        # origin_id: strict spec segment grammar (the WHAT identifier).
+        ExchangeURI.validate_segment(origin_id, role="json_param")
+        # destination: relaxed validation (the WHERE) — reject only null
+        # bytes, control chars, and leading/trailing whitespace; the
+        # receiver validates the rest.
+        if destination is not None:
+            if destination != destination.strip():
+                return _upload_transfer_failed(
+                    receiver_server=namespace,
+                    origin_id=origin_id,
+                    message="destination must not have leading or trailing whitespace",
+                )
+            if any(ord(c) < 0x20 for c in destination):
+                return _upload_transfer_failed(
+                    receiver_server=namespace,
+                    origin_id=origin_id,
+                    message="destination must not contain control characters",
+                )
+        # content_type hint: pre-filter against the receiver's accepts
+        # list so a mismatched hint is rejected in-band, before a wasted
+        # POST round-trip (the route still enforces 415 on the actual
+        # POST Content-Type header). _accepts_match is imported from
+        # _file_exchange_runtime — add it to that module's imports in
+        # file_exchange.py.
+        if content_type is not None and not _accepts_match(content_type, accepts):
+            return _upload_transfer_failed(
+                receiver_server=namespace,
+                origin_id=origin_id,
+                message=f"content_type {content_type!r} is not accepted by this receiver",
+            )
+        if pre_link_validator is not None:
+            try:
+                if inspect.iscoroutinefunction(pre_link_validator):
+                    await pre_link_validator(origin_id, destination)
+                else:
+                    validator_result = await asyncio.to_thread(
+                        pre_link_validator, origin_id, destination
+                    )
+                    if inspect.isawaitable(validator_result):
+                        await validator_result
+            except ValueError as exc:
+                # Caller-facing rejection — return the spec transfer_failed
+                # envelope rather than letting it surface as a tool error.
+                return _upload_transfer_failed(
+                    receiver_server=namespace,
+                    origin_id=origin_id,
+                    message=str(exc),
+                )
+            except Exception:
+                logger.exception(
+                    "pre_link_validator raised non-ValueError "
+                    "(origin_id=%r) — server-side bug, not a client "
+                    "validation failure",
+                    origin_id,
+                )
+                raise
+        url, eff_ttl, eff_max_bytes = handle.create_link(
+            origin_id=origin_id,
+            ttl_seconds=ttl_seconds,
+            max_bytes=max_bytes,
+            destination=destination,
+            content_type=content_type,
+        )
+        return {
+            "url": url,
+            "ttl_seconds": int(eff_ttl),
+            "max_bytes": int(eff_max_bytes),
+        }
+```
+
+- [ ] **Step 12: Run the upload tests to verify they pass**
+
+Run: `uv run pytest tests/test_uploads.py tests/test_file_exchange_upload_facade.py tests/test_file_exchange_upload_route.py -q`
+Expected: PASS. If a test fails because it still references a removed symbol, fix the test to the v0.3.0 contract (Step 1's transformation rules). If a test reveals a real implementation gap, fix the source.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_token_store.py src/fastmcp_pvl_core/_file_exchange_runtime.py src/fastmcp_pvl_core/file_exchange.py tests/test_uploads.py tests/test_file_exchange_upload_facade.py tests/test_file_exchange_upload_route.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): re-implement http_upload receiver against v0.3.0 spec (refs #74)
+
+Clean-slate rebuild of the receiver/sink-side http_upload primitive,
+superseding the A11-era implementation:
+
+- create_upload_link: origin_id (required) + optional destination /
+  content_type / ttl_seconds / max_bytes; returns {url, ttl_seconds,
+  max_bytes}; in-band rejection returns the transfer_failed envelope
+  (with receiver_server, not origin_server).
+- POST route: 410-on-expired removed; unknown / expired / consumed
+  tokens all return an indistinguishable 404 (anti-leak).
+- UploadRecord models the WHAT/WHERE split (origin_id / destination /
+  content_type); the non-spec extra field is gone.
+- UploadStore.consume_or_status removed; consume returns
+  UploadRecord | None.
+- register_file_exchange_upload kwarg surface cut to six domain
+  hooks; upload_tool_name / tool_tags / transport / max_bytes_default
+  / ttl_default / ttl_max removed (pvl-core-fixed shape or env vars).
+- pre_link_validator signature is now (origin_id, destination).
+
+Refs #74.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Full-suite sweep and quality gate
+
+**Files:** potentially any test outside the three upload files that references the removed upload surface.
+
+- [ ] **Step 1: Sync dependencies and run the full suite**
+
+```bash
+uv sync --all-extras
+uv run pytest -q
+```
+
+Expected: green except possibly tests outside the three upload files that referenced `target_id` / `upload_url` / `expires_in_seconds` / `consume_or_status` / `UploadRecord.extra` / the removed `register_file_exchange_upload` kwargs / a `410` upload response.
+
+- [ ] **Step 2: Fix any straggler test**
+
+For each failure, apply Task 1 Step 1's transformation rules (the same v0.3.0-contract renames). A test that only existed to exercise removed behaviour (`extra` passthrough, the `410` branch, an `upload_tool_name` override) is rewritten to assert the new state, or deleted if the behaviour itself is gone. Re-run `uv run pytest -q` until green.
+
+- [ ] **Step 3: Quality gate**
+
+```bash
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
+```
+
+All three clean. Fix each finding minimally — e.g. an import left unused after `consume_or_status` / the removed kwargs were deleted (`Literal` in `_token_store.py`, `Literal`/`_DEFAULT_*` references in `file_exchange.py`).
+
+- [ ] **Step 4: Commit**
+
+If Steps 2–3 changed any file:
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+test(file-exchange): realign remaining tests to v0.3.0 upload contract (refs #74)
+
+<one or two lines naming the files swept>
+
+Refs #74.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If Steps 2–3 changed nothing, skip the commit — report only.
+
+---
+
+## Summary
+
+Two tasks. Task 1 is the atomic receiver-primitive rebuild across `_token_store.py`, `_file_exchange_runtime.py`, `file_exchange.py`, plus the three upload test files, test-first. Task 2 sweeps the rest of the suite and runs the quality gate.
+
+## What changes
+
+- `create_upload_link`: `origin_id`/`destination`/`content_type`/`ttl_seconds`/`max_bytes` params; `{url, ttl_seconds, max_bytes}` return; `transfer_failed` envelope on in-band rejection.
+- POST route: `410` removed; `404` covers unknown/expired/consumed indistinguishably.
+- `UploadRecord`: WHAT/WHERE split; no `extra`.
+- `UploadStore`: `consume_or_status` removed.
+- `register_file_exchange_upload`: six domain-hook kwargs only.
+- `PreLinkValidator`: `(origin_id, destination)`.
+
+## What does NOT change
+
+- Token-store mechanics (UUID4 entropy, atomic one-time consume, lazy TTL purge).
+- The route's `_bounded_chunks` streaming generator, sync/async receiver dispatch, and the `413`/`415`/`5xx` handling.
+- The capability builder (#86) and the download `http` method (#87).
+- The sender-side `upload` tool (#85).
+
+## Local review
+
+`preflight-circus` (five core lenses + `pr-review-toolkit:code-reviewer`) runs on the cumulative diff; clean at the ≥80 confidence bar before opening the draft PR.
+
+## Test plan
+
+- [ ] `uv run pytest` green on the full suite.
+- [ ] `uv run ruff format --check .` / `ruff check .` / `mypy src` clean.
+- [ ] `create_upload_link` accepts the five v0.3.0 params and returns `{url, ttl_seconds, max_bytes}`.
+- [ ] In-band rejection returns the `transfer_failed` envelope with `receiver_server`.
+- [ ] The upload POST route returns `404` (never `410`) for unknown / expired / consumed, indistinguishably.
+- [ ] `grep -rn 'target_id\|upload_url\|expires_in_seconds\|consume_or_status\|\.extra\b' src/` shows no upload-surface survivals.
+- [ ] CI green; bot review clean.
+
+## Out of scope
+
+- The sender-side `upload` tool (`http_upload.source`) — #85.
+- The `http`-direction tool/route conformance audit — #87.
+- The produce-and-consume e2e test — #88.
+
+## Acceptance (from #74 / the design doc)
+
+- [ ] `register_file_exchange_upload` has six domain-hook kwargs; every removed kwarg is env-var or pvl-core-fixed.
+- [ ] `create_upload_link` matches the v0.3.0 parameter/return contract.
+- [ ] In-band rejection returns the `transfer_failed` envelope.
+- [ ] The POST route emits no `410`; unknown/expired/consumed are indistinguishable `404`s.
+- [ ] `UploadRecord` models the WHAT/WHERE split; no `extra` field.
+- [ ] The old `target_id` / `upload_url` / `expires_in_seconds` / `410` surface is grep-verified gone.
+- [ ] Tests rewritten to the v0.3.0 shape; full suite + ruff + mypy clean.

--- a/docs/superpowers/specs/2026-05-15-upload-primitive-v030-design.md
+++ b/docs/superpowers/specs/2026-05-15-upload-primitive-v030-design.md
@@ -1,0 +1,254 @@
+# Design: re-implement the http_upload receiver primitive (issue #74)
+
+**Status**: approved (brainstorm 2026-05-15)
+**Issue**: [pvliesdonk/fastmcp-pvl-core#74](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/74)
+**Umbrella**: #75
+**Depends on**: #83 (dual-role spec) and #86 (capability builder) — both merged.
+
+## Problem
+
+`register_file_exchange_upload`, the `create_upload_link` MCP tool, and the
+POST upload route were built against the LLM-invented "Amendment 11", not a
+real spec. They diverge from the v0.3.0 `http_upload` contract on every
+externally observable surface:
+
+- The tool parameter is `target_id`; the spec names it `origin_id` and adds
+  optional `destination` (the WHERE) and `content_type`.
+- The tool return is `{upload_url, expires_in_seconds, target_id}`; the spec
+  mandates `{url, ttl_seconds, max_bytes}` — and `max_bytes` is currently
+  absent entirely (a MUST field).
+- The POST route emits `410 Gone` for an expired token; the spec requires all
+  three token-unusable conditions (unknown / expired / consumed) to be
+  **indistinguishable** `404`s (anti-leak).
+- In-band tool rejection returns a generic tool error, not the spec's
+  `transfer_failed` envelope.
+- `UploadRecord` collapses the WHAT/WHERE split into one `target_id` field
+  and carries a non-spec `extra` dict.
+- `register_file_exchange_upload` carries 13 kwargs — including
+  `upload_tool_name` and `tool_tags` (shape overrides) and four operator-
+  config kwargs — failing the #72/#73 classification test.
+
+#74 is a clean-slate rebuild of the receiver (`sink`) side, 100% conformant
+to the v0.3.0 spec. The capability declaration is already migrated (#86);
+the sender (`source`) side is #85.
+
+## Scope
+
+In scope: `register_file_exchange_upload`, the `create_upload_link` tool, the
+POST upload route, the `UploadRecord` shape, and the `_token_store.py`
+`UploadRecord`/`consume` surface. The token-store *mechanics* (UUID4 token —
+128 bits of entropy, atomic one-time consumption on first POST, lazy TTL
+purge) are already spec-conformant and are kept as-is.
+
+Out of scope: the sender-side `upload` tool (`http_upload.source`) — #85; the
+capability builder — done in #86; the `http` (download) method — #87; the
+stale "Amendment 11" comments are re-grounded against v0.3.0 spec sections
+as part of this rebuild.
+
+## The design
+
+### 1. `register_file_exchange_upload` — kwarg surface
+
+Six kwargs, all domain hooks (matching the `register_file_exchange` worked
+example in CLAUDE.md):
+
+```python
+def register_file_exchange_upload(
+    mcp: FastMCP,
+    *,
+    namespace: str,
+    env_prefix: str,
+    receiver: BufferedReceiver | None = None,
+    stream_receiver: StreamReceiver | None = None,
+    pre_link_validator: PreLinkValidator | None = None,
+    accepts: tuple[str, ...] = ("*/*",),
+) -> UploadHandle:
+```
+
+Exactly one of `receiver` / `stream_receiver` MUST be supplied. `accepts` is
+a domain hook — which MIME types this receiver handles is determined by the
+downstream server's domain, not by pvl-core.
+
+**Removed kwargs:**
+
+- `upload_tool_name`, `tool_tags` — shape overrides. pvl-core fixes the tool
+  name to `create_upload_link` and the tag set to `{"write"}`. Downstream
+  has no domain-specific basis to disagree; if the shape must change, it
+  changes in pvl-core for everyone.
+- `transport`, `max_bytes_default`, `ttl_default`, `ttl_max` — operator
+  configuration, not domain hooks. They move to environment variables
+  (`{PREFIX}_UPLOAD_MAX_BYTES`, `{PREFIX}_UPLOAD_TTL`, `{PREFIX}_UPLOAD_TTL_MAX`
+  — which the current code already reads — plus transport resolution from
+  the existing transport env var) with pvl-core built-in defaults. The
+  kwargs disappear; the env vars are the operator surface.
+
+### 2. The `create_upload_link` tool contract
+
+**Parameters** (verbatim to the v0.3.0 spec):
+
+| Param | Cardinality | Meaning |
+|---|---|---|
+| `origin_id` | MUST | Sender's opaque stable handle for the bytes (WHAT). Validated as a raw JSON string: no `/` or `\`, not `.`/`..`, no null/control chars, no leading/trailing whitespace. |
+| `destination` | optional | Sender's destination instruction (WHERE). Spec-level validation forbids only null bytes, control chars (U+0000–U+001F), and leading/trailing whitespace — path separators and dots are allowed; the receiver validates per its own domain rules via `pre_link_validator`. |
+| `content_type` | optional | Sender's hint of the POST `Content-Type`; pre-filtered against `accepts`. |
+| `ttl_seconds` | optional | Sender's TTL hint; clamped to the receiver's `{PREFIX}_UPLOAD_TTL_MAX` ceiling. |
+| `max_bytes` | optional | Sender's size hint; clamped to the receiver's `{PREFIX}_UPLOAD_MAX_BYTES` ceiling. |
+
+**Return** — exactly the three MUST fields, all *effective* (post-clamp) values:
+
+```json
+{"url": "https://.../uploads/<token>", "ttl_seconds": 3600, "max_bytes": 10485760}
+```
+
+The non-spec `extra` parameter and the `upload_url` / `expires_in_seconds`
+field names are gone.
+
+**In-band failure** — when the tool rejects before minting a URL (a
+`destination` rejected by `pre_link_validator`, or a `content_type` not in
+`accepts`), it returns the `transfer_failed` envelope rather than a generic
+tool error:
+
+```json
+{
+  "error": "transfer_failed",
+  "method": "http_upload",
+  "receiver_server": "<namespace>",
+  "origin_id": "<the origin_id passed in>",
+  "message": "<reason>"
+}
+```
+
+The envelope carries `receiver_server` (not `origin_server`): the upload
+direction has produced no file, so the responding server is identified as
+the receiver of an attempted upload.
+
+### 3. The POST upload route and status codes
+
+Route: `POST /{namespace}/uploads/{token}`. Status-code classes per the
+v0.3.0 spec's POST-contract table:
+
+| Status | Condition |
+|---|---|
+| `2xx` | Bytes accepted. Body is the receiver callback's returned dict, as JSON. |
+| `404` | Token unknown **or** expired **or** already-consumed — indistinguishable, empty body. |
+| `413` | Body exceeds the effective `max_bytes` — whether `Content-Length` declares it up front or the running total breaches it mid-stream. |
+| `415` | POST `Content-Type` does not match the `accepts` filter. |
+| other `4xx` | Receiver-domain rejection (the `receiver`/`stream_receiver` callback raises) — body carries the `transfer_failed` envelope. |
+| `5xx` | Server error — generic body, no internal detail echoed. |
+
+The single behavioural change versus the current route is removing the
+`expired → 410 Gone` branch: `410` is deleted; expired tokens join the `404`
+class. This is the spec's anti-leak rule — a probing caller MUST NOT be able
+to tell "expired" from "never existed" from "already consumed".
+
+Token consumption is unchanged: the token is atomically consumed on the
+first POST attempt, success or failure; a retry on the same URL gets `404`.
+
+### 4. `UploadRecord` and the token store
+
+`_token_store.py` mechanics are kept. Two changes:
+
+**`UploadRecord` restructure** — model the WHAT/WHERE split:
+
+```python
+@dataclass(frozen=True)
+class UploadRecord:
+    origin_id: str              # WHAT — replaces target_id
+    destination: str | None     # WHERE — new; the sender's destination hint
+    content_type: str | None    # new; the sender's Content-Type hint
+    max_bytes: int              # effective (clamped) size ceiling
+    expires_at: float           # internal TTL boundary
+```
+
+The non-spec `extra` dict field is removed — the v0.3.0 spec defines the
+upload's data surface exactly (`origin_id` / `destination` / `content_type`),
+and #74's mandate is binary spec compliance.
+
+**`consume_or_status` → `consume`** — with `410` removed, the route no longer
+needs to distinguish `"expired"` from `"missing"`. The 3-way
+`consume_or_status(token) -> (UploadRecord | None, Literal["ok","expired","missing"])`
+is replaced by `consume(token) -> UploadRecord | None`, which returns `None`
+for unknown / expired / consumed alike. The atomic-pop-then-TTL-check stays
+internal; the status enum (which existed only to feed the `410` split) is
+deleted.
+
+### 5. Domain-hook interfaces
+
+**`pre_link_validator`** — runs inside `create_upload_link`, after spec-level
+`origin_id` character validation, before the token is minted:
+
+```python
+PreLinkValidator = Callable[[str, str | None], None | Awaitable[None]]
+#                            origin_id  destination
+```
+
+It validates `destination` against the receiver's domain rules — the spec
+explicitly delegates `destination` validation to the receiver. Raising
+`ValueError` causes the tool to return a `transfer_failed` envelope (§2); any
+other exception propagates as a server error. Sync and async validators are
+both supported.
+
+**`receiver` / `stream_receiver`** — run inside the POST handler; they
+receive the restructured `UploadRecord`:
+
+```python
+BufferedReceiver = Callable[[UploadRecord, bytes], dict[str, Any] | Awaitable[dict[str, Any]]]
+StreamReceiver   = Callable[[UploadRecord, AsyncIterator[bytes]], dict[str, Any] | Awaitable[dict[str, Any]]]
+```
+
+`receiver` gets the fully-buffered body; `stream_receiver` gets a
+`max_bytes`-bounded async chunk iterator. The returned dict becomes the `2xx`
+JSON response body. A callback raising `ValueError` / `FileExistsError` /
+similar produces a domain `4xx` carrying the `transfer_failed` envelope; sync
+callbacks run via `asyncio.to_thread`.
+
+### 6. Testing
+
+TDD throughout. Coverage:
+
+- `create_upload_link`: the five-parameter shape; `origin_id` raw-string
+  validation; `ttl_seconds` / `max_bytes` clamping to the env ceilings; the
+  exact `{url, ttl_seconds, max_bytes}` return.
+- The in-band `transfer_failed` envelope on `pre_link_validator` rejection
+  and on `content_type` not in `accepts` — including the `receiver_server`
+  field name.
+- POST status classes: `404` for all three token-unusable conditions (the
+  anti-leak guard) and **no `410` anywhere**; `413` for both pre-declared
+  `Content-Length` and mid-stream overflow; `415`; domain `4xx` with the
+  envelope; `5xx` with no internal-detail echo.
+- The restructured `UploadRecord` (`origin_id` / `destination` /
+  `content_type`) reaching both `receiver` and `stream_receiver`.
+- `pre_link_validator` accept and reject paths, sync and async.
+
+The existing upload tests (`tests/test_uploads.py`,
+`tests/test_file_exchange_upload_facade.py`,
+`tests/test_file_exchange_upload_route.py`) are rewritten to the v0.3.0 shape,
+not patched — tests asserting the removed `target_id` / `upload_url` /
+`expires_in_seconds` / `410` behaviour assert the new state instead.
+
+## Backward compatibility
+
+`register_file_exchange_upload`'s public surface changes: the kwarg set
+shrinks, and `UploadRecord` (passed to `receiver` / `stream_receiver`) is
+restructured (`target_id` → `origin_id`, `+destination`, `+content_type`,
+`−extra`). This is a breaking change for the one downstream consumer,
+`markdown-vault-mcp`, whose adoption is tracked in
+`pvliesdonk/markdown-vault-mcp#488`. pvl-core ships the breaking change;
+downstream migrates — no compatibility shim, per the umbrella's discipline
+and #73's framing principle.
+
+## Acceptance (from #74)
+
+- [ ] New `register_file_exchange_upload` — six domain-hook kwargs, every
+  removed kwarg either env-var (operator config) or pvl-core-fixed (shape).
+- [ ] `create_upload_link` accepts `origin_id` / `destination` /
+  `content_type` / `ttl_seconds` / `max_bytes` and returns
+  `{url, ttl_seconds, max_bytes}`.
+- [ ] In-band rejection returns the `transfer_failed` envelope.
+- [ ] POST route emits the spec status classes; no `410`; the three
+  token-unusable conditions are indistinguishable `404`s.
+- [ ] `UploadRecord` models the WHAT/WHERE split; no `extra` field.
+- [ ] Old `target_id` / `upload_url` / `expires_in_seconds` / `410` surface
+  is gone (grep-verified).
+- [ ] Tests rewritten to the v0.3.0 shape; full suite + ruff + mypy clean.
+- [ ] Downstream migration tracked in `markdown-vault-mcp#488`.

--- a/src/fastmcp_pvl_core/_file_exchange_runtime.py
+++ b/src/fastmcp_pvl_core/_file_exchange_runtime.py
@@ -637,10 +637,9 @@ def register_upload_route(
     The route returns:
 
     - ``200`` with the receiver's dict serialised as JSON on success.
-    - ``404 Not Found`` if the token is unknown or already consumed
-      (the response does NOT distinguish "never existed" from "consumed",
-      to avoid leaking token-existence to a probing caller).
-    - ``410 Gone`` if the token existed but has expired.
+    - ``404 Not Found`` if the token is unknown, expired, or already
+      consumed (indistinguishable, to avoid leaking token state to a
+      probing caller).
     - ``413 Payload Too Large`` if ``Content-Length`` exceeds
       ``record.max_bytes`` OR the body's running total exceeds the cap
       mid-stream (defense in depth against lying clients).
@@ -709,16 +708,11 @@ def register_upload_route(
         # (uvicorn, hypercorn) handle the connection-state reset; we
         # do NOT need to call await request.body() to drain.
         token = request.path_params.get("token", "")
-        record, status = store.consume_or_status(token)
-        if status == "expired":
-            logger.info("upload_handler_expired token_prefix=%s", token[:8])
-            return Response(content="Gone", status_code=410)
+        record = store.consume(token)
         if record is None:
-            # Log policy: 404-miss is DEBUG because the cause is ambiguous
-            # (typo, probe, replay of an already-consumed token). The other
-            # 4xx mappings (410 expired, 413 oversize, 415 unsupported) log
-            # at INFO because they signal a clear client-side misuse the
-            # operator likely wants to see in default logs.
+            # 404 covers all three token-unusable conditions — unknown,
+            # expired, already-consumed — indistinguishably (spec
+            # §"http_upload / POST contract": anti-leak, no 410).
             logger.debug("upload_handler_miss token_prefix=%s", (token or "")[:8])
             return Response(content="Not Found", status_code=404)
 

--- a/src/fastmcp_pvl_core/_file_exchange_runtime.py
+++ b/src/fastmcp_pvl_core/_file_exchange_runtime.py
@@ -704,7 +704,7 @@ def register_upload_route(
     @mcp.custom_route(path, methods=["POST"])
     async def _upload_handler(request: Request) -> Response:
         # Note: the request body is intentionally not consumed on
-        # early-return error paths (404/410/413/415). ASGI servers
+        # early-return error paths (404/413/415). ASGI servers
         # (uvicorn, hypercorn) handle the connection-state reset; we
         # do NOT need to call await request.body() to drain.
         token = request.path_params.get("token", "")
@@ -714,7 +714,7 @@ def register_upload_route(
             # expired, already-consumed — indistinguishably (spec
             # §"http_upload / POST contract": anti-leak, no 410).
             logger.debug("upload_handler_miss token_prefix=%s", (token or "")[:8])
-            return Response(content="Not Found", status_code=404)
+            return Response(status_code=404)
 
         # Reject unsupported media types BEFORE any size check or body
         # read. ``"*/*"`` in ``accepts`` (the default) disables this gate.

--- a/src/fastmcp_pvl_core/_token_store.py
+++ b/src/fastmcp_pvl_core/_token_store.py
@@ -21,7 +21,7 @@ import logging
 import time
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, Literal, Protocol, TypeVar
+from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
 
 from starlette.responses import Response
 
@@ -408,36 +408,32 @@ def get_artifact_store() -> ArtifactStore:
 class UploadRecord:
     """A reservation slot for an in-flight upload (intake direction).
 
-    Unlike :class:`TokenRecord`, an ``UploadRecord`` does **not** carry
-    bytes — bytes arrive over the wire when the agent ``POST``s to
-    ``/<ns>/uploads/{token}``. The record carries only the metadata the
-    receiver needs to commit the bytes to its domain (``target_id``,
-    ``extra``) plus the runtime guards (``max_bytes``, ``expires_at``).
+    An ``UploadRecord`` does not carry bytes — bytes arrive over the wire
+    when a client ``POST``s to ``/<ns>/uploads/{token}``. The record
+    carries the metadata the receiver needs to commit the bytes, modelling
+    the v0.3.0 spec's WHAT/WHERE split, plus the runtime guards.
 
     Attributes:
-        target_id: Opaque identifier for the upload destination, chosen
-            by the tool caller. The receiver decides what it means
-            (path, document id, etc.).
-            Same character rules as ``origin_id`` and ``exchange://``
-            segments — see ``docs/specs/file-exchange.md`` §"Security
-            and Path Resolution" for the precise grammar.
-        max_bytes: Hard size cap for the POST body, enforced at the
-            HTTP route before dispatch.
-        extra: Caller-supplied dict passed verbatim to the receiver.
-            By convention, callers reserve through ``UploadStore.reserve``
-            (Task 4 onward), which snapshots the dict before storing it
-            here, so consumers can rely on the receiver seeing what the
-            tool caller said at link-creation time. Direct construction
-            of ``UploadRecord`` does not snapshot — the field holds the
-            caller's dict by reference.
+        origin_id: The sender's opaque stable handle for the bytes (the
+            *what*). Validated against the spec's segment grammar — see
+            ``docs/specs/file-exchange.md`` §"Security and Path
+            Resolution".
+        destination: The sender's destination instruction (the *where*),
+            or ``None`` if the sender gave none. The receiver validates
+            and interprets it per its own domain rules.
+        content_type: The sender's hint of the ``Content-Type`` the POST
+            will declare, or ``None``.
+        max_bytes: Hard size cap for the POST body, enforced at the HTTP
+            route before dispatch.
         expires_at: Unix timestamp after which the reservation is
             invalid; consumed reservations are removed atomically by
             ``UploadStore.consume``.
     """
 
-    target_id: str
+    origin_id: str
+    destination: str | None
+    content_type: str | None
     max_bytes: int
-    extra: dict[str, Any]
     expires_at: float
 
 
@@ -469,80 +465,45 @@ class UploadStore(_BaseTokenStore[UploadRecord]):
     def reserve(
         self,
         *,
-        target_id: str,
+        origin_id: str,
         max_bytes: int,
         ttl_seconds: float | None = None,
-        extra: dict[str, Any] | None = None,
+        destination: str | None = None,
+        content_type: str | None = None,
     ) -> str:
         """Mint a token reserving a one-shot upload slot.
 
-        ``extra`` is snapshotted (``dict(extra)``) at reservation time so
-        post-construction caller mutations are not visible to the
-        receiver. Pairs with the by-reference semantic documented on
-        :class:`UploadRecord`.
-
-        Validation note: ``max_bytes`` and ``target_id`` are stored verbatim;
-        no validation runs at this layer. Values of ``max_bytes <= 0`` will
-        cause every upload body to be rejected as oversize at the route layer.
-        Higher-level callers (``register_file_exchange_upload``'s
-        ``pre_link_validator``) are expected to validate before reserving.
+        Validation note: ``max_bytes`` / ``origin_id`` / ``destination``
+        are stored verbatim; no validation runs at this layer. Higher-level
+        callers (``register_file_exchange_upload`` and its
+        ``pre_link_validator``) validate before reserving.
         """
         self._purge_expired()
         token = self._mint_token()
         ttl = self._ttl if ttl_seconds is None else float(ttl_seconds)
         self._records[token] = UploadRecord(
-            target_id=target_id,
+            origin_id=origin_id,
+            destination=destination,
+            content_type=content_type,
             max_bytes=int(max_bytes),
-            extra=dict(extra or {}),
             expires_at=time.time() + ttl,
         )
         logger.debug(
-            "upload_reserve token_prefix=%s target_id=%s max_bytes=%d ttl=%.1fs",
+            "upload_reserve token_prefix=%s origin_id=%s max_bytes=%d ttl=%.1fs",
             token[:8],
-            target_id,
+            origin_id,
             max_bytes,
             ttl,
         )
         return token
 
     def consume(self, token: str) -> UploadRecord | None:
-        """Atomic consume; returns the record or ``None`` for missing/expired/consumed.
-
-        Use this when callers do not need to distinguish "expired" from
-        "missing/consumed". For HTTP routes that map the three states to
-        distinct status codes (200 / 410 / 404), see
-        :meth:`consume_or_status`.
+        """Atomic consume; returns the record, or ``None`` for an
+        unusable token — unknown, expired, or already consumed are
+        indistinguishable, per the spec's anti-leak rule for the
+        ``http_upload`` POST route.
         """
         return self._atomic_consume(token)
-
-    def consume_or_status(
-        self, token: str
-    ) -> tuple[UploadRecord | None, Literal["ok", "expired", "missing"]]:
-        """Atomic consume that distinguishes expired from missing/consumed.
-
-        Returns one of:
-            (record, "ok")       — token was valid; record consumed.
-            (None,   "expired")  — token existed but had passed expires_at; removed.
-            (None,   "missing")  — token unknown (never existed, or already consumed).
-
-        Use this in HTTP route handlers that need to map the three
-        states to distinct status codes (200, 410, 404). Plain
-        :meth:`consume` collapses expired and missing into ``None``.
-        """
-        # Pop the requested token BEFORE purging so we can still observe
-        # the "expired" branch — :meth:`_purge_expired` would otherwise
-        # remove the record and we'd report it as "missing", losing the
-        # 410-vs-404 distinction this method exists to provide.
-        record = self._records.pop(token, None)
-        # Sweep the rest of the table after we have our answer; no
-        # functional dependency, just keeping the table tidy on each
-        # access path the way :meth:`_atomic_consume` does.
-        self._purge_expired()
-        if record is None:
-            return None, "missing"
-        if time.time() > record.expires_at:
-            return None, "expired"
-        return record, "ok"
 
     def _peek_for_tests(self, token: str) -> UploadRecord | None:
         """Test-only inspection — do not use in production.

--- a/src/fastmcp_pvl_core/_token_store.py
+++ b/src/fastmcp_pvl_core/_token_store.py
@@ -498,10 +498,11 @@ class UploadStore(_BaseTokenStore[UploadRecord]):
         return token
 
     def consume(self, token: str) -> UploadRecord | None:
-        """Atomic consume; returns the record, or ``None`` for an
-        unusable token — unknown, expired, or already consumed are
-        indistinguishable, per the spec's anti-leak rule for the
-        ``http_upload`` POST route.
+        """Atomic consume; return the record, or ``None`` if unusable.
+
+        Unknown, expired, and already-consumed tokens are
+        indistinguishable (all yield ``None``), per the spec's
+        anti-leak rule for the ``http_upload`` POST route.
         """
         return self._atomic_consume(token)
 

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -70,6 +70,7 @@ from fastmcp_pvl_core._file_exchange_runtime import (
     FileExchange,
     FileExchangeConfigError,
     StreamReceiver,
+    _accepts_match,
     register_upload_route,
 )
 from fastmcp_pvl_core._token_store import (
@@ -940,6 +941,28 @@ def _transfer_failed(
     return out
 
 
+def _upload_transfer_failed(
+    *,
+    receiver_server: str,
+    origin_id: str,
+    message: str,
+) -> dict[str, Any]:
+    """Build an ``http_upload`` in-band ``transfer_failed`` envelope.
+
+    The upload direction identifies the responding server as
+    ``receiver_server`` (not ``origin_server``): no file has been
+    produced, so the server is the receiver of an attempted upload.
+    See spec §"Transfer Methods / http_upload".
+    """
+    return {
+        "error": "transfer_failed",
+        "method": "http_upload",
+        "receiver_server": receiver_server,
+        "origin_id": origin_id,
+        "message": message,
+    }
+
+
 def _transfer_exhausted(
     *,
     origin_server: str,
@@ -1374,7 +1397,7 @@ _DEFAULT_UPLOAD_TTL_MAX_SECONDS = 3600.0
 _DEFAULT_UPLOAD_MAX_BYTES = 10 * 1024 * 1024
 
 PreLinkValidator = Callable[
-    [str, "dict[str, Any] | None"],
+    [str, "str | None"],
     "None | Awaitable[None]",
 ]
 
@@ -1443,67 +1466,55 @@ class UploadHandle:
     def create_link(
         self,
         *,
-        target_id: str,
+        origin_id: str,
         ttl_seconds: float | None = None,
         max_bytes: int | None = None,
-        extra: dict[str, Any] | None = None,
-    ) -> tuple[str, float]:
+        destination: str | None = None,
+        content_type: str | None = None,
+    ) -> tuple[str, float, int]:
         """Mint an upload reservation directly. Escape valve for advanced wraps.
 
         Returns:
-            ``(upload_url, effective_ttl_seconds)``.
+            ``(upload_url, effective_ttl_seconds, effective_max_bytes)``.
 
         Raises:
             RuntimeError: if upload is not enabled (transport is stdio,
-                or ``{PREFIX}_BASE_URL`` was not set, or upload was
-                disabled by env).
+                ``{PREFIX}_BASE_URL`` unset, or upload disabled by env).
         """
         if self.upload_store is None:
             raise RuntimeError(
                 "upload not enabled (transport=stdio, missing BASE_URL, or disabled)"
             )
-        # Floor non-positive ttl_seconds to the default — symmetry with
-        # _register_create_download_link's guard. Avoids minting tokens
-        # that are born expired when callers (LLM tool calls, advanced
-        # wraps) pass 0 or a negative TTL.
         if ttl_seconds is None or ttl_seconds <= 0:
             ttl = float(self.ttl_default)
         else:
             ttl = float(ttl_seconds)
         ttl = min(ttl, self.ttl_max)
-        # Floor non-positive max_bytes to default — symmetry with the TTL floor.
-        # An LLM passing max_bytes=0 to the create_upload_link tool would otherwise
-        # reserve a slot that 413s every POST.
         if max_bytes is None or max_bytes <= 0:
             cap = int(self.max_bytes_default)
         else:
-            cap = int(max_bytes)
+            cap = min(int(max_bytes), int(self.max_bytes_default))
         token = self.upload_store.reserve(
-            target_id=target_id,
+            origin_id=origin_id,
             max_bytes=cap,
             ttl_seconds=ttl,
-            extra=extra,
+            destination=destination,
+            content_type=content_type,
         )
-        return self.upload_store.build_url(token), ttl
+        return self.upload_store.build_url(token), ttl, cap
 
 
 def _disabled_upload_handle(
     *,
     namespace: str,
-    upload_tool_name: str,
     ttl_default: float,
     ttl_max: float,
     max_bytes_default: int,
 ) -> UploadHandle:
-    """Return a no-op UploadHandle for the upload-disabled path.
-
-    Shared shape: ``enabled=False``, ``upload_store=None``, all other
-    fields preserved so the caller can still introspect the configured
-    namespace and tool name.
-    """
+    """Return a no-op UploadHandle for the upload-disabled path."""
     return UploadHandle(
         namespace=namespace,
-        tool_name=upload_tool_name,
+        tool_name=_DEFAULT_UPLOAD_TOOL,
         enabled=False,
         upload_store=None,
         ttl_default=ttl_default,
@@ -1520,13 +1531,7 @@ def register_file_exchange_upload(
     receiver: BufferedReceiver | None = None,
     stream_receiver: StreamReceiver | None = None,
     pre_link_validator: PreLinkValidator | None = None,
-    transport: Literal["http", "stdio", "auto"] = "auto",
-    upload_tool_name: str = _DEFAULT_UPLOAD_TOOL,
-    tool_tags: frozenset[str] = frozenset({"write"}),
     accepts: tuple[str, ...] = ("*/*",),
-    max_bytes_default: int = _DEFAULT_UPLOAD_MAX_BYTES,
-    ttl_default: float = _DEFAULT_UPLOAD_TTL_SECONDS,
-    ttl_max: float = _DEFAULT_UPLOAD_TTL_MAX_SECONDS,
 ) -> UploadHandle:
     """Wire MCP File Exchange upload direction onto ``mcp``.
 
@@ -1534,20 +1539,20 @@ def register_file_exchange_upload(
     one of ``receiver`` / ``stream_receiver`` MUST be supplied. The
     helper:
 
-    1. Resolves transport (``auto`` → reads ``{PREFIX}_TRANSPORT`` /
+    1. Resolves transport from env (``{PREFIX}_TRANSPORT`` /
        ``FASTMCP_TRANSPORT``).
     2. Reads ``{PREFIX}_UPLOAD_ENABLED`` (default ``true``),
        ``{PREFIX}_UPLOAD_MAX_BYTES``, ``{PREFIX}_UPLOAD_TTL``,
-       ``{PREFIX}_UPLOAD_TTL_MAX`` for env overrides.
+       ``{PREFIX}_UPLOAD_TTL_MAX`` for operator-side configuration.
     3. Builds an :class:`UploadStore`, mounts ``POST /<namespace>/uploads/{token}``
        via :func:`register_upload_route`, installs the module-level
        singleton.
-    4. Registers an MCP tool named ``upload_tool_name`` (default
-       ``create_upload_link``) with tags ``tool_tags`` (default
-       ``{"write"}``). The tool wraps :meth:`UploadHandle.create_link`
+    4. Registers an MCP tool named ``create_upload_link`` with tags
+       ``{"write"}``. The tool wraps :meth:`UploadHandle.create_link`
        and runs ``pre_link_validator`` (if provided) before token
-       creation so an invalid ``target_id`` surfaces as a clean tool
-       error in-band rather than after a wasted upload round-trip.
+       creation so an invalid ``origin_id`` or ``destination`` surfaces
+       as a clean in-band rejection rather than after a wasted upload
+       round-trip.
 
     When transport is stdio OR ``{PREFIX}_BASE_URL`` is unset, the
     helper returns an :class:`UploadHandle` with ``enabled=False`` and
@@ -1568,43 +1573,26 @@ def register_file_exchange_upload(
         receiver: Buffered receiver; mutually exclusive with
             ``stream_receiver``.
         stream_receiver: Streaming receiver; receives chunks live.
-        pre_link_validator: Optional callback ``(target_id, extra) -> None``
-            (sync OR async) run inside the registered tool AFTER baseline
-            ``target_id`` character validation but BEFORE token creation.
-            Raising ``ValueError`` surfaces as an in-band tool error with
-            the exception message visible to the caller. Any other
-            exception type also propagates (FastMCP wraps tool errors
-            uniformly) but is additionally logged at ERROR with a
+        pre_link_validator: Optional callback
+            ``(origin_id, destination) -> None`` (sync OR async) run
+            inside the registered tool AFTER baseline ``origin_id``
+            character validation but BEFORE token creation. Raising
+            ``ValueError`` surfaces as an in-band ``transfer_failed``
+            envelope to the caller. Any other exception type also
+            propagates but is additionally logged at ERROR with a
             "non-ValueError" marker so operators can distinguish
             server-side validator bugs from caller-input errors.
             ``ValueError`` is the conventional choice for caller-facing
             diagnostics. Sync validators run in an asyncio threadpool
             (``asyncio.to_thread``) so blocking work (DB lookups,
             filesystem checks) does not stall the event loop; async
-            validators run on the loop. The call site uses
-            :func:`inspect.iscoroutinefunction` to dispatch and falls
-            back to :func:`inspect.isawaitable` for the unusual
-            sync-function-returning-an-awaitable shape, so ``async def``
-            callbacks are not silently no-op'd.
-        transport: ``"auto"`` (default), ``"http"``, or ``"stdio"``.
-        upload_tool_name: Tool name override. Default
-            ``"create_upload_link"``. Override this when registering
-            more than one upload direction on the same FastMCP
-            instance (FastMCP rejects duplicate tool names).
-        tool_tags: Tags applied to the registered tool. Default
-            ``frozenset({"write"})`` — change for downstream authz
-            mappings that need a finer grain.
+            validators run on the loop.
         accepts: ``Content-Type`` filter at the route layer. Default
             ``("*/*",)`` disables the gate. See
-            :func:`register_upload_route` for semantics.
-        max_bytes_default: Default body cap if caller omits
-            ``max_bytes``. Operator-overridable via
-            ``{PREFIX}_UPLOAD_MAX_BYTES``.
-        ttl_default: Default TTL if caller omits ``ttl_seconds``.
-            Operator-overridable via ``{PREFIX}_UPLOAD_TTL``.
-        ttl_max: Operator ceiling. Requested TTL is clamped; the
-            effective value is returned to the caller.
-            Operator-overridable via ``{PREFIX}_UPLOAD_TTL_MAX``.
+            :func:`register_upload_route` for semantics. Also used as a
+            pre-filter in ``create_upload_link``: a ``content_type`` hint
+            that does not match ``accepts`` returns a ``transfer_failed``
+            envelope in-band before any token is minted.
 
     Returns:
         An :class:`UploadHandle`. Stash if you need ``create_link`` for
@@ -1620,6 +1608,10 @@ def register_file_exchange_upload(
             "register_file_exchange_upload requires exactly one of "
             "receiver= or stream_receiver="
         )
+
+    max_bytes_default = _DEFAULT_UPLOAD_MAX_BYTES
+    ttl_default = _DEFAULT_UPLOAD_TTL_SECONDS
+    ttl_max = _DEFAULT_UPLOAD_TTL_MAX_SECONDS
 
     # Env-driven knob overrides — validate first so a malformed value
     # fails fast with an operator-readable error before any state is
@@ -1667,7 +1659,7 @@ def register_file_exchange_upload(
                 f"{env_prefix}_UPLOAD_TTL_MAX must be positive; got {ttl_max}"
             )
 
-    resolved_transport = _resolve_transport(env_prefix, transport)
+    resolved_transport = _resolve_transport(env_prefix)
     upload_enabled_env = parse_bool(env(env_prefix, "UPLOAD_ENABLED", "true"))
     enabled = resolved_transport != "stdio" and upload_enabled_env
     if not enabled:
@@ -1685,7 +1677,6 @@ def register_file_exchange_upload(
             )
         return _disabled_upload_handle(
             namespace=namespace,
-            upload_tool_name=upload_tool_name,
             ttl_default=ttl_default,
             ttl_max=ttl_max,
             max_bytes_default=max_bytes_default,
@@ -1700,7 +1691,6 @@ def register_file_exchange_upload(
         )
         return _disabled_upload_handle(
             namespace=namespace,
-            upload_tool_name=upload_tool_name,
             ttl_default=ttl_default,
             ttl_max=ttl_max,
             max_bytes_default=max_bytes_default,
@@ -1727,7 +1717,7 @@ def register_file_exchange_upload(
 
     handle = UploadHandle(
         namespace=namespace,
-        tool_name=upload_tool_name,
+        tool_name=_DEFAULT_UPLOAD_TOOL,
         enabled=True,
         upload_store=store,
         ttl_default=ttl_default,
@@ -1739,105 +1729,122 @@ def register_file_exchange_upload(
     # paired ``register_file_exchange`` (download direction) advertises
     # both halves under one ``http`` block instead of clobbering.
     # ``accepts`` is passed verbatim — including the default
-    # ``("*/*",)`` wildcard. Per Amendment 11 an absent ``accepts`` key
-    # means the route inherits the server-wide ``consumes`` list; if a
-    # server has a non-empty ``consumes`` AND a wildcard route, omitting
-    # ``accepts`` would mislead clients into thinking only ``consumes``
-    # types are accepted. Advertising ``["*/*"]`` explicitly keeps the
-    # wire signal aligned with the route's actual permissiveness.
+    # ``("*/*",)`` wildcard. Per spec §"Transfer Methods / http_upload",
+    # an absent ``accepts`` key means the route inherits the server-wide
+    # ``consumes`` list; if a server has a non-empty ``consumes`` AND a
+    # wildcard route, omitting ``accepts`` would mislead clients into
+    # thinking only ``consumes`` types are accepted. Advertising
+    # ``["*/*"]`` explicitly keeps the wire signal aligned with the
+    # route's actual permissiveness.
     builder = _get_or_create_builder(mcp, namespace=namespace)
     builder.set_http_upload_sink(
-        tool_name=upload_tool_name,
+        tool_name=_DEFAULT_UPLOAD_TOOL,
         max_bytes=int(max_bytes_default),
         max_ttl_seconds=int(ttl_max),
         accepts=accepts,
     )
     _emit_capability(mcp)
 
-    @mcp.tool(name=upload_tool_name, tags=set(tool_tags))
+    @mcp.tool(name=_DEFAULT_UPLOAD_TOOL, tags={"write"})
     async def create_upload_link(
-        target_id: str,
-        ttl_seconds: int = int(ttl_default),
+        origin_id: str,
+        destination: str | None = None,
+        content_type: str | None = None,
+        ttl_seconds: int | None = None,
         max_bytes: int | None = None,
-        extra: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         r"""Mint a one-time HTTPS POST URL for an inbound upload.
 
         Args:
-            target_id: Opaque destination identifier the receiver
-                interprets (e.g. a filename or document id). Validated
-                against the spec's segment rules (Amendment 11): no
-                ``/``, ``\``, ``.``, ``..``, control bytes, leading or
-                trailing whitespace. Receivers that interpret
-                ``target_id`` as a path must construct the full path
-                themselves from the bare filename.
-            ttl_seconds: Requested lifetime in integer seconds. Clamped
-                to the server's ``ttl_max`` ceiling; values <= 0 fall
-                back to the configured default. Sub-second TTLs are not
-                supported through this tool — use
-                :meth:`UploadHandle.create_link` for the
-                fractional-second escape valve.
-            max_bytes: Body cap. Defaults to the server's configured
-                ``max_bytes_default``.
-            extra: Caller-supplied dict passed verbatim to the
-                receiver. Snapshotted at link creation.
+            origin_id: The sender's opaque stable handle for the bytes
+                (the *what*). Validated against the spec's segment rules
+                (§"Security and Path Resolution"): no ``/``, ``\``, ``.``,
+                ``..``, control bytes, leading/trailing whitespace.
+            destination: Optional destination instruction (the *where*).
+                Only null bytes, control characters, and leading/trailing
+                whitespace are rejected at the spec level; the receiver
+                validates the rest per its own domain rules via
+                ``pre_link_validator``.
+            content_type: Optional hint of the ``Content-Type`` the POST
+                will declare; pre-filtered against the receiver's
+                ``accepts`` list.
+            ttl_seconds: Optional requested lifetime in seconds; clamped
+                to the server's TTL ceiling.
+            max_bytes: Optional requested body cap; clamped to the
+                server's ``max_bytes`` ceiling.
 
         Returns:
-            ``{upload_url, expires_in_seconds, target_id}``.
+            On success, ``{url, ttl_seconds, max_bytes}`` — the effective
+            (post-clamp) values. On in-band rejection, a ``transfer_failed``
+            envelope.
         """
-        # Spec rules (Amendment 11): no /, \, ., .., control bytes,
-        # leading/trailing whitespace. Mirrors the download direction's
-        # origin_id validation. The optional pre_link_validator may
-        # then refine with domain-specific checks.
-        ExchangeURI.validate_segment(target_id, role="json_param")
+        # origin_id: strict spec segment grammar (the WHAT identifier).
+        ExchangeURI.validate_segment(origin_id, role="json_param")
+        # destination: relaxed validation (the WHERE) — reject only null
+        # bytes, control chars, and leading/trailing whitespace; the
+        # receiver validates the rest.
+        if destination is not None:
+            if destination != destination.strip():
+                return _upload_transfer_failed(
+                    receiver_server=namespace,
+                    origin_id=origin_id,
+                    message="destination must not have leading or trailing whitespace",
+                )
+            if any(ord(c) < 0x20 for c in destination):
+                return _upload_transfer_failed(
+                    receiver_server=namespace,
+                    origin_id=origin_id,
+                    message="destination must not contain control characters",
+                )
+        # content_type hint: pre-filter against the receiver's accepts
+        # list so a mismatched hint is rejected in-band, before a wasted
+        # POST round-trip (the route still enforces 415 on the actual
+        # POST Content-Type header). _accepts_match is imported from
+        # _file_exchange_runtime — add it to that module's imports in
+        # file_exchange.py.
+        if content_type is not None and not _accepts_match(content_type, accepts):
+            return _upload_transfer_failed(
+                receiver_server=namespace,
+                origin_id=origin_id,
+                message=f"content_type {content_type!r} is not accepted by this receiver",
+            )
         if pre_link_validator is not None:
             try:
-                # Mirror the buffered receiver pattern: accept both sync
-                # and async validators, and dispatch sync ones via
-                # ``asyncio.to_thread`` so blocking work (DB lookups,
-                # filesystem checks) does not stall the event loop.
-                # Without ``inspect.iscoroutinefunction`` / ``isawaitable``
-                # an ``async def`` validator would silently no-op (the
-                # coroutine would never be awaited).
                 if inspect.iscoroutinefunction(pre_link_validator):
-                    await pre_link_validator(target_id, extra)
+                    await pre_link_validator(origin_id, destination)
                 else:
                     validator_result = await asyncio.to_thread(
-                        pre_link_validator,
-                        target_id,
-                        extra,
+                        pre_link_validator, origin_id, destination
                     )
                     if inspect.isawaitable(validator_result):
-                        # Sync function that returned an awaitable
-                        # (uncommon but legal). Await on the loop.
                         await validator_result
-            except ValueError:
-                # Caller-facing validation rejection — surface to the
-                # LLM with the exception's message intact.
-                raise
+            except ValueError as exc:
+                # Caller-facing rejection — return the spec transfer_failed
+                # envelope rather than letting it surface as a tool error.
+                return _upload_transfer_failed(
+                    receiver_server=namespace,
+                    origin_id=origin_id,
+                    message=str(exc),
+                )
             except Exception:
-                # Anything else is a bug in the validator (NameError,
-                # typo, AttributeError on extra-dict access, etc.). Log
-                # with full traceback so operators can diagnose; re-raise
-                # so FastMCP surfaces it rather than treating it as
-                # caller-fixable.
                 logger.exception(
                     "pre_link_validator raised non-ValueError "
-                    "(target_id=%r) — this is a server-side bug, not a "
-                    "client validation failure",
-                    target_id,
+                    "(origin_id=%r) — server-side bug, not a client "
+                    "validation failure",
+                    origin_id,
                 )
                 raise
-        url, eff = handle.create_link(
-            target_id=target_id,
+        url, eff_ttl, eff_max_bytes = handle.create_link(
+            origin_id=origin_id,
             ttl_seconds=ttl_seconds,
             max_bytes=max_bytes,
-            extra=extra,
+            destination=destination,
+            content_type=content_type,
         )
         return {
-            "upload_url": url,
-            "expires_in_seconds": int(eff),
-            "target_id": target_id,
+            "url": url,
+            "ttl_seconds": int(eff_ttl),
+            "max_bytes": int(eff_max_bytes),
         }
 
     return handle

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -1409,18 +1409,24 @@ class UploadHandle:
     Attributes:
         namespace: The server's logical name (also the URL prefix for
             the upload route).
-        tool_name: The name under which ``create_upload_link`` was
-            registered (overridable; default ``"create_upload_link"``).
+        tool_name: The name under which the upload tool was registered.
+            Always ``"create_upload_link"`` — pvl-core owns this shape.
         enabled: ``True`` iff upload is wired (transport != stdio AND
             ``{PREFIX}_BASE_URL`` is set AND opt-in env not disabled).
         upload_store: The :class:`UploadStore` instance, or ``None``
             when upload is disabled.
         ttl_default: Default TTL applied when ``ttl_seconds`` is omitted
-            on ``create_upload_link``.
+            on ``create_upload_link``. Resolved from
+            ``{PREFIX}_UPLOAD_TTL`` env var or the module default; not
+            a constructor kwarg.
         ttl_max: Operator ceiling — requested TTL is clamped to this
             value, with the effective TTL returned to the caller.
+            Resolved from ``{PREFIX}_TTL_MAX`` env var or the module
+            default; not a constructor kwarg.
         max_bytes_default: Default ``max_bytes`` applied when caller
-            omits the field.
+            omits the field. Resolved from
+            ``{PREFIX}_UPLOAD_MAX_BYTES`` env var or the module
+            default; not a constructor kwarg.
     """
 
     namespace: str
@@ -1779,7 +1785,14 @@ def register_file_exchange_upload(
             envelope.
         """
         # origin_id: strict spec segment grammar (the WHAT identifier).
-        ExchangeURI.validate_segment(origin_id, role="json_param")
+        try:
+            ExchangeURI.validate_segment(origin_id, role="json_param")
+        except ExchangeURIError as exc:
+            return _upload_transfer_failed(
+                receiver_server=namespace,
+                origin_id=origin_id,
+                message=str(exc),
+            )
         # destination: relaxed validation (the WHERE) — reject only null
         # bytes, control chars, and leading/trailing whitespace; the
         # receiver validates the rest.
@@ -1799,9 +1812,7 @@ def register_file_exchange_upload(
         # content_type hint: pre-filter against the receiver's accepts
         # list so a mismatched hint is rejected in-band, before a wasted
         # POST round-trip (the route still enforces 415 on the actual
-        # POST Content-Type header). _accepts_match is imported from
-        # _file_exchange_runtime — add it to that module's imports in
-        # file_exchange.py.
+        # POST Content-Type header).
         if content_type is not None and not _accepts_match(content_type, accepts):
             return _upload_transfer_failed(
                 receiver_server=namespace,

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -795,11 +795,11 @@ def _resolve_transport(
 ) -> Literal["http", "stdio"]:
     """Resolve transport from ``{PREFIX}_TRANSPORT`` / ``FASTMCP_TRANSPORT``.
 
-    Defaults to ``"stdio"`` when neither env var is set. ``override`` is
-    retained for :func:`register_file_exchange_upload` which still
-    accepts a ``transport=`` kwarg (its removal is tracked separately
-    under issue #74). :func:`register_file_exchange` no longer passes an
-    override — env-var resolution is the sole path.
+    Defaults to ``"stdio"`` when neither env var is set. ``override``
+    allows callers to force a specific transport; both
+    :func:`register_file_exchange` and :func:`register_file_exchange_upload`
+    currently rely on the ``"auto"`` default so resolution goes through
+    the env-var path.
     """
     if override != "auto":
         return override
@@ -1806,7 +1806,7 @@ def register_file_exchange_upload(
             return _upload_transfer_failed(
                 receiver_server=namespace,
                 origin_id=origin_id,
-                message=f"content_type {content_type!r} is not accepted by this receiver",
+                message=f"content_type {content_type!r} is not accepted",
             )
         if pre_link_validator is not None:
             try:

--- a/tests/test_file_exchange_upload_facade.py
+++ b/tests/test_file_exchange_upload_facade.py
@@ -407,8 +407,9 @@ async def test_create_upload_link_rejects_path_traversal_origin_id(
     The spec requires ``origin_id`` to follow the same character rules as
     ``exchange://`` segments. The ``create_upload_link`` tool calls
     ``ExchangeURI.validate_segment(..., role="json_param")`` BEFORE running
-    ``pre_link_validator``, so a traversal attempt is rejected even when
-    no validator is configured.
+    ``pre_link_validator``, so a traversal attempt is rejected in-band even
+    when no validator is configured — consistent with all other in-band
+    rejections in this tool.
     """
     monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
     monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
@@ -422,10 +423,15 @@ async def test_create_upload_link_rejects_path_traversal_origin_id(
     )
     tool = await mcp.get_tool("create_upload_link")
     assert tool is not None
-    # ExchangeURIError is a ValueError subclass; FastMCP surfaces it
-    # in-band as a tool error.
-    with pytest.raises(Exception, match="forbidden|traversal|segment"):
-        await tool.run({"origin_id": "../etc/passwd"})
+    # ExchangeURIError is wrapped and returned as a transfer_failed
+    # envelope — consistent with destination/content_type/pre_link_validator
+    # rejections — rather than surfacing as a raw tool error.
+    result = await tool.run({"origin_id": "../etc/passwd"})
+    payload = result.structured_content or {}
+    assert payload["error"] == "transfer_failed"
+    assert payload["method"] == "http_upload"
+    assert payload["receiver_server"] == "ns"
+    assert payload["origin_id"] == "../etc/passwd"
 
 
 def test_malformed_upload_max_bytes_raises_configuration_error(

--- a/tests/test_file_exchange_upload_facade.py
+++ b/tests/test_file_exchange_upload_facade.py
@@ -434,6 +434,64 @@ async def test_create_upload_link_rejects_path_traversal_origin_id(
     assert payload["origin_id"] == "../etc/passwd"
 
 
+@pytest.mark.asyncio
+async def test_create_upload_link_rejects_destination_with_leading_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Built-in destination guard rejects leading/trailing whitespace.
+
+    This validation runs BEFORE any pre_link_validator, so no validator
+    is registered here — the tool's own guard is under test.
+    """
+    monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
+    monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
+
+    mcp = FastMCP(name="test")
+    register_file_exchange_upload(
+        mcp,
+        namespace="ns",
+        env_prefix="TEST_UPLOAD",
+        receiver=lambda rec, body: {"ok": True},
+    )
+    tool = await mcp.get_tool("create_upload_link")
+    assert tool is not None
+    result = await tool.run({"origin_id": "x", "destination": " foo"})
+    payload = result.structured_content or {}
+    assert payload["error"] == "transfer_failed"
+    assert payload["method"] == "http_upload"
+    assert payload["receiver_server"] == "ns"
+    assert payload["origin_id"] == "x"
+
+
+@pytest.mark.asyncio
+async def test_create_upload_link_rejects_destination_with_control_char(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Built-in destination guard rejects control characters (ord < 0x20).
+
+    This validation runs BEFORE any pre_link_validator, so no validator
+    is registered here — the tool's own guard is under test.
+    """
+    monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
+    monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
+
+    mcp = FastMCP(name="test")
+    register_file_exchange_upload(
+        mcp,
+        namespace="ns",
+        env_prefix="TEST_UPLOAD",
+        receiver=lambda rec, body: {"ok": True},
+    )
+    tool = await mcp.get_tool("create_upload_link")
+    assert tool is not None
+    result = await tool.run({"origin_id": "x", "destination": "foo\x01bar"})
+    payload = result.structured_content or {}
+    assert payload["error"] == "transfer_failed"
+    assert payload["method"] == "http_upload"
+    assert payload["receiver_server"] == "ns"
+    assert payload["origin_id"] == "x"
+
+
 def test_malformed_upload_max_bytes_raises_configuration_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_file_exchange_upload_facade.py
+++ b/tests/test_file_exchange_upload_facade.py
@@ -19,7 +19,7 @@ async def test_registration_adds_create_upload_link_tool(
     monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
 
     def recv(record: UploadRecord, body: bytes) -> dict[str, Any]:
-        return {"target_id": record.target_id}
+        return {"origin_id": record.origin_id}
 
     mcp = FastMCP(name="test")
     handle = register_file_exchange_upload(
@@ -37,14 +37,14 @@ async def test_registration_adds_create_upload_link_tool(
 
 
 @pytest.mark.asyncio
-async def test_create_upload_link_returns_url_and_ttl(
+async def test_create_upload_link_success_returns_url_ttl_maxbytes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
     monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
 
     mcp = FastMCP(name="test")
-    register_file_exchange_upload(
+    handle = register_file_exchange_upload(
         mcp,
         namespace="ns",
         env_prefix="TEST_UPLOAD",
@@ -52,11 +52,12 @@ async def test_create_upload_link_returns_url_and_ttl(
     )
     tool = await mcp.get_tool("create_upload_link")
     assert tool is not None
-    result = await tool.run({"target_id": "foo.md"})
+    result = await tool.run({"origin_id": "x"})
     payload = result.structured_content or {}
-    assert payload["target_id"] == "foo.md"
-    assert payload["upload_url"].startswith("http://srv.test/ns/uploads/")
-    assert payload["expires_in_seconds"] > 0
+    assert set(payload) == {"url", "ttl_seconds", "max_bytes"}
+    assert payload["url"].startswith("http://srv.test/ns/uploads/")
+    assert payload["ttl_seconds"] > 0
+    assert payload["max_bytes"] == handle.max_bytes_default
 
 
 @pytest.mark.asyncio
@@ -94,18 +95,15 @@ async def test_missing_base_url_returns_disabled_handle(
 
 
 @pytest.mark.asyncio
-async def test_pre_link_validator_blocks_invalid_target(
+async def test_create_upload_link_rejection_returns_transfer_failed_envelope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """pre_link_validator raising ValueError returns a transfer_failed envelope."""
     monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
     monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
 
-    def reject(target_id: str, extra: dict[str, Any] | None) -> None:
-        # ``target_id`` shape passes the baseline segment rules
-        # (Amendment 11); the validator rejects on a domain-specific
-        # rule (allow-list of extensions).
-        if not target_id.endswith(".md"):
-            raise ValueError(f"only .md uploads accepted: {target_id}")
+    def reject(origin_id: str, destination: str | None) -> None:
+        raise ValueError("bad destination")
 
     mcp = FastMCP(name="test")
     register_file_exchange_upload(
@@ -117,8 +115,98 @@ async def test_pre_link_validator_blocks_invalid_target(
     )
     tool = await mcp.get_tool("create_upload_link")
     assert tool is not None
-    with pytest.raises(Exception, match="only .md uploads accepted"):
-        await tool.run({"target_id": "passwd.txt"})
+    result = await tool.run({"origin_id": "x", "destination": "../etc"})
+    payload = result.structured_content or {}
+    assert payload == {
+        "error": "transfer_failed",
+        "method": "http_upload",
+        "receiver_server": "ns",
+        "origin_id": "x",
+        "message": "bad destination",
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_upload_link_content_type_mismatch_returns_transfer_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Content-type hint mismatching accepts list returns a transfer_failed envelope."""
+    monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
+    monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
+
+    mcp = FastMCP(name="test")
+    register_file_exchange_upload(
+        mcp,
+        namespace="ns",
+        env_prefix="TEST_UPLOAD",
+        receiver=lambda rec, body: {"ok": True},
+        accepts=("text/markdown",),
+    )
+    tool = await mcp.get_tool("create_upload_link")
+    assert tool is not None
+    result = await tool.run({"origin_id": "x", "content_type": "image/png"})
+    payload = result.structured_content or {}
+    assert payload["error"] == "transfer_failed"
+    assert payload["method"] == "http_upload"
+    assert payload["receiver_server"] == "ns"
+    assert payload["origin_id"] == "x"
+
+
+@pytest.mark.asyncio
+async def test_create_upload_link_clamps_ttl_and_max_bytes_to_ceilings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ttl_seconds and max_bytes in the response are clamped to operator ceilings."""
+    monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
+    monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
+    monkeypatch.setenv("TEST_UPLOAD_UPLOAD_TTL_MAX", "600")
+    monkeypatch.setenv("TEST_UPLOAD_UPLOAD_MAX_BYTES", "1000000")
+
+    mcp = FastMCP(name="test")
+    register_file_exchange_upload(
+        mcp,
+        namespace="ns",
+        env_prefix="TEST_UPLOAD",
+        receiver=lambda rec, body: {"ok": True},
+    )
+    tool = await mcp.get_tool("create_upload_link")
+    assert tool is not None
+    result = await tool.run(
+        {"origin_id": "x", "ttl_seconds": 99999, "max_bytes": 99999999}
+    )
+    payload = result.structured_content or {}
+    assert payload["ttl_seconds"] == 600
+    assert payload["max_bytes"] == 1_000_000
+
+
+@pytest.mark.asyncio
+async def test_pre_link_validator_blocks_invalid_origin_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
+    monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
+
+    def reject(origin_id: str, destination: str | None) -> None:
+        # ``origin_id`` shape passes the baseline segment rules;
+        # the validator rejects on a domain-specific rule.
+        if not origin_id.endswith(".md"):
+            raise ValueError(f"only .md uploads accepted: {origin_id}")
+
+    mcp = FastMCP(name="test")
+    register_file_exchange_upload(
+        mcp,
+        namespace="ns",
+        env_prefix="TEST_UPLOAD",
+        receiver=lambda rec, body: {"ok": True},
+        pre_link_validator=reject,
+    )
+    tool = await mcp.get_tool("create_upload_link")
+    assert tool is not None
+    # ValueError from pre_link_validator surfaces as transfer_failed envelope.
+    result = await tool.run({"origin_id": "passwd.txt"})
+    payload = result.structured_content or {}
+    assert payload["error"] == "transfer_failed"
+    assert "only .md uploads accepted" in payload["message"]
 
 
 @pytest.mark.asyncio
@@ -138,7 +226,7 @@ async def test_pre_link_validator_other_exception_logs_as_bug(
     monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
     monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
 
-    def buggy(target_id: str, extra: dict[str, Any] | None) -> None:
+    def buggy(origin_id: str, destination: str | None) -> None:
         raise RuntimeError("kaboom")
 
     mcp = FastMCP(name="test")
@@ -153,34 +241,8 @@ async def test_pre_link_validator_other_exception_logs_as_bug(
     assert tool is not None
     with caplog.at_level(logging.ERROR):
         with pytest.raises(Exception, match="kaboom"):
-            await tool.run({"target_id": "x.md"})
+            await tool.run({"origin_id": "x.md"})
     assert any("non-ValueError" in r.getMessage() for r in caplog.records)
-
-
-@pytest.mark.asyncio
-async def test_pre_link_validator_passes_extra_through(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
-    monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
-    seen: dict[str, Any] = {}
-
-    def vlog(target_id: str, extra: dict[str, Any] | None) -> None:
-        seen["target_id"] = target_id
-        seen["extra"] = extra
-
-    mcp = FastMCP(name="test")
-    register_file_exchange_upload(
-        mcp,
-        namespace="ns",
-        env_prefix="TEST_UPLOAD",
-        receiver=lambda rec, body: {"ok": True},
-        pre_link_validator=vlog,
-    )
-    tool = await mcp.get_tool("create_upload_link")
-    assert tool is not None
-    await tool.run({"target_id": "x.md", "extra": {"k": 1}})
-    assert seen == {"target_id": "x.md", "extra": {"k": 1}}
 
 
 @pytest.mark.asyncio
@@ -197,8 +259,8 @@ async def test_pre_link_validator_async_is_awaited(
     monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
     seen: dict[str, Any] = {}
 
-    async def vlog(target_id: str, extra: dict[str, Any] | None) -> None:
-        seen["target_id"] = target_id
+    async def vlog(origin_id: str, destination: str | None) -> None:
+        seen["origin_id"] = origin_id
         seen["called"] = True
 
     mcp = FastMCP(name="test")
@@ -211,29 +273,8 @@ async def test_pre_link_validator_async_is_awaited(
     )
     tool = await mcp.get_tool("create_upload_link")
     assert tool is not None
-    await tool.run({"target_id": "x.md"})
-    assert seen == {"target_id": "x.md", "called": True}
-
-
-@pytest.mark.asyncio
-async def test_ttl_clamped_to_ttl_max(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
-    monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
-
-    mcp = FastMCP(name="test")
-    register_file_exchange_upload(
-        mcp,
-        namespace="ns",
-        env_prefix="TEST_UPLOAD",
-        receiver=lambda rec, body: {"ok": True},
-        ttl_default=300.0,
-        ttl_max=600.0,
-    )
-    tool = await mcp.get_tool("create_upload_link")
-    assert tool is not None
-    result = await tool.run({"target_id": "x", "ttl_seconds": 99999})
-    payload = result.structured_content or {}
-    assert payload["expires_in_seconds"] == 600  # clamped
+    await tool.run({"origin_id": "x.md"})
+    assert seen == {"origin_id": "x.md", "called": True}
 
 
 @pytest.mark.asyncio
@@ -332,7 +373,7 @@ def test_create_link_raises_when_upload_disabled() -> None:
         max_bytes_default=10 * 1024 * 1024,
     )
     with pytest.raises(RuntimeError, match="upload not enabled"):
-        handle.create_link(target_id="x")
+        handle.create_link(origin_id="x")
 
 
 def test_create_link_floors_non_positive_ttl_to_default(
@@ -347,28 +388,27 @@ def test_create_link_floors_non_positive_ttl_to_default(
         namespace="ns",
         env_prefix="TEST_UPLOAD_FLOOR",
         receiver=lambda rec, body: {"ok": True},
-        ttl_default=222.0,
-        ttl_max=3600.0,
     )
-    _, eff_zero = handle.create_link(target_id="x", ttl_seconds=0)
-    assert eff_zero == 222.0
-    _, eff_neg = handle.create_link(target_id="y", ttl_seconds=-5)
-    assert eff_neg == 222.0
-    _, eff_none = handle.create_link(target_id="z", ttl_seconds=None)
-    assert eff_none == 222.0
+    # Set ttl_default via env for test isolation.
+    _, eff_zero, _ = handle.create_link(origin_id="x", ttl_seconds=0)
+    assert eff_zero == handle.ttl_default
+    _, eff_neg, _ = handle.create_link(origin_id="y", ttl_seconds=-5)
+    assert eff_neg == handle.ttl_default
+    _, eff_none, _ = handle.create_link(origin_id="z", ttl_seconds=None)
+    assert eff_none == handle.ttl_default
 
 
 @pytest.mark.asyncio
-async def test_create_upload_link_rejects_path_traversal_target_id(
+async def test_create_upload_link_rejects_path_traversal_origin_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Baseline ExchangeURI.validate_segment fires before pre_link_validator.
 
-    Spec Amendment 11 requires `target_id` to follow the same character
-    rules as `origin_id` and `exchange://` segments. The
-    ``create_upload_link`` tool calls ``ExchangeURI.validate_segment(...,
-    role="json_param")`` BEFORE running ``pre_link_validator``, so a
-    traversal attempt is rejected even when no validator is configured.
+    The spec requires ``origin_id`` to follow the same character rules as
+    ``exchange://`` segments. The ``create_upload_link`` tool calls
+    ``ExchangeURI.validate_segment(..., role="json_param")`` BEFORE running
+    ``pre_link_validator``, so a traversal attempt is rejected even when
+    no validator is configured.
     """
     monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
     monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
@@ -385,7 +425,7 @@ async def test_create_upload_link_rejects_path_traversal_target_id(
     # ExchangeURIError is a ValueError subclass; FastMCP surfaces it
     # in-band as a tool error.
     with pytest.raises(Exception, match="forbidden|traversal|segment"):
-        await tool.run({"target_id": "../etc/passwd"})
+        await tool.run({"origin_id": "../etc/passwd"})
 
 
 def test_malformed_upload_max_bytes_raises_configuration_error(
@@ -531,7 +571,7 @@ async def test_sync_pre_link_validator_runs_in_threadpool(
 
     captured: dict[str, Any] = {}
 
-    def sync_vld(target_id: str, extra: dict[str, Any] | None) -> None:
+    def sync_vld(origin_id: str, destination: str | None) -> None:
         captured["thread"] = threading.current_thread().name
         captured["is_main"] = threading.current_thread() is threading.main_thread()
 
@@ -545,5 +585,5 @@ async def test_sync_pre_link_validator_runs_in_threadpool(
     )
     tool = await mcp.get_tool("create_upload_link")
     assert tool is not None
-    await tool.run({"target_id": "x.md"})
+    await tool.run({"origin_id": "x.md"})
     assert captured["is_main"] is False

--- a/tests/test_file_exchange_upload_route.py
+++ b/tests/test_file_exchange_upload_route.py
@@ -182,8 +182,9 @@ async def test_upload_route_unknown_and_consumed_and_expired_all_404() -> None:
     assert r_consumed.status_code == 404
     assert r_expired.status_code == 404
 
-    # Bodies are byte-identical.
+    # Bodies are byte-identical and empty (spec §http_upload anti-leak rule).
     assert r_unknown.content == r_consumed.content == r_expired.content
+    assert r_unknown.content == b""
 
 
 @pytest.mark.asyncio

--- a/tests/test_file_exchange_upload_route.py
+++ b/tests/test_file_exchange_upload_route.py
@@ -34,12 +34,12 @@ async def test_post_happy_path_returns_receiver_dict() -> None:
     captured: dict[str, Any] = {}
 
     def recv(record: UploadRecord, body: bytes) -> dict[str, Any]:
-        captured["target_id"] = record.target_id
+        captured["origin_id"] = record.origin_id
         captured["body"] = body
-        return {"path": record.target_id, "size_bytes": len(body)}
+        return {"path": record.origin_id, "size_bytes": len(body)}
 
     mcp, store = _build_app(recv)
-    token = store.reserve(target_id="hello.txt", max_bytes=1024)
+    token = store.reserve(origin_id="hello.txt", max_bytes=1024)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
@@ -53,7 +53,7 @@ async def test_post_happy_path_returns_receiver_dict() -> None:
 
     assert resp.status_code == 200
     assert resp.json() == {"path": "hello.txt", "size_bytes": 11}
-    assert captured["target_id"] == "hello.txt"
+    assert captured["origin_id"] == "hello.txt"
     assert captured["body"] == b"hello world"
 
 
@@ -96,7 +96,7 @@ async def test_post_unknown_token_returns_404() -> None:
 @pytest.mark.asyncio
 async def test_post_already_consumed_token_returns_404() -> None:
     mcp, store = _build_app(lambda rec, body: {"ok": True})
-    token = store.reserve(target_id="x", max_bytes=10)
+    token = store.reserve(origin_id="x", max_bytes=10)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
         base_url="http://test",
@@ -108,9 +108,14 @@ async def test_post_already_consumed_token_returns_404() -> None:
 
 
 @pytest.mark.asyncio
-async def test_post_expired_token_returns_410() -> None:
+async def test_upload_route_expired_token_returns_404_not_410() -> None:
+    """Expired tokens return 404, not 410 (spec §http_upload anti-leak rule).
+
+    The v0.3.0 spec mandates that unknown, expired, and already-consumed
+    tokens are all indistinguishable to the caller — all return 404.
+    """
     mcp, store = _build_app(lambda rec, body: {})
-    token = store.reserve(target_id="x", max_bytes=10, ttl_seconds=-1)
+    token = store.reserve(origin_id="x", max_bytes=10, ttl_seconds=-1)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
         base_url="http://test",
@@ -120,13 +125,71 @@ async def test_post_expired_token_returns_410() -> None:
             content=b"x",
             headers={"Content-Type": "application/octet-stream"},
         )
-    assert resp.status_code == 410
+    assert resp.status_code == 404
+    assert resp.status_code != 410
+
+
+@pytest.mark.asyncio
+async def test_upload_route_unknown_and_consumed_and_expired_all_404() -> None:
+    """Unknown, consumed, and expired tokens all return identical 404 responses.
+
+    The spec anti-leak rule: callers cannot distinguish why a token is
+    unusable — it may have never existed, already been consumed, or expired.
+    All three conditions produce the same status code and body.
+    """
+    mcp, store = _build_app(lambda rec, body: {"ok": True})
+
+    # Three tokens representing each unusable-token condition.
+    never_minted = "a" * 32  # unknown: never minted
+
+    # Consumed: mint, consume successfully (POST once), then POST again.
+    consumed_token = store.reserve(origin_id="c", max_bytes=1024)
+
+    # Expired: mint with negative TTL.
+    expired_token = store.reserve(origin_id="e", max_bytes=10, ttl_seconds=-1)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=mcp.http_app()),
+        base_url="http://test",
+    ) as client:
+        # First POST to consumed_token succeeds (token is consumed).
+        first = await client.post(
+            f"/ns/uploads/{consumed_token}",
+            content=b"data",
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        assert first.status_code == 200
+
+        # Now collect the three 404 responses.
+        r_unknown = await client.post(
+            f"/ns/uploads/{never_minted}",
+            content=b"x",
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        r_consumed = await client.post(
+            f"/ns/uploads/{consumed_token}",
+            content=b"x",
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        r_expired = await client.post(
+            f"/ns/uploads/{expired_token}",
+            content=b"x",
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
+    # All three are 404 — indistinguishable.
+    assert r_unknown.status_code == 404
+    assert r_consumed.status_code == 404
+    assert r_expired.status_code == 404
+
+    # Bodies are byte-identical.
+    assert r_unknown.content == r_consumed.content == r_expired.content
 
 
 @pytest.mark.asyncio
 async def test_post_oversize_by_content_length_returns_413() -> None:
     mcp, store = _build_app(lambda rec, body: {"ok": True})
-    token = store.reserve(target_id="x", max_bytes=10)
+    token = store.reserve(origin_id="x", max_bytes=10)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
         base_url="http://test",
@@ -152,7 +215,7 @@ async def test_post_oversize_by_content_length_burns_token() -> None:
     succeed) returns 404 rather than the original 413.
     """
     mcp, store = _build_app(lambda rec, body: {"ok": True})
-    token = store.reserve(target_id="x", max_bytes=10)
+    token = store.reserve(origin_id="x", max_bytes=10)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
         base_url="http://test",
@@ -186,7 +249,7 @@ async def test_post_unaccepted_content_type_burns_token() -> None:
         lambda rec, body: {"ok": True},
         accepts=("application/octet-stream",),
     )
-    token = store.reserve(target_id="x", max_bytes=10)
+    token = store.reserve(origin_id="x", max_bytes=10)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
         base_url="http://test",
@@ -215,7 +278,7 @@ async def test_post_oversize_via_chunk_overrun_returns_413() -> None:
         return {"ok": True}
 
     mcp, store = _build_app(recv)
-    token = store.reserve(target_id="x", max_bytes=10)
+    token = store.reserve(origin_id="x", max_bytes=10)
 
     async def chunk_iter() -> AsyncIterator[bytes]:
         yield b"x" * 8
@@ -244,7 +307,7 @@ async def test_post_malformed_content_length_falls_through_to_chunk_reader() -> 
         return {"size_bytes": len(body), "ok": True}
 
     mcp, store = _build_app(recv)
-    token = store.reserve(target_id="x", max_bytes=100)
+    token = store.reserve(origin_id="x", max_bytes=100)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
@@ -271,7 +334,7 @@ async def test_post_unaccepted_content_type_returns_415() -> None:
         lambda rec, body: {"ok": True},
         accepts=("application/octet-stream", "image/png"),
     )
-    token = store.reserve(target_id="x", max_bytes=1024)
+    token = store.reserve(origin_id="x", max_bytes=1024)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
@@ -288,7 +351,7 @@ async def test_post_unaccepted_content_type_returns_415() -> None:
 @pytest.mark.asyncio
 async def test_post_wildcard_accepts_disables_check() -> None:
     mcp, store = _build_app(lambda rec, body: {"ok": True}, accepts=("*/*",))
-    token = store.reserve(target_id="x", max_bytes=1024)
+    token = store.reserve(origin_id="x", max_bytes=1024)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
         base_url="http://test",
@@ -304,7 +367,7 @@ async def test_post_wildcard_accepts_disables_check() -> None:
 @pytest.mark.asyncio
 async def test_post_glob_accepts_matches_subtype() -> None:
     mcp, store = _build_app(lambda rec, body: {"ok": True}, accepts=("image/*",))
-    token = store.reserve(target_id="x", max_bytes=1024)
+    token = store.reserve(origin_id="x", max_bytes=1024)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
         base_url="http://test",
@@ -324,7 +387,7 @@ async def test_post_missing_content_type_with_explicit_accepts_returns_415() -> 
         lambda rec, body: {"ok": True},
         accepts=("application/octet-stream",),
     )
-    token = store.reserve(target_id="x", max_bytes=1024)
+    token = store.reserve(origin_id="x", max_bytes=1024)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
@@ -340,7 +403,7 @@ async def test_post_missing_content_type_with_explicit_accepts_returns_415() -> 
 async def test_post_content_type_with_parameters_matches() -> None:
     """``image/png; charset=binary`` matches ``image/png`` (parameters stripped)."""
     mcp, store = _build_app(lambda rec, body: {"ok": True}, accepts=("image/png",))
-    token = store.reserve(target_id="x", max_bytes=1024)
+    token = store.reserve(origin_id="x", max_bytes=1024)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
         base_url="http://test",
@@ -357,7 +420,7 @@ async def test_post_content_type_with_parameters_matches() -> None:
 async def test_post_content_type_match_is_case_insensitive() -> None:
     """``Image/PNG`` against accepts ``image/*`` should match (case folded)."""
     mcp, store = _build_app(lambda rec, body: {"ok": True}, accepts=("image/*",))
-    token = store.reserve(target_id="x", max_bytes=1024)
+    token = store.reserve(origin_id="x", max_bytes=1024)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
         base_url="http://test",
@@ -376,7 +439,7 @@ async def test_post_receiver_value_error_returns_400() -> None:
         raise ValueError("bad path")
 
     mcp, store = _build_app(recv)
-    token = store.reserve(target_id="x", max_bytes=10)
+    token = store.reserve(origin_id="x", max_bytes=10)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
         base_url="http://test",
@@ -396,7 +459,7 @@ async def test_post_receiver_file_exists_returns_409() -> None:
         raise FileExistsError("already there")
 
     mcp, store = _build_app(recv)
-    token = store.reserve(target_id="x", max_bytes=10)
+    token = store.reserve(origin_id="x", max_bytes=10)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
         base_url="http://test",
@@ -417,7 +480,7 @@ async def test_post_receiver_other_exception_returns_500(
         raise RuntimeError("kaboom")
 
     mcp, store = _build_app(recv)
-    token = store.reserve(target_id="x", max_bytes=10)
+    token = store.reserve(origin_id="x", max_bytes=10)
     with caplog.at_level(logging.ERROR):
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=mcp.http_app()),
@@ -449,7 +512,7 @@ async def test_post_receiver_returning_non_dict_returns_500(
         return "not-a-dict"  # type: ignore[return-value]
 
     mcp, store = _build_app(recv)
-    token = store.reserve(target_id="x", max_bytes=10)
+    token = store.reserve(origin_id="x", max_bytes=10)
     with caplog.at_level(logging.ERROR):
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=mcp.http_app()),
@@ -473,12 +536,12 @@ async def test_post_async_buffered_receiver_runs_to_completion() -> None:
     captured: dict[str, Any] = {}
 
     async def recv(record: UploadRecord, body: bytes) -> dict[str, Any]:
-        captured["target_id"] = record.target_id
+        captured["origin_id"] = record.origin_id
         captured["body"] = body
         return {"size": len(body), "ok": True}
 
     mcp, store = _build_app(recv)
-    token = store.reserve(target_id="x", max_bytes=100)
+    token = store.reserve(origin_id="x", max_bytes=100)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
@@ -512,7 +575,7 @@ async def test_post_stream_receiver_sees_chunks_live() -> None:
         namespace="ns",
         stream_receiver=recv,
     )
-    token = store.reserve(target_id="x", max_bytes=1024)
+    token = store.reserve(origin_id="x", max_bytes=1024)
 
     async def chunk_iter() -> AsyncIterator[bytes]:
         yield b"abc"
@@ -553,7 +616,7 @@ async def test_post_stream_receiver_oversize_aborts_before_completion() -> None:
         namespace="ns",
         stream_receiver=recv,
     )
-    token = store.reserve(target_id="x", max_bytes=5)
+    token = store.reserve(origin_id="x", max_bytes=5)
 
     async def chunk_iter() -> AsyncIterator[bytes]:
         yield b"abcd"
@@ -582,12 +645,12 @@ async def test_post_sync_stream_receiver_returning_plain_dict() -> None:
 
     def sync_recv(record: UploadRecord, body: AsyncIterator[bytes]) -> dict[str, Any]:
         # Sync receiver — ignores the body iterator and returns a plain dict.
-        return {"ok": True, "target_id": record.target_id}
+        return {"ok": True, "origin_id": record.origin_id}
 
     mcp = FastMCP(name="test-upload")
     store = UploadStore(base_url="http://test.invalid")
     register_upload_route(mcp, store=store, namespace="ns", stream_receiver=sync_recv)
-    token = store.reserve(target_id="x.md", max_bytes=100)
+    token = store.reserve(origin_id="x.md", max_bytes=100)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
@@ -600,7 +663,7 @@ async def test_post_sync_stream_receiver_returning_plain_dict() -> None:
         )
 
     assert resp.status_code == 200
-    assert resp.json() == {"ok": True, "target_id": "x.md"}
+    assert resp.json() == {"ok": True, "origin_id": "x.md"}
 
 
 @pytest.mark.asyncio
@@ -623,7 +686,7 @@ async def test_post_sync_receiver_runs_in_threadpool() -> None:
         return {"ok": True}
 
     mcp, store = _build_app(sync_recv)
-    token = store.reserve(target_id="x.md", max_bytes=100)
+    token = store.reserve(origin_id="x.md", max_bytes=100)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),
@@ -662,7 +725,7 @@ async def test_post_sync_stream_receiver_runs_in_threadpool() -> None:
     mcp = FastMCP(name="test-upload")
     store = UploadStore(base_url="http://test.invalid")
     register_upload_route(mcp, store=store, namespace="ns", stream_receiver=sync_recv)
-    token = store.reserve(target_id="x.md", max_bytes=100)
+    token = store.reserve(origin_id="x.md", max_bytes=100)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=mcp.http_app()),

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -115,7 +115,7 @@ def test_upload_store_has_base_url_property() -> None:
 def test_upload_store_peek_for_tests_returns_none_for_expired() -> None:
     """The test-only peek treats expired the same as missing."""
     store = UploadStore()
-    token = store.reserve(target_id="x", max_bytes=10, ttl_seconds=-1)
+    token = store.reserve(origin_id="x", max_bytes=10, ttl_seconds=-1)
     # Record sat in the table after reserve (the negative TTL only affects
     # subsequent purge); peek must observe expires_at and report None.
     assert store._peek_for_tests(token) is None

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -18,72 +18,68 @@ from fastmcp_pvl_core._token_store import (
 class TestUploadRecord:
     def test_is_frozen(self) -> None:
         record = UploadRecord(
-            target_id="foo.md",
+            origin_id="foo.md",
+            destination=None,
+            content_type=None,
             max_bytes=1024,
-            extra={},
             expires_at=time.time() + 60,
         )
         assert dataclasses.is_dataclass(record)
         with pytest.raises(dataclasses.FrozenInstanceError):
-            record.target_id = "x"  # type: ignore[misc]
-
-    def test_extra_is_held_by_reference(self) -> None:
-        """UploadRecord does not snapshot ``extra`` on construction.
-
-        The snapshot policy lives one layer up in ``UploadStore.reserve``
-        (Task 4); direct construction holds the caller's dict by reference.
-        Pinning this behavior here makes any future change of mind explicit
-        rather than silent.
-        """
-        extra = {"k": "v1"}
-        record = UploadRecord(target_id="a", max_bytes=10, extra=extra, expires_at=0.0)
-        extra["k"] = "v2"
-        assert record.extra["k"] == "v2"
-        assert record.extra is extra
+            record.origin_id = "x"  # type: ignore[misc]
 
     def test_required_fields(self) -> None:
         with pytest.raises(TypeError):
             UploadRecord()  # type: ignore[call-arg]
 
+    def test_upload_record_carries_origin_id_destination_content_type(self) -> None:
+        rec = UploadRecord(
+            origin_id="a",
+            destination="d/x.md",
+            content_type="text/markdown",
+            max_bytes=10,
+            expires_at=time.time() + 60,
+        )
+        assert rec.origin_id == "a"
+        assert rec.destination == "d/x.md"
+        assert rec.content_type == "text/markdown"
+        assert not hasattr(rec, "target_id")
+        assert not hasattr(rec, "extra")
+
 
 class TestUploadStore:
     def test_reserve_returns_token_and_url(self) -> None:
         store = UploadStore(base_url="https://srv.test")
-        token = store.reserve(target_id="foo.md", max_bytes=1024)
+        token = store.reserve(origin_id="foo.md", max_bytes=1024)
         assert isinstance(token, str) and len(token) == 32
         url = store.build_url(token)
         assert url == f"https://srv.test/uploads/{token}"
 
-    def test_reserve_with_explicit_ttl_and_extra(self) -> None:
+    def test_reserve_with_explicit_ttl_destination_content_type(self) -> None:
         store = UploadStore(base_url="https://srv.test")
         token = store.reserve(
-            target_id="x.md", max_bytes=10, ttl_seconds=42, extra={"k": 1}
+            origin_id="x.md",
+            max_bytes=10,
+            ttl_seconds=42,
+            destination="vault/x.md",
+            content_type="text/markdown",
         )
         record = store._peek_for_tests(token)
         assert record is not None
-        assert record.extra == {"k": 1}
+        assert record.destination == "vault/x.md"
+        assert record.content_type == "text/markdown"
         assert record.expires_at - time.time() == pytest.approx(42, abs=2)
-
-    def test_reserve_snapshots_extra(self) -> None:
-        """Mutating the source dict after reserve must not affect the record."""
-        store = UploadStore(base_url="https://srv.test")
-        extra = {"k": "v1"}
-        token = store.reserve(target_id="x", max_bytes=10, extra=extra)
-        extra["k"] = "v2"
-        record = store._peek_for_tests(token)
-        assert record is not None
-        assert record.extra == {"k": "v1"}
 
     def test_consume_returns_record_then_none(self) -> None:
         store = UploadStore(base_url="https://srv.test")
-        token = store.reserve(target_id="x", max_bytes=10)
+        token = store.reserve(origin_id="x", max_bytes=10)
         first = store.consume(token)
-        assert first is not None and first.target_id == "x"
+        assert first is not None and first.origin_id == "x"
         assert store.consume(token) is None
 
     def test_consume_returns_none_for_expired(self) -> None:
         store = UploadStore(base_url="https://srv.test")
-        token = store.reserve(target_id="x", max_bytes=10, ttl_seconds=-1)
+        token = store.reserve(origin_id="x", max_bytes=10, ttl_seconds=-1)
         assert store.consume(token) is None
 
     def test_consume_returns_none_for_unknown(self) -> None:
@@ -92,7 +88,7 @@ class TestUploadStore:
 
     def test_build_url_requires_base_url(self) -> None:
         store = UploadStore()
-        token = store.reserve(target_id="x", max_bytes=10)
+        token = store.reserve(origin_id="x", max_bytes=10)
         with pytest.raises(RuntimeError, match="base_url"):
             store.build_url(token)
 


### PR DESCRIPTION
## Summary

Clean-slate re-implementation of the receiver/`sink`-side `http_upload` primitive — the `create_upload_link` tool, the POST upload route, `UploadRecord`, and `register_file_exchange_upload` — 100% conformant with the v0.3.0 file-exchange spec, superseding the A11-era implementation.

- **`create_upload_link` tool** — parameters `origin_id` (required), `destination`, `content_type`, `ttl_seconds`, `max_bytes`; returns `{url, ttl_seconds, max_bytes}` (effective post-clamp values) on success. In-band rejection (bad `origin_id`, a `destination` rejected by `pre_link_validator`, a `content_type` outside `accepts`) returns the `transfer_failed` envelope — `{error, method, receiver_server, origin_id, message}` — rather than a raw tool error.
- **POST route** — the `410`-on-expired branch is removed; unknown / expired / already-consumed tokens all return an indistinguishable `404` with an empty body (the spec's anti-leak rule).
- **`UploadRecord`** — models the WHAT/WHERE split (`origin_id` / `destination` / `content_type`); the non-spec `extra` field is gone. `UploadStore.consume_or_status` removed; `consume` returns `UploadRecord | None`.
- **`register_file_exchange_upload`** — kwarg surface cut to six domain hooks (`namespace`, `env_prefix`, `receiver`, `stream_receiver`, `pre_link_validator`, `accepts`). The shape-override kwargs (`upload_tool_name`, `tool_tags`) and operator-config kwargs (`transport`, `max_bytes_default`, `ttl_default`, `ttl_max`) are removed — pvl-core fixes the tool name/tags; operator config moves to the existing `{PREFIX}_UPLOAD_*` env vars.
- **`PreLinkValidator`** — signature is now `(origin_id, destination)`.

The token-store mechanics (UUID4 entropy, atomic one-time consume, lazy TTL purge, the `_bounded_chunks` streaming generator, sync/async receiver dispatch, `413`/`415`/`5xx` handling) are spec-conformant and preserved unchanged.

## Breaking change

`register_file_exchange_upload`'s kwarg surface shrinks and `UploadRecord` (passed to `receiver` / `stream_receiver`) is restructured. The one downstream consumer, `markdown-vault-mcp`, migrates via `pvliesdonk/markdown-vault-mcp#488` — pvl-core ships the breaking change; downstream follows (no compat shim, per the umbrella's discipline).

## Out of scope

- The sender-side `upload` tool (`http_upload.source`) — #85.
- The `http`-direction tool/route conformance audit — #87.

## Test plan

- [x] `uv run pytest` — 617 passed.
- [x] `uv run ruff format --check .` / `ruff check .` / `mypy src` — all clean.
- [x] The three upload test files rewritten to the v0.3.0 contract, including: `404`-not-`410` for expired tokens; unknown/expired/consumed all byte-identical `404`s; the `transfer_failed` envelope on `pre_link_validator`, `content_type`, and `origin_id` rejection; `{url, ttl_seconds, max_bytes}` return and clamping; the `UploadRecord` WHAT/WHERE split.
- [ ] CI green.
- [ ] Bot review clean.

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)