### PR TITLE
docs: drop the spec's Reference Implementations section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ concerns so the server family stays coherent as it grows.
 ## The framing principle
 
 Shape decisions live in pvl-core. Downstream contributes
-domain-specific logic only. Four facets in detail.
+domain-specific logic only. Five facets in detail.
 
 ### Shape decisions live in pvl-core
 
@@ -100,6 +100,23 @@ This applies to *shape* divergence (the things owned by pvl-core).
 Domain-specific divergence between downstreams is expected and does
 not require any migration — downstreams are supposed to differ in
 domain logic.
+
+### Downstream reuses pvl-core; it does not reimplement the protocol
+
+Downstream servers reuse pvl-core's implementation of the shared
+cross-cutting protocols (file exchange, auth, logging, ...). They do
+not reimplement a wire protocol independently. The `docs/specs/` spec
+is the wire authority; pvl-core is its single shared implementation.
+**No implementation is "the reference" — not even pvl-core's; the spec
+is.** A downstream is never a reference implementation entitled to
+declare its own behaviour authoritative.
+
+If pvl-core's implementation is wrong, or diverges from a `docs/specs/`
+spec, the resolution is to fix pvl-core centrally — one change, every
+downstream follows — or to evolve the spec. A downstream that believes
+pvl-core is wrong files against pvl-core; it does not fork the
+behaviour and reimplement. "pvl-core is wrong, so I'll do it myself" is
+the failure this principle exists to prevent.
 
 ## Practical consequences
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ classification test that follows from it.
 `fastmcp-pvl-core` is not a buffet of helpers downstream picks from
 à la carte. It is the load-bearing layer that fixes the shape of
 cross-cutting concerns across the server family so the family stays
-coherent as it grows. Four principles follow from that role.
+coherent as it grows. Five principles follow from that role.
 
 ### Shape decisions live in pvl-core
 
@@ -98,6 +98,21 @@ This applies to *shape* divergence (the things owned by pvl-core).
 Domain-specific divergence between downstreams is expected and does
 not require any migration — downstreams are *supposed* to differ in
 domain logic.
+
+### Downstream reuses pvl-core; it does not reimplement the protocol
+
+Downstream servers reuse pvl-core's implementation of the shared
+cross-cutting protocols — file exchange, auth, logging, and the rest.
+They do not reimplement a wire protocol independently. The specs under
+`docs/specs/` are the wire authority; pvl-core is their single shared
+implementation. No implementation is "the reference" — not pvl-core's
+either; the spec is.
+
+If pvl-core's implementation is wrong, or diverges from a spec, the fix
+is to correct pvl-core centrally — one change, every downstream follows
+— or to evolve the spec. A downstream that believes pvl-core is wrong
+files the issue against pvl-core; it does not fork the behaviour and
+reimplement it locally.
 
 ## API stability
 

--- a/docs/specs/file-exchange.md
+++ b/docs/specs/file-exchange.md
@@ -867,8 +867,3 @@ The general rule above ("Across minor versions: may introduce new required field
 ### Mixed-OS exchange groups
 
 The spec assumes POSIX filesystem semantics. Mixed-OS exchange groups would require standardising path handling. Out of scope since Docker containers are Linux regardless of host OS.
-
-## Reference Implementations
-
-- **markdown-vault-mcp** ([pvliesdonk/markdown-vault-mcp](https://github.com/pvliesdonk/markdown-vault-mcp)): Consumer. Has `fetch` tool (accepts URL + path). Would add exchange resolution and declare `transfer_methods: {exchange: {}, http: {sink: {tool: "fetch"}}}`.
-- **image-mcp**: Producer. Has `create_download_link` tool with TTL. Would add exchange writes, file references in tool responses, and declare `transfer_methods: {exchange: {}, http: {source: {tool: "create_download_link"}}}`. The `create_download_link` tool would need to accept `origin_id` as a parameter.


### PR DESCRIPTION
## Summary

Two coupled editorial documentation changes for #103. No code, no
wire-contract change.

- **Removes the file-exchange spec's `## Reference Implementations`
  section.** A protocol spec defines the wire contract between
  independently developed servers and names no implementations. The
  section listed two downstream servers as "reference implementations"
  — which hands a downstream the footing to claim its behaviour is
  authoritative over the shared pvl-core implementation. The `0.3.0`
  wire contract is unchanged, so this is an **editorial revision — no
  version bump.**
- **Adds a fifth facet** to the framing principle in `CLAUDE.md` and the
  README `## Design principles`: downstream *reuses* pvl-core's
  implementation of the shared cross-cutting protocols rather than
  reimplementing them; the `docs/specs/` spec is the wire authority and
  pvl-core its single shared implementation; **no implementation is
  "the reference"**; "pvl-core is wrong" is resolved by fixing pvl-core
  centrally or evolving the spec — never a downstream reimplementation.

## Notes

- The removed section's capability snippets were kept current to the
  v0.3.0 `source`/`sink` shape by #84; the section is removed wholesale
  regardless, because naming implementations does not belong in a
  protocol spec at all.
- `CLAUDE.md` (contributor voice) and the README (user-facing voice) are
  kept aligned per the CLAUDE.md rule; the framing intro counts are
  bumped "Four" → "Five" in both.

## Test plan

- [x] `grep` confirms no `Reference Implementations` section remains in
  `docs/specs/file-exchange.md`; the spec version field is still
  `0.3.0`.
- [x] Exactly five `###` facets under the framing principle in both
  `CLAUDE.md` and the README, intro counts updated, both aligned.
- [x] Local multi-lens pre-flight review clean.

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)