### PR TITLE
feat(logging): conforming tool-aware logging middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ so they do not flood the operator log stream:
 Both reappear at `DEBUG` (`-v` or `FASTMCP_LOG_LEVEL=DEBUG`). `uvicorn.error`
 is never demoted — it carries genuine bind / startup failures.
 
+`wire_middleware_stack` installs a single conforming request-logging
+middleware. Every line it emits starts with a bare snake_case event name,
+followed by `key=value` pairs, with request timing carried inline:
+
+```
+tool_call_started   tool=read method=tools/call source=client
+tool_call_completed tool=read duration_ms=68.57
+tool_call_failed    tool=read duration_ms=109.84 error_type=ValueError error="Section '1.3' not found"
+```
+
+Non-tool messages use a generic `request_*` / `notification_*` vocabulary
+keyed by `method=`. Set `FASTMCP_ENABLE_RICH_LOGGING=false` to emit one JSON
+object per record instead of `key=value` text — for log aggregators such as
+the ELK stack or Splunk.
+
 ### Per-user subject mapping (bearer auth)
 
 Bearer auth has two modes:

--- a/src/fastmcp_pvl_core/_logging_middleware.py
+++ b/src/fastmcp_pvl_core/_logging_middleware.py
@@ -35,13 +35,20 @@ def _render_value(value: object) -> str:
     """Render a field value for the rich (text) output mode.
 
     Strings containing whitespace or a double quote are wrapped in
-    double quotes — with embedded backslashes and double quotes escaped
-    — so the surrounding ``key=value`` structure stays unambiguous;
-    everything else renders bare.
+    double quotes — with embedded backslashes, double quotes, and
+    control characters (newline, carriage return, tab) escaped — so the
+    record stays on one unambiguous ``key=value`` line; everything else
+    renders bare.
     """
     text = str(value)
     if any(char.isspace() for char in text) or '"' in text:
-        escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+        escaped = (
+            text.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        )
         return '"' + escaped + '"'
     return text
 

