### PR TITLE
spec: http_upload sender source union → origin_id; HTTP-capability clarification (#93)

### DIFF
--- a/docs/specs/file-exchange.md
+++ b/docs/specs/file-exchange.md
@@ -204,6 +204,8 @@ The producer exposes a tool that generates a download URL. The consumer exposes 
 
 The `http` method serves double duty: the generated URL can be used for server-to-server transfer (consumer calls its fetch tool with the URL) or for **direct human download** (the LLM includes the URL in its response for the user to click). This means the `http` method is useful even without a consuming server: a producer can generate a download link that the LLM presents to the user as a clickable link in the conversation.
 
+**HTTP-server capability.** The `http` method requires the *producer* to be reachable as an HTTP server — it mints and serves the download URL. The consumer needs only the ability to make an *outbound* HTTP request; it does not accept inbound connections and need not itself be an HTTP-transport MCP server. A stdio MCP server can therefore be the consumer for `http` (it issues an outbound `GET`), but cannot be the producer. The spec cares about the *capability* — can a side serve a URL, can it make outbound requests — not how the server obtains HTTP access.
+
 In a file reference:
 
 ```json
@@ -247,7 +249,9 @@ A server that is both producer and consumer populates both sub-keys:
 
 #### `http_upload` (push to receiver-issued URL)
 
-The reverse of the `http` method: the *receiver* mints a one-time POST URL; any party with the URL pushes bytes. The sender can be an LLM/agent, another MCP server, or a human with an HTTP client (`curl`, browser, custom script) — the spec does not constrain who pushes. The motivating use case is when the *sender* cannot serve an HTTP endpoint: with the `http` (download) method the consumer must pull bytes from a producer-served URL, which fails if the sender is a local agent, a `curl` invocation, or any client that can make outbound requests but cannot receive inbound connections. `http_upload` inverts the direction — the receiver issues the URL, the sender only needs outbound HTTP access to reach it.
+The reverse of the `http` method: the *receiver* mints a one-time POST URL; any party with the URL pushes bytes. The sender can be an LLM/agent, another MCP server, or a human with an HTTP client (`curl`, browser, custom script) — the spec does not constrain who pushes.
+
+**HTTP-server capability.** `http_upload` mirrors `http` with the roles inverted: the method requires the *receiver* to be reachable as an HTTP server — it mints and serves the upload URL. The sender needs only the ability to make an *outbound* HTTP request; it does not accept inbound connections and need not itself be an HTTP-transport MCP server. A stdio MCP server can therefore be the sender for `http_upload` (it issues an outbound `POST`), but cannot be the receiver. This is the method's reason to exist: the `http` (download) method requires the *producer* to serve the URL, so it cannot move bytes out of a producer that has no HTTP server; `http_upload` puts the URL-serving on the receiver instead. Between the two methods, whichever side can serve HTTP, one method places the URL-serving there; `exchange` (shared volume) covers the case where neither side can.
 
 Like the existing `http` (download) method, both the URL-mint tool on the receiver side and the POST-perform tool on the sender side are wire-optional from the spec's perspective. Any HTTP client that can issue a `POST` is a valid sender, just as any HTTP client that can `GET` is a valid consumer of the existing `http` method. The tool definitions exist to standardize MCP-mediated transfer between MCP servers; they are not the only valid implementation of either side.
 

--- a/docs/specs/file-exchange.md
+++ b/docs/specs/file-exchange.md
@@ -372,7 +372,7 @@ A server that wants to act as an MCP-mediated *pusher* of bytes (e.g., a mover-s
 | Param | Cardinality | Description |
 |---|---|---|
 | `url` | MUST | The receiver-issued POST endpoint (returned from `create_upload_link`). |
-| `source` | MUST | Tagged union: exactly one of `{ "path": "<local path>" }`, `{ "exchange_uri": "exchange://..." }`, `{ "http_url": "https://..." }`, or `{ "inline_b64": "<base64 content>" }`. Implementations MAY support a subset; `path` is the lowest-common-denominator. |
+| `origin_id` | MUST | The sender's opaque stable handle for the bytes to push. Same raw-JSON validation rules as `origin_id` in the `http` method's `create_download_link` (no path separators `/` or `\`; not `.` or `..`; no null bytes / control characters; no leading or trailing whitespace). The sender resolves it to bytes by its own domain logic — a file, a database row, an in-memory object, anything; callers treat it as opaque. |
 | `content_type` | SHOULD | The MIME type the sender will declare in the POST `Content-Type` header. If omitted, the sender SHOULD sniff or default. |
 
 The tool MUST return:
@@ -388,21 +388,6 @@ The tool MUST return:
 - `body` (MAY) — the receiver's response body, passed through to the caller (opaque to the sender tool itself).
 
 On 4xx with a structured `transfer_failed` envelope, the sender tool SHOULD unwrap and re-raise as a tool error, mirroring how the existing `http` method's `fetch` tool propagates `transfer_failed`.
-
-When called with a `source` variant the sender tool does not implement, the tool MUST return an in-band failure envelope with `error: "unsupported_source_variant"` (a defined error code distinct from the generic `transfer_failed`-with-message form). The envelope MUST include the `url` parameter the caller passed (so a unified handler can correlate the error to the in-flight upload), SHOULD include a `requested_variant` field naming the variant the caller asked for, and SHOULD include a `supported_variants` field listing the variants the tool *does* implement — equivalent in content to the `source_variants` capability field if advertised:
-
-```json
-{
-  "error": "unsupported_source_variant",
-  "method": "http_upload",
-  "url": "https://receiver.example/uploads/<token>",
-  "requested_variant": "exchange_uri",
-  "supported_variants": ["path"],
-  "message": "this sender only implements 'path'; caller requested 'exchange_uri'"
-}
-```
-
-Callers that pre-checked against `source_variants` in the capability declaration will normally avoid this error; the envelope exists for the case where the capability was unavailable or stale.
 
 **Worked example — agent push:**
 
@@ -449,7 +434,7 @@ A mover-server is asked to copy bytes from an internal `exchange://` URI into an
 // step 2: mover.upload
 {
   "url": "https://vault-mcp.example/uploads/<token>",
-  "source": {"exchange_uri": "exchange://hades-01/mover-mcp/moved-from-vault.bin"},
+  "origin_id": "moved-from-vault",
   "content_type": "application/octet-stream"
 }
 // -> {"status": 201, "body": {"saved_path": "incoming/2026-05-15/movement.bin"}}

--- a/docs/specs/file-exchange.md
+++ b/docs/specs/file-exchange.md
@@ -376,7 +376,7 @@ A server that wants to act as an MCP-mediated *pusher* of bytes (e.g., a mover-s
 | Param | Cardinality | Description |
 |---|---|---|
 | `url` | MUST | The receiver-issued POST endpoint (returned from `create_upload_link`). |
-| `origin_id` | MUST | The sender's opaque stable handle for the bytes to push. Same raw-JSON validation rules as `origin_id` in the `http` method's `create_download_link` (no path separators `/` or `\`; not `.` or `..`; no null bytes / control characters; no leading or trailing whitespace). The sender resolves it to bytes by its own domain logic — a file, a database row, an in-memory object, anything; callers treat it as opaque. |
+| `origin_id` | MUST | The sender's opaque stable handle for the bytes to push. Same rules as `origin_id` in the `http` method's `create_download_link` (raw-JSON validation; no path separators `/` or `\`; not equal to `.` or `..`; no null bytes / control characters; no leading or trailing whitespace). The sender resolves it to bytes by its own domain logic — a file, a database row, an in-memory object, anything; callers treat it as opaque. |
 | `content_type` | SHOULD | The MIME type the sender will declare in the POST `Content-Type` header. If omitted, the sender SHOULD sniff or default. |
 
 The tool MUST return:

--- a/docs/specs/file-exchange.md
+++ b/docs/specs/file-exchange.md
@@ -270,10 +270,7 @@ A sender-only server (the sender side is optional):
 
 ```json
 "http_upload": {
-  "source": {
-    "tool": "upload",
-    "source_variants": ["path", "exchange_uri", "http_url", "inline_b64"]
-  }
+  "source": {"tool": "upload"}
 }
 ```
 
@@ -281,7 +278,7 @@ A server that implements both roles populates both sub-keys:
 
 ```json
 "http_upload": {
-  "source": {"tool": "upload", "source_variants": ["path"]},
+  "source": {"tool": "upload"},
   "sink": {
     "tool": "create_upload_link",
     "accepts": ["*/*"],
@@ -295,11 +292,8 @@ Fields within each role sub-object:
 
 - `tool` (MUST, both roles) — name of the MCP tool for that role (`create_upload_link` on the `sink` side, `upload` on the `source` side; the names are implementation-defined).
 - `accepts` / `max_bytes` / `max_ttl_seconds` (`sink` only) — the receiver's admission policy: accepted `Content-Type` filter, body-size ceiling, TTL ceiling.
-- `source_variants` (SHOULD, `source` only) — array of the `source` tagged-union variants the sender's tool implements. Allows callers to pre-filter and avoid round-trips on unsupported variants. If omitted, callers MUST assume only `path` is supported (the lowest-common-denominator variant per the `source` table below).
 
 The role is identified by **sub-key presence** (`source` vs `sink`), not by the tool-name string (which is implementation-defined). A server that implements both roles advertises both sub-keys — the `source`/`sink` structure expresses dual-role servers without ambiguity.
-
-The `source` role sub-key here is a capability-declaration construct. It is distinct from the `source` *parameter* on the `upload` tool (the tagged-union payload variant, defined below): same word, different protocol levels — one names a server-wide role, the other a per-invocation argument.
 
 **Receiver-side tool: `create_upload_link`**
 

--- a/docs/superpowers/plans/2026-05-15-http-upload-source-spec-fix.md
+++ b/docs/superpowers/plans/2026-05-15-http-upload-source-spec-fix.md
@@ -1,0 +1,400 @@
+# http_upload sender `source` spec fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Strip the `http_upload` sender-side `source` tagged-union machinery from `docs/specs/file-exchange.md` (it is implementation detail, not wire format), replacing it with an opaque `origin_id` parameter, and fold in a clarification of the HTTP-server-capability asymmetry.
+
+**Architecture:** Spec-document-only change — verbatim edits to one file, `docs/specs/file-exchange.md`. Three substantive tasks (the capability-shape strip; the `upload`-tool-section strip; the HTTP-capability clarification), one commit each, then a verification + draft-PR task. The spec version stays `0.3.0` — fix in place, no bump (pre-release draft spec; the sender side has zero implementations).
+
+**Tech Stack:** Markdown. No code, no tests. The implementation of the sender `upload` tool lands separately in #85.
+
+**Design doc:** `docs/superpowers/specs/2026-05-15-http-upload-source-spec-fix-design.md` (issue #93).
+
+---
+
+## File Structure
+
+- `docs/specs/file-exchange.md` — the only file changed. Edits land in three section areas: §"Transfer Methods / `http_upload`" (the capability-shape examples and the sender-tool subsection), and §"Transfer Methods / `http`" + §"Transfer Methods / `http_upload`" (the HTTP-capability clarification).
+
+Every edit below gives the exact `old_string` to find and the exact `new_string`. The `old_string`s are quoted verbatim from the current file. If any does not match, STOP and report BLOCKED — the file may have drifted.
+
+---
+
+## Task 1: Remove `source_variants` from the `http_upload` capability shape
+
+**Files:**
+- Modify: `docs/specs/file-exchange.md` — §"Transfer Methods / `http_upload`", the capability examples and the role-field list.
+
+- [ ] **Step 1: Sender-only capability example — drop `source_variants`**
+
+Find:
+
+````
+A sender-only server (the sender side is optional):
+
+```json
+"http_upload": {
+  "source": {
+    "tool": "upload",
+    "source_variants": ["path", "exchange_uri", "http_url", "inline_b64"]
+  }
+}
+```
+````
+
+Replace with:
+
+````
+A sender-only server (the sender side is optional):
+
+```json
+"http_upload": {
+  "source": {"tool": "upload"}
+}
+```
+````
+
+- [ ] **Step 2: Both-roles capability example — drop `source_variants`**
+
+Find:
+
+```
+  "source": {"tool": "upload", "source_variants": ["path"]},
+```
+
+Replace with:
+
+```
+  "source": {"tool": "upload"},
+```
+
+- [ ] **Step 3: Remove the `source_variants` field-list bullet**
+
+Find (the `source_variants` bullet, including the preceding bullet's trailing text as an anchor):
+
+```
+- `accepts` / `max_bytes` / `max_ttl_seconds` (`sink` only) — the receiver's admission policy: accepted `Content-Type` filter, body-size ceiling, TTL ceiling.
+- `source_variants` (SHOULD, `source` only) — array of the `source` tagged-union variants the sender's tool implements. Allows callers to pre-filter and avoid round-trips on unsupported variants. If omitted, callers MUST assume only `path` is supported (the lowest-common-denominator variant per the `source` table below).
+```
+
+Replace with:
+
+```
+- `accepts` / `max_bytes` / `max_ttl_seconds` (`sink` only) — the receiver's admission policy: accepted `Content-Type` filter, body-size ceiling, TTL ceiling.
+```
+
+- [ ] **Step 4: Delete the `source` role-key vs `source` parameter disambiguation paragraph**
+
+Find:
+
+```
+The role is identified by **sub-key presence** (`source` vs `sink`), not by the tool-name string (which is implementation-defined). A server that implements both roles advertises both sub-keys — the `source`/`sink` structure expresses dual-role servers without ambiguity.
+
+The `source` role sub-key here is a capability-declaration construct. It is distinct from the `source` *parameter* on the `upload` tool (the tagged-union payload variant, defined below): same word, different protocol levels — one names a server-wide role, the other a per-invocation argument.
+
+**Receiver-side tool: `create_upload_link`**
+```
+
+Replace with:
+
+```
+The role is identified by **sub-key presence** (`source` vs `sink`), not by the tool-name string (which is implementation-defined). A server that implements both roles advertises both sub-keys — the `source`/`sink` structure expresses dual-role servers without ambiguity.
+
+**Receiver-side tool: `create_upload_link`**
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/specs/file-exchange.md
+git commit -m "$(cat <<'EOF'
+docs(spec): remove source_variants from the http_upload capability shape (refs #93)
+
+source_variants advertised the sender tool's byte-acquisition
+variants — implementation detail, not wire format. The
+http_upload.source sub-object becomes {tool: "upload"}, structurally
+identical to every other tool-based role. The paragraph
+disambiguating the capability source role-key from the (now removed)
+source tool parameter goes with it.
+
+Refs #93.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Replace the `upload` tool's `source` union with `origin_id`
+
+**Files:**
+- Modify: `docs/specs/file-exchange.md` — §"Transfer Methods / `http_upload`", the "Sender-side tool: `upload`" subsection and its worked example.
+
+- [ ] **Step 1: Replace the `source` parameter row with `origin_id`**
+
+Find:
+
+```
+| Param | Cardinality | Description |
+|---|---|---|
+| `url` | MUST | The receiver-issued POST endpoint (returned from `create_upload_link`). |
+| `source` | MUST | Tagged union: exactly one of `{ "path": "<local path>" }`, `{ "exchange_uri": "exchange://..." }`, `{ "http_url": "https://..." }`, or `{ "inline_b64": "<base64 content>" }`. Implementations MAY support a subset; `path` is the lowest-common-denominator. |
+| `content_type` | SHOULD | The MIME type the sender will declare in the POST `Content-Type` header. If omitted, the sender SHOULD sniff or default. |
+```
+
+Replace with:
+
+```
+| Param | Cardinality | Description |
+|---|---|---|
+| `url` | MUST | The receiver-issued POST endpoint (returned from `create_upload_link`). |
+| `origin_id` | MUST | The sender's opaque stable handle for the bytes to push. Same raw-JSON validation rules as `origin_id` in the `http` method's `create_download_link` (no path separators `/` or `\`; not `.` or `..`; no null bytes / control characters; no leading or trailing whitespace). The sender resolves it to bytes by its own domain logic — a file, a database row, an in-memory object, anything; callers treat it as opaque. |
+| `content_type` | SHOULD | The MIME type the sender will declare in the POST `Content-Type` header. If omitted, the sender SHOULD sniff or default. |
+```
+
+- [ ] **Step 2: Remove the `unsupported_source_variant` paragraph and envelope**
+
+Find:
+
+````
+On 4xx with a structured `transfer_failed` envelope, the sender tool SHOULD unwrap and re-raise as a tool error, mirroring how the existing `http` method's `fetch` tool propagates `transfer_failed`.
+
+When called with a `source` variant the sender tool does not implement, the tool MUST return an in-band failure envelope with `error: "unsupported_source_variant"` (a defined error code distinct from the generic `transfer_failed`-with-message form). The envelope MUST include the `url` parameter the caller passed (so a unified handler can correlate the error to the in-flight upload), SHOULD include a `requested_variant` field naming the variant the caller asked for, and SHOULD include a `supported_variants` field listing the variants the tool *does* implement — equivalent in content to the `source_variants` capability field if advertised:
+
+```json
+{
+  "error": "unsupported_source_variant",
+  "method": "http_upload",
+  "url": "https://receiver.example/uploads/<token>",
+  "requested_variant": "exchange_uri",
+  "supported_variants": ["path"],
+  "message": "this sender only implements 'path'; caller requested 'exchange_uri'"
+}
+```
+
+Callers that pre-checked against `source_variants` in the capability declaration will normally avoid this error; the envelope exists for the case where the capability was unavailable or stale.
+
+**Worked example — agent push:**
+````
+
+Replace with:
+
+````
+On 4xx with a structured `transfer_failed` envelope, the sender tool SHOULD unwrap and re-raise as a tool error, mirroring how the existing `http` method's `fetch` tool propagates `transfer_failed`.
+
+**Worked example — agent push:**
+````
+
+- [ ] **Step 3: Update the "MCP-mediated push" worked example**
+
+Find:
+
+```
+// step 2: mover.upload
+{
+  "url": "https://vault-mcp.example/uploads/<token>",
+  "source": {"exchange_uri": "exchange://hades-01/mover-mcp/moved-from-vault.bin"},
+  "content_type": "application/octet-stream"
+}
+```
+
+Replace with:
+
+```
+// step 2: mover.upload
+{
+  "url": "https://vault-mcp.example/uploads/<token>",
+  "origin_id": "moved-from-vault",
+  "content_type": "application/octet-stream"
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/specs/file-exchange.md
+git commit -m "$(cat <<'EOF'
+docs(spec): http_upload upload tool takes origin_id, not a source union (refs #93)
+
+The upload tool's `source` tagged union (path / exchange_uri /
+http_url / inline_b64) prescribed how the sender locates its bytes —
+sender-side implementation detail. Replace it with an opaque
+origin_id parameter, mirroring the http method's create_download_link:
+both are the source-side "share this resource" operation and take an
+opaque, server-resolved handle. The unsupported_source_variant error
+code (meaningless with no variants) is removed; the MCP-mediated-push
+worked example uses origin_id.
+
+Refs #93.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Fold in the HTTP-server-capability clarification
+
+**Files:**
+- Modify: `docs/specs/file-exchange.md` — §"Transfer Methods / `http`" and §"Transfer Methods / `http_upload`".
+
+- [ ] **Step 1: §`http` — state the producer-serves / consumer-outbound-only rule**
+
+Find:
+
+```
+The `http` method serves double duty: the generated URL can be used for server-to-server transfer (consumer calls its fetch tool with the URL) or for **direct human download** (the LLM includes the URL in its response for the user to click). This means the `http` method is useful even without a consuming server: a producer can generate a download link that the LLM presents to the user as a clickable link in the conversation.
+
+In a file reference:
+```
+
+Replace with:
+
+```
+The `http` method serves double duty: the generated URL can be used for server-to-server transfer (consumer calls its fetch tool with the URL) or for **direct human download** (the LLM includes the URL in its response for the user to click). This means the `http` method is useful even without a consuming server: a producer can generate a download link that the LLM presents to the user as a clickable link in the conversation.
+
+**HTTP-server capability.** The `http` method requires the *producer* to be reachable as an HTTP server — it mints and serves the download URL. The consumer needs only the ability to make an *outbound* HTTP request; it does not accept inbound connections and need not itself be an HTTP-transport MCP server. A stdio MCP server can therefore be the consumer for `http` (it issues an outbound `GET`), but cannot be the producer. The spec cares about the *capability* — can a side serve a URL, can it make outbound requests — not how the server obtains HTTP access.
+
+In a file reference:
+```
+
+- [ ] **Step 2: §`http_upload` — tighten the motivating paragraph into the symmetric form**
+
+Find:
+
+```
+The reverse of the `http` method: the *receiver* mints a one-time POST URL; any party with the URL pushes bytes. The sender can be an LLM/agent, another MCP server, or a human with an HTTP client (`curl`, browser, custom script) — the spec does not constrain who pushes. The motivating use case is when the *sender* cannot serve an HTTP endpoint: with the `http` (download) method the consumer must pull bytes from a producer-served URL, which fails if the sender is a local agent, a `curl` invocation, or any client that can make outbound requests but cannot receive inbound connections. `http_upload` inverts the direction — the receiver issues the URL, the sender only needs outbound HTTP access to reach it.
+```
+
+Replace with:
+
+```
+The reverse of the `http` method: the *receiver* mints a one-time POST URL; any party with the URL pushes bytes. The sender can be an LLM/agent, another MCP server, or a human with an HTTP client (`curl`, browser, custom script) — the spec does not constrain who pushes.
+
+**HTTP-server capability.** `http_upload` mirrors `http` with the roles inverted: the method requires the *receiver* to be reachable as an HTTP server — it mints and serves the upload URL. The sender needs only the ability to make an *outbound* HTTP request; it does not accept inbound connections and need not itself be an HTTP-transport MCP server. A stdio MCP server can therefore be the sender for `http_upload` (it issues an outbound `POST`), but cannot be the receiver. This is the method's reason to exist: the `http` (download) method requires the *producer* to serve the URL, so it cannot move bytes out of a producer that has no HTTP server; `http_upload` puts the URL-serving on the receiver instead. Between the two methods, whichever side can serve HTTP, one method places the URL-serving there; `exchange` (shared volume) covers the case where neither side can.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/specs/file-exchange.md
+git commit -m "$(cat <<'EOF'
+docs(spec): clarify the http-family HTTP-server-capability asymmetry (refs #93)
+
+The http and http_upload methods each require an HTTP server on
+exactly one side — the side that mints and serves the URL. The other
+side needs only outbound HTTP and may be a stdio MCP server. §http
+gains an explicit producer-serves / consumer-outbound-only statement;
+the §http_upload motivating paragraph is tightened into the crisp
+symmetric form, noting the two methods are complementary.
+
+Refs #93.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Verify, preflight-circus, draft PR
+
+**Files:** none — verification and PR mechanics.
+
+- [ ] **Step 1: Verify the strip is complete**
+
+Run:
+
+```bash
+grep -nE 'source_variants|unsupported_source_variant|inline_b64|exchange_uri.*http_url|tagged union' docs/specs/file-exchange.md
+```
+
+Expected: no matches for `source_variants`, `unsupported_source_variant`, or the `source` tagged-union variant names in the sender context. (A surviving match means an edit was missed — fix it.) Note: `exchange_uri` may legitimately appear elsewhere if the spec references `exchange://` URIs by that phrase — inspect any match and confirm it is not the removed sender machinery.
+
+- [ ] **Step 2: Verify the version line and JSON examples**
+
+Confirm `**Version:** 0.3.0` is unchanged (line 3). Eyeball every JSON block touched by Tasks 1–3 — the `http_upload` capability examples and the `mover.upload` example — for balanced braces and valid JSON. Confirm the `upload` tool parameter table has exactly three rows: `url`, `origin_id`, `content_type`.
+
+- [ ] **Step 3: Invoke the `preflight-circus` skill**
+
+Run the `preflight-circus` skill on the cumulative diff (`git diff origin/main...HEAD`). Address every finding at confidence ≥ 80 before opening the PR. Re-run until the skill reports clean.
+
+- [ ] **Step 4: Open the PR as draft**
+
+```bash
+git push -u origin spec/http-upload-source-fix-issue-93
+gh pr create --draft --title "spec: http_upload sender source union → origin_id; HTTP-capability clarification (#93)" --body "$(cat <<'EOF'
+## Summary
+
+Strips the `http_upload` sender-side `source` tagged-union machinery from the file-exchange spec — it was implementation detail, not wire format — and folds in a clarification of the HTTP-server-capability asymmetry.
+
+- The `upload` tool's `source` tagged union (`path` / `exchange_uri` / `http_url` / `inline_b64`) is replaced by an opaque `origin_id` parameter, mirroring the `http` method's `create_download_link`: both are the source-side "share this resource" operation and take an opaque, server-resolved handle.
+- `source_variants` (capability field) and `unsupported_source_variant` (error code) are removed — with no variants, there is nothing to advertise or mismatch. `http_upload.source` becomes `{tool: "upload"}`.
+- §`http` / §`http_upload` now state crisply that each method requires an HTTP server on exactly one side (the URL-minting side); the other side needs only outbound HTTP and may be a stdio MCP server.
+
+Spec version stays `0.3.0` — fix-in-place of a pre-release draft spec; the sender side has zero implementations. The `http_upload` wire contract and the receiver side are unchanged.
+
+## Test plan
+
+- [ ] No `source_variants` / `unsupported_source_variant` / `source` tagged-union survives (grep).
+- [ ] `upload` tool parameter table is `url` / `origin_id` / `content_type`.
+- [ ] `**Version:**` line is `0.3.0`.
+- [ ] All touched JSON examples parse.
+
+Closes #93.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Watch CI + claude-review; flip ready when clean**
+
+Per the project PR workflow: read `claude-review`'s body (not just the check status), address findings within the one-round iteration cap, flip ready (`gh pr ready <N>`) once CI is green and the bot body says LGTM.
+
+---
+
+## Summary
+
+Four tasks, three substantive commits to one file. Task 1 removes `source_variants` from the capability shape. Task 2 replaces the `upload` tool's `source` union with `origin_id` and removes `unsupported_source_variant`. Task 3 folds in the HTTP-server-capability clarification. Task 4 verifies and opens the PR.
+
+## What changes
+
+- `docs/specs/file-exchange.md` — the `upload` tool parameter contract, the `http_upload` capability shape, and clarifying prose in §`http` / §`http_upload`.
+
+## What does NOT change
+
+- The `http_upload` wire contract (POST raw bytes + `Content-Type`; status codes; `transfer_failed` envelope).
+- The receiver side (`create_upload_link`, the POST contract, `http_upload.sink`).
+- The `http` and `exchange` methods' behaviour and wire contracts.
+- The spec version (`0.3.0`).
+
+## Local review
+
+`preflight-circus` runs on the cumulative diff; clean at the ≥80 confidence bar before the PR opens.
+
+## Test plan
+
+- [ ] `grep` finds no `source_variants` / `unsupported_source_variant` / sender `source` tagged-union.
+- [ ] The `upload` tool parameter table is exactly `url` / `origin_id` / `content_type`.
+- [ ] `**Version:**` line is `0.3.0`.
+- [ ] Touched JSON examples parse.
+- [ ] CI green; bot review clean.
+
+## Out of scope
+
+- The sender-side `upload` tool **implementation** — #85 (resolves `origin_id` → a file-like object via a downstream domain hook, then POSTs).
+- Any change to the receiver side, the `http` method, or `exchange`.
+
+## Acceptance (from #93 / the design doc)
+
+- [ ] The `upload` tool's `source` tagged union is replaced by an opaque `origin_id` parameter; `url` and `content_type` retained.
+- [ ] `source_variants` removed from the capability shape (examples + field list).
+- [ ] The `unsupported_source_variant` error code and envelope removed.
+- [ ] The `source` role-key vs `source` parameter disambiguation paragraph removed.
+- [ ] The "MCP-mediated push" worked example uses `origin_id`.
+- [ ] §`http` and §`http_upload` state the HTTP-server-capability asymmetry crisply.
+- [ ] The spec version stays `0.3.0`.
+- [ ] The `http_upload` wire contract and the receiver side are unchanged.

--- a/docs/superpowers/specs/2026-05-15-http-upload-source-spec-fix-design.md
+++ b/docs/superpowers/specs/2026-05-15-http-upload-source-spec-fix-design.md
@@ -1,0 +1,161 @@
+# Design: strip the http_upload sender `source` union from the spec (issue #93)
+
+**Status**: approved (brainstorm 2026-05-15)
+**Issue**: [pvliesdonk/fastmcp-pvl-core#93](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/93)
+**Umbrella**: #75
+**Blocks**: #85 (the sender-side `http_upload` implementation)
+
+## Problem
+
+The v0.3.0 file-exchange spec's §"Sender-side tool: `upload`" defines the
+tool's `source` parameter as a tagged union — `{path}` / `{exchange_uri}`
+/ `{http_url}` / `{inline_b64}` — with a companion `source_variants` field
+in the `http_upload.source` capability sub-object and an
+`unsupported_source_variant` error code.
+
+This is an implementation detail that leaked into the wire spec. The
+`source` union prescribes *how a sender locates the bytes it is about to
+push* — which is the sender server's own domain, not a wire-format interop
+concern. It is the same class of defect the #75 umbrella exists to undo.
+
+## The corrected model
+
+The protocol already has the right pattern, and uses it for the
+counterpart operation.
+
+`create_download_link` is the `http` method's **source-side** operation:
+the client/LLM says "share this resource" and passes `origin_id` — an
+**opaque handle the producing server resolves itself**. The spec is
+explicit (§"File Reference", `origin_id` row): the producer "MAY interpret
+it as a path, document id, image id, HMAC token, or any other
+internally-meaningful handle; clients and consumers MUST treat it as
+opaque." The protocol never learns whether the resource is a file, an
+in-memory image, or a database row.
+
+`http` and `http_upload` are simply two byte-transfer mechanisms.
+`create_download_link` and `upload` are *both* the source-side "share this
+resource" MCP operation — `create_download_link` shares the resource by
+minting a pull URL, `upload` shares it by pushing to a receiver-issued
+URL. They must have the **same input model**: an opaque, server-resolved
+`origin_id`. The `source` tagged union was a second, wrong way of saying
+"where are the bytes" that only `http_upload` was saddled with.
+
+The fix is to *replace* the `source` union with `origin_id`, not merely
+delete it. The `upload` tool stays normative spec — standardising
+per-method tool parameter names is explicitly the spec's job (§"Design
+Decisions / Standardised parameter names per method"). Only the resolution
+*mechanics* were the leak.
+
+## The design
+
+### 1. The `upload` tool parameter table
+
+§"Sender-side tool: `upload`" — the parameter table becomes:
+
+| Param | Cardinality | Description |
+|---|---|---|
+| `url` | MUST | The receiver-issued POST endpoint (returned from `create_upload_link`). |
+| `origin_id` | MUST | The sender's opaque stable handle for the bytes to push. Same opaque-handle semantics and segment rules as the `http` method's `create_download_link` `origin_id` (§"Security and Path Resolution"). The sender resolves it to bytes by its own domain logic; callers treat it as opaque. |
+| `content_type` | SHOULD | The MIME type the sender declares in the POST `Content-Type` header. If omitted, the sender SHOULD sniff or default. |
+
+The `source` tagged-union row is removed.
+
+The tool's return — `{status, body}` — and the rule that a `4xx` carrying
+a `transfer_failed` envelope SHOULD be unwrapped and re-raised as a tool
+error are unchanged: those are the wire/error contract, correctly placed.
+
+### 2. Remove `unsupported_source_variant`
+
+The entire `unsupported_source_variant` paragraph and its JSON envelope
+example are deleted. With no variants, there is no variant to mismatch on,
+so the error code has nothing to describe.
+
+### 3. Capability shape — remove `source_variants`
+
+The `http_upload.source` capability sub-object becomes `{"tool": "upload"}`
+— structurally identical to `http.source` and every other tool-based role.
+
+- §"Transfer Methods / `http_upload`" — the sender-only example and the
+  both-roles example drop `source_variants`.
+- The "Fields within each role sub-object" list — the `source_variants`
+  bullet is removed.
+- The paragraph that disambiguates "the `source` role sub-key" from "the
+  `source` *parameter* on the `upload` tool (the tagged-union payload
+  variant)" is **deleted entirely** — with the `source` tool parameter
+  gone, there is no longer a name collision to disambiguate.
+
+§"Discovery" carries no sender-side capability example, so its worked
+examples need no change.
+
+### 4. The worked example
+
+§"Transfer Methods / `http_upload`" → "Worked example — MCP-mediated push"
+— step 2's `mover.upload` call changes from
+`{"url": ..., "source": {"exchange_uri": "exchange://..."}, "content_type": ...}`
+to `{"url": ..., "origin_id": "<mover's resource handle>", "content_type": ...}`.
+The "agent push" example is a raw `curl` POST and is unaffected.
+
+### 5. Security and Path Resolution
+
+The `upload` tool's `origin_id` is governed by the existing `origin_id`
+segment rules (§"Security and Path Resolution"). The `upload` parameter
+table's `origin_id` row references those rules, exactly as the
+`create_upload_link` `origin_id` row already does ("Same rules as
+`origin_id` in the `http` method's `create_download_link`"). No change to
+§"Security and Path Resolution" itself is required.
+
+### What does NOT change
+
+- The `http_upload` **wire contract** — the sender POSTs raw bytes plus a
+  `Content-Type` header to the receiver-issued URL; the URL-token rules;
+  the status-code class table; the `transfer_failed` envelope. This was
+  always correct.
+- The receiver side (`create_upload_link`, the POST contract,
+  `http_upload.sink`) — entirely untouched.
+- The `http` and `exchange` methods.
+
+## Version framing — fix in place, stays 0.3.0
+
+The spec version stays `0.3.0`. The file-exchange spec is a **pre-release
+draft**: `**Status:** experimental`, internal to this repo, with no spec
+release or tag and no external consumer implementing a released spec
+version. The `source` union, `source_variants`, and the sender `upload`
+tool have **zero implementations** anywhere — the sender side is exactly
+what #85 will build, blocked on this fix. #74 shipped the v0.3.0
+*receiver*, which this change does not touch (the receiver contract —
+`create_upload_link`, the POST route, `http_upload.sink` — is unchanged),
+so no implementation needs realignment and the `SPEC_VERSION` constant
+stays `"0.3"`.
+
+This is the same fix-in-place reasoning as #83: a still-draft, in-repo
+spec corrected before first implementation of the affected surface. The
+"`0.4` permanently skipped" note is unaffected and stays.
+
+## Backward compatibility
+
+None at stake. No server advertises an `http_upload.source` capability or
+implements an `upload` tool; no `source_variants` is emitted by any
+implementation. The change is to un-implemented draft spec text.
+
+## Out of scope
+
+- The sender-side `upload` tool **implementation** — #85. #85's pvl-core
+  helper resolves the opaque `origin_id` to a file-like object through a
+  domain hook the downstream supplies (the downstream knows whether the
+  resource is a file, a database blob, or an in-memory image), then POSTs
+  it — mirroring how the download-producer side already treats
+  `origin_id` → bytes resolution as the server's own concern.
+- Any change to the receiver side, the `http` method, or `exchange`.
+
+## Acceptance (from #93)
+
+- [ ] The `upload` tool's `source` tagged union is replaced by an opaque
+  `origin_id` parameter; `url` and `content_type` retained.
+- [ ] `source_variants` is removed from the capability declaration shape
+  (examples + field list).
+- [ ] The `unsupported_source_variant` error code and envelope are removed.
+- [ ] The `source` role-key vs `source` parameter disambiguation paragraph
+  is removed.
+- [ ] The "MCP-mediated push" worked example uses `origin_id`.
+- [ ] The spec version stays `0.3.0`.
+- [ ] The `http_upload` wire contract and the receiver side are unchanged.

--- a/docs/superpowers/specs/2026-05-15-http-upload-source-spec-fix-design.md
+++ b/docs/superpowers/specs/2026-05-15-http-upload-source-spec-fix-design.md
@@ -104,6 +104,44 @@ table's `origin_id` row references those rules, exactly as the
 `origin_id` in the `http` method's `create_download_link`"). No change to
 §"Security and Path Resolution" itself is required.
 
+### 6. Clarify the HTTP-server-capability asymmetry
+
+A second, independent protocol clarification, folded into this issue by
+maintainer decision (both edits are small and land in the same §`http` /
+§`http_upload` section family).
+
+The spec does not state crisply which side of an `http`-family transfer
+must be an HTTP *server*. The principle: the `http` and `http_upload`
+methods each require an HTTP server on exactly **one** side — the side
+that mints and serves the URL. The other side needs only the ability to
+issue *outbound* HTTP requests; it does not accept inbound connections and
+need not run an HTTP-transport MCP server (a stdio MCP server can still
+make outbound requests).
+
+- `http` (download): the producer (`source`) serves the download URL, so
+  the producer must be HTTP-server-capable; the consumer (`sink`) only
+  issues an outbound GET. Usable producer-HTTP-server → consumer-stdio.
+- `http_upload`: the receiver (`sink`) serves the upload URL, so the
+  receiver must be HTTP-server-capable; the sender (`source`) only issues
+  an outbound POST. Usable sender-stdio → receiver-HTTP-server.
+- The two methods are complementary by design: between them they cover
+  both transport-asymmetry directions — whichever side can serve HTTP,
+  one of the two methods puts the URL-serving on that side. `exchange`
+  (shared volume) covers the case where neither side can serve HTTP.
+- The spec speaks of the *capability* — can a side serve a URL, can it
+  make outbound requests — not the MCP transport. How a server obtains
+  HTTP access is out of the spec's concern.
+
+Spec edits: §`http` gains an explicit statement of the
+producer-serves / consumer-outbound-only rule. The §`http_upload`
+"motivating use case" paragraph — which already states the
+sender-outbound-only half informally — is tightened into the crisp
+symmetric form. A unifying sentence framing the pair as complementary may
+go in §"Transfer Methods". Exact wording is the implementation plan's job.
+
+This is explanatory/clarifying text: it changes no behaviour and no wire
+construct, it makes existing protocol intent precise.
+
 ### What does NOT change
 
 - The `http_upload` **wire contract** — the sender POSTs raw bytes plus a
@@ -112,7 +150,9 @@ table's `origin_id` row references those rules, exactly as the
   always correct.
 - The receiver side (`create_upload_link`, the POST contract,
   `http_upload.sink`) — entirely untouched.
-- The `http` and `exchange` methods.
+- The `exchange` method.
+- The *behaviour and wire contract* of the `http` method — `http` gains
+  only clarifying prose (§6); no behavioural or wire change.
 
 ## Version framing — fix in place, stays 0.3.0
 
@@ -145,7 +185,9 @@ implementation. The change is to un-implemented draft spec text.
   resource is a file, a database blob, or an in-memory image), then POSTs
   it — mirroring how the download-producer side already treats
   `origin_id` → bytes resolution as the server's own concern.
-- Any change to the receiver side, the `http` method, or `exchange`.
+- Any *behavioural* change to the receiver side, the `http` method, or
+  `exchange`. (§6 adds clarifying prose to §`http` / §`http_upload` but
+  changes no behaviour or wire construct.)
 
 ## Acceptance (from #93)
 
@@ -157,5 +199,8 @@ implementation. The change is to un-implemented draft spec text.
 - [ ] The `source` role-key vs `source` parameter disambiguation paragraph
   is removed.
 - [ ] The "MCP-mediated push" worked example uses `origin_id`.
+- [ ] §`http` and §`http_upload` state crisply that exactly the
+  URL-minting side must be HTTP-server-capable and the other side needs
+  only outbound HTTP (§6).
 - [ ] The spec version stays `0.3.0`.
 - [ ] The `http_upload` wire contract and the receiver side are unchanged.


### PR DESCRIPTION
## Summary

The `http_upload` sender-side `upload` tool defined a `source` tagged-union parameter (`path` / `exchange_uri` / `http_url` / `inline_b64`), a `source_variants` capability field, and an `unsupported_source_variant` error code. These describe *how a sender obtains its bytes* — sender-side implementation detail — not the wire contract. This is the same class of over-specification the #75 umbrella exists to undo.

This PR:

- **Replaces `source` with an opaque `origin_id` parameter.** The `upload` tool is the `http_upload` source-side "share this resource" operation — the exact counterpart of the `http` method's `create_download_link`. Both should take an opaque, server-resolved handle; the producing/sending server knows whether the resource is a file, a DB row, or an in-memory object. The protocol stays agnostic. The `upload` tool's parameters are now `url` / `origin_id` / `content_type`.
- **Removes `source_variants` and `unsupported_source_variant`** — with no variants, there is nothing to advertise or mismatch. `http_upload.source` becomes `{tool: "upload"}`, structurally identical to every other tool-based capability role.
- **Folds in an HTTP-server-capability clarification** (§`http` / §`http_upload`): each method requires an HTTP server on exactly one side — the side that mints and serves the URL. The other side needs only outbound HTTP and may be a stdio MCP server. The two methods are complementary; this completes a reachability-asymmetry point raised in #82's review.

Spec-doc-only — `docs/specs/file-exchange.md`. No code, no tests. The `http_upload` wire contract (POST raw bytes + `Content-Type`; status codes; `transfer_failed`) and the receiver side are unchanged. The sender `upload` tool implementation lands in #85.

## Version: fix-in-place at 0.3.0 — deliberate, and why

The spec stays at `0.3.0`; this is **not** an inline amendment of a published spec version.

- The MCP File Exchange spec is `Status: experimental` and has **never been released**. "Version: 0.3.0" is an in-repo working version of a draft. Neither the spec nor any implementation of it has been published to, or consumed by, anyone outside this repository — it has not seen public light.
- The "no inline amendments to a published version" rule protects an *external interop contract*: once independently-developed servers implement a released version, it cannot be silently changed. That situation does not exist here — there is no released v0.3.0 and no external implementer to break.
- #93 changes **only the `http_upload` sender side**, which has **zero implementations anywhere**. The v0.3.0 *receiver* implementation (#74, PR #92) is untouched — `source` / `source_variants` are sender-only constructs.
- Precedent: #83 / PR #84 already corrected v0.3.0 in place, after #82 merged it, on exactly this reasoning. #93 is consistent with that.

A version bump (to `0.5`; `0.4` is permanently skipped) becomes the right mechanism once the spec is genuinely released. Until then, correcting a draft before its first implementation is fix-in-place.

## Test plan

- [x] No `source_variants` / `unsupported_source_variant` / sender `source` tagged-union survives anywhere (grep — verified clean).
- [x] The `upload` tool parameter table is exactly `url` / `origin_id` / `content_type`.
- [x] `**Version:**` line is `0.3.0`.
- [x] All touched JSON examples parse.
- [ ] CI green.
- [ ] Bot review clean.

Closes #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)