### PR TITLE
file-exchange v0.5: decouple origin_id from transport encoding

### DIFF
--- a/docs/specs/file-exchange.md
+++ b/docs/specs/file-exchange.md
@@ -60,6 +60,10 @@ The interop surface. When an MCP tool produces a file intended for cross-server 
 }
 ```
 
+> The `exchange://` URI's final `{id}` segment is **producer-derived** and
+> need not resemble `origin_id` — the matching values in these examples are
+> for readability only. See §"Exchange URI".
+
 | Field | Required | Description |
 |---|---|---|
 | `origin_server` | MUST | Namespace of the producing server. The client uses this to identify which server connection to call for transfer negotiation. |

--- a/docs/specs/file-exchange.md
+++ b/docs/specs/file-exchange.md
@@ -1,6 +1,6 @@
 # MCP File Exchange Specification
 
-**Version:** 0.3.0
+**Version:** 0.5.0
 **Status:** experimental
 **Tags:** mcp, spec, interop
 
@@ -63,13 +63,15 @@ The interop surface. When an MCP tool produces a file intended for cross-server 
 | Field | Required | Description |
 |---|---|---|
 | `origin_server` | MUST | Namespace of the producing server. The client uses this to identify which server connection to call for transfer negotiation. |
-| `origin_id` | MUST | Opaque round-trip handle for this file on the origin server. The producer MAY interpret it as a path, document id, image id with embedded variant, HMAC token, or any other internally-meaningful handle; clients and consumers MUST treat it as opaque. The producer's only obligation is round-trip: the exact string returned in `file_ref.origin_id` MUST, when handed back to the producer via any transfer method that accepts an `origin_id` parameter (e.g. the `http` method's producer tool — see [Transfer Methods](#transfer-methods)), resolve to the same file (subject to TTL). |
+| `origin_id` | MUST | Opaque round-trip handle for this file on the origin server. The producer MAY interpret it as a path, document id, image id with embedded variant, HMAC token, MCP resource URI, or any other internally-meaningful handle. It is opaque to **intermediaries** — the transport and the consuming server — which MUST NOT parse, decode, or embed it verbatim in any URI, path, or filename; they only round-trip it unchanged. The producer's only obligation is round-trip: the exact string returned in `file_ref.origin_id` MUST, when handed back to the producer via any transfer method that accepts an `origin_id` parameter, resolve to the same file (subject to TTL). `origin_id` is validated only against the minimal-safety floor (§"Security and Path Resolution"); the producer's source resolution MUST itself validate the reference against its own domain rules and the caller's authorization before resolving it to bytes. |
 | `mime_type` | SHOULD | MIME type of the file. |
 | `size_bytes` | MAY | File size in bytes. |
 | `transfer` | MUST | Object whose keys are transfer method names and whose values are method-specific metadata. At least one method MUST be present. See [Transfer Methods](#transfer-methods). |
 | `preview` | SHOULD | Lightweight representation of the file for LLM context. See below. |
 
 The file reference does **not** contain a download URL or inline content. Transfer is initiated lazily by the client through the declared methods.
+
+Because the file-exchange tools are themselves MCP tools, a server that exposes its bytes as MCP resources MAY reuse the resource URI as the `origin_id` (and a sink MAY likewise accept a resource URI as `destination`). The protocol neither requires nor assumes this — it is one natural choice of opaque reference among others.
 
 #### Preview
 
@@ -305,8 +307,8 @@ The receiver registers a tool that mints upload URLs given a sender's identifier
 
 | Param | Cardinality | Rules | Description |
 |---|---|---|---|
-| `origin_id` | MUST | Same rules as `origin_id` in the `http` method's `create_download_link` (raw-JSON validation; no path separators `/` or `\`; not equal to `.` or `..`; no null bytes / control characters; no leading or trailing whitespace). | The sender's opaque stable handle for the bytes (the *what*). The receiver MAY treat it as a filename, document id, content hash, or any internally-meaningful key, but MUST NOT interpret it as a path component. |
-| `destination` | MAY | Forbids only null bytes, control characters (U+0000 through U+001F), and leading/trailing whitespace. Path separators, dots, and traversal-shaped strings are **NOT** spec-rejected. The receiver MUST validate per its own domain rules before any filesystem interaction. | The sender's destination instruction (the *where*). The receiver decides semantics — path, slot, parent document key, anything. The relaxed character rules vs. `origin_id` reflect the asymmetric role: `destination` is consumed only by the receiver's own domain logic and never embedded in a URI by anyone else. |
+| `origin_id` | MUST | Validated against the minimal-safety floor (§"Security and Path Resolution") — identical to `destination`. | The sender's opaque stable handle for the bytes (the *what*). The receiver MAY treat it as a filename, document id, content hash, MCP resource URI, or any internally-meaningful key, but MUST NOT interpret it as a path component. |
+| `destination` | MAY | Validated against the minimal-safety floor (§"Security and Path Resolution") — identical to `origin_id`. Path separators, dots, and traversal-shaped strings are **NOT** spec-rejected. The receiver MUST validate per its own domain rules before any filesystem interaction. | The sender's destination instruction (the *where*). The receiver decides semantics — path, slot, parent document key, MCP resource URI, anything. |
 | `ttl_seconds` | MAY | Positive number of seconds. | Sender's TTL hint for the minted URL. The receiver MAY clamp to its own ceiling (`max_ttl_seconds`); the effective TTL is returned. |
 | `max_bytes` | MAY | Positive integer. | Sender's intended upper bound on the upload size, used as a hint to the receiver. The receiver MAY clamp to its own ceiling (`max_bytes` in its capability declaration); the *effective* ceiling — the value the receiver will enforce at POST time — is returned in the response's `max_bytes` field. The receiver MAY use this hint to reject the link request early (via `transfer_failed`) if the requested size already exceeds policy, sparing a POST round-trip; no resource is pre-allocated. |
 | `content_type` | MAY | Standard MIME type string. | Sender's hint about what `Content-Type` the upload will declare. The receiver MAY pre-filter against its `accepts` list at link-mint time and surface a `transfer_failed` envelope in-band, sparing the sender a 415 round-trip. |
@@ -376,7 +378,7 @@ A server that wants to act as an MCP-mediated *pusher* of bytes (e.g., a mover-s
 | Param | Cardinality | Description |
 |---|---|---|
 | `url` | MUST | The receiver-issued POST endpoint (returned from `create_upload_link`). |
-| `origin_id` | MUST | The sender's opaque stable handle for the bytes to push. Same rules as `origin_id` in the `http` method's `create_download_link` (raw-JSON validation; no path separators `/` or `\`; not equal to `.` or `..`; no null bytes / control characters; no leading or trailing whitespace). The sender resolves it to bytes by its own domain logic — a file, a database row, an in-memory object, anything; callers treat it as opaque. |
+| `origin_id` | MUST | The sender's opaque stable handle for the bytes to push. Validated against the minimal-safety floor (§"Security and Path Resolution") — identical to `destination`. The sender resolves it to bytes by its own domain logic — a file, a database row, an in-memory object, anything; callers treat it as opaque. |
 | `content_type` | SHOULD | The MIME type the sender will declare in the POST `Content-Type` header. If omitted, the sender SHOULD sniff or default. |
 
 The tool MUST return:
@@ -488,7 +490,7 @@ exchange://{exchange-id}/{namespace}/{id}.{ext}
 
 - **exchange-id**: Identifies the exchange group. Scoped to the shared volume, not the server.
 - **namespace**: Namespace of the producing server. Each server writes only to its own namespace.
-- **id.ext**: File identifier with extension. The extension is informational and SHOULD match the `mime_type`.
+- **id.ext**: File identifier with extension. The `{id}` segment is **producer-derived** and **independent of `file_ref.origin_id`**: the producer derives it from the file's identity by any means (the spec does not mandate how), and it MUST satisfy the segment rules (§"Security and Path Resolution") because it is a literal path component. An `exchange://` URI is self-contained — a consumer resolving it never needs `file_ref.origin_id`. The extension is informational and SHOULD match the `mime_type`.
 
 ### Security and Path Resolution
 
@@ -497,16 +499,20 @@ All servers MUST sanitise the `{namespace}` and `{id}.{ext}` segments of exchang
 **URI decoding scope:** validation rules apply differently depending on the source of the data:
 
 - When parsing an `exchange://` URI, validation MUST occur after exactly one pass of URI decoding. Iterative or recursive decoding MUST NOT be applied, as double-encoded payloads (e.g. `%252e%252e%252f`) could bypass validation on a first-pass decode and execute traversal on a second.
-- When handling direct JSON-RPC parameters (such as `origin_id`), validation MUST be applied to the raw string as-is. Servers MUST NOT apply URI decoding to JSON parameters. An `origin_id` value is an opaque string, not a URI component; applying URI decoding would corrupt legitimate `%` characters (e.g. `req-%20-id` would be mutated to `req- -id`).
+- The `origin_id` and `destination` parameters are **opaque domain references, not URI components**. They MUST be validated as raw strings and MUST NOT be URI-decoded — URI-decoding would corrupt a legitimate `%` (e.g. `req-%20-id` would be mutated to `req- -id`). They are subject only to the **minimal-safety floor** defined below — not the segment rules.
 
-After decoding (for URIs) or direct extraction (for JSON parameters), segments:
+**`exchange://` URI segments — segment rules.** After a single URI-decode pass, the `{namespace}` and `{id}.{ext}` segments of an `exchange://` URI:
 
 - MUST NOT contain path separators (`/` or `\`).
 - MUST NOT be equal to `.` or `..`.
 - MUST NOT contain null bytes (`\0`) or control characters (U+0000 through U+001F).
 - MUST NOT contain leading or trailing whitespace.
 
-The `destination` parameter passed to a receiver's `create_upload_link` tool (new in v0.3, used by the `http_upload` method) is **not** subject to the segment-validation rules above. It is opaque to anyone but the receiver — the spec mandates only minimum safety constraints (no null bytes, no control characters U+0000 through U+001F, no leading or trailing whitespace). Path separators, dots, and traversal-shaped strings are NOT spec-rejected; the receiver MUST validate per its own domain rules before any filesystem interaction. The asymmetric rules vs. `origin_id` reflect the role split: `origin_id` MAY be echoed by the receiver into URIs or filenames (so it MUST be URI-safe), but `destination` is consumed only by the receiver's own domain logic and never embedded in a URI by anyone else.
+These segment rules apply to `exchange://` URI components only. They do **not** apply to `origin_id` or `destination`, which are opaque domain references rather than path components.
+
+**Minimal-safety floor.** Every `origin_id` and `destination` value MUST be non-empty, MUST NOT contain null bytes or control characters (U+0000 through U+001F), and MUST NOT have leading or trailing whitespace. `origin_id` and `destination` share this floor identically. Path separators, dots, and traversal-shaped strings are NOT spec-rejected by the floor; the domain server that owns the reference MUST validate it per its own domain rules before any filesystem interaction.
+
+`origin_id` and `destination` are **symmetric**: both are opaque domain references, both are validated against the minimal-safety floor only, neither is embedded verbatim in a URI by any party, and each is resolved by the domain server that owns it.
 
 In addition, `exchange://` URIs themselves MUST NOT contain a query component (`?...`) or fragment (`#...`). A URI with either is rejected as `exchange_uri_invalid`. This closes a parser-bypass class where a query string or fragment could slip past naive parsing and be misinterpreted as part of a path segment or file extension.
 
@@ -548,7 +554,7 @@ During the MCP `initialize` handshake, a participating server declares exchange 
   "capabilities": {
     "experimental": {
       "file_exchange": {
-        "version": "0.3",
+        "version": "0.5",
         "namespace": "image-mcp",
         "exchange_id": "hades-01",
         "produces": ["image/png", "image/webp", "image/jpeg"],
@@ -572,7 +578,7 @@ During the MCP `initialize` handshake, a participating server declares exchange 
   "capabilities": {
     "experimental": {
       "file_exchange": {
-        "version": "0.3",
+        "version": "0.5",
         "namespace": "vault-mcp",
         "exchange_id": "hades-01",
         "produces": [],
@@ -599,7 +605,7 @@ During the MCP `initialize` handshake, a participating server declares exchange 
 
 | Field | Required | Description |
 |---|---|---|
-| `version` | MUST | Spec version as `MAJOR.MINOR` (e.g. `"0.3"`). Patch versions are spec-internal and MUST NOT appear in the capability declaration. A server implementing spec version `0.3.0` MUST advertise `"0.3"`; patch-level differences do not change the wire-level capability. |
+| `version` | MUST | Spec version as `MAJOR.MINOR` (e.g. `"0.5"`). Patch versions are spec-internal and MUST NOT appear in the capability declaration. A server implementing spec version `0.5.0` MUST advertise `"0.5"`; patch-level differences do not change the wire-level capability. |
 | `namespace` | MUST | The server's exchange namespace. |
 | `exchange_id` | SHOULD | The exchange group ID. Present when the server participates in an exchange group. |
 | `produces` | SHOULD | MIME types this server can produce as file references. |
@@ -738,7 +744,7 @@ This signals definitively to the client that retrying is pointless. The client S
 - **MUST** write exchange files atomically: write to a temporary dotfile (e.g. `.{id}.{ext}.tmp`), close the file descriptor, then rename to the final path. This prevents consumers from reading partially written files.
 - **MUST** own the complete lifecycle of exchange files it produces. Only the producer deletes its own files. Implementation-specific (SQLite TTL, cron, stat-based, etc.).
 - **SHOULD** implement a storage ceiling or LRU eviction policy alongside time-based TTL to prevent shared volume exhaustion during high-throughput operation (e.g. generating thousands of images). TTL alone is insufficient if the production rate exceeds the expiry rate.
-- **MUST** validate `origin_id` against the path segment rules before writing. This validation applies to the raw JSON string; producers MUST NOT apply URI decoding to the `origin_id` parameter.
+- **MUST** validate `origin_id` against the minimal-safety floor. The source resolution MUST validate the reference against the server's own domain rules and the caller's authorization before resolving it to bytes (the removed segment rules were traversal hygiene, never authorization).
 - **MUST**, for tools declared in `transfer_methods.http.source`, accept a parameter named `origin_id` and return a JSON object with at minimum a `url` field.
 - **SHOULD** support the `exchange` method when `MCP_EXCHANGE_DIR` is configured.
 - **SHOULD** support the `http` method to enable cross-host transfers.
@@ -749,7 +755,7 @@ This signals definitively to the client that retrying is pointless. The client S
 - **MUST** attempt `exchange` resolution before signalling failure when a file reference includes an `exchange` entry.
 - **MUST** treat the exchange directory as read-only. Consumers MUST NOT modify exchange files. Lifecycle management is the exclusive responsibility of the producing server.
 - **MUST** ignore dotfiles in namespace directories.
-- **MUST** validate all path segments from exchange URIs after a single pass of URI decoding. JSON-RPC parameters (such as `origin_id`) MUST be validated as raw strings without URI decoding.
+- **MUST** validate the `{namespace}` and `{id}.{ext}` segments of exchange URIs against the segment rules after a single pass of URI decoding. The `origin_id` and `destination` parameters are opaque domain references — they MUST be validated as raw strings against the minimal-safety floor and MUST NOT be URI-decoded (§"Security and Path Resolution").
 - **MUST** include `remaining_transfer` in the `transfer_failed` error, containing the file reference's `transfer` with the failed method removed.
 - **SHOULD**, for tools declared in `transfer_methods.http.sink`, accept a parameter named `url` and an optional parameter named `path`. If `path` is omitted, the tool MUST auto-generate a safe local path.
 
@@ -818,7 +824,7 @@ The `http` method is deliberately simple (produce a URL, consume a URL) because 
 
 ### Validate after single decode, but only for URIs
 
-Path validation after URI decoding applies strictly to `exchange://` URI parsing. JSON-RPC parameters like `origin_id` are opaque strings that MUST be validated as-is, never URI-decoded. This distinction prevents a subtle data corruption bug: an `origin_id` containing a literal `%` character (e.g. `file-%2F-name`) would be mutated by URI decoding into `file-/-name`, which would then fail path validation or, worse, create a traversal path. The two validation contexts (URI components vs JSON strings) share the same rules but differ in preprocessing.
+`exchange://` URI segments are validated against the segment rules after exactly one URI-decode pass. `origin_id` and `destination` are opaque domain references, not URI components: they are validated as raw strings against the minimal-safety floor and are never URI-decoded. Keeping them raw prevents a subtle data corruption bug: an `origin_id` containing a literal `%` character (e.g. `file-%2F-name`) would be mutated by URI decoding into `file-/-name`, which would then misvalidate or, worse, create a traversal path. The two contexts use different rules (segment rules for URI components, the minimal-safety floor for domain references) and different preprocessing (single-decode for URIs, none for domain references).
 
 ### Implicit discovery is deliberately incomplete
 

--- a/docs/specs/file-exchange.md
+++ b/docs/specs/file-exchange.md
@@ -63,7 +63,7 @@ The interop surface. When an MCP tool produces a file intended for cross-server 
 | Field | Required | Description |
 |---|---|---|
 | `origin_server` | MUST | Namespace of the producing server. The client uses this to identify which server connection to call for transfer negotiation. |
-| `origin_id` | MUST | Opaque round-trip handle for this file on the origin server. The producer MAY interpret it as a path, document id, image id with embedded variant, HMAC token, MCP resource URI, or any other internally-meaningful handle. It is opaque to **intermediaries** — the transport and the consuming server — which MUST NOT parse, decode, or embed it verbatim in any URI, path, or filename; they only round-trip it unchanged. The producer's only obligation is round-trip: the exact string returned in `file_ref.origin_id` MUST, when handed back to the producer via any transfer method that accepts an `origin_id` parameter, resolve to the same file (subject to TTL). `origin_id` is validated only against the minimal-safety floor (§"Security and Path Resolution"); the producer's source resolution MUST itself validate the reference against its own domain rules and the caller's authorization before resolving it to bytes. |
+| `origin_id` | MUST | Opaque round-trip handle for this file on the origin server. The producer MAY interpret it as a path, document id, image id with embedded variant, HMAC token, MCP resource URI, or any other internally-meaningful handle. It is opaque to intermediaries — the transport and the consuming server — which MUST NOT parse, decode, or embed it verbatim in any URI, path, or filename; they only round-trip it unchanged. The producer's only obligation is round-trip: the exact string returned in `file_ref.origin_id` MUST, when handed back to the producer via any transfer method that accepts an `origin_id` parameter, resolve to the same file (subject to TTL). `origin_id` is validated only against the minimal-safety floor — non-empty, no null or control characters, no leading or trailing whitespace — (§"Security and Path Resolution"); the producer's source resolution MUST itself validate the reference against its own domain rules and the caller's authorization before resolving it to bytes. |
 | `mime_type` | SHOULD | MIME type of the file. |
 | `size_bytes` | MAY | File size in bytes. |
 | `transfer` | MUST | Object whose keys are transfer method names and whose values are method-specific metadata. At least one method MUST be present. See [Transfer Methods](#transfer-methods). |
@@ -512,7 +512,7 @@ These segment rules apply to `exchange://` URI components only. They do **not** 
 
 **Minimal-safety floor.** Every `origin_id` and `destination` value MUST be non-empty, MUST NOT contain null bytes or control characters (U+0000 through U+001F), and MUST NOT have leading or trailing whitespace. `origin_id` and `destination` share this floor identically. Path separators, dots, and traversal-shaped strings are NOT spec-rejected by the floor; the domain server that owns the reference MUST validate it per its own domain rules before any filesystem interaction.
 
-`origin_id` and `destination` are **symmetric**: both are opaque domain references, both are validated against the minimal-safety floor only, neither is embedded verbatim in a URI by any party, and each is resolved by the domain server that owns it.
+`origin_id` and `destination` are **symmetric**: both are opaque domain references, neither is embedded verbatim in a URI by any party, and each is resolved by the domain server that owns it.
 
 In addition, `exchange://` URIs themselves MUST NOT contain a query component (`?...`) or fragment (`#...`). A URI with either is rejected as `exchange_uri_invalid`. This closes a parser-bypass class where a query string or fragment could slip past naive parsing and be misinterpreted as part of a path segment or file extension.
 
@@ -525,7 +525,7 @@ If a server detects an invalid segment, it MUST abort and return an error:
 }
 ```
 
-Both producers (when writing) and consumers (when reading) MUST apply these rules.
+Both producers (when writing) and consumers (when reading) MUST apply the segment rules and the no-query/no-fragment rule above to `exchange://` URIs.
 
 ### Server Identification
 
@@ -744,7 +744,7 @@ This signals definitively to the client that retrying is pointless. The client S
 - **MUST** write exchange files atomically: write to a temporary dotfile (e.g. `.{id}.{ext}.tmp`), close the file descriptor, then rename to the final path. This prevents consumers from reading partially written files.
 - **MUST** own the complete lifecycle of exchange files it produces. Only the producer deletes its own files. Implementation-specific (SQLite TTL, cron, stat-based, etc.).
 - **SHOULD** implement a storage ceiling or LRU eviction policy alongside time-based TTL to prevent shared volume exhaustion during high-throughput operation (e.g. generating thousands of images). TTL alone is insufficient if the production rate exceeds the expiry rate.
-- **MUST** validate `origin_id` against the minimal-safety floor. The source resolution MUST validate the reference against the server's own domain rules and the caller's authorization before resolving it to bytes (the removed segment rules were traversal hygiene, never authorization).
+- **MUST** validate `origin_id` against the minimal-safety floor. The source resolution MUST validate the reference against the server's own domain rules and the caller's authorization before resolving it to bytes.
 - **MUST**, for tools declared in `transfer_methods.http.source`, accept a parameter named `origin_id` and return a JSON object with at minimum a `url` field.
 - **SHOULD** support the `exchange` method when `MCP_EXCHANGE_DIR` is configured.
 - **SHOULD** support the `http` method to enable cross-host transfers.

--- a/src/fastmcp_pvl_core/_file_exchange_protocol.py
+++ b/src/fastmcp_pvl_core/_file_exchange_protocol.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 #: field in the ``experimental.file_exchange`` capability declaration
 #: (spec §"Capability declaration"). Major.minor only — patch revisions
 #: are spec-internal.
-SPEC_VERSION = "0.3"
+SPEC_VERSION = "0.5"
 
 
 # ---------------------------------------------------------------------------
@@ -72,6 +72,26 @@ traversal-bypass vector (``%252e%252e%252f`` decodes once to
 §"Security and Path Resolution" mandates exactly one decode pass and
 rejection of residuals.
 """
+
+
+def validate_reference(value: str, *, field: str = "origin_id") -> str:
+    """Validate an opaque domain reference (``origin_id`` / ``destination``).
+
+    The minimal-safety floor (spec v0.5 §"Security and Path Resolution"):
+    non-empty, no null bytes, no control characters U+0000-U+001F, no
+    leading or trailing whitespace. The reference is otherwise opaque —
+    the owning domain server's hook validates it against its own domain
+    rules and the caller's authorization. Returns the value unchanged.
+    """
+    if not value:
+        raise ExchangeURIError(f"{field} MUST NOT be empty")
+    if value != value.strip():
+        raise ExchangeURIError(f"{field} MUST NOT have leading or trailing whitespace")
+    if any(ord(c) < 0x20 for c in value):
+        raise ExchangeURIError(
+            f"{field} MUST NOT contain null bytes or control characters"
+        )
+    return value
 
 
 def _check_segment_rules(value: str, *, where: str) -> str:
@@ -707,4 +727,5 @@ __all__ = [
     "FileRefPreview",
     "TransferMethods",
     "register_file_exchange_capability",
+    "validate_reference",
 ]

--- a/src/fastmcp_pvl_core/_file_exchange_protocol.py
+++ b/src/fastmcp_pvl_core/_file_exchange_protocol.py
@@ -482,7 +482,7 @@ class _FileExchangeCapabilityBuilder:
     instance; the capability dict is materialised by :meth:`build` once
     every registrar has run.
 
-    Transfer methods are advertised in the v0.3.0 ``source``/``sink``
+    Transfer methods are advertised in the v0.5 ``source``/``sink``
     role-keyed shape (spec §"Transfer Methods"): ``http`` and
     ``http_upload`` are separate top-level method keys, and each carries
     whichever of the ``source`` / ``sink`` roles the server fills.
@@ -548,7 +548,7 @@ class _FileExchangeCapabilityBuilder:
             ``None`` if no transfer method has been set (neither
             exchange nor an ``http`` role nor an ``http_upload`` role).
             Otherwise a frozen :class:`FileExchangeCapability` whose
-            ``transfer_methods`` uses the v0.3.0 ``source``/``sink`` shape.
+            ``transfer_methods`` uses the v0.5 ``source``/``sink`` shape.
         """
         transfer_methods: dict[str, dict[str, Any]] = {}
         if self._exchange_present:

--- a/src/fastmcp_pvl_core/_file_exchange_protocol.py
+++ b/src/fastmcp_pvl_core/_file_exchange_protocol.py
@@ -56,9 +56,14 @@ class ExchangeURIError(ValueError):
 # - inside an ``exchange://`` URI (where a single pass of percent-decoding
 #   MUST be applied before validation, and double-encoded payloads MUST
 #   be rejected); and
-# - as raw JSON-RPC parameters such as ``origin_id`` (where decoding
-#   MUST NOT be applied — a literal ``%`` in the value is data, not
-#   encoding). Both contexts share the rule set below.
+# - as raw JSON-RPC-derived path components such as ``namespace``,
+#   ``exchange_id``, and ``ext`` (where decoding MUST NOT be applied — a
+#   literal ``%`` in the value is data, not encoding). Both contexts
+#   share the rule set below.
+#
+# Opaque domain references (``origin_id``, ``destination``) are NOT
+# segment values: they go through the looser minimal-safety floor in
+# ``validate_reference``, not these rules.
 
 _FORBIDDEN_SEGMENT_CHARS = re.compile(r"[/\\\x00-\x1f]")
 """Path separators and ASCII control characters (U+0000–U+001F)."""
@@ -385,8 +390,9 @@ class ExchangeURI:
             role: ``"uri"`` decodes the value once before validating
                 (and rejects residual ``%XX`` to defeat double-encoded
                 traversal). ``"json_param"`` validates the value as-is
-                — JSON-RPC parameters such as ``origin_id`` MUST NOT be
-                URI-decoded (a literal ``%`` is data, not encoding).
+                — JSON-RPC-derived components such as ``namespace`` or
+                ``ext`` MUST NOT be URI-decoded (a literal ``%`` is data,
+                not encoding).
 
         Returns:
             The decoded (for ``role="uri"``) or raw (for

--- a/src/fastmcp_pvl_core/_file_exchange_runtime.py
+++ b/src/fastmcp_pvl_core/_file_exchange_runtime.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import errno
+import hashlib
 import logging
 import os
 import secrets
@@ -204,6 +205,19 @@ def _resolve_exchange_id(base_dir: Path, explicit: str | None) -> str:
     return candidate
 
 
+def _exchange_segment(origin_id: str) -> str:
+    """Derive the ``exchange://`` URI ``{id}`` segment from an ``origin_id``.
+
+    The segment is a literal path component and filename, so it must
+    satisfy the spec segment rules whatever the ``origin_id`` contains.
+    A SHA-256 hex digest is unconditionally segment-safe, fixed-length,
+    and deterministic — repeated writes for the same ``origin_id``
+    resolve to the same exchange file. One-way by design: the
+    ``file_ref`` carries the real ``origin_id``; nothing reverses this.
+    """
+    return hashlib.sha256(origin_id.encode("utf-8")).hexdigest()
+
+
 # ---------------------------------------------------------------------------
 # FileExchange — env-driven runtime
 # ---------------------------------------------------------------------------
@@ -321,11 +335,14 @@ class FileExchange:
         filesystem (spec §"Producing server").
 
         Args:
-            origin_id: Producer-chosen file id. Validated as a raw JSON
-                parameter (spec §"Security and Path Resolution") — a
-                literal ``%`` is preserved.
-            ext: File extension (no leading dot). Validated the same
-                way.
+            origin_id: Producer-chosen opaque reference. Never used
+                verbatim as a path component — the ``exchange://`` URI
+                ``{id}`` segment is derived from it via
+                :func:`_exchange_segment` (spec v0.5 §"Security and
+                Path Resolution"). Used here only for the debug log and
+                as the derivation input.
+            ext: File extension (no leading dot). Validated as a literal
+                URI segment.
             content: Bytes to write, OR a :class:`pathlib.Path` to a
                 file to copy. The Path form is stream-copied chunk by
                 chunk and never materialises the full file in memory —
@@ -336,18 +353,11 @@ class FileExchange:
             The resulting :class:`ExchangeURI`.
 
         Raises:
-            ExchangeURIError: ``origin_id`` or ``ext`` violates spec
-                segment rules from spec §"Security and Path Resolution",
-                or ``origin_id`` starts with a dot
-                (which would land in the dotfile name space and be
-                hidden from consumers).
+            ExchangeURIError: ``ext`` violates the spec segment rules
+                from spec §"Security and Path Resolution".
         """
-        ExchangeURI.validate_segment(origin_id, role="json_param")
         ExchangeURI.validate_segment(ext, role="json_param")
-        if origin_id.startswith("."):
-            raise ExchangeURIError(
-                f"origin_id MUST NOT start with a dot: {origin_id!r}"
-            )
+        seg = _exchange_segment(origin_id)
 
         namespace_dir = self.base_dir / self.namespace
         namespace_dir.mkdir(mode=0o755, exist_ok=True)
@@ -361,7 +371,7 @@ class FileExchange:
                 namespace_dir,
                 exc,
             )
-        final_path = namespace_dir / f"{origin_id}.{ext}"
+        final_path = namespace_dir / f"{seg}.{ext}"
         # Include a random suffix in the temp name so two concurrent
         # writes for the same origin_id don't collide on the same temp
         # path (one writer's truncate would otherwise corrupt the
@@ -369,7 +379,7 @@ class FileExchange:
         # writer-wins on the final filename, which is the documented
         # contract — but each writer's stream is now isolated.
         unique = secrets.token_hex(8)
-        tmp_path = namespace_dir / f".{origin_id}.{unique}.{ext}.tmp"
+        tmp_path = namespace_dir / f".{seg}.{unique}.{ext}.tmp"
 
         try:
             # Open restrictively (0o600) to satisfy CodeQL's
@@ -421,7 +431,7 @@ class FileExchange:
         return ExchangeURI(
             exchange_id=self.exchange_id,
             namespace=self.namespace,
-            id=origin_id,
+            id=seg,
             ext=ext,
         )
 

--- a/src/fastmcp_pvl_core/_file_exchange_runtime.py
+++ b/src/fastmcp_pvl_core/_file_exchange_runtime.py
@@ -35,7 +35,11 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 from fastmcp_pvl_core._env import env
-from fastmcp_pvl_core._file_exchange_protocol import ExchangeURI, ExchangeURIError
+from fastmcp_pvl_core._file_exchange_protocol import (
+    ExchangeURI,
+    ExchangeURIError,
+    validate_reference,
+)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -339,8 +343,9 @@ class FileExchange:
                 verbatim as a path component — the ``exchange://`` URI
                 ``{id}`` segment is derived from it via
                 :func:`_exchange_segment` (spec v0.5 §"Security and
-                Path Resolution"). Used here only for the debug log and
-                as the derivation input.
+                Path Resolution"). Validated against the minimal-safety
+                floor; otherwise used only for the debug log and as the
+                derivation input.
             ext: File extension (no leading dot). Validated as a literal
                 URI segment.
             content: Bytes to write, OR a :class:`pathlib.Path` to a
@@ -353,10 +358,15 @@ class FileExchange:
             The resulting :class:`ExchangeURI`.
 
         Raises:
-            ExchangeURIError: ``ext`` violates the spec segment rules
-                from spec §"Security and Path Resolution".
+            ExchangeURIError: ``ext`` violates the spec segment rules,
+                or ``origin_id`` violates the minimal-safety floor
+                (spec §"Security and Path Resolution").
         """
         ExchangeURI.validate_segment(ext, role="json_param")
+        # Defence-in-depth: the producing facade validates origin_id
+        # before calling here, but write_atomic is also reachable
+        # directly — enforce the spec v0.5 minimal-safety floor too.
+        validate_reference(origin_id, field="origin_id")
         seg = _exchange_segment(origin_id)
 
         namespace_dir = self.base_dir / self.namespace

--- a/src/fastmcp_pvl_core/_token_store.py
+++ b/src/fastmcp_pvl_core/_token_store.py
@@ -106,35 +106,13 @@ class TokenRecord:
 
     Attributes:
         content: The raw bytes to serve.
-        filename: Suggested filename for the ``Content-Disposition`` header.
         mime_type: MIME type served in the ``Content-Type`` header.
         expires_at: Unix timestamp after which the record is considered expired.
     """
 
     content: bytes
-    filename: str
     mime_type: str
     expires_at: float
-
-
-def _sanitize_filename(filename: str) -> str:
-    """Strip characters that would break a ``Content-Disposition`` header.
-
-    The HTTP header grammar forbids raw CR/LF and treats double quote and
-    backslash as structural characters. We remove CR/LF entirely (prevents
-    header injection) and replace quote and backslash with ``_`` so the
-    header remains parseable. Non-ASCII code points are not percent-encoded
-    here — callers that need them should pass an already-sanitised filename.
-
-    Args:
-        filename: Raw filename supplied by the caller.
-
-    Returns:
-        A filename safe to embed inside a quoted-string ``filename=`` param.
-    """
-    cleaned = filename.replace("\r", "").replace("\n", "")
-    cleaned = cleaned.replace('"', "_").replace("\\", "_")
-    return cleaned or "download"
 
 
 class ArtifactStore(_BaseTokenStore[TokenRecord]):
@@ -185,7 +163,6 @@ class ArtifactStore(_BaseTokenStore[TokenRecord]):
         self,
         content: bytes,
         *,
-        filename: str,
         mime_type: str,
         ttl_seconds: float | None = None,
     ) -> str:
@@ -193,7 +170,6 @@ class ArtifactStore(_BaseTokenStore[TokenRecord]):
 
         Args:
             content: Raw bytes to serve on retrieval.
-            filename: Filename advertised via ``Content-Disposition``.
             mime_type: MIME type advertised via ``Content-Type``.
             ttl_seconds: Per-token lifetime override. ``None`` (default)
                 uses the store's default TTL set at construction.
@@ -206,7 +182,6 @@ class ArtifactStore(_BaseTokenStore[TokenRecord]):
         ttl = self._ttl if ttl_seconds is None else float(ttl_seconds)
         self._records[token] = TokenRecord(
             content=content,
-            filename=filename,
             mime_type=mime_type,
             expires_at=time.time() + ttl,
         )
@@ -275,7 +250,6 @@ class ArtifactStore(_BaseTokenStore[TokenRecord]):
         content: bytes,
         *,
         content_type: str,
-        filename: str,
         ttl_seconds: float | None = None,
     ) -> str:
         """Stash ``content`` and return a one-time download URL.
@@ -286,7 +260,6 @@ class ArtifactStore(_BaseTokenStore[TokenRecord]):
         Args:
             content: Raw bytes to serve on retrieval.
             content_type: MIME type advertised via ``Content-Type``.
-            filename: Filename advertised via ``Content-Disposition``.
             ttl_seconds: Per-token lifetime override. ``None`` (default)
                 uses the store's default TTL.
 
@@ -299,7 +272,6 @@ class ArtifactStore(_BaseTokenStore[TokenRecord]):
         """
         token = self.add(
             content,
-            filename=filename,
             mime_type=content_type,
             ttl_seconds=ttl_seconds,
         )
@@ -340,7 +312,6 @@ class ArtifactStore(_BaseTokenStore[TokenRecord]):
                 )
                 return Response(content="Not Found", status_code=404)
 
-            safe_filename = _sanitize_filename(record.filename)
             logger.info(
                 "artifact_handler_serve token_prefix=%s size=%d mime=%s",
                 token[:8],
@@ -351,7 +322,7 @@ class ArtifactStore(_BaseTokenStore[TokenRecord]):
                 content=record.content,
                 media_type=record.mime_type,
                 headers={
-                    "Content-Disposition": (f'attachment; filename="{safe_filename}"'),
+                    "Content-Disposition": "attachment",
                 },
             )
 

--- a/src/fastmcp_pvl_core/_token_store.py
+++ b/src/fastmcp_pvl_core/_token_store.py
@@ -411,11 +411,11 @@ class UploadRecord:
     An ``UploadRecord`` does not carry bytes — bytes arrive over the wire
     when a client ``POST``s to ``/<ns>/uploads/{token}``. The record
     carries the metadata the receiver needs to commit the bytes, modelling
-    the v0.3.0 spec's WHAT/WHERE split, plus the runtime guards.
+    the v0.5 spec's WHAT/WHERE split, plus the runtime guards.
 
     Attributes:
         origin_id: The sender's opaque stable handle for the bytes (the
-            *what*). Validated against the spec's segment grammar — see
+            *what*). Validated against the minimal-safety floor — see
             ``docs/specs/file-exchange.md`` §"Security and Path
             Resolution".
         destination: The sender's destination instruction (the *where*),

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -811,7 +811,9 @@ def _disposition_filename(origin_id: str, ext: str) -> str:
     characters; it is never used verbatim. Keep a readable tail and
     sanitise to a conservative charset.
     """
-    tail = origin_id.rsplit("/", 1)[-1] or origin_id
+    # Treat ``\`` like ``/`` so a path-shaped origin_id yields the same
+    # tail regardless of separator style.
+    tail = origin_id.replace("\\", "/").rsplit("/", 1)[-1] or origin_id
     safe = re.sub(r"[^A-Za-z0-9._-]", "_", tail).strip("._") or "download"
     return f"{safe}.{ext}"
 

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -52,7 +52,6 @@ import io
 import ipaddress
 import logging
 import mimetypes
-import re
 import tempfile
 from collections.abc import (
     AsyncIterator,
@@ -564,9 +563,9 @@ class FileExchangeHandle:
 def _ext_for(mime_type: str | None) -> str:
     """Pick a file extension (no leading dot) for a MIME type.
 
-    Used for the ``exchange`` URI's filename segment and the ``http``
-    download's ``Content-Disposition``. Always pvl-core-derived — never
-    a hook input — so the result is always a safe path segment.
+    Used for the ``exchange`` URI's filename-segment extension. Always
+    pvl-core-derived — never a hook input — so the result is always a
+    safe path segment.
     """
     guessed = mimetypes.guess_extension(mime_type or "") or ".bin"
     return guessed.lstrip(".")
@@ -804,20 +803,6 @@ def _resolve_enabled(env_prefix: str, transport: Literal["http", "stdio"]) -> bo
 # ---------------------------------------------------------------------------
 
 
-def _disposition_filename(origin_id: str, ext: str) -> str:
-    """Derive a header-safe Content-Disposition filename from an origin_id.
-
-    ``origin_id`` is opaque: pvl-core does not parse its structure, so
-    it is not split on ``/`` (or any other character) to extract a
-    "tail" — nothing inside an opaque reference is a path separator.
-    The whole reference is folded to a conservative charset; slash,
-    backslash, colon, space and every other non-``[A-Za-z0-9._-]``
-    character are treated identically. Advisory download-name only.
-    """
-    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", origin_id).strip("._") or "download"
-    return f"{safe}.{ext}"
-
-
 def _register_create_download_link(mcp: FastMCP, handle: FileExchangeHandle) -> None:
     """Register the spec-compliant ``create_download_link`` MCP tool."""
 
@@ -886,7 +871,6 @@ def _register_create_download_link(mcp: FastMCP, handle: FileExchangeHandle) -> 
         url = handle.artifact_store.put_ephemeral(
             data,
             content_type=content_type,
-            filename=_disposition_filename(origin_id, _ext_for(resolved.content_type)),
             ttl_seconds=effective_ttl,
         )
         return {

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -1,13 +1,13 @@
 """MCP File Exchange — public facade.
 
 Single-entry-point wiring for downstream MCP servers that want to
-participate in the File Exchange convention (spec v0.3.0). Composes
+participate in the File Exchange convention (spec v0.5). Composes
 the artifact store, the protocol surface, and the exchange-volume
 runtime, and registers the spec-compliant ``create_download_link``
 and ``fetch_file`` MCP tools.
 
 The ``experimental.file_exchange`` capability this module advertises
-uses the v0.3.0 ``transfer_methods`` shape: ``http`` and
+uses the v0.5 ``transfer_methods`` shape: ``http`` and
 ``http_upload`` are separate method keys, each carrying ``source`` /
 ``sink`` role sub-objects for whichever role(s) the server fills.
 
@@ -587,7 +587,7 @@ def register_file_exchange(
     source: SourceHook | None = None,
     sink: SinkHook | None = None,
 ) -> FileExchangeHandle:
-    """Wire MCP File Exchange (v0.3.0) onto ``mcp``.
+    """Wire MCP File Exchange (v0.5) onto ``mcp``.
 
     The kwarg surface is intentionally minimal — only domain hooks,
     no operator-config kwargs, no override seams. Operator config
@@ -721,7 +721,7 @@ def register_file_exchange(
     # --- Capability declaration ---
     # Push contributions into the per-FastMCP builder so that an upload
     # registrar on the same ``mcp`` can merge into one capability dict.
-    # The shape emitted is the v0.3.0 ``source``/``sink`` role-keyed form.
+    # The shape emitted is the v0.5 ``source``/``sink`` role-keyed form.
     capability: FileExchangeCapability | None = None
     if enabled:
         builder = _get_or_create_builder(

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -1801,21 +1801,14 @@ def register_file_exchange_upload(
         # rest per its own domain rules.
         try:
             validate_reference(origin_id, field="origin_id")
+            if destination is not None:
+                validate_reference(destination, field="destination")
         except ExchangeURIError as exc:
             return _upload_transfer_failed(
                 receiver_server=namespace,
                 origin_id=origin_id,
                 message=str(exc),
             )
-        if destination is not None:
-            try:
-                validate_reference(destination, field="destination")
-            except ExchangeURIError as exc:
-                return _upload_transfer_failed(
-                    receiver_server=namespace,
-                    origin_id=origin_id,
-                    message=str(exc),
-                )
         # content_type hint: pre-filter against the receiver's accepts
         # list so a mismatched hint is rejected in-band, before a wasted
         # POST round-trip (the route still enforces 415 on the actual

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -807,14 +807,14 @@ def _resolve_enabled(env_prefix: str, transport: Literal["http", "stdio"]) -> bo
 def _disposition_filename(origin_id: str, ext: str) -> str:
     """Derive a header-safe Content-Disposition filename from an origin_id.
 
-    ``origin_id`` is an opaque reference that MAY contain URI/path
-    characters; it is never used verbatim. Keep a readable tail and
-    sanitise to a conservative charset.
+    ``origin_id`` is opaque: pvl-core does not parse its structure, so
+    it is not split on ``/`` (or any other character) to extract a
+    "tail" — nothing inside an opaque reference is a path separator.
+    The whole reference is folded to a conservative charset; slash,
+    backslash, colon, space and every other non-``[A-Za-z0-9._-]``
+    character are treated identically. Advisory download-name only.
     """
-    # Treat ``\`` like ``/`` so a path-shaped origin_id yields the same
-    # tail regardless of separator style.
-    tail = origin_id.replace("\\", "/").rsplit("/", 1)[-1] or origin_id
-    safe = re.sub(r"[^A-Za-z0-9._-]", "_", tail).strip("._") or "download"
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", origin_id).strip("._") or "download"
     return f"{safe}.{ext}"
 
 

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -293,9 +293,13 @@ class SinkContext(NamedTuple):
     """Per-call context handed to a :data:`SinkHook` alongside the bytes.
 
     Attributes:
-        origin_id: The opaque id the bytes arrived under, when the
-            mechanism carries one (``exchange`` URI, ``http_upload``
-            POST); ``None`` for a bare-``url`` ``http`` fetch.
+        origin_id: The producer's opaque ``origin_id`` when the call
+            carries one — a ``file_ref``-driven ``fetch_file`` (from
+            ``file_ref.origin_id``) or an ``http_upload`` receive (from
+            the POST parameter). ``None`` for a bare-``url`` fetch,
+            ``http`` or ``exchange`` alike: a bare URL carries no
+            ``origin_id`` — an ``exchange://`` URL carries only the
+            pvl-core-derived segment, which is not the reference.
         mime_type: Best-known MIME type — from the file reference, the
             HTTP ``Content-Type`` header, or the upload request hint.
         size_bytes: Byte length when known up front, else ``None``.

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -52,6 +52,7 @@ import io
 import ipaddress
 import logging
 import mimetypes
+import re
 import tempfile
 from collections.abc import (
     AsyncIterator,
@@ -76,6 +77,7 @@ from fastmcp_pvl_core._file_exchange_protocol import (
     FileRefPreview,
     _FileExchangeCapabilityBuilder,
     register_file_exchange_capability,
+    validate_reference,
 )
 from fastmcp_pvl_core._file_exchange_runtime import (
     ExchangeGroupMismatch,
@@ -450,8 +452,12 @@ class FileExchangeHandle:
                 content. It MUST be resolvable by this handle's
                 ``source`` hook — pvl-core never invents one, because a
                 pvl-core-generated id would be unknown to the hook.
-                Validated as a raw JSON parameter (spec §"Security and
-                Path Resolution" — never URI-decoded).
+                Validated only against the minimal-safety floor (spec
+                v0.5 §"Security and Path Resolution"): non-empty, no
+                null bytes or control characters, no leading/trailing
+                whitespace. It is otherwise opaque — the ``source`` hook
+                owns domain validation, and pvl-core derives every path
+                and URI segment it needs, never embedding it verbatim.
             mime_type: MIME type of the content. Required; also selects
                 the ``exchange`` URI extension via :mod:`mimetypes`.
             size_bytes: Optional size for the file reference. When the
@@ -471,11 +477,7 @@ class FileExchangeHandle:
                 "hook was passed to register_file_exchange (where {prefix} "
                 "is the env_prefix)"
             )
-        ExchangeURI.validate_segment(origin_id, role="json_param")
-        if origin_id.startswith("."):
-            raise ExchangeURIError(
-                f"origin_id MUST NOT start with a dot: {origin_id!r}"
-            )
+        validate_reference(origin_id, field="origin_id")
 
         transfer: dict[str, dict[str, Any]] = {}
 
@@ -802,6 +804,18 @@ def _resolve_enabled(env_prefix: str, transport: Literal["http", "stdio"]) -> bo
 # ---------------------------------------------------------------------------
 
 
+def _disposition_filename(origin_id: str, ext: str) -> str:
+    """Derive a header-safe Content-Disposition filename from an origin_id.
+
+    ``origin_id`` is an opaque reference that MAY contain URI/path
+    characters; it is never used verbatim. Keep a readable tail and
+    sanitise to a conservative charset.
+    """
+    tail = origin_id.rsplit("/", 1)[-1] or origin_id
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", tail).strip("._") or "download"
+    return f"{safe}.{ext}"
+
+
 def _register_create_download_link(mcp: FastMCP, handle: FileExchangeHandle) -> None:
     """Register the spec-compliant ``create_download_link`` MCP tool."""
 
@@ -818,7 +832,7 @@ def _register_create_download_link(mcp: FastMCP, handle: FileExchangeHandle) -> 
         clamped to the server's configured maximum.
         """
         try:
-            ExchangeURI.validate_segment(origin_id, role="json_param")
+            validate_reference(origin_id, field="origin_id")
         except ExchangeURIError as exc:
             return _transfer_failed(
                 origin_server=handle.namespace,
@@ -870,7 +884,7 @@ def _register_create_download_link(mcp: FastMCP, handle: FileExchangeHandle) -> 
         url = handle.artifact_store.put_ephemeral(
             data,
             content_type=content_type,
-            filename=f"{origin_id}.{_ext_for(resolved.content_type)}",
+            filename=_disposition_filename(origin_id, _ext_for(resolved.content_type)),
             ttl_seconds=effective_ttl,
         )
         return {
@@ -1754,14 +1768,15 @@ def register_file_exchange_upload(
 
         Args:
             origin_id: The sender's opaque stable handle for the bytes
-                (the *what*). Validated against the spec's segment rules
-                (§"Security and Path Resolution"): no ``/``, ``\``, ``.``,
-                ``..``, control bytes, leading/trailing whitespace.
+                (the *what*). Validated against the minimal-safety floor
+                (spec v0.5 §"Security and Path Resolution"): non-empty,
+                no null bytes or control characters, no leading/trailing
+                whitespace. Otherwise opaque — the receiver validates
+                the rest per its own domain rules.
             destination: Optional destination instruction (the *where*).
-                Only null bytes, control characters, and leading/trailing
-                whitespace are rejected at the spec level; the receiver
-                validates the rest per its own domain rules via
-                ``pre_link_validator``.
+                Validated against the same minimal-safety floor as
+                ``origin_id``; the receiver validates the rest per its
+                own domain rules via ``pre_link_validator``.
             content_type: Optional hint of the ``Content-Type`` the POST
                 will declare; pre-filtered against the receiver's
                 ``accepts`` list.
@@ -1775,30 +1790,27 @@ def register_file_exchange_upload(
             (post-clamp) values. On in-band rejection, a ``transfer_failed``
             envelope.
         """
-        # origin_id: strict spec segment grammar (the WHAT identifier).
+        # origin_id and destination share the minimal-safety floor (spec
+        # v0.5 §"Security and Path Resolution"): non-empty, no null bytes
+        # or control chars, no leading/trailing whitespace. Both are
+        # otherwise opaque domain references — the receiver validates the
+        # rest per its own domain rules.
         try:
-            ExchangeURI.validate_segment(origin_id, role="json_param")
+            validate_reference(origin_id, field="origin_id")
         except ExchangeURIError as exc:
             return _upload_transfer_failed(
                 receiver_server=namespace,
                 origin_id=origin_id,
                 message=str(exc),
             )
-        # destination: relaxed validation (the WHERE) — reject only null
-        # bytes, control chars, and leading/trailing whitespace; the
-        # receiver validates the rest.
         if destination is not None:
-            if destination != destination.strip():
+            try:
+                validate_reference(destination, field="destination")
+            except ExchangeURIError as exc:
                 return _upload_transfer_failed(
                     receiver_server=namespace,
                     origin_id=origin_id,
-                    message="destination must not have leading or trailing whitespace",
-                )
-            if any(ord(c) < 0x20 for c in destination):
-                return _upload_transfer_failed(
-                    receiver_server=namespace,
-                    origin_id=origin_id,
-                    message="destination must not contain control characters",
+                    message=str(exc),
                 )
         # content_type hint: pre-filter against the receiver's accepts
         # list so a mismatched hint is rejected in-band, before a wasted
@@ -1920,10 +1932,11 @@ def register_file_exchange_upload_sender(
             url: The receiver-issued POST endpoint, from a prior
                 ``create_upload_link`` call.
             origin_id: The sender's opaque stable handle for the bytes to
-                push. Validated against the spec's segment rules (no
-                ``/``, ``\``, ``.``, ``..``, control bytes,
-                leading/trailing whitespace); resolved to bytes by the
-                server's ``source`` hook. This ``origin_id`` is the
+                push. Validated against the minimal-safety floor (spec
+                v0.5 §"Security and Path Resolution"): non-empty, no null
+                bytes or control characters, no leading/trailing
+                whitespace; resolved to bytes by the server's ``source``
+                hook. This ``origin_id`` is the
                 *sender's own* handle, independent of any ``origin_id``
                 the caller earlier passed to the receiver's
                 ``create_upload_link`` — the two are unrelated opaque
@@ -1944,7 +1957,7 @@ def register_file_exchange_upload_sender(
         # issued transfer_failed body is passed through verbatim instead
         # (see the non-2xx branch), so it keeps the receiver's real value.
         try:
-            ExchangeURI.validate_segment(origin_id, role="json_param")
+            validate_reference(origin_id, field="origin_id")
         except ExchangeURIError as exc:
             return _upload_transfer_failed(
                 receiver_server="", origin_id=origin_id, message=str(exc)

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -1027,6 +1027,10 @@ async def _fetch_via_url(
         try:
             parsed = ExchangeURI.parse(url)
             origin_server = parsed.namespace
+            # parsed.id is the exchange URI's {id} segment — a producer-
+            # derived value (pvl-core derives it as a SHA-256 digest),
+            # not the real origin_id, which a bare exchange:// URL on
+            # this no-file_ref path does not carry.
             origin_id = parsed.id
         except ExchangeURIError:
             origin_server = ""

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -15,35 +15,33 @@ class TestTokenRecord:
     def test_is_frozen(self) -> None:
         record = TokenRecord(
             content=b"x",
-            filename="x.txt",
             mime_type="text/plain",
             expires_at=0.0,
         )
         assert dataclasses.is_dataclass(record)
         with pytest.raises(dataclasses.FrozenInstanceError):
-            record.filename = "y.txt"  # type: ignore[misc]
+            record.mime_type = "text/html"  # type: ignore[misc]
 
 
 class TestArtifactStore:
     def test_add_returns_token(self) -> None:
         store = ArtifactStore()
-        token = store.add(b"hello", filename="a.txt", mime_type="text/plain")
+        token = store.add(b"hello", mime_type="text/plain")
         assert isinstance(token, str)
         assert len(token) > 0
 
     def test_add_returns_unique_tokens(self) -> None:
         store = ArtifactStore()
-        t1 = store.add(b"a", filename="a", mime_type="text/plain")
-        t2 = store.add(b"b", filename="b", mime_type="text/plain")
+        t1 = store.add(b"a", mime_type="text/plain")
+        t2 = store.add(b"b", mime_type="text/plain")
         assert t1 != t2
 
     def test_pop_returns_data_and_removes_token(self) -> None:
         store = ArtifactStore()
-        token = store.add(b"hello", filename="a.txt", mime_type="text/plain")
+        token = store.add(b"hello", mime_type="text/plain")
         record = store.pop(token)
         assert record is not None
         assert record.content == b"hello"
-        assert record.filename == "a.txt"
         assert record.mime_type == "text/plain"
         # Second pop is idempotent — returns None.
         assert store.pop(token) is None
@@ -54,7 +52,7 @@ class TestArtifactStore:
 
     def test_expired_tokens_are_purged(self, monkeypatch: pytest.MonkeyPatch) -> None:
         store = ArtifactStore(ttl_seconds=1)
-        token = store.add(b"x", filename="x", mime_type="application/octet-stream")
+        token = store.add(b"x", mime_type="application/octet-stream")
         original_time = time.time()
         monkeypatch.setattr(time, "time", lambda: original_time + 10)
         assert store.pop(token) is None
@@ -62,17 +60,17 @@ class TestArtifactStore:
     def test_purge_runs_on_add(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Expired tokens should be pruned from memory when a new token is added."""
         store = ArtifactStore(ttl_seconds=1)
-        t1 = store.add(b"one", filename="one.txt", mime_type="text/plain")
+        t1 = store.add(b"one", mime_type="text/plain")
         original_time = time.time()
         monkeypatch.setattr(time, "time", lambda: original_time + 10)
         # Add a fresh token at the shifted time — the prior one should purge.
-        store.add(b"two", filename="two.txt", mime_type="text/plain")
+        store.add(b"two", mime_type="text/plain")
         # Internal store no longer retains t1.
         assert t1 not in store._records  # type: ignore[attr-defined]
 
     def test_custom_ttl(self) -> None:
         store = ArtifactStore(ttl_seconds=42.0)
-        token = store.add(b"x", filename="x.txt", mime_type="text/plain")
+        token = store.add(b"x", mime_type="text/plain")
         record = store.pop(token)
         assert record is not None
         # expires_at roughly now + 42 seconds
@@ -104,7 +102,6 @@ class TestRegisterRoute:
 
         token = store.add(
             b"hello world",
-            filename="greeting.txt",
             mime_type="text/plain; charset=utf-8",
         )
 
@@ -114,9 +111,10 @@ class TestRegisterRoute:
             assert resp.status_code == 200
             assert resp.content == b"hello world"
             assert resp.headers["content-type"].startswith("text/plain")
-            cd = resp.headers["content-disposition"]
-            assert "attachment" in cd
-            assert 'filename="greeting.txt"' in cd
+            # Content-Disposition is bare ``attachment`` — file exchange
+            # carries no filename, so no ``filename=`` parameter is emitted.
+            assert resp.headers["content-disposition"] == "attachment"
+            assert "filename" not in resp.headers["content-disposition"]
 
             # Second request is 404 — token is single-use.
             resp2 = client.get(f"/artifacts/{token}")
@@ -131,7 +129,7 @@ class TestRegisterRoute:
         store = ArtifactStore(ttl_seconds=1)
         ArtifactStore.register_route(mcp, store)
 
-        token = store.add(b"x", filename="x.txt", mime_type="text/plain")
+        token = store.add(b"x", mime_type="text/plain")
         original_time = time.time()
         monkeypatch.setattr(time, "time", lambda: original_time + 10)
 
@@ -147,37 +145,10 @@ class TestRegisterRoute:
         store = ArtifactStore()
         ArtifactStore.register_route(mcp, store, path="/downloads/{token}")
 
-        token = store.add(
-            b"payload", filename="payload.bin", mime_type="application/octet-stream"
-        )
+        token = store.add(b"payload", mime_type="application/octet-stream")
 
         app = mcp.http_app()
         with TestClient(app) as client:
             resp = client.get(f"/downloads/{token}")
         assert resp.status_code == 200
         assert resp.content == b"payload"
-
-    async def test_filename_with_quote_is_sanitised(self) -> None:
-        """Quote/backslash/newline in filename must not break the header."""
-        from starlette.testclient import TestClient
-
-        mcp = FastMCP("test")
-        store = ArtifactStore()
-        ArtifactStore.register_route(mcp, store)
-
-        token = store.add(
-            b"data",
-            filename='evil".txt\r\nX-Injected: yes',
-            mime_type="text/plain",
-        )
-
-        app = mcp.http_app()
-        with TestClient(app) as client:
-            resp = client.get(f"/artifacts/{token}")
-        assert resp.status_code == 200
-        cd = resp.headers["content-disposition"]
-        # No raw CR/LF in the header value.
-        assert "\r" not in cd
-        assert "\n" not in cd
-        # No unescaped injection header leaked.
-        assert "X-Injected" not in resp.headers

--- a/tests/test_artifacts_ext.py
+++ b/tests/test_artifacts_ext.py
@@ -29,9 +29,7 @@ class TestPerTokenTTL:
     ) -> None:
         # Default would expire in 1s; per-token override sets it to 60s.
         store = ArtifactStore(ttl_seconds=1)
-        token = store.add(
-            b"x", filename="x.txt", mime_type="text/plain", ttl_seconds=60
-        )
+        token = store.add(b"x", mime_type="text/plain", ttl_seconds=60)
         original = time.time()
         # Move past the default TTL but well before the per-token one.
         monkeypatch.setattr(time, "time", lambda: original + 5)
@@ -44,14 +42,14 @@ class TestPerTokenTTL:
     ) -> None:
         # Default would not expire for an hour; per-token override makes it 1s.
         store = ArtifactStore(ttl_seconds=3600)
-        token = store.add(b"x", filename="x.txt", mime_type="text/plain", ttl_seconds=1)
+        token = store.add(b"x", mime_type="text/plain", ttl_seconds=1)
         original = time.time()
         monkeypatch.setattr(time, "time", lambda: original + 5)
         assert store.pop(token) is None
 
     def test_default_ttl_used_when_none_passed(self) -> None:
         store = ArtifactStore(ttl_seconds=42.0)
-        token = store.add(b"x", filename="x.txt", mime_type="text/plain")
+        token = store.add(b"x", mime_type="text/plain")
         record = store.pop(token)
         assert record is not None
         # Within ±1s of "now + 42".
@@ -110,7 +108,6 @@ class TestPutEphemeral:
         url = store.put_ephemeral(
             b"hello",
             content_type="text/plain; charset=utf-8",
-            filename="hello.txt",
         )
         assert url.startswith("http://testserver/artifacts/")
 
@@ -122,7 +119,8 @@ class TestPutEphemeral:
         assert resp.status_code == 200
         assert resp.content == b"hello"
         assert resp.headers["content-type"].startswith("text/plain")
-        assert 'filename="hello.txt"' in resp.headers["content-disposition"]
+        # Bare ``attachment`` — file exchange carries no filename.
+        assert resp.headers["content-disposition"] == "attachment"
 
     async def test_put_ephemeral_is_one_time(self) -> None:
         from starlette.testclient import TestClient
@@ -131,9 +129,7 @@ class TestPutEphemeral:
         store = ArtifactStore(base_url="http://testserver")
         ArtifactStore.register_route(mcp, store)
 
-        url = store.put_ephemeral(
-            b"data", content_type="application/octet-stream", filename="d.bin"
-        )
+        url = store.put_ephemeral(b"data", content_type="application/octet-stream")
         path = url.replace("http://testserver", "")
 
         app = mcp.http_app()
@@ -148,7 +144,6 @@ class TestPutEphemeral:
         url = store.put_ephemeral(
             b"x",
             content_type="text/plain",
-            filename="x.txt",
             ttl_seconds=60,
         )
         token = url.rsplit("/", 1)[-1]
@@ -160,7 +155,7 @@ class TestPutEphemeral:
     def test_put_ephemeral_without_base_url_raises(self) -> None:
         store = ArtifactStore()
         with pytest.raises(RuntimeError, match="base_url is required"):
-            store.put_ephemeral(b"x", content_type="text/plain", filename="x.txt")
+            store.put_ephemeral(b"x", content_type="text/plain")
 
 
 class TestSingleton:

--- a/tests/test_file_exchange_capability_merge.py
+++ b/tests/test_file_exchange_capability_merge.py
@@ -50,7 +50,7 @@ def test_builder_http_source_only_emits_source_role() -> None:
     cap = b.build()
     assert cap is not None
     d = cap.to_capability_dict()
-    assert d["version"] == "0.3"
+    assert d["version"] == "0.5"
     assert d["transfer_methods"]["http"] == {
         "source": {"tool": "create_download_link"},
     }

--- a/tests/test_file_exchange_capability_merge.py
+++ b/tests/test_file_exchange_capability_merge.py
@@ -1,6 +1,6 @@
 """Tests for capability-merge across the http / http_upload registrars.
 
-Capability declarations use the v0.3.0 ``source``/``sink`` role-keyed
+Capability declarations use the v0.5 ``source``/``sink`` role-keyed
 ``transfer_methods`` shape (spec §"Transfer Methods").
 """
 

--- a/tests/test_file_exchange_coverage.py
+++ b/tests/test_file_exchange_coverage.py
@@ -45,7 +45,10 @@ from fastmcp_pvl_core import (
     register_file_exchange,
     set_artifact_store,
 )
-from fastmcp_pvl_core._file_exchange_runtime import _resolve_exchange_id
+from fastmcp_pvl_core._file_exchange_runtime import (
+    _exchange_segment,
+    _resolve_exchange_id,
+)
 from fastmcp_pvl_core.file_exchange import (
     FetchTransportError,
     SinkHook,
@@ -459,11 +462,11 @@ class TestUmaskResistance:
                 exchange_id="g",
                 namespace="image-mcp",
             )
-            fx.write_atomic(origin_id="abc", ext="png", content=b"x")
+            uri = fx.write_atomic(origin_id="abc", ext="png", content=b"x")
         finally:
             os.umask(previous)
         ns_st = (tmp_path / "image-mcp").stat()
-        file_st = (tmp_path / "image-mcp" / "abc.png").stat()
+        file_st = (tmp_path / "image-mcp" / uri.filename).stat()
         assert (ns_st.st_mode & 0o777) == 0o755
         assert (file_st.st_mode & 0o777) == 0o644
 
@@ -678,14 +681,25 @@ class TestCreateDownloadLink:
         out = await _call_download_link(mcp, origin_id="abc")
         assert out["ttl_seconds"] == 600.0
 
-    async def test_invalid_origin_id_returns_transfer_failed(
+    async def test_floor_violation_origin_id_returns_transfer_failed(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # v0.5: ``../escape`` is now an opaque reference, not a rejection.
+        # The minimal-safety floor still rejects control characters.
         mcp = _new_producer_mcp(monkeypatch, _src(b"PNG", "image/png"))
-        out = await _call_download_link(mcp, origin_id="../escape")
+        out = await _call_download_link(mcp, origin_id="bad\x00id")
         assert out["error"] == "transfer_failed"
         assert out["method"] == "http"
         assert "validation" in out["message"]
+
+    async def test_opaque_origin_id_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A path-shaped origin_id reaches the source hook and yields a URL.
+        mcp = _new_producer_mcp(monkeypatch, _src(b"PNG", "image/png"))
+        out = await _call_download_link(mcp, origin_id="../escape")
+        assert "error" not in out
+        assert "url" in out
 
 
 # ---------------------------------------------------------------------------
@@ -724,7 +738,25 @@ class TestMakeFileRef:
         assert "exchange" not in ref.transfer
         assert invoked is False
 
-    async def test_make_file_ref_rejects_dotted_origin_id(
+    async def test_make_file_ref_accepts_dotted_origin_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # v0.5: a leading dot is opaque data — make_file_ref accepts it
+        # and echoes it back; no segment-rule rejection.
+        monkeypatch.setenv("TEST_FE_BASE_URL", "http://test.example")
+        monkeypatch.setenv("TEST_FE_TRANSPORT", "http")
+        mcp = FastMCP("test-fe")
+        handle = register_file_exchange(
+            mcp,
+            namespace="image-mcp",
+            env_prefix="TEST_FE",
+            produces=("image/png",),
+            source=_src(b"x", "image/png"),
+        )
+        ref = await handle.make_file_ref(".hidden", mime_type="image/png")
+        assert ref.origin_id == ".hidden"
+
+    async def test_make_file_ref_rejects_floor_violation_origin_id(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from fastmcp_pvl_core._file_exchange_protocol import ExchangeURIError
@@ -739,8 +771,8 @@ class TestMakeFileRef:
             produces=("image/png",),
             source=_src(b"x", "image/png"),
         )
-        with pytest.raises(ExchangeURIError, match="dot"):
-            await handle.make_file_ref(".hidden", mime_type="image/png")
+        with pytest.raises(ExchangeURIError):
+            await handle.make_file_ref("bad\x00id", mime_type="image/png")
 
 
 # ---------------------------------------------------------------------------
@@ -815,17 +847,17 @@ class TestSizeCap:
     def test_read_exchange_uri_rejects_oversize_file(self, tmp_path: Path) -> None:
         (tmp_path / ".exchange-id").write_text("g\n", encoding="utf-8")
         fx = FileExchange(base_dir=tmp_path, exchange_id="g", namespace="image-mcp")
-        fx.write_atomic(origin_id="big", ext="bin", content=b"x" * 1000)
+        uri = fx.write_atomic(origin_id="big", ext="bin", content=b"x" * 1000)
         with pytest.raises(OSError, match="exceeds max_bytes"):
-            fx.read_exchange_uri("exchange://g/image-mcp/big.bin", max_bytes=100)
+            fx.read_exchange_uri(str(uri), max_bytes=100)
 
     def test_read_exchange_uri_no_cap_by_default(self, tmp_path: Path) -> None:
         (tmp_path / ".exchange-id").write_text("g\n", encoding="utf-8")
         fx = FileExchange(base_dir=tmp_path, exchange_id="g", namespace="image-mcp")
-        fx.write_atomic(origin_id="big", ext="bin", content=b"x" * 1000)
+        uri = fx.write_atomic(origin_id="big", ext="bin", content=b"x" * 1000)
         # Direct callers (without max_bytes) get the unguarded read —
         # only fetch_file passes the cap.
-        assert len(fx.read_exchange_uri("exchange://g/image-mcp/big.bin")) == 1000
+        assert len(fx.read_exchange_uri(str(uri))) == 1000
 
 
 class TestStreamingWriteAtomic:
@@ -842,8 +874,8 @@ class TestStreamingWriteAtomic:
         src.write_bytes(body * 3)  # 192 KiB → 3 chunks
 
         uri = fx.write_atomic(origin_id="big", ext="bin", content=src)
-        assert uri.id == "big"
-        out = (tmp_path / "image-mcp" / "big.bin").read_bytes()
+        assert uri.id == _exchange_segment("big")
+        out = (tmp_path / "image-mcp" / uri.filename).read_bytes()
         assert out == body * 3
 
     def test_path_source_does_not_load_full_file_in_memory(
@@ -865,8 +897,8 @@ class TestStreamingWriteAtomic:
             return original_read_bytes(self)
 
         monkeypatch.setattr(Path, "read_bytes", boom)
-        fx.write_atomic(origin_id="abc", ext="bin", content=src)
-        assert (tmp_path / "image-mcp" / "abc.bin").read_bytes() == b"hello"
+        uri = fx.write_atomic(origin_id="abc", ext="bin", content=src)
+        assert (tmp_path / "image-mcp" / uri.filename).read_bytes() == b"hello"
 
 
 class TestHTTPClientReuse:

--- a/tests/test_file_exchange_facade.py
+++ b/tests/test_file_exchange_facade.py
@@ -798,17 +798,20 @@ class TestDispositionFilename:
     @pytest.mark.parametrize(
         ("origin_id", "ext", "expected"),
         [
-            ("folder/note.md", "png", "note.md.png"),
-            ("image://job-1/0", "webp", "0.webp"),
+            # origin_id is opaque — pvl-core does not parse it; the whole
+            # reference is folded to a safe charset, never split.
+            ("folder/note.md", "png", "folder_note.md.png"),
+            ("image://job-1/0", "webp", "image_job-1_0.webp"),
             ("a1b2c3", "png", "a1b2c3.png"),
+            # Runs of unsafe characters collapse to one "_"; an all-unsafe
+            # id falls back to "download".
             ("///", "png", "download.png"),
-            # A tail that already carries an extension yields a double
-            # extension; harmless for an advisory Content-Disposition name,
-            # asserted here as the documented contract.
-            ("image://job-1/0.png", "png", "0.png.png"),
-            # Backslash is treated as a path separator, same as a forward
-            # slash, so tail extraction is separator-style-agnostic.
-            ("dir\\file.txt", "png", "file.txt.png"),
+            # Slash and backslash are folded identically — neither is a
+            # path separator inside an opaque reference.
+            ("dir\\file.txt", "png", "dir_file.txt.png"),
+            # A "." is kept, so an extension-suffixed id plus the appended
+            # ext yields a (harmless) double extension.
+            ("image://job-1/0.png", "png", "image_job-1_0.png.png"),
         ],
     )
     def test_derives_header_safe_filename(

--- a/tests/test_file_exchange_facade.py
+++ b/tests/test_file_exchange_facade.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 from collections.abc import Iterator, Mapping
@@ -398,6 +399,42 @@ class TestMakeFileRef:
         assert uri.startswith("exchange://")
         assert ref.size_bytes == len(b"rendered")
 
+    async def test_exchange_segment_decoupled_from_origin_id(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """The ``exchange://`` URI segment is a SHA-256 of the origin_id.
+
+        v0.5: a path-shaped ``origin_id`` is never embedded verbatim in
+        the URI, path, or filename — pvl-core derives a segment-safe
+        digest. The ``file_ref`` still carries the real ``origin_id``.
+        """
+        monkeypatch.setenv("MCP_EXCHANGE_DIR", str(tmp_path))
+        monkeypatch.setenv("TEST_FE_BASE_URL", "http://test.example")
+        monkeypatch.setenv("TEST_FE_TRANSPORT", "http")
+        mcp = _new_mcp()
+        h = register_file_exchange(
+            mcp,
+            namespace="image-mcp",
+            env_prefix="TEST_FE",
+            produces=("image/png",),
+            source=_src(b"rendered"),
+        )
+        origin_id = "folder/to/note.md"
+        ref = await h.make_file_ref(origin_id, mime_type="image/png")
+
+        uri = ref.transfer["exchange"]["uri"]
+        sha256hex = hashlib.sha256(b"folder/to/note.md").hexdigest()
+        # The raw origin_id never appears in the URI…
+        assert origin_id not in uri
+        # …and the URI ends with the derived segment + ext.
+        assert uri.endswith(f"/{sha256hex}.png")
+        # The file is on disk under the derived segment.
+        assert (tmp_path / "image-mcp" / f"{sha256hex}.png").exists()
+        # The file_ref still carries the real, opaque origin_id.
+        assert ref.origin_id == origin_id
+
     async def test_dual_transport_ref_carries_both_keys(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -521,12 +558,54 @@ class TestCreateDownloadLinkTool:
         assert out["origin_id"] == "never-published"
         assert out["origin_server"] == "image-mcp"
 
-    async def test_invalid_origin_id_returns_transfer_failed(
+    async def test_opaque_origin_id_accepted(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # v0.5: origin_id is an opaque domain reference — path-shaped and
+        # URI-shaped values are passed through to the source hook, not
+        # rejected by pvl-core.
+        for origin_id in ("folder/to/note.md", "image://job-1/0", "../weird"):
+            mcp, _ = _make_handle_http(
+                monkeypatch, source=_src(b"x", origin_id=origin_id)
+            )
+            out = await _call_tool(mcp, "create_download_link", origin_id=origin_id)
+            assert "url" in out, out
+            assert "error" not in out
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["", " leading", "trailing ", "with\x00null", "with\x01ctrl"],
+    )
+    async def test_floor_violation_origin_id_returns_transfer_failed(
+        self, monkeypatch: pytest.MonkeyPatch, bad: str
+    ) -> None:
+        # The minimal-safety floor is still enforced: empty, whitespace
+        # edges, null bytes, control characters.
         mcp, _ = _make_handle_http(monkeypatch)
-        out = await _call_tool(mcp, "create_download_link", origin_id="bad/with-slash")
+        out = await _call_tool(mcp, "create_download_link", origin_id=bad)
         assert out["error"] == "transfer_failed"
+
+    async def test_resource_uri_origin_id_round_trips_to_hook(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # v0.5: a resource-URI-shaped origin_id reaches the source hook
+        # verbatim and a download URL comes back.
+        seen: list[str] = []
+
+        def render(requested: str) -> ResolvedSource:
+            seen.append(requested)
+            if requested != "image://job-1/view":
+                raise ValueError(f"unknown origin_id: {requested!r}")
+            return ResolvedSource(
+                stream=io.BytesIO(b"png-bytes"), content_type="image/png"
+            )
+
+        mcp, _ = _make_handle_http(monkeypatch, source=render)
+        out = await _call_tool(
+            mcp, "create_download_link", origin_id="image://job-1/view"
+        )
+        assert seen == ["image://job-1/view"]
+        assert out["url"].startswith("http://test.example/artifacts/")
 
     async def test_source_non_value_error_is_reraised(
         self, monkeypatch: pytest.MonkeyPatch
@@ -708,6 +787,29 @@ class TestFetchFileTool:
         assert out["error"] == "transfer_failed"
         assert out["method"] == "http"
         assert "private/loopback" in out["message"]
+
+
+# ---------------------------------------------------------------------------
+# _disposition_filename — header-safe filename derivation
+# ---------------------------------------------------------------------------
+
+
+class TestDispositionFilename:
+    @pytest.mark.parametrize(
+        ("origin_id", "ext", "expected"),
+        [
+            ("folder/note.md", "png", "note.md.png"),
+            ("image://job-1/0", "webp", "0.webp"),
+            ("a1b2c3", "png", "a1b2c3.png"),
+            ("///", "png", "download.png"),
+        ],
+    )
+    def test_derives_header_safe_filename(
+        self, origin_id: str, ext: str, expected: str
+    ) -> None:
+        from fastmcp_pvl_core.file_exchange import _disposition_filename
+
+        assert _disposition_filename(origin_id, ext) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_file_exchange_facade.py
+++ b/tests/test_file_exchange_facade.py
@@ -802,6 +802,10 @@ class TestDispositionFilename:
             ("image://job-1/0", "webp", "0.webp"),
             ("a1b2c3", "png", "a1b2c3.png"),
             ("///", "png", "download.png"),
+            # A tail that already carries an extension yields a double
+            # extension; harmless for an advisory Content-Disposition name,
+            # asserted here as the documented contract.
+            ("image://job-1/0.png", "png", "0.png.png"),
         ],
     )
     def test_derives_header_safe_filename(

--- a/tests/test_file_exchange_facade.py
+++ b/tests/test_file_exchange_facade.py
@@ -790,39 +790,6 @@ class TestFetchFileTool:
 
 
 # ---------------------------------------------------------------------------
-# _disposition_filename — header-safe filename derivation
-# ---------------------------------------------------------------------------
-
-
-class TestDispositionFilename:
-    @pytest.mark.parametrize(
-        ("origin_id", "ext", "expected"),
-        [
-            # origin_id is opaque — pvl-core does not parse it; the whole
-            # reference is folded to a safe charset, never split.
-            ("folder/note.md", "png", "folder_note.md.png"),
-            ("image://job-1/0", "webp", "image_job-1_0.webp"),
-            ("a1b2c3", "png", "a1b2c3.png"),
-            # Runs of unsafe characters collapse to one "_"; an all-unsafe
-            # id falls back to "download".
-            ("///", "png", "download.png"),
-            # Slash and backslash are folded identically — neither is a
-            # path separator inside an opaque reference.
-            ("dir\\file.txt", "png", "dir_file.txt.png"),
-            # A "." is kept, so an extension-suffixed id plus the appended
-            # ext yields a (harmless) double extension.
-            ("image://job-1/0.png", "png", "image_job-1_0.png.png"),
-        ],
-    )
-    def test_derives_header_safe_filename(
-        self, origin_id: str, ext: str, expected: str
-    ) -> None:
-        from fastmcp_pvl_core.file_exchange import _disposition_filename
-
-        assert _disposition_filename(origin_id, ext) == expected
-
-
-# ---------------------------------------------------------------------------
 # Misc
 # ---------------------------------------------------------------------------
 

--- a/tests/test_file_exchange_facade.py
+++ b/tests/test_file_exchange_facade.py
@@ -806,6 +806,9 @@ class TestDispositionFilename:
             # extension; harmless for an advisory Content-Disposition name,
             # asserted here as the documented contract.
             ("image://job-1/0.png", "png", "0.png.png"),
+            # Backslash is treated as a path separator, same as a forward
+            # slash, so tail extraction is separator-style-agnostic.
+            ("dir\\file.txt", "png", "file.txt.png"),
         ],
     )
     def test_derives_header_safe_filename(

--- a/tests/test_file_exchange_protocol.py
+++ b/tests/test_file_exchange_protocol.py
@@ -15,6 +15,7 @@ from fastmcp_pvl_core._file_exchange_protocol import (
     FileRef,
     FileRefPreview,
     register_file_exchange_capability,
+    validate_reference,
 )
 
 # ---------------------------------------------------------------------------
@@ -253,6 +254,42 @@ class TestValidateSegment:
             ExchangeURI.validate_segment(bad, role="uri")
 
 
+class TestValidateReference:
+    """Spec v0.5 minimal-safety floor for opaque domain references."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "folder/to/note.md",  # path separators are now data, not banned
+            "image://job-1/0",  # a resource URI
+            "../weird",  # ``..`` is opaque data, not traversal
+            ".hidden",  # a leading dot is opaque data
+            "req-%20-id",  # a literal '%' is data
+            "a single id",  # interior whitespace is allowed
+        ],
+    )
+    def test_accepts_opaque_references(self, value: str) -> None:
+        assert validate_reference(value) == value
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",  # empty
+            " leading",  # leading whitespace
+            "trailing ",  # trailing whitespace
+            "with\x00null",  # null byte
+            "with\x01ctrl",  # control character
+        ],
+    )
+    def test_rejects_floor_violations(self, bad: str) -> None:
+        with pytest.raises(ExchangeURIError):
+            validate_reference(bad)
+
+    def test_field_name_appears_in_message(self) -> None:
+        with pytest.raises(ExchangeURIError, match="destination"):
+            validate_reference("", field="destination")
+
+
 # ---------------------------------------------------------------------------
 # FileExchangeCapability
 # ---------------------------------------------------------------------------
@@ -286,7 +323,7 @@ class TestFileExchangeCapability:
         )
         d = cap.to_capability_dict()
         assert d == {
-            "version": "0.3",
+            "version": "0.5",
             "namespace": "image-mcp",
             "exchange_id": "hades-01",
             "produces": ["image/png", "image/webp", "image/jpeg"],

--- a/tests/test_file_exchange_protocol.py
+++ b/tests/test_file_exchange_protocol.py
@@ -310,7 +310,7 @@ class TestFileExchangeCapability:
         }
 
     def test_full_round_trip_matches_spec_3_9(self) -> None:
-        # Verbatim shape from spec §3.9 producer example (v0.3.0 source/sink shape).
+        # Verbatim shape from spec §3.9 producer example (v0.5 source/sink shape).
         cap = FileExchangeCapability(
             namespace="image-mcp",
             exchange_id="hades-01",

--- a/tests/test_file_exchange_runtime.py
+++ b/tests/test_file_exchange_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import threading
 import time
@@ -18,7 +19,20 @@ from fastmcp_pvl_core._file_exchange_runtime import (
     ExchangeGroupMismatch,
     FileExchange,
     FileExchangeConfigError,
+    _exchange_segment,
 )
+
+
+def _seg(origin_id: str) -> str:
+    """Expected ``exchange://`` ``{id}`` segment for an ``origin_id``.
+
+    Computed independently from :func:`_exchange_segment` (raw SHA-256
+    hexdigest) so the test asserts the digest contract, not just that
+    the function agrees with itself; the two are cross-checked below.
+    """
+    independent = hashlib.sha256(origin_id.encode("utf-8")).hexdigest()
+    assert independent == _exchange_segment(origin_id)
+    return independent
 
 
 @pytest.fixture(autouse=True)
@@ -200,8 +214,12 @@ class TestWriteAtomic:
         fx = _make_fx(tmp_path)
         uri = fx.write_atomic(origin_id="abc", ext="png", content=b"hello")
         assert isinstance(uri, ExchangeURI)
-        assert str(uri) == "exchange://hades-01/image-mcp/abc.png"
-        assert (tmp_path / "image-mcp" / "abc.png").read_bytes() == b"hello"
+        # The exchange segment is the SHA-256 of the origin_id, not the
+        # raw origin_id (spec v0.5 decoupling).
+        seg = _seg("abc")
+        assert uri.id == seg
+        assert str(uri) == f"exchange://hades-01/image-mcp/{seg}.png"
+        assert (tmp_path / "image-mcp" / f"{seg}.png").read_bytes() == b"hello"
 
     def test_no_tmp_file_remains_on_success(self, tmp_path: Path) -> None:
         fx = _make_fx(tmp_path)
@@ -209,58 +227,64 @@ class TestWriteAtomic:
         # Only the final file should exist (no leftover dotfile).
         ns_dir = tmp_path / "image-mcp"
         names = sorted(p.name for p in ns_dir.iterdir())
-        assert names == ["abc.png"]
+        assert names == [f"{_seg('abc')}.png"]
 
     def test_pre_existing_tmp_invisible_to_consumer(self, tmp_path: Path) -> None:
         """A simulated crashed writer leaves a .tmp file consumers ignore."""
         fx = _make_fx(tmp_path)
         ns_dir = tmp_path / "image-mcp"
         ns_dir.mkdir()
+        seg = _seg("abc")
         # Writer crashed mid-flight — only the dotfile temp exists.
-        (ns_dir / ".abc.png.tmp").write_bytes(b"half-written")
+        (ns_dir / f".{seg}.png.tmp").write_bytes(b"half-written")
         # The consumer side refuses to read it (file isn't visible by URI).
         with pytest.raises(FileNotFoundError):
-            fx.read_exchange_uri("exchange://hades-01/image-mcp/abc.png")
+            fx.read_exchange_uri(f"exchange://hades-01/image-mcp/{seg}.png")
 
-    def test_invalid_origin_id_rejected(self, tmp_path: Path) -> None:
+    def test_opaque_origin_id_accepted(self, tmp_path: Path) -> None:
+        # v0.5: origin_id is opaque — path-shaped values are no longer
+        # rejected by write_atomic; the exchange segment is derived.
+        fx = _make_fx(tmp_path)
+        for origin_id in ("bad/id", ".hidden", "../weird", "image://job-1/0"):
+            uri = fx.write_atomic(origin_id=origin_id, ext="png", content=b"x")
+            assert uri.id == _seg(origin_id)
+            assert origin_id not in str(uri)
+
+    def test_invalid_ext_still_rejected(self, tmp_path: Path) -> None:
+        # ``ext`` is a literal URI segment and is still validated.
         fx = _make_fx(tmp_path)
         with pytest.raises(ExchangeURIError):
-            fx.write_atomic(origin_id="bad/id", ext="png", content=b"x")
-
-    def test_origin_id_starting_with_dot_rejected(self, tmp_path: Path) -> None:
-        fx = _make_fx(tmp_path)
-        with pytest.raises(ExchangeURIError, match="dot"):
-            fx.write_atomic(origin_id=".hidden", ext="png", content=b"x")
+            fx.write_atomic(origin_id="abc", ext="p/g", content=b"x")
 
     def test_overwrite_replaces_atomically(self, tmp_path: Path) -> None:
         fx = _make_fx(tmp_path)
         fx.write_atomic(origin_id="abc", ext="png", content=b"v1")
         fx.write_atomic(origin_id="abc", ext="png", content=b"v2")
-        assert (tmp_path / "image-mcp" / "abc.png").read_bytes() == b"v2"
+        assert (tmp_path / "image-mcp" / f"{_seg('abc')}.png").read_bytes() == b"v2"
 
 
 class TestReadExchangeURI:
     def test_round_trip(self, tmp_path: Path) -> None:
         fx = _make_fx(tmp_path)
-        fx.write_atomic(origin_id="abc", ext="png", content=b"hello")
-        data = fx.read_exchange_uri("exchange://hades-01/image-mcp/abc.png")
+        uri = fx.write_atomic(origin_id="abc", ext="png", content=b"hello")
+        data = fx.read_exchange_uri(str(uri))
         assert data == b"hello"
 
     def test_cross_namespace_read(self, tmp_path: Path) -> None:
         """A consumer (vault-mcp) reads bytes a different namespace produced."""
         producer = _make_fx(tmp_path, namespace="image-mcp")
-        producer.write_atomic(origin_id="abc", ext="png", content=b"image")
+        uri = producer.write_atomic(origin_id="abc", ext="png", content=b"image")
 
         consumer = FileExchange(
             base_dir=tmp_path, exchange_id="hades-01", namespace="vault-mcp"
         )
-        data = consumer.read_exchange_uri("exchange://hades-01/image-mcp/abc.png")
+        data = consumer.read_exchange_uri(str(uri))
         assert data == b"image"
 
     def test_group_mismatch_carries_both_ids(self, tmp_path: Path) -> None:
         fx = _make_fx(tmp_path)
         with pytest.raises(ExchangeGroupMismatch) as exc_info:
-            fx.read_exchange_uri("exchange://other-group/image-mcp/abc.png")
+            fx.read_exchange_uri(f"exchange://other-group/image-mcp/{_seg('abc')}.png")
         msg = str(exc_info.value)
         assert "other-group" in msg
         assert "hades-01" in msg
@@ -300,7 +324,7 @@ class TestSweep:
         )
         fx.write_atomic(origin_id="old", ext="bin", content=b"x")
         # Backdate the file's mtime by 5 seconds.
-        target = tmp_path / "image-mcp" / "old.bin"
+        target = tmp_path / "image-mcp" / f"{_seg('old')}.bin"
         past = time.time() - 5
         os.utime(target, (past, past))
         # And add a fresh one.
@@ -310,7 +334,7 @@ class TestSweep:
         assert removed == 1
         ns = tmp_path / "image-mcp"
         names = sorted(p.name for p in ns.iterdir())
-        assert names == ["fresh.bin"]
+        assert names == [f"{_seg('fresh')}.bin"]
 
     def test_dotfiles_skipped(self, tmp_path: Path) -> None:
         fx = _make_fx(tmp_path)
@@ -344,7 +368,7 @@ class TestSweep:
         for i, name in enumerate(("a", "b", "c")):
             fx.write_atomic(origin_id=name, ext="bin", content=b"x" * 100)
             # Each file gets a distinct mtime in increasing order.
-            target = tmp_path / "image-mcp" / f"{name}.bin"
+            target = tmp_path / "image-mcp" / f"{_seg(name)}.bin"
             mtime = time.time() - (3 - i) * 10
             os.utime(target, (mtime, mtime))
 
@@ -352,4 +376,4 @@ class TestSweep:
         removed = fx.sweep(storage_ceiling_bytes=150)
         assert removed == 2
         names = sorted(p.name for p in (tmp_path / "image-mcp").iterdir())
-        assert names == ["c.bin"]
+        assert names == [f"{_seg('c')}.bin"]

--- a/tests/test_file_exchange_runtime.py
+++ b/tests/test_file_exchange_runtime.py
@@ -256,6 +256,14 @@ class TestWriteAtomic:
         with pytest.raises(ExchangeURIError):
             fx.write_atomic(origin_id="abc", ext="p/g", content=b"x")
 
+    def test_floor_violation_origin_id_rejected(self, tmp_path: Path) -> None:
+        # v0.5: write_atomic enforces the minimal-safety floor on
+        # origin_id (defence-in-depth alongside the producing facade).
+        fx = _make_fx(tmp_path)
+        for bad in ("", " leading", "trailing ", "with\x00null", "ctl\x01"):
+            with pytest.raises(ExchangeURIError):
+                fx.write_atomic(origin_id=bad, ext="png", content=b"x")
+
     def test_overwrite_replaces_atomically(self, tmp_path: Path) -> None:
         fx = _make_fx(tmp_path)
         fx.write_atomic(origin_id="abc", ext="png", content=b"v1")

--- a/tests/test_file_exchange_upload_facade.py
+++ b/tests/test_file_exchange_upload_facade.py
@@ -404,17 +404,18 @@ def test_create_link_floors_non_positive_ttl_to_default(
 
 
 @pytest.mark.asyncio
-async def test_create_upload_link_rejects_path_traversal_origin_id(
+@pytest.mark.parametrize(
+    "origin_id", ["folder/to/note.md", "image://job-1/0", "../weird"]
+)
+async def test_create_upload_link_accepts_opaque_origin_id(
+    origin_id: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Baseline ExchangeURI.validate_segment fires before pre_link_validator.
+    """v0.5: ``origin_id`` is an opaque domain reference.
 
-    The spec requires ``origin_id`` to follow the same character rules as
-    ``exchange://`` segments. The ``create_upload_link`` tool calls
-    ``ExchangeURI.validate_segment(..., role="json_param")`` BEFORE running
-    ``pre_link_validator``, so a traversal attempt is rejected in-band even
-    when no validator is configured — consistent with all other in-band
-    rejections in this tool.
+    Path-shaped and URI-shaped values are no longer rejected — they are
+    only checked against the minimal-safety floor and otherwise passed
+    through. A well-formed value mints a URL.
     """
     monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
     monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
@@ -428,15 +429,46 @@ async def test_create_upload_link_rejects_path_traversal_origin_id(
     )
     tool = await mcp.get_tool("create_upload_link")
     assert tool is not None
-    # ExchangeURIError is wrapped and returned as a transfer_failed
-    # envelope — consistent with destination/content_type/pre_link_validator
-    # rejections — rather than surfacing as a raw tool error.
-    result = await tool.run({"origin_id": "../etc/passwd"})
+    result = await tool.run({"origin_id": origin_id})
+    payload = result.structured_content or {}
+    assert "error" not in payload, payload
+    assert "url" in payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["origin_id", "destination"])
+@pytest.mark.parametrize(
+    "bad", ["", " leading", "trailing ", "with\x00null", "with\x01ctrl"]
+)
+async def test_create_upload_link_enforces_floor_on_both_references(
+    field: str,
+    bad: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The minimal-safety floor is enforced symmetrically.
+
+    Both ``origin_id`` and ``destination`` are rejected for empty,
+    whitespace-edged, null-byte, and control-character values.
+    """
+    monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
+    monkeypatch.setenv("TEST_UPLOAD_BASE_URL", "http://srv.test")
+
+    mcp = FastMCP(name="test")
+    register_file_exchange_upload(
+        mcp,
+        namespace="ns",
+        env_prefix="TEST_UPLOAD",
+        sink=_sink,
+    )
+    tool = await mcp.get_tool("create_upload_link")
+    assert tool is not None
+    args: dict[str, str] = {"origin_id": "ok-id"}
+    args[field] = bad
+    result = await tool.run(args)
     payload = result.structured_content or {}
     assert payload["error"] == "transfer_failed"
     assert payload["method"] == "http_upload"
     assert payload["receiver_server"] == "ns"
-    assert payload["origin_id"] == "../etc/passwd"
 
 
 @pytest.mark.asyncio

--- a/tests/test_file_exchange_upload_route.py
+++ b/tests/test_file_exchange_upload_route.py
@@ -100,7 +100,7 @@ async def test_post_already_consumed_token_returns_404() -> None:
 async def test_upload_route_expired_token_returns_404_not_410() -> None:
     """Expired tokens return 404, not 410 (spec §http_upload anti-leak rule).
 
-    The v0.3.0 spec mandates that unknown, expired, and already-consumed
+    The spec mandates that unknown, expired, and already-consumed
     tokens are all indistinguishable to the caller — all return 404.
     """
     mcp, store = _build_app(_ok_sink())

--- a/tests/test_file_exchange_upload_sender.py
+++ b/tests/test_file_exchange_upload_sender.py
@@ -356,17 +356,19 @@ async def test_upload_non_json_body_passed_through_as_text(
 
 
 # ---------------------------------------------------------------------------
-# H1: Invalid origin_id returns transfer_failed; POST is never invoked
+# H1: origin_id minimal-safety floor returns transfer_failed; POST never invoked
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("bad_id", ["a/b", "..", ".\x00a", " leading", "trailing "])
-async def test_upload_invalid_origin_id_returns_transfer_failed(
+@pytest.mark.parametrize(
+    "bad_id", ["", ".\x00a", "ctrl\x01here", " leading", "trailing "]
+)
+async def test_upload_floor_violation_origin_id_returns_transfer_failed(
     bad_id: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Segment-rule violations → transfer_failed without touching the network."""
+    """Minimal-safety floor violations → transfer_failed without the network."""
     call_count: list[int] = [0]
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -389,6 +391,36 @@ async def test_upload_invalid_origin_id_returns_transfer_failed(
     assert payload["error"] == "transfer_failed"
     assert payload["method"] == "http_upload"
     assert call_count[0] == 0, "POST handler must not be called for invalid origin_id"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("origin_id", ["a/b", "../weird", "image://job-1/0"])
+async def test_upload_opaque_origin_id_accepted(
+    origin_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """v0.5: path-/URI-shaped origin_id is opaque — the POST proceeds."""
+    call_count: list[int] = [0]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count[0] += 1
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(
+        "fastmcp_pvl_core.file_exchange._upload_sender_transport",
+        httpx.MockTransport(handler),
+        raising=False,
+    )
+    mcp = FastMCP(name="t")
+    register_file_exchange_upload_sender(
+        mcp, namespace="ns", env_prefix="TEST_SEND", source=_resolver(b"x")
+    )
+    tool = await mcp.get_tool("upload")
+    assert tool is not None
+    result = await tool.run({"url": "https://recv.test/u/t", "origin_id": origin_id})
+    payload = result.structured_content or {}
+    assert "error" not in payload, payload
+    assert call_count[0] == 1, "POST handler must run for an opaque origin_id"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Evolves the MCP File Exchange spec to **v0.5** and realigns the pvl-core
implementation. `origin_id` previously conflated three concerns — identity
(producer-owned), round-trip resolution (producer-owned), and transport
encoding (pvl-core-owned) — so transport path-rules leaked onto the opaque
identity, and the spec was internally contradictory ("opaque string, not a URI
component" yet constrained as a path segment).

v0.5:

- **`origin_id` ⇄ `destination` symmetry** — one shared definition: opaque
  domain references validated against a *minimal-safety floor* (non-empty, no
  null/control characters, no leading/trailing whitespace). The path-segment
  rules are scoped to `exchange://` URI segments only.
- **`exchange://` `{id}` segment decoupled** from `file_ref.origin_id` —
  pvl-core derives it (SHA-256) and never embeds the raw reference in any
  URI, path, or filename.
- **`filename` concept removed** — v0.5 has no filename anywhere (the File
  Reference, `ResolvedSource`, and the opaque `origin_id` carry none). The
  artifact store's `filename` field/parameters and the `_disposition_filename`
  derivation are gone; the `http` download serves `Content-Disposition:
  attachment` with no filename, and per spec §http the consuming server names
  the local file itself.
- MCP resource URIs are mentioned in the spec as one example of an opaque
  reference among equals — never a required or recommended shape.

`0.4` stays permanently skipped (per the spec's own versioning section). No
downstream server has adopted file-exchange — no migration burden.

Closes #111. Follow-up: #113 (rename `ArtifactStore` → `DownloadStore`).

## Test plan

- [x] `uv run pytest` — 712 passed
- [x] `uv run ruff format --check .` / `uv run ruff check .` — clean
- [x] `uv run mypy src` — clean
- [x] Local multi-lens preflight review on each commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)