--- a/src/fastmcp_pvl_core/_logging_middleware.py
+++ b/src/fastmcp_pvl_core/_logging_middleware.py
@@ -1,0 +1,158 @@
+"""Conforming, tool-aware request-logging middleware.
+
+Emits family-standard log lines for every MCP message: a bare
+snake_case event name as the first token, followed by ``key=value``
+pairs. Tool calls surface the tool name via ``tool=<name>``; request
+duration is carried inline on the terminal (``*_completed`` /
+``*_failed``) line. This middleware replaces FastMCP's
+``LoggingMiddleware`` and ``TimingMiddleware`` in
+:func:`fastmcp_pvl_core.wire_middleware_stack`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import time
+from typing import Any
+
+from fastmcp.server.middleware.middleware import (
+    CallNext,
+    Middleware,
+    MiddlewareContext,
+)
+
+_DEFAULT_LOGGER_NAME = "fastmcp.middleware.requests"
+
+
+def _duration_ms(start: float) -> float:
+    """Elapsed wall-clock milliseconds since *start*, rounded to 2 dp."""
+    return round((time.perf_counter() - start) * 1000, 2)
+
+
+def _render_value(value: object) -> str:
+    """Render a field value for the rich (text) output mode.
+
+    Strings containing whitespace are double-quoted so the surrounding
+    ``key=value`` structure stays unambiguous; everything else renders
+    bare.
+    """
+    text = str(value)
+    if any(char.isspace() for char in text):
+        return '"' + text + '"'
+    return text
+
+
+def _render_fields(fields: dict[str, object]) -> str:
+    """Join an ordered field mapping into ``key=value`` text."""
+    return " ".join(key + "=" + _render_value(value) for key, value in fields.items())
+
+
+class RequestLoggingMiddleware(Middleware):
+    """Logs every MCP message as a conforming, tool-aware event pair.
+
+    Overrides only :meth:`on_message` — the single outermost dispatch
+    hook — so each message produces exactly one ``*_started`` line and
+    one terminal (``*_completed`` / ``*_failed``) line. Overriding a
+    method-specific hook in addition would double-log.
+
+    Tool calls (``tools/call``) use the ``tool_call_*`` event vocabulary
+    and carry ``tool=<name>``; every other message uses ``request_*`` or
+    ``notification_*`` keyed by ``method=``.
+
+    Args:
+        structured: When ``True``, emit one JSON object per record (for
+            log aggregators). When ``False`` (default), emit
+            bare-event-name-first ``key=value`` text.
+        include_traceback: When ``True``, ``*_failed`` records carry
+            ``exc_info`` so the log handler renders a traceback.
+        logger: Logger to emit through. Defaults to a logger named
+            ``fastmcp.middleware.requests``.
+    """
+
+    def __init__(
+        self,
+        *,
+        structured: bool = False,
+        include_traceback: bool = False,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.structured = structured
+        self.include_traceback = include_traceback
+        self.logger = logger or logging.getLogger(_DEFAULT_LOGGER_NAME)
+
+    async def on_message(
+        self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]
+    ) -> Any:
+        is_tool_call = context.method == "tools/call"
+        if is_tool_call:
+            event_base = "tool_call"
+            id_key = "tool"
+            id_val: str = getattr(context.message, "name", None) or "unknown"
+        else:
+            event_base = context.type
+            id_key = "method"
+            id_val = context.method or "unknown"
+
+        started_fields: dict[str, object] = {id_key: id_val}
+        if is_tool_call:
+            started_fields["method"] = "tools/call"
+        started_fields["source"] = context.source
+        self._emit(event_base + "_started", started_fields, logging.INFO)
+
+        start = time.perf_counter()
+        try:
+            result = await call_next(context)
+        except Exception as exc:
+            self._emit(
+                event_base + "_failed",
+                {
+                    id_key: id_val,
+                    "duration_ms": _duration_ms(start),
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+                logging.ERROR,
+                exc_info=self.include_traceback,
+            )
+            raise
+        self._emit(
+            event_base + "_completed",
+            {id_key: id_val, "duration_ms": _duration_ms(start)},
+            logging.INFO,
+        )
+        return result
+
+    def _emit(
+        self,
+        event: str,
+        fields: dict[str, object],
+        level: int,
+        *,
+        exc_info: bool = False,
+    ) -> None:
+        """Emit one conforming record in the configured output mode.
+
+        ``exc_info=True`` attaches the current exception triple; ``False``
+        (default) passes ``None`` to logging so the record's ``exc_info``
+        attribute is ``None`` rather than ``False``.
+        """
+        # logging stores exc_info=False as False on the record, which breaks
+        # ``assert record.exc_info is None`` assertions.  Always pass None for
+        # the "no traceback" case; logging treats None identically to False.
+        effective_exc_info = sys.exc_info() if exc_info else None
+        if self.structured:
+            payload: dict[str, object] = {"event": event}
+            payload.update(fields)
+            self.logger.log(
+                level, "%s", json.dumps(payload), exc_info=effective_exc_info
+            )
+        else:
+            self.logger.log(
+                level,
+                "%s %s",
+                event,
+                _render_fields(fields),
+                exc_info=effective_exc_info,
+            )

--- a/src/fastmcp_pvl_core/_logging_middleware.py
+++ b/src/fastmcp_pvl_core/_logging_middleware.py
@@ -34,13 +34,15 @@ def _duration_ms(start: float) -> float:
 def _render_value(value: object) -> str:
     """Render a field value for the rich (text) output mode.
 
-    Strings containing whitespace are double-quoted so the surrounding
-    ``key=value`` structure stays unambiguous; everything else renders
-    bare.
+    Strings containing whitespace or a double quote are wrapped in
+    double quotes — with embedded backslashes and double quotes escaped
+    — so the surrounding ``key=value`` structure stays unambiguous;
+    everything else renders bare.
     """
     text = str(value)
-    if any(char.isspace() for char in text):
-        return '"' + text + '"'
+    if any(char.isspace() for char in text) or '"' in text:
+        escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+        return '"' + escaped + '"'
     return text
 
 

--- a/src/fastmcp_pvl_core/_middleware.py
+++ b/src/fastmcp_pvl_core/_middleware.py
@@ -1,8 +1,8 @@
 """FastMCP middleware stack installation.
 
