### PR TITLE
ci(release): expose `prerelease` as a force option so a second rc can be cut

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ jobs:
       id-token: write
 
     steps:
+      - name: Reject contradictory dispatch inputs
+        if: inputs.force == 'prerelease' && inputs.prerelease == false
+        run: |
+          echo "::error::force=prerelease advances the rc revision and requires the pre-release box to stay checked"
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: 'Force version bump (empty = auto; "prerelease" advances the rc revision, e.g. rc.1 → rc.2)'
+        description: 'Force version bump (empty = auto; "prerelease" advances the rc revision e.g. rc.1 → rc.2 — keep the pre-release box below checked)'
         type: choice
         default: ''
         options:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: 'Force version bump (leave empty for auto)'
+        description: 'Force version bump (empty = auto; "prerelease" advances the rc revision, e.g. rc.1 → rc.2)'
         type: choice
         default: ''
         options:
           - ''
+          - prerelease
           - patch
           - minor
           - major


### PR DESCRIPTION
## Summary

- Adds `prerelease` to the `force` `workflow_dispatch` choice in `release.yml`, and clarifies the input description.
- The release workflow could cut `X.Y.Z-rc.1` but never `rc.2` — every release line in repo history has exactly one rc. `prerelease: true` maps to PSR's `--as-prerelease`, which does **not** force a release when none would otherwise occur. Advancing the rc revision needs PSR's `--prerelease` *force* flag, surfaced by the action as `force: prerelease` (valid `force` values: `prerelease`/`patch`/`minor`/`major`). The workflow_dispatch choice list simply never exposed it.
- `force: patch` is not a substitute — it bumps the base off the highest tag (`3.0.0-rc.1` → `3.0.1-rc.1`) rather than advancing the rc revision.

## Behaviour

Dispatching with `force: prerelease` (pre-release box checked) runs `semantic-release version --prerelease --as-prerelease --prerelease-token rc`, which PSR's own docs example resolves as `rc.1 → rc.2`. The description spells out the dependency on the pre-release checkbox so the two dispatch inputs aren't read in isolation.

Closes #109

## Test plan

- [ ] Dispatch the `Release` workflow with `force: prerelease` against the `v3.0.0-rc.1` state and confirm it cuts `v3.0.0-rc.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)