### PR TITLE
test(file-exchange): e2e coverage for produce-and-consume dual-role path

### DIFF
--- a/docs/superpowers/plans/2026-05-15-dual-role-e2e-test.md
+++ b/docs/superpowers/plans/2026-05-15-dual-role-e2e-test.md
@@ -23,7 +23,7 @@
 **Files:**
 - Modify: `tests/test_file_exchange_capability_merge.py` (imports block at lines 7-13; append fixture + test at end of file)
 
-- [ ] **Step 1: Extend the imports block**
+- [x] **Step 1: Extend the imports block**
 
 The file currently starts (lines 1-13):
 
@@ -65,7 +65,7 @@ from fastmcp_pvl_core._file_exchange_protocol import (
 )
 ```
 
-- [ ] **Step 2: Append the autouse env-isolation fixture**
+- [x] **Step 2: Append the autouse env-isolation fixture**
 
 Add at the end of `tests/test_file_exchange_capability_merge.py`:
 
@@ -100,7 +100,7 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     yield
 ```
 
-- [ ] **Step 3: Append the dual-role e2e test**
+- [x] **Step 3: Append the dual-role e2e test**
 
 Add immediately after the fixture:
 
@@ -141,12 +141,12 @@ def test_register_file_exchange_dual_role_advertises_http_source_and_sink(
     }
 ```
 
-- [ ] **Step 4: Run the new test — expect PASS**
+- [x] **Step 4: Run the new test — expect PASS**
 
 Run: `uv run pytest tests/test_file_exchange_capability_merge.py::test_register_file_exchange_dual_role_advertises_http_source_and_sink -v`
 Expected: PASS (the #86 fix is already in `main`).
 
-- [ ] **Step 5: Optional local-only regression-guard verification — DO NOT COMMIT**
+- [x] **Step 5: Optional local-only regression-guard verification — DO NOT COMMIT**
 
 To confirm the test genuinely catches the #86 bug, temporarily reintroduce it.
 In `src/fastmcp_pvl_core/file_exchange.py`, find the two independent role
@@ -166,7 +166,7 @@ Re-run the test to confirm it PASSES again. This step proves the guard works
 and leaves no production change behind. If you skip this step, that is
 acceptable — but do not commit any production-file modification.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add tests/test_file_exchange_capability_merge.py
@@ -180,7 +180,7 @@ git commit -m "test(file-exchange): e2e dual-role http capability guard (refs #8
 **Files:**
 - Modify: `tests/test_file_exchange_capability_merge.py` (append one test at end of file)
 
-- [ ] **Step 1: Append the default-accepts test**
+- [x] **Step 1: Append the default-accepts test**
 
 Add at the end of `tests/test_file_exchange_capability_merge.py`, after the
 dual-role test from Task 1:
@@ -223,18 +223,18 @@ The local `from ... import _BUILDER_ATTR` mirrors the existing
 helper pushes its `set_http_upload_sink` contribution there and the `accepts`
 argument (default `("*/*",)`) is passed verbatim.
 
-- [ ] **Step 2: Run the new test — expect PASS**
+- [x] **Step 2: Run the new test — expect PASS**
 
 Run: `uv run pytest tests/test_file_exchange_capability_merge.py::test_register_file_exchange_upload_default_accepts_wildcard_on_wire -v`
 Expected: PASS.
 
-- [ ] **Step 3: Run the whole test file**
+- [x] **Step 3: Run the whole test file**
 
 Run: `uv run pytest tests/test_file_exchange_capability_merge.py -v`
 Expected: every test PASSES — the pre-existing builder-unit tests plus the two
 new public-call-site tests.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add tests/test_file_exchange_capability_merge.py
@@ -247,17 +247,17 @@ git commit -m "test(file-exchange): e2e guard for default upload accepts wildcar
 
 **Files:** none (verification only).
 
-- [ ] **Step 1: Sync dependencies to match CI**
+- [x] **Step 1: Sync dependencies to match CI**
 
 Run: `uv sync --all-extras`
 Expected: completes without error.
 
-- [ ] **Step 2: Run the full test suite**
+- [x] **Step 2: Run the full test suite**
 
 Run: `uv run pytest -q`
 Expected: all tests pass (the prior baseline plus the 2 new tests).
 
-- [ ] **Step 3: Formatting and lint**
+- [x] **Step 3: Formatting and lint**
 
 Run: `uv run ruff format --check .`
 Expected: all files already formatted.
@@ -265,13 +265,13 @@ Expected: all files already formatted.
 Run: `uv run ruff check .`
 Expected: `All checks passed!`
 
-- [ ] **Step 4: Type check**
+- [x] **Step 4: Type check**
 
 Run: `uv run mypy src`
 Expected: `Success: no issues found` — unchanged from baseline, since no
 `src/` file was modified.
 
-- [ ] **Step 5: No production changes — verify**
+- [x] **Step 5: No production changes — verify**
 
 Run: `git diff origin/main --stat`
 Expected: only `tests/test_file_exchange_capability_merge.py` and the two

--- a/docs/superpowers/plans/2026-05-15-dual-role-e2e-test.md
+++ b/docs/superpowers/plans/2026-05-15-dual-role-e2e-test.md
@@ -1,0 +1,280 @@
+# Dual-Role e2e Test Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add end-to-end regression coverage for the produce-and-consume http dual-role capability path (issue #88) and for the default `accepts` wildcard reaching the wire.
+
+**Architecture:** Two synchronous test functions plus one autouse env-isolation fixture, all added to `tests/test_file_exchange_capability_merge.py`. These are the first public-call-site tests in that file (its existing tests drive `_FileExchangeCapabilityBuilder` directly). No production code changes — #86 already shipped the dual-role fix; this plan only adds the missing regression tests.
+
+**Tech Stack:** Python, pytest, `pytest.MonkeyPatch` for env, `fastmcp.FastMCP`.
+
+---
+
+## Notes for the implementer
+
+- **This is regression coverage for already-correct code.** Both tests are expected to **PASS** on first run — the production behavior is already right (the #86 fix shipped). There is no red-then-green TDD cycle. To *prove* Test 1 genuinely guards the regression, Task 1 includes an **optional, local-only** verification step that temporarily reverts the #86 fix; that revert is never committed.
+- All env is set via `monkeypatch.setenv`; the autouse `_clean_env` fixture (Task 1) clears every file-exchange env var so the two tests are hermetic regardless of order.
+- The `consumer_sink` and `receiver` callables are **never invoked** — the capability is built at registration time. They only need the correct type and a non-`None` identity.
+
+---
+
+## Task 1: Env-isolation fixture + http dual-role e2e test
+
+**Files:**
+- Modify: `tests/test_file_exchange_capability_merge.py` (imports block at lines 7-13; append fixture + test at end of file)
+
+- [ ] **Step 1: Extend the imports block**
+
+The file currently starts (lines 1-13):
+
+```python
+"""Tests for capability-merge across the http / http_upload registrars.
+
+Capability declarations use the v0.3.0 ``source``/``sink`` role-keyed
+``transfer_methods`` shape (spec §"Transfer Methods").
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._file_exchange_protocol import (
+    _FileExchangeCapabilityBuilder,
+)
+```
+
+Replace that import section (everything from `from __future__` through the
+`_FileExchangeCapabilityBuilder` import) with:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core import (
+    FetchContext,
+    FetchResult,
+    register_file_exchange,
+    register_file_exchange_upload,
+)
+from fastmcp_pvl_core._file_exchange_protocol import (
+    _FileExchangeCapabilityBuilder,
+)
+```
+
+- [ ] **Step 2: Append the autouse env-isolation fixture**
+
+Add at the end of `tests/test_file_exchange_capability_merge.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Public-call-site e2e tests (register_file_exchange* → capability shape)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Each test runs with no file-exchange env vars set.
+
+    The builder-unit tests above do not read env; the public-call-site
+    tests below do. Clearing keeps both kinds hermetic and order-independent.
+    """
+    for var in (
+        "MCP_EXCHANGE_DIR",
+        "MCP_EXCHANGE_ID",
+        "MCP_EXCHANGE_NAMESPACE",
+        "FASTMCP_TRANSPORT",
+        "TEST_FE_TRANSPORT",
+        "TEST_FE_BASE_URL",
+        "TEST_FE_FILE_EXCHANGE_ENABLED",
+        "TEST_FE_FILE_EXCHANGE_PRODUCE",
+        "TEST_FE_FILE_EXCHANGE_CONSUME",
+        "TEST_UP_TRANSPORT",
+        "TEST_UP_BASE_URL",
+        "TEST_UP_UPLOAD_ENABLED",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+```
+
+- [ ] **Step 3: Append the dual-role e2e test**
+
+Add immediately after the fixture:
+
+```python
+def test_register_file_exchange_dual_role_advertises_http_source_and_sink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A produce-and-consume server advertises BOTH http roles.
+
+    Regression guard for #86: ``register_file_exchange`` used
+    ``if produce / elif consume``, which hid the consumer (``sink``) tool
+    on a server that did both. #86 changed it to two independent ``if``s.
+    #86's own guard is at the builder-unit level
+    (``test_builder_http_both_roles_emits_source_and_sink``); this is the
+    integration-level twin, exercising the ``register_file_exchange``
+    public call site where the fix actually lives.
+    """
+    monkeypatch.setenv("TEST_FE_TRANSPORT", "http")
+    monkeypatch.setenv("TEST_FE_BASE_URL", "http://test.example")
+
+    async def _sink(data: bytes, ctx: FetchContext) -> FetchResult:
+        raise AssertionError("consumer_sink must not be invoked by this test")
+
+    mcp = FastMCP(name="dual-role-probe")
+    handle = register_file_exchange(
+        mcp,
+        namespace="image-mcp",
+        env_prefix="TEST_FE",
+        produces=("image/png",),
+        consumer_sink=_sink,
+    )
+
+    assert handle.capability is not None
+    http = handle.capability.to_capability_dict()["transfer_methods"]["http"]
+    assert http == {
+        "source": {"tool": "create_download_link"},
+        "sink": {"tool": "fetch_file"},
+    }
+```
+
+- [ ] **Step 4: Run the new test — expect PASS**
+
+Run: `uv run pytest tests/test_file_exchange_capability_merge.py::test_register_file_exchange_dual_role_advertises_http_source_and_sink -v`
+Expected: PASS (the #86 fix is already in `main`).
+
+- [ ] **Step 5: Optional local-only regression-guard verification — DO NOT COMMIT**
+
+To confirm the test genuinely catches the #86 bug, temporarily reintroduce it.
+In `src/fastmcp_pvl_core/file_exchange.py`, find the two independent role
+assignments inside `register_file_exchange` (search for
+`builder.set_http_source` and `builder.set_http_sink` — they sit under
+separate `if produce ...:` / `if consume:` statements). Temporarily change
+the `if consume:` to `elif consume:` so it chains onto the producer `if`.
+
+Run: `uv run pytest tests/test_file_exchange_capability_merge.py::test_register_file_exchange_dual_role_advertises_http_source_and_sink -v`
+Expected: FAIL — the `sink` role is missing, so the dict assertion fails.
+
+Then **revert** the `elif` back to `if`:
+
+Run: `git checkout -- src/fastmcp_pvl_core/file_exchange.py`
+
+Re-run the test to confirm it PASSES again. This step proves the guard works
+and leaves no production change behind. If you skip this step, that is
+acceptable — but do not commit any production-file modification.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_file_exchange_capability_merge.py
+git commit -m "test(file-exchange): e2e dual-role http capability guard (refs #88)"
+```
+
+---
+
+## Task 2: Default `accepts` wildcard reaches the wire
+
+**Files:**
+- Modify: `tests/test_file_exchange_capability_merge.py` (append one test at end of file)
+
+- [ ] **Step 1: Append the default-accepts test**
+
+Add at the end of `tests/test_file_exchange_capability_merge.py`, after the
+dual-role test from Task 1:
+
+```python
+def test_register_file_exchange_upload_default_accepts_wildcard_on_wire(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default ("*/*",) accepts reaches the http_upload.sink wire shape.
+
+    Complements ``test_builder_http_upload_sink_includes_explicit_accepts``,
+    which covers an *explicit* accepts value at the builder-unit level. This
+    confirms the default propagates through the ``register_file_exchange_upload``
+    public helper unchanged.
+    """
+    from fastmcp_pvl_core.file_exchange import _BUILDER_ATTR
+
+    monkeypatch.setenv("TEST_UP_TRANSPORT", "http")
+    monkeypatch.setenv("TEST_UP_BASE_URL", "http://test.example")
+
+    mcp = FastMCP(name="upload-accepts-probe")
+    register_file_exchange_upload(
+        mcp,
+        namespace="ns",
+        env_prefix="TEST_UP",
+        receiver=lambda record, body: {"ok": True},
+    )
+
+    builder = getattr(mcp, _BUILDER_ATTR)
+    cap = builder.build()
+    assert cap is not None
+    sink = cap.to_capability_dict()["transfer_methods"]["http_upload"]["sink"]
+    assert sink["accepts"] == ["*/*"]
+```
+
+The local `from ... import _BUILDER_ATTR` mirrors the existing
+`test_builder_is_attached_per_instance_not_module_level` in this same file.
+`register_file_exchange_upload` returns an `UploadHandle` (which carries no
+`capability`), so the capability is read off the per-`mcp` builder — the
+helper pushes its `set_http_upload_sink` contribution there and the `accepts`
+argument (default `("*/*",)`) is passed verbatim.
+
+- [ ] **Step 2: Run the new test — expect PASS**
+
+Run: `uv run pytest tests/test_file_exchange_capability_merge.py::test_register_file_exchange_upload_default_accepts_wildcard_on_wire -v`
+Expected: PASS.
+
+- [ ] **Step 3: Run the whole test file**
+
+Run: `uv run pytest tests/test_file_exchange_capability_merge.py -v`
+Expected: every test PASSES — the pre-existing builder-unit tests plus the two
+new public-call-site tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_file_exchange_capability_merge.py
+git commit -m "test(file-exchange): e2e guard for default upload accepts wildcard (refs #88)"
+```
+
+---
+
+## Task 3: Full quality gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Sync dependencies to match CI**
+
+Run: `uv sync --all-extras`
+Expected: completes without error.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `uv run pytest -q`
+Expected: all tests pass (the prior baseline plus the 2 new tests).
+
+- [ ] **Step 3: Formatting and lint**
+
+Run: `uv run ruff format --check .`
+Expected: all files already formatted.
+
+Run: `uv run ruff check .`
+Expected: `All checks passed!`
+
+- [ ] **Step 4: Type check**
+
+Run: `uv run mypy src`
+Expected: `Success: no issues found` — unchanged from baseline, since no
+`src/` file was modified.
+
+- [ ] **Step 5: No production changes — verify**
+
+Run: `git diff origin/main --stat`
+Expected: only `tests/test_file_exchange_capability_merge.py` and the two
+`docs/superpowers/` files (design + plan) appear. No `src/` file is listed.
+If a `src/` file shows up, the Task 1 Step 5 revert was not undone — restore it
+with `git checkout -- <file>` and re-run the gate.

--- a/docs/superpowers/specs/2026-05-15-dual-role-e2e-test-design.md
+++ b/docs/superpowers/specs/2026-05-15-dual-role-e2e-test-design.md
@@ -123,12 +123,12 @@ to need a running event loop.
 
 ## Acceptance (from #88)
 
-- [ ] A test in `tests/test_file_exchange_capability_merge.py` registers
+- [x] A test in `tests/test_file_exchange_capability_merge.py` registers
   `register_file_exchange(produces=..., consumer_sink=...)` on one
   `FastMCP` with the http transport + base URL, and asserts
   `transfer_methods["http"]` advertises both `source`
   (`create_download_link`) and `sink` (`fetch_file`).
-- [ ] A test asserts the default `("*/*",)` `accepts` wildcard reaches
+- [x] A test asserts the default `("*/*",)` `accepts` wildcard reaches
   the wire via `register_file_exchange_upload`.
-- [ ] No production code is modified; the full suite, `ruff`, and `mypy`
+- [x] No production code is modified; the full suite, `ruff`, and `mypy`
   stay clean.

--- a/docs/superpowers/specs/2026-05-15-dual-role-e2e-test-design.md
+++ b/docs/superpowers/specs/2026-05-15-dual-role-e2e-test-design.md
@@ -1,0 +1,134 @@
+# Design: e2e test for the produce-and-consume http dual-role path (issue #88)
+
+**Status**: approved (brainstorm 2026-05-15)
+**Issue**: [pvliesdonk/fastmcp-pvl-core#88](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/88)
+**Umbrella**: #75 — this is the last open umbrella item.
+
+## Problem
+
+#86 fixed a dual-role bug in `register_file_exchange`: the helper used
+`if produce / elif consume`, so a server that both produced and consumed
+advertised only the producer (`source`) tool — the consumer
+(`fetch_file` / `sink`) tool was hidden. #86 changed the `elif` to two
+independent `if`s.
+
+#86 guards that fix only at the **builder-unit** level
+(`test_builder_http_both_roles_emits_source_and_sink` in
+`tests/test_file_exchange_capability_merge.py` — the builder, given both
+roles, emits both). It adds **no** test exercising the
+`register_file_exchange` **public call site** with `produce and consume`,
+which is where the `if/elif`→`if/if` fix actually lives.
+
+The nearest existing test, `test_advertises_both_methods` in
+`tests/test_file_exchange_facade.py`, registers a produce-and-consume
+server but asserts only that the `http` and `exchange` *method* keys are
+present — it never inspects `http`'s `source` / `sink` *role* sub-keys.
+So the dual-role guard is untested end-to-end.
+
+A produce-*only* e2e would not guard the fix: with `produce` only, the
+old `elif consume` branch was already dead, so buggy and fixed code
+behave identically. The test must register **both** roles.
+
+Separately, #86 review noted a small coverage gap: no test confirms the
+default `("*/*",)` `accepts` wildcard reaches the wire through the
+`register_file_exchange_upload` public helper. The existing
+`test_builder_http_upload_sink_includes_explicit_accepts` covers only an
+*explicit* `accepts` value at the builder-unit level.
+
+## The design
+
+Two synchronous test functions added to
+`tests/test_file_exchange_capability_merge.py` (the file issue #88
+specifies). **Purely additive — no production code changes.**
+
+### Test 1 — http dual-role at the public call site
+
+Set the environment via `monkeypatch` so the producer and consumer sides
+both activate:
+
+- `{PREFIX}_TRANSPORT=http` and `{PREFIX}_BASE_URL=http://...` — makes
+  `enabled` true and gives the artifact store a base URL, so
+  `set_http_source` fires.
+- `produce` and `consume_env` both default to `true`
+  (`{PREFIX}_FILE_EXCHANGE_PRODUCE` / `_CONSUME`), so no extra env is
+  needed for them; passing a non-`None` `consumer_sink` makes `consume`
+  true, so `set_http_sink` fires.
+- `MCP_EXCHANGE_DIR` is cleared (it is unprefixed and deployer-global) so
+  no `exchange` method leaks into the assertion.
+
+Call `register_file_exchange(mcp, namespace=..., env_prefix=...,
+produces=("image/png",), consumer_sink=<stub>)`, then assert:
+
+```python
+handle.capability.to_capability_dict()["transfer_methods"]["http"] == {
+    "source": {"tool": "create_download_link"},
+    "sink":   {"tool": "fetch_file"},
+}
+```
+
+The `consumer_sink` is a correctly-typed `ConsumerSink`
+(`Callable[[bytes, FetchContext], Awaitable[FetchResult]]`) stub. It is
+**never invoked** — the capability is built at registration time — so it
+only needs the right type and a non-`None` identity. The facade test's
+`_identity_sink` is the existing pattern to mirror.
+
+This is the integration-level twin of #86's builder-unit guard: it would
+fail against the pre-#86 `if/elif` code (which hid the `sink` role) and
+pass against the fixed `if/if` code.
+
+### Test 2 — default `accepts` wildcard reaches the wire
+
+Register `register_file_exchange_upload` with **no** explicit `accepts`
+kwarg, build the capability, and assert:
+
+```python
+transfer_methods["http_upload"]["sink"]["accepts"] == ["*/*"]
+```
+
+This confirms the `("*/*",)` default propagates through the public helper
+to the wire — complementing `test_builder_http_upload_sink_includes_explicit_accepts`,
+which covers only an explicit value at the builder-unit level.
+
+### Deviation from the issue text
+
+Issue #88 says `pytest.mark.asyncio`. Both tests are in fact plain
+**synchronous** `def`s: `register_file_exchange` /
+`register_file_exchange_upload` are synchronous, the capability is built
+during registration, and the `consumer_sink` is never awaited. This
+matches the sibling `test_advertises_both_methods`, which is also
+synchronous. The `asyncio` marker is dropped unless registration is found
+to need a running event loop.
+
+## Test mechanics
+
+- Env is set via `monkeypatch.setenv` / cleared via
+  `monkeypatch.delenv(..., raising=False)`, matching
+  `tests/test_file_exchange_facade.py`. An env-isolation fixture (mirroring
+  that file's `_clean_env`) keeps the two new tests hermetic — in
+  particular clearing `MCP_EXCHANGE_DIR` and the `{PREFIX}_*` vars.
+- The new tests are the first public-call-site tests in
+  `test_file_exchange_capability_merge.py` (its current tests drive
+  `_FileExchangeCapabilityBuilder` directly). This is consistent with the
+  file's stated scope — "capability-merge across the http / http_upload
+  registrars" — and is what issue #88 directs.
+
+## Out of scope
+
+- Any production code change. #86 already shipped the fix; #88 only adds
+  the missing regression coverage.
+- Exercising the `consumer_sink` or `byte_source` runtime paths — the
+  tests assert capability shape only.
+- The `http_upload` `source` role and the sender `upload` tool — covered
+  by #85.
+
+## Acceptance (from #88)
+
+- [ ] A test in `tests/test_file_exchange_capability_merge.py` registers
+  `register_file_exchange(produces=..., consumer_sink=...)` on one
+  `FastMCP` with the http transport + base URL, and asserts
+  `transfer_methods["http"]` advertises both `source`
+  (`create_download_link`) and `sink` (`fetch_file`).
+- [ ] A test asserts the default `("*/*",)` `accepts` wildcard reaches
+  the wire via `register_file_exchange_upload`.
+- [ ] No production code is modified; the full suite, `ruff`, and `mypy`
+  stay clean.

--- a/tests/test_file_exchange_capability_merge.py
+++ b/tests/test_file_exchange_capability_merge.py
@@ -6,8 +6,16 @@ Capability declarations use the v0.3.0 ``source``/``sink`` role-keyed
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
+import pytest
 from fastmcp import FastMCP
 
+from fastmcp_pvl_core import (
+    FetchContext,
+    FetchResult,
+    register_file_exchange,
+)
 from fastmcp_pvl_core._file_exchange_protocol import (
     _FileExchangeCapabilityBuilder,
 )
@@ -161,3 +169,69 @@ def test_builder_http_upload_both_roles() -> None:
     block = cap.to_capability_dict()["transfer_methods"]["http_upload"]
     assert block["source"] == {"tool": "upload"}
     assert block["sink"]["tool"] == "create_upload_link"
+
+
+# ---------------------------------------------------------------------------
+# Public-call-site e2e tests (register_file_exchange* → capability shape)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Each test runs with no file-exchange env vars set.
+
+    The builder-unit tests above do not read env; the public-call-site
+    tests below do. Clearing keeps both kinds hermetic and order-independent.
+    """
+    for var in (
+        "MCP_EXCHANGE_DIR",
+        "MCP_EXCHANGE_ID",
+        "MCP_EXCHANGE_NAMESPACE",
+        "FASTMCP_TRANSPORT",
+        "TEST_FE_TRANSPORT",
+        "TEST_FE_BASE_URL",
+        "TEST_FE_FILE_EXCHANGE_ENABLED",
+        "TEST_FE_FILE_EXCHANGE_PRODUCE",
+        "TEST_FE_FILE_EXCHANGE_CONSUME",
+        "TEST_UP_TRANSPORT",
+        "TEST_UP_BASE_URL",
+        "TEST_UP_UPLOAD_ENABLED",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+def test_register_file_exchange_dual_role_advertises_http_source_and_sink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A produce-and-consume server advertises BOTH http roles.
+
+    Regression guard for #86: ``register_file_exchange`` used
+    ``if produce / elif consume``, which hid the consumer (``sink``) tool
+    on a server that did both. #86 changed it to two independent ``if``s.
+    #86's own guard is at the builder-unit level
+    (``test_builder_http_both_roles_emits_source_and_sink``); this is the
+    integration-level twin, exercising the ``register_file_exchange``
+    public call site where the fix actually lives.
+    """
+    monkeypatch.setenv("TEST_FE_TRANSPORT", "http")
+    monkeypatch.setenv("TEST_FE_BASE_URL", "http://test.example")
+
+    async def _sink(data: bytes, ctx: FetchContext) -> FetchResult:
+        raise AssertionError("consumer_sink must not be invoked by this test")
+
+    mcp = FastMCP(name="dual-role-probe")
+    handle = register_file_exchange(
+        mcp,
+        namespace="image-mcp",
+        env_prefix="TEST_FE",
+        produces=("image/png",),
+        consumer_sink=_sink,
+    )
+
+    assert handle.capability is not None
+    http = handle.capability.to_capability_dict()["transfer_methods"]["http"]
+    assert http == {
+        "source": {"tool": "create_download_link"},
+        "sink": {"tool": "fetch_file"},
+    }

--- a/tests/test_file_exchange_capability_merge.py
+++ b/tests/test_file_exchange_capability_merge.py
@@ -211,10 +211,12 @@ def test_register_file_exchange_dual_role_advertises_http_source_and_sink(
 ) -> None:
     """A produce-and-consume server advertises BOTH http roles.
 
-    Regression guard for #86: ``register_file_exchange`` used
-    ``if produce / elif consume``, which hid the consumer (``sink``) tool
-    on a server that did both. #86 changed it to two independent ``if``s.
-    #86's own guard is at the builder-unit level
+    Regression guard for #86: ``register_file_exchange`` chained the
+    consumer (``sink``) role assignment onto the producer branch as an
+    ``elif``, so whenever the producer branch was taken a server doing
+    both advertised only the producer (``source``) tool. #86 made the
+    ``set_http_sink`` call an independent ``if consume:``. #86's own
+    guard is at the builder-unit level
     (``test_builder_http_both_roles_emits_source_and_sink``); this is the
     integration-level twin, exercising the ``register_file_exchange``
     public call site where the fix actually lives.

--- a/tests/test_file_exchange_capability_merge.py
+++ b/tests/test_file_exchange_capability_merge.py
@@ -193,9 +193,13 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
         "TEST_FE_FILE_EXCHANGE_ENABLED",
         "TEST_FE_FILE_EXCHANGE_PRODUCE",
         "TEST_FE_FILE_EXCHANGE_CONSUME",
+        "TEST_FE_FILE_EXCHANGE_TTL",
         "TEST_UP_TRANSPORT",
         "TEST_UP_BASE_URL",
         "TEST_UP_UPLOAD_ENABLED",
+        "TEST_UP_UPLOAD_MAX_BYTES",
+        "TEST_UP_UPLOAD_TTL",
+        "TEST_UP_UPLOAD_TTL_MAX",
     ):
         monkeypatch.delenv(var, raising=False)
     yield

--- a/tests/test_file_exchange_capability_merge.py
+++ b/tests/test_file_exchange_capability_merge.py
@@ -15,6 +15,7 @@ from fastmcp_pvl_core import (
     FetchContext,
     FetchResult,
     register_file_exchange,
+    register_file_exchange_upload,
 )
 from fastmcp_pvl_core._file_exchange_protocol import (
     _FileExchangeCapabilityBuilder,
@@ -239,3 +240,33 @@ def test_register_file_exchange_dual_role_advertises_http_source_and_sink(
         "source": {"tool": "create_download_link"},
         "sink": {"tool": "fetch_file"},
     }
+
+
+def test_register_file_exchange_upload_default_accepts_wildcard_on_wire(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default ("*/*",) accepts reaches the http_upload.sink wire shape.
+
+    Complements ``test_builder_http_upload_sink_includes_explicit_accepts``,
+    which covers an *explicit* accepts value at the builder-unit level. This
+    confirms the default propagates through the ``register_file_exchange_upload``
+    public helper unchanged.
+    """
+    from fastmcp_pvl_core.file_exchange import _BUILDER_ATTR
+
+    monkeypatch.setenv("TEST_UP_TRANSPORT", "http")
+    monkeypatch.setenv("TEST_UP_BASE_URL", "http://test.example")
+
+    mcp = FastMCP(name="upload-accepts-probe")
+    register_file_exchange_upload(
+        mcp,
+        namespace="ns",
+        env_prefix="TEST_UP",
+        receiver=lambda record, body: {"ok": True},
+    )
+
+    builder = getattr(mcp, _BUILDER_ATTR)
+    cap = builder.build()
+    assert cap is not None
+    sink = cap.to_capability_dict()["transfer_methods"]["http_upload"]["sink"]
+    assert sink["accepts"] == ["*/*"]

--- a/tests/test_file_exchange_capability_merge.py
+++ b/tests/test_file_exchange_capability_merge.py
@@ -223,6 +223,9 @@ def test_register_file_exchange_dual_role_advertises_http_source_and_sink(
     """
     monkeypatch.setenv("TEST_FE_TRANSPORT", "http")
     monkeypatch.setenv("TEST_FE_BASE_URL", "http://test.example")
+    # FILE_EXCHANGE_PRODUCE / _CONSUME both default to "true", so the
+    # producer side and — with consumer_sink supplied — the consumer side
+    # both activate without setting those env vars explicitly.
 
     async def _sink(data: bytes, ctx: FetchContext) -> FetchResult:
         raise AssertionError("consumer_sink must not be invoked by this test")


### PR DESCRIPTION
## Summary

Adds end-to-end regression coverage for the produce-and-consume http
dual-role capability path — the last open item in the #75 umbrella.
**No production code changes.**

Two synchronous tests plus an autouse env-isolation fixture in
`tests/test_file_exchange_capability_merge.py`:

1. **`test_register_file_exchange_dual_role_advertises_http_source_and_sink`**
   — registers `register_file_exchange` with both `produces` and a
   `consumer_sink` on one `FastMCP`, and asserts `transfer_methods["http"]`
   advertises **both** `source` (`create_download_link`) and `sink`
   (`fetch_file`).
2. **`test_register_file_exchange_upload_default_accepts_wildcard_on_wire`**
   — registers `register_file_exchange_upload` with no explicit `accepts`
   and asserts the default `("*/*",)` reaches the wire as
   `transfer_methods["http_upload"]["sink"]["accepts"] == ["*/*"]`.

## Details

- Test 1 is the integration-level twin of #86's builder-unit guard
  `test_builder_http_both_roles_emits_source_and_sink`. #86 fixed a bug
  where the `sink` role assignment was chained as an `elif` onto the
  producer branch (a dual-role server advertised only the producer tool);
  #86 made `set_http_sink` an independent `if consume:`. #86 guarded the
  fix only at the builder-unit level — Test 1 covers the
  `register_file_exchange` public call site where the fix actually lives.
  Verified during development that Test 1 fails against the pre-#86
  chained-`elif` code and passes against the fixed code.
- Test 2 complements `test_builder_http_upload_sink_includes_explicit_accepts`
  (which covers an *explicit* `accepts` at the builder-unit level) by
  covering the *default* via the `register_file_exchange_upload` public
  helper.
- The autouse `_clean_env` fixture clears every file-exchange env var so
  the new public-call-site tests and the pre-existing builder-unit tests
  in the file are hermetic and order-independent.

## Test plan

- [x] 14 tests in `tests/test_file_exchange_capability_merge.py`; full
  suite `668 passed`
- [x] `ruff format --check` / `ruff check` / `mypy src` clean; the diff
  touches no `src/` file
- [x] Local multi-lens pre-flight review clean

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)