-Installs the standard three-middleware stack on a FastMCP instance:
-ErrorHandling, Timing, then either rich or structured Logging.
-The logging flavor is controlled by ``FASTMCP_ENABLE_RICH_LOGGING``.
+Installs the conforming request-logging middleware on a FastMCP
+instance. The rich-vs-structured output mode is controlled by the
+``FASTMCP_ENABLE_RICH_LOGGING`` environment variable.
 """
 
 from __future__ import annotations
@@ -11,57 +11,36 @@ import logging
 import os
 
 from fastmcp import FastMCP
-from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
-from fastmcp.server.middleware.logging import (
-    LoggingMiddleware,
-    StructuredLoggingMiddleware,
-)
-from fastmcp.server.middleware.timing import TimingMiddleware
 
 from fastmcp_pvl_core._env import parse_bool
+from fastmcp_pvl_core._logging_middleware import RequestLoggingMiddleware
 
 
-def wire_middleware_stack(
-    mcp: FastMCP,
-    *,
-    include_traceback: bool | None = None,
-    transform_errors: bool = False,
-) -> None:
-    """Install the standard middleware stack on a FastMCP instance.
+def wire_middleware_stack(mcp: FastMCP) -> None:
+    """Install the standard logging middleware on a FastMCP instance.
 
-    Installation order (outermost first):
+    Installs a single :class:`RequestLoggingMiddleware`, which emits
+    family-conforming, tool-aware log lines — a bare event name as the
+    first token, then ``key=value`` pairs — with request timing carried
+    inline on the terminal line.
 
-    1. :class:`ErrorHandlingMiddleware` — catches unhandled exceptions and
-       (optionally) logs them with a traceback.
-    2. :class:`TimingMiddleware` — records tool invocation duration.
-    3. :class:`LoggingMiddleware` (rich) or
-       :class:`StructuredLoggingMiddleware` (JSON) — selected by the
-       ``FASTMCP_ENABLE_RICH_LOGGING`` environment variable (default: rich).
+    Output mode is selected by ``FASTMCP_ENABLE_RICH_LOGGING`` (default
+    ``true``): rich mode emits ``key=value`` text; structured mode emits
+    one JSON object per record for log aggregators.
+
+    Traceback inclusion on failure records is inferred from the root
+    logger — tracebacks are emitted when it is at ``DEBUG`` or below.
+    Call this *after* CLI / log-level setup so the inference sees the
+    right level.
 
     Args:
         mcp: The :class:`FastMCP` instance to install middleware on.
-        include_traceback: Whether ``ErrorHandlingMiddleware`` should log
-            tracebacks for unhandled exceptions. ``None`` (default) infers
-            from the root logger: tracebacks are enabled when the root
-            logger is at ``DEBUG`` or below. Pass ``True``/``False`` to
-            override. Call this *after* CLI/log-level setup so inference
-            sees the right level.
-        transform_errors: Whether ``ErrorHandlingMiddleware`` should
-            convert exceptions into MCP error responses. Defaults to
-            ``False`` (let exceptions propagate to FastMCP's own handlers).
     """
