### PR TITLE
docs(readme): correct stale file-exchange spec references for v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,9 +384,9 @@ wire contract.
 
 Both helpers cooperate on the same `experimental.file_exchange`
 capability — registering both on one FastMCP instance advertises a
-single capability whose `transfer_methods` carries a separate `http`
-block (the download direction) and `http_upload` block (the upload
-direction), each using `source` / `sink` role sub-objects.
+single capability whose `transfer_methods` object carries a separate
+`http` block (the download direction) and `http_upload` block (the
+upload direction), each following the `source` / `sink` role pattern.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -377,15 +377,16 @@ register_file_exchange_upload(
 ```
 
 This mints one-time `POST` URLs via a `create_upload_link` tool and
-dispatches the bytes to your receiver. See File Exchange spec
-§"Inbound HTTP transfer" (v0.4 amendments) at
+dispatches the bytes to your receiver. See the File Exchange spec's
+§"Transfer Methods → `http_upload`" at
 [`docs/specs/file-exchange.md`](docs/specs/file-exchange.md) for the
 wire contract.
 
 Both helpers cooperate on the same `experimental.file_exchange`
 capability — registering both on one FastMCP instance advertises a
-single capability whose `transfer_methods.http` block carries both
-`download` and `upload` sub-keys.
+single capability whose `transfer_methods` carries a separate `http`
+block (the download direction) and `http_upload` block (the upload
+direction), each using `source` / `sink` role sub-objects.
 
 ## License
 


### PR DESCRIPTION
## Summary

Corrects two stale claims in the README's File Exchange section, both
overtaken by the #75 umbrella work (v0.3.0 spec). Docs-only — no code,
no spec-doc changes.

- The README pointed at a spec section `§"Inbound HTTP transfer" (v0.4
  amendments)` that no longer exists — the v0.4 amendments were reverted
  in PR #77. It now points at the real v0.3.0 section,
  §"Transfer Methods → `http_upload`".
- The README described the capability as a `transfer_methods.http` block
  carrying `download` / `upload` sub-keys. The v0.3.0 shape is a separate
  `http` block and `http_upload` block under `transfer_methods`, each
  using `source` / `sink` role sub-objects. Corrected.

## Test plan

- [x] `grep` confirms no remaining `v0.4 amendments` / `Inbound HTTP
  transfer` / `download`-`upload`-sub-keys references in the README (the
  one surviving "amendments" mention is the design-principle policy
  statement, which is correct).
- [x] New spec-section reference resolves to a real heading
  (`#### \`http_upload\`` under `### Transfer Methods`).
- [x] Local multi-lens pre-flight review clean.

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)