-    if include_traceback is None:
-        include_traceback = logging.getLogger().isEnabledFor(logging.DEBUG)
+    include_traceback = logging.getLogger().isEnabledFor(logging.DEBUG)
+    rich_raw = os.environ.get("FASTMCP_ENABLE_RICH_LOGGING", "true")
     mcp.add_middleware(
-        ErrorHandlingMiddleware(
+        RequestLoggingMiddleware(
+            structured=not parse_bool(rich_raw),
             include_traceback=include_traceback,
-            transform_errors=transform_errors,
         )
     )
-    mcp.add_middleware(TimingMiddleware())
-
-    rich_raw = os.environ.get("FASTMCP_ENABLE_RICH_LOGGING", "true")
-    if parse_bool(rich_raw):
-        mcp.add_middleware(LoggingMiddleware())
-    else:
-        mcp.add_middleware(StructuredLoggingMiddleware())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Iterator
 
@@ -36,6 +37,27 @@ def _reset_authorizer() -> Iterator[None]:
     set_current_authorizer(None)
     yield
     set_current_authorizer(None)
+
+
+@pytest.fixture(autouse=True)
+def _fastmcp_logger_propagates() -> Iterator[None]:
+    """Allow pytest's caplog to capture records from the ``fastmcp.*`` hierarchy.
+
+    FastMCP installs a RichHandler on the ``fastmcp`` root logger and sets
+    ``propagate=False``, which prevents records from reaching the stdlib root
+    logger that pytest's caplog handler is attached to.  Any test that uses
+    ``caplog`` with a logger under ``fastmcp.*`` would silently capture nothing
+    without this fixture.
+
+    The fixture temporarily re-enables propagation and yields; teardown
+    restores the original state so other tests (and the RichHandler output
+    stream) are not affected.
+    """
+    fastmcp_logger = logging.getLogger("fastmcp")
+    original_propagate = fastmcp_logger.propagate
+    fastmcp_logger.propagate = True
+    yield
+    fastmcp_logger.propagate = original_propagate
 
 
 @pytest.fixture

--- a/tests/test_logging_middleware.py
+++ b/tests/test_logging_middleware.py
@@ -189,3 +189,15 @@ async def test_render_value_escapes_embedded_quotes(caplog):
         with pytest.raises(ValueError):
             await mw.on_message(ctx, _failing_call_next(ValueError('say"hi"')))
     assert r'error="say\"hi\""' in caplog.records[-1].getMessage()
+
+
+async def test_render_value_escapes_newlines_to_one_line(caplog):
+    mw = RequestLoggingMiddleware()
+    ctx = _context(method="tools/call", message=_ToolParams("read"))
+    err = ValueError("line one\nline two")
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        with pytest.raises(ValueError):
+            await mw.on_message(ctx, _failing_call_next(err))
+    msg = caplog.records[-1].getMessage()
+    assert "\n" not in msg
+    assert r'error="line one\nline two"' in msg

--- a/tests/test_logging_middleware.py
+++ b/tests/test_logging_middleware.py
@@ -191,13 +191,17 @@ async def test_render_value_escapes_embedded_quotes(caplog):
     assert r'error="say\"hi\""' in caplog.records[-1].getMessage()
 
 
-async def test_render_value_escapes_newlines_to_one_line(caplog):
+@pytest.mark.parametrize(
+    ("raw", "escaped"),
+    [("\n", "\\n"), ("\r", "\\r"), ("\t", "\\t")],
+)
+async def test_render_value_escapes_control_chars_to_one_line(caplog, raw, escaped):
     mw = RequestLoggingMiddleware()
     ctx = _context(method="tools/call", message=_ToolParams("read"))
-    err = ValueError("line one\nline two")
+    err = ValueError("line one" + raw + "line two")
     with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
         with pytest.raises(ValueError):
             await mw.on_message(ctx, _failing_call_next(err))
     msg = caplog.records[-1].getMessage()
-    assert "\n" not in msg
-    assert r'error="line one\nline two"' in msg
+    assert raw not in msg
+    assert 'error="line one' + escaped + 'line two"' in msg

--- a/tests/test_logging_middleware.py
+++ b/tests/test_logging_middleware.py
@@ -1,0 +1,171 @@
+"""Tests for RequestLoggingMiddleware."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from fastmcp.server.middleware.middleware import MiddlewareContext
+
+from fastmcp_pvl_core._logging_middleware import RequestLoggingMiddleware
+
+_LOGGER_NAME = "fastmcp.middleware.requests"
+
+
+class _ToolParams:
+    """Minimal stand-in for CallToolRequestParams — only ``.name`` is read."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def _context(*, method, message=None, type_="request", source="client"):
+    return MiddlewareContext(message=message, method=method, type=type_, source=source)
+
+
+async def _ok_call_next(context):
+    return "result"
+
+
+def _failing_call_next(exc):
+    async def _call_next(context):
+        raise exc
+
+    return _call_next
+
+
+async def test_tool_call_started_and_completed(caplog):
+    mw = RequestLoggingMiddleware()
+    ctx = _context(method="tools/call", message=_ToolParams("read"))
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        result = await mw.on_message(ctx, _ok_call_next)
+    assert result == "result"
+    messages = [r.getMessage() for r in caplog.records]
+    assert messages[0].startswith("tool_call_started ")
+    assert "tool=read" in messages[0]
+    assert "method=tools/call" in messages[0]
+    assert "source=client" in messages[0]
+    assert messages[1].startswith("tool_call_completed ")
+    assert "tool=read" in messages[1]
+    assert "duration_ms=" in messages[1]
+
+
+async def test_request_uses_method_vocabulary(caplog):
+    mw = RequestLoggingMiddleware()
+    ctx = _context(method="initialize")
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        await mw.on_message(ctx, _ok_call_next)
+    messages = [r.getMessage() for r in caplog.records]
+    assert messages[0].startswith("request_started ")
+    assert "method=initialize" in messages[0]
+    assert messages[1].startswith("request_completed ")
+    assert "method=initialize" in messages[1]
+    assert "duration_ms=" in messages[1]
+
+
+async def test_notification_uses_notification_vocabulary(caplog):
+    mw = RequestLoggingMiddleware()
+    ctx = _context(method="notifications/initialized", type_="notification")
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        await mw.on_message(ctx, _ok_call_next)
+    assert caplog.records[0].getMessage().startswith("notification_started ")
+    assert caplog.records[1].getMessage().startswith("notification_completed ")
+
+
+async def test_tool_call_failed_line(caplog):
+    mw = RequestLoggingMiddleware()
+    ctx = _context(method="tools/call", message=_ToolParams("read"))
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        with pytest.raises(ValueError):
+            await mw.on_message(ctx, _failing_call_next(ValueError("bad section here")))
+    failed = caplog.records[-1]
+    msg = failed.getMessage()
+    assert msg.startswith("tool_call_failed ")
+    assert "tool=read" in msg
+    assert "duration_ms=" in msg
+    assert "error_type=ValueError" in msg
+    assert 'error="bad section here"' in msg
+    assert failed.levelno == logging.ERROR
+
+
+async def test_failed_error_value_unquoted_when_no_whitespace(caplog):
+    mw = RequestLoggingMiddleware()
+    ctx = _context(method="tools/call", message=_ToolParams("read"))
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        with pytest.raises(ValueError):
+            await mw.on_message(ctx, _failing_call_next(ValueError("oneword")))
+    assert "error=oneword" in caplog.records[-1].getMessage()
+
+
+async def test_include_traceback_attaches_exc_info(caplog):
+    mw = RequestLoggingMiddleware(include_traceback=True)
+    ctx = _context(method="tools/call", message=_ToolParams("read"))
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        with pytest.raises(ValueError):
+            await mw.on_message(ctx, _failing_call_next(ValueError("boom")))
+    assert caplog.records[-1].exc_info is not None
+
+
+async def test_no_traceback_when_include_traceback_false(caplog):
+    mw = RequestLoggingMiddleware(include_traceback=False)
+    ctx = _context(method="tools/call", message=_ToolParams("read"))
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        with pytest.raises(ValueError):
+            await mw.on_message(ctx, _failing_call_next(ValueError("boom")))
+    assert caplog.records[-1].exc_info is None
+
+
+async def test_unknown_tool_name_falls_back(caplog):
+    mw = RequestLoggingMiddleware()
+    ctx = _context(method="tools/call", message=object())
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        await mw.on_message(ctx, _ok_call_next)
+    assert "tool=unknown" in caplog.records[0].getMessage()
+
+
+async def test_structured_mode_emits_json(caplog):
+    mw = RequestLoggingMiddleware(structured=True)
+    ctx = _context(method="tools/call", message=_ToolParams("read"))
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        await mw.on_message(ctx, _ok_call_next)
+    started = json.loads(caplog.records[0].getMessage())
+    assert started["event"] == "tool_call_started"
+    assert started["tool"] == "read"
+    assert started["method"] == "tools/call"
+    assert started["source"] == "client"
+    completed = json.loads(caplog.records[1].getMessage())
+    assert completed["event"] == "tool_call_completed"
+    assert completed["tool"] == "read"
+    assert "duration_ms" in completed
+
+
+async def test_structured_mode_failed_json(caplog):
+    mw = RequestLoggingMiddleware(structured=True)
+    ctx = _context(method="tools/call", message=_ToolParams("read"))
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        with pytest.raises(ValueError):
+            await mw.on_message(ctx, _failing_call_next(ValueError("bad section here")))
+    failed = json.loads(caplog.records[-1].getMessage())
+    assert failed["event"] == "tool_call_failed"
+    assert failed["error_type"] == "ValueError"
+    assert failed["error"] == "bad section here"
+
+
+async def test_exception_is_reraised_unchanged(caplog):
+    mw = RequestLoggingMiddleware()
+    ctx = _context(method="tools/call", message=_ToolParams("read"))
+    sentinel = ValueError("propagate me")
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        with pytest.raises(ValueError) as excinfo:
+            await mw.on_message(ctx, _failing_call_next(sentinel))
+    assert excinfo.value is sentinel
+
+
+async def test_custom_logger_is_used(caplog):
+    mw = RequestLoggingMiddleware(logger=logging.getLogger("test.custom.requests"))
+    ctx = _context(method="tools/call", message=_ToolParams("read"))
+    with caplog.at_level(logging.INFO, logger="test.custom.requests"):
+        await mw.on_message(ctx, _ok_call_next)
+    assert caplog.records
+    assert all(record.name == "test.custom.requests" for record in caplog.records)

--- a/tests/test_logging_middleware.py
+++ b/tests/test_logging_middleware.py
@@ -69,7 +69,10 @@ async def test_notification_uses_notification_vocabulary(caplog):
     ctx = _context(method="notifications/initialized", type_="notification")
     with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
         await mw.on_message(ctx, _ok_call_next)
-    assert caplog.records[0].getMessage().startswith("notification_started ")
+    started = caplog.records[0].getMessage()
+    assert started.startswith("notification_started ")
+    assert "method=notifications/initialized" in started
+    assert "source=client" in started
     assert caplog.records[1].getMessage().startswith("notification_completed ")
 
 
@@ -169,3 +172,20 @@ async def test_custom_logger_is_used(caplog):
         await mw.on_message(ctx, _ok_call_next)
     assert caplog.records
     assert all(record.name == "test.custom.requests" for record in caplog.records)
+
+
+async def test_tool_name_with_whitespace_is_quoted(caplog):
+    mw = RequestLoggingMiddleware()
+    ctx = _context(method="tools/call", message=_ToolParams("read section"))
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        await mw.on_message(ctx, _ok_call_next)
+    assert 'tool="read section"' in caplog.records[0].getMessage()
+
+
+async def test_render_value_escapes_embedded_quotes(caplog):
+    mw = RequestLoggingMiddleware()
+    ctx = _context(method="tools/call", message=_ToolParams("read"))
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        with pytest.raises(ValueError):
+            await mw.on_message(ctx, _failing_call_next(ValueError('say"hi"')))
+    assert r'error="say\"hi\""' in caplog.records[-1].getMessage()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -5,116 +5,68 @@ from __future__ import annotations
 import logging
 
 from fastmcp import FastMCP
-from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
-from fastmcp.server.middleware.logging import (
-    LoggingMiddleware,
-    StructuredLoggingMiddleware,
-)
-from fastmcp.server.middleware.timing import TimingMiddleware
 
 from fastmcp_pvl_core import wire_middleware_stack
-
-# Middleware types that wire_middleware_stack installs — used to filter
-# out any built-in middlewares FastMCP installs by default.
-_INSTALLED_BY_HELPER = (
-    ErrorHandlingMiddleware,
-    TimingMiddleware,
-    LoggingMiddleware,
-    StructuredLoggingMiddleware,
-)
+from fastmcp_pvl_core._logging_middleware import RequestLoggingMiddleware
 
 
-def _installed_types(mcp: FastMCP) -> list[type]:
-    """Return the ordered types of middlewares added by wire_middleware_stack.
+def _request_logging_mws(mcp: FastMCP) -> list[RequestLoggingMiddleware]:
+    """Return the RequestLoggingMiddleware instances wire_middleware_stack added.
 
     FastMCP may pre-install its own middlewares (e.g. DereferenceRefsMiddleware);
-    this filters to only those wire_middleware_stack is responsible for so
-    tests assert our installation order, not FastMCP internals.
+    this filters to only the one wire_middleware_stack is responsible for.
     """
-    return [type(m) for m in mcp.middleware if isinstance(m, _INSTALLED_BY_HELPER)]
+    return [m for m in mcp.middleware if isinstance(m, RequestLoggingMiddleware)]
 
 
-def test_installs_three_middlewares_in_order():
+def test_installs_single_request_logging_middleware():
     mcp = FastMCP(name="t")
     wire_middleware_stack(mcp)
-    types = _installed_types(mcp)
-    assert len(types) == 3
-    assert types[0] is ErrorHandlingMiddleware
-    assert types[1] is TimingMiddleware
-    assert types[2] in (LoggingMiddleware, StructuredLoggingMiddleware)
+    assert len(_request_logging_mws(mcp)) == 1
 
 
-def test_structured_when_rich_disabled(monkeypatch):
-    monkeypatch.setenv("FASTMCP_ENABLE_RICH_LOGGING", "false")
-    mcp = FastMCP(name="t")
-    wire_middleware_stack(mcp)
-    types = _installed_types(mcp)
-    assert types[2] is StructuredLoggingMiddleware
-
-
-def test_rich_when_rich_unset(monkeypatch):
+def test_rich_mode_when_rich_unset(monkeypatch):
     monkeypatch.delenv("FASTMCP_ENABLE_RICH_LOGGING", raising=False)
     mcp = FastMCP(name="t")
     wire_middleware_stack(mcp)
-    types = _installed_types(mcp)
-    assert types[2] is LoggingMiddleware
+    assert _request_logging_mws(mcp)[0].structured is False
 
 
-def test_rich_when_rich_explicitly_enabled(monkeypatch):
+def test_rich_mode_when_rich_explicitly_enabled(monkeypatch):
     monkeypatch.setenv("FASTMCP_ENABLE_RICH_LOGGING", "true")
     mcp = FastMCP(name="t")
     wire_middleware_stack(mcp)
-    types = _installed_types(mcp)
-    assert types[2] is LoggingMiddleware
+    assert _request_logging_mws(mcp)[0].structured is False
 
 
-def _error_mw(mcp: FastMCP) -> ErrorHandlingMiddleware:
-    return next(m for m in mcp.middleware if isinstance(m, ErrorHandlingMiddleware))
+def test_structured_mode_when_rich_disabled(monkeypatch):
+    monkeypatch.setenv("FASTMCP_ENABLE_RICH_LOGGING", "false")
+    mcp = FastMCP(name="t")
+    wire_middleware_stack(mcp)
+    assert _request_logging_mws(mcp)[0].structured is True
 
 
-def test_include_traceback_inferred_from_debug_log_level(caplog):
-    """Default (None) infers include_traceback from root logger DEBUG-enabled."""
-    with caplog.at_level("DEBUG"):
+def test_include_traceback_inferred_from_debug_log_level():
+    """include_traceback is inferred True when the root logger is at DEBUG."""
+    root = logging.getLogger()
+    prev = root.level
+    root.setLevel(logging.DEBUG)
+    try:
         mcp = FastMCP(name="t")
         wire_middleware_stack(mcp)
-    assert _error_mw(mcp).include_traceback is True
+        assert _request_logging_mws(mcp)[0].include_traceback is True
+    finally:
+        root.setLevel(prev)
 
 
 def test_include_traceback_inferred_off_when_root_above_debug():
-    """Default (None) yields False when root logger sits above DEBUG."""
+    """include_traceback is inferred False when the root logger sits above DEBUG."""
     root = logging.getLogger()
     prev = root.level
     root.setLevel(logging.WARNING)
     try:
         mcp = FastMCP(name="t")
         wire_middleware_stack(mcp)
-        assert _error_mw(mcp).include_traceback is False
+        assert _request_logging_mws(mcp)[0].include_traceback is False
     finally:
         root.setLevel(prev)
-
-
-def test_include_traceback_explicit_override():
-    """Explicit include_traceback wins over log-level inference."""
-    root = logging.getLogger()
-    prev = root.level
-    root.setLevel(logging.WARNING)
-    try:
-        mcp = FastMCP(name="t")
-        wire_middleware_stack(mcp, include_traceback=True)
-        assert _error_mw(mcp).include_traceback is True
-    finally:
-        root.setLevel(prev)
-
-
-def test_transform_errors_default_false():
-    """Default transform_errors is False (matches MV behavior)."""
-    mcp = FastMCP(name="t")
-    wire_middleware_stack(mcp)
-    assert _error_mw(mcp).transform_errors is False
-
-
-def test_transform_errors_explicit_true():
-    """transform_errors=True is honored."""
-    mcp = FastMCP(name="t")
-    wire_middleware_stack(mcp, transform_errors=True)
-    assert _error_mw(mcp).transform_errors is True

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -46,27 +46,17 @@ def test_structured_mode_when_rich_disabled(monkeypatch):
     assert _request_logging_mws(mcp)[0].structured is True
 
 
-def test_include_traceback_inferred_from_debug_log_level():
+def test_include_traceback_inferred_from_debug_log_level(caplog):
     """include_traceback is inferred True when the root logger is at DEBUG."""
-    root = logging.getLogger()
-    prev = root.level
-    root.setLevel(logging.DEBUG)
-    try:
+    with caplog.at_level(logging.DEBUG):
         mcp = FastMCP(name="t")
         wire_middleware_stack(mcp)
-        assert _request_logging_mws(mcp)[0].include_traceback is True
-    finally:
-        root.setLevel(prev)
+    assert _request_logging_mws(mcp)[0].include_traceback is True
 
 
-def test_include_traceback_inferred_off_when_root_above_debug():
+def test_include_traceback_inferred_off_when_root_above_debug(caplog):
     """include_traceback is inferred False when the root logger sits above DEBUG."""
-    root = logging.getLogger()
-    prev = root.level
-    root.setLevel(logging.WARNING)
-    try:
+    with caplog.at_level(logging.WARNING):
         mcp = FastMCP(name="t")
         wire_middleware_stack(mcp)
-        assert _request_logging_mws(mcp)[0].include_traceback is False
-    finally:
-        root.setLevel(prev)
+    assert _request_logging_mws(mcp)[0].include_traceback is False


### PR DESCRIPTION
## Summary

- Add `RequestLoggingMiddleware` — a conforming, tool-aware logging middleware that emits bare-event-name-first `key=value` lines (or one JSON object per record when `FASTMCP_ENABLE_RICH_LOGGING=false`), with request timing carried inline and `tool=<name>` surfaced on tool calls.
- Rewire `wire_middleware_stack` to install only this middleware, dropping FastMCP's `LoggingMiddleware`, `TimingMiddleware`, and `ErrorHandlingMiddleware`.
- `wire_middleware_stack` is now zero-kwarg: `transform_errors` is dropped with `ErrorHandlingMiddleware`; `include_traceback` is inferred internally from the root log level.
- A failed tool call now emits exactly one conforming `*_failed` line (plus traceback) instead of four redundant records.
- Document the conforming event vocabulary in the README `### Logging` section.

Closes #90

## Test plan

- [x] `uv run pytest` — 635 pass; new `RequestLoggingMiddleware` tests and rewritten `wire_middleware_stack` tests included.
- [x] `ruff format --check`, `ruff check`, `mypy src` — all clean.
- [x] Tool-call logs carry `tool=<name>`; a failed tool call emits one `*_failed` line, not three.
- [x] Rich and structured (JSON) output modes both conform; rich-mode values with embedded quotes are escaped.

## Cross-repo impact

`wire_middleware_stack` is consumed by `markdown-vault-mcp`, `image-generation-mcp`, and `paperless-mcp`. Deliberate behaviour change: the `Request X completed in Yms` line is replaced by the conforming `*_completed duration_ms=` line; any call site passing `include_traceback` / `transform_errors` must drop those arguments.

## Follow-up

#95 — an end-to-end integration test driving a real FastMCP dispatch through the wired stack (the current tests are unit-level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)