### PR TITLE
file-exchange v0.6: symmetrize sink reference (path -> destination)

### DIFF
--- a/docs/specs/file-exchange.md
+++ b/docs/specs/file-exchange.md
@@ -1,6 +1,6 @@
 # MCP File Exchange Specification
 
-**Version:** 0.5.0
+**Version:** 0.6.0
 **Status:** experimental
 **Tags:** mcp, spec, interop
 
@@ -251,7 +251,7 @@ A server that is both producer and consumer populates both sub-keys:
 - Producer tool MUST accept a parameter named `origin_id`.
 - Producer tool MUST return a JSON object with at minimum a `url` field. It MAY include `ttl_seconds` and `mime_type`.
 - The generated URL MUST be cryptographically unguessable (e.g. containing a UUID or HMAC token in the path or query string). The producer SHOULD invalidate the URL after a single successful download (one-time use). TLS/HTTPS is assumed; the URL path is encrypted in transit, so embedding secrets in the URL is equivalent in security to using an `Authorization` header while being compatible with any consumer that can fetch a URL.
-- Consumer tool MUST accept a parameter named `url`. It SHOULD accept an optional parameter named `path` to allow client-directed placement. If `path` is omitted or invalid, the consumer MUST auto-generate a safe local path (e.g. derived from `origin_id` or a UUID). This prevents failures caused by LLMs hallucinating invalid directory structures.
+- Consumer tool MUST accept a parameter named `url`. It SHOULD accept an optional parameter named `destination` to allow client-directed placement. `destination` is an opaque domain reference, validated against the minimal-safety floor (§"Security and Path Resolution"), which the consumer interprets per its own domain — directly as a path/slot, a handle minted by a downstream prepare-receive tool, or a (possibly parametrized) resource URI. If `destination` is omitted, the consumer MUST auto-place the bytes per its own domain (a domain-default location, a UUID-derived name, etc.). This prevents failures caused by LLMs hallucinating invalid directory structures.
 
 #### `http_upload` (push to receiver-issued URL)
 
@@ -558,7 +558,7 @@ During the MCP `initialize` handshake, a participating server declares exchange 
   "capabilities": {
     "experimental": {
       "file_exchange": {
-        "version": "0.5",
+        "version": "0.6",
         "namespace": "image-mcp",
         "exchange_id": "hades-01",
         "produces": ["image/png", "image/webp", "image/jpeg"],
@@ -582,7 +582,7 @@ During the MCP `initialize` handshake, a participating server declares exchange 
   "capabilities": {
     "experimental": {
       "file_exchange": {
-        "version": "0.5",
+        "version": "0.6",
         "namespace": "vault-mcp",
         "exchange_id": "hades-01",
         "produces": [],
@@ -609,7 +609,7 @@ During the MCP `initialize` handshake, a participating server declares exchange 
 
 | Field | Required | Description |
 |---|---|---|
-| `version` | MUST | Spec version as `MAJOR.MINOR` (e.g. `"0.5"`). Patch versions are spec-internal and MUST NOT appear in the capability declaration. A server implementing spec version `0.5.0` MUST advertise `"0.5"`; patch-level differences do not change the wire-level capability. |
+| `version` | MUST | Spec version as `MAJOR.MINOR` (e.g. `"0.6"`). Patch versions are spec-internal and MUST NOT appear in the capability declaration. A server implementing spec version `0.6.0` MUST advertise `"0.6"`; patch-level differences do not change the wire-level capability. |
 | `namespace` | MUST | The server's exchange namespace. |
 | `exchange_id` | SHOULD | The exchange group ID. Present when the server participates in an exchange group. |
 | `produces` | SHOULD | MIME types this server can produce as file references. |
@@ -719,7 +719,7 @@ The client orchestrates a two-step handoff:
 
 1. Call the producer's tool (from `transfer.http.tool` or `remaining_transfer.http.tool`) with `origin_id` set to the file's `origin_id`.
 2. The tool returns `{"url": "https://...", "ttl_seconds": 3600}`.
-3. Call the consumer's tool (from `transfer_methods.http.sink.tool` in the consumer's capabilities, or known by configuration) with `url` and optionally `path`. If the LLM cannot determine a sensible path, it should omit the parameter and let the consumer auto-generate one.
+3. Call the consumer's tool (from `transfer_methods.http.sink.tool` in the consumer's capabilities, or known by configuration) with `url` and optionally `destination`. If the LLM cannot determine a sensible destination, it should omit the parameter and let the consumer auto-place the bytes.
 
 ### Step 3: Exhaustion
 
@@ -761,7 +761,7 @@ This signals definitively to the client that retrying is pointless. The client S
 - **MUST** ignore dotfiles in namespace directories.
 - **MUST** validate the `{namespace}` and `{id}.{ext}` segments of exchange URIs against the segment rules after a single pass of URI decoding. The `origin_id` and `destination` parameters are opaque domain references — they MUST be validated as raw strings against the minimal-safety floor and MUST NOT be URI-decoded (§"Security and Path Resolution").
 - **MUST** include `remaining_transfer` in the `transfer_failed` error, containing the file reference's `transfer` with the failed method removed.
-- **SHOULD**, for tools declared in `transfer_methods.http.sink`, accept a parameter named `url` and an optional parameter named `path`. If `path` is omitted, the tool MUST auto-generate a safe local path.
+- **SHOULD**, for tools declared in `transfer_methods.http.sink`, accept a parameter named `url` and an optional parameter named `destination`. If `destination` is omitted, the tool MUST auto-place the bytes per its own domain.
 
 ### Receiver server (`http_upload`)
 
@@ -804,7 +804,7 @@ Consumers never delete exchange files. This prevents a class of bugs where one c
 
 ### Standardised parameter names per method
 
-Each transfer method defines standard parameter names (e.g. `origin_id` for the `http` producer, `url` and `path` for the `http` consumer). Servers that internally use different names MUST alias. This trades a one-time implementation cost for permanent simplicity: clients never need parameter mappings.
+Each transfer method defines standard parameter names (e.g. `origin_id` for the `http` producer, `url` and `destination` for the `http` consumer). Servers that internally use different names MUST alias. This trades a one-time implementation cost for permanent simplicity: clients never need parameter mappings.
 
 ### Remaining methods in error payloads
 

--- a/docs/superpowers/plans/2026-05-17-sink-reference-symmetrization.md
+++ b/docs/superpowers/plans/2026-05-17-sink-reference-symmetrization.md
@@ -1,0 +1,186 @@
+# Sink-Reference Symmetrization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development`
+> or `superpowers:executing-plans`. Design-style plan (matching the repo's prior
+> file-exchange plans) — concrete changes per file, not bite-sized TDD micro-steps.
+
+**Goal:** Complete file-exchange's source/sink symmetry — `fetch_file`'s `path`
+parameter becomes the opaque `destination` reference, matching `create_upload_link`
+and mirroring `origin_id` on the source side. Ships as file-exchange spec **v0.6**.
+
+**Architecture:** One coherent change — the spec evolution
+(`docs/specs/file-exchange.md` → v0.6) plus the matching pvl-core implementation
+and tests — shipped as **one issue ([#114](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/114)), one PR**.
+
+**Tech stack:** Python 3.10–3.13, `uv`, `pytest`, `ruff`, `mypy`. FastMCP.
+
+Design doc: `docs/superpowers/specs/2026-05-17-sink-reference-symmetrization-design.md`.
+
+---
+
+## Context
+
+The file-exchange *source* side has one reference name — `origin_id` — across
+every source tool. The *sink* side has two: `fetch_file` takes `path` (still
+filesystem-framed), `create_upload_link` takes `destination` (made an opaque
+domain reference in v0.5). Same role, two names. This change unifies them:
+`fetch_file`'s `path` → `destination`, one opaque sink-side domain reference,
+with `SinkContext` exposing it as a first-class field. Scope boundary:
+file-exchange's sink job ends at placement — domain postprocessing (e.g.
+markdown-vault front matter) is downstream follow-up tooling, out of scope.
+
+No downstream server has adopted file-exchange → the `path`→`destination` rename
+is a clean breaking change with no compatibility alias.
+
+## Part A — Spec evolution (`docs/specs/file-exchange.md` → v0.6)
+
+`0.5 → 0.6` is a **minor** bump (changes a tool-contract parameter and its
+validation regime). `0.4` was already permanently skipped; `0.6` follows `0.5`
+normally.
+
+### A1. Version field
+`**Version:** 0.5.0` → `**Version:** 0.6.0`.
+
+### A2. `http` consumer tool — the `path` parameter
+In the `http` method's consumer-tool bullet (current text: *"It SHOULD accept
+an optional parameter named `path` to allow client-directed placement. If
+`path` is omitted or invalid, the consumer MUST auto-generate a safe local
+path (e.g. derived from `origin_id` or a UUID)…"*):
+
+- Rename the parameter `path` → `destination`.
+- Replace the "safe local path" filesystem framing with the opaque-domain-reference
+  definition — reuse the wording of the `create_upload_link` `destination` row:
+  an opaque domain reference, validated against the minimal-safety floor
+  (§"Security and Path Resolution"), which the consumer interprets per its own
+  domain (directly as a path/slot, a handle minted by a downstream
+  prepare-receive tool, or a — possibly parametrized — resource URI).
+- Keep the omitted-→-auto-place fallback, generalised: *"If `destination` is
+  omitted, the consumer MUST auto-place the bytes per its own domain (a
+  domain-default location, a UUID-derived name, etc.). This prevents failures
+  caused by LLMs hallucinating invalid directory structures."*
+
+### A3. Consuming-server requirements
+The `SHOULD … accept a parameter named `url` and an optional parameter named
+`path`` bullet → `destination`. Keep the "if omitted, auto-place" clause.
+
+### A4. Worked example / step list
+Every reference to the consumer placement parameter `path` in the worked
+example / negotiation step list → `destination`.
+
+### A5. Capability `version` examples
+`"version": "0.5"` → `"version": "0.6"` in the capability-declaration JSON
+examples; the `version` field-table row `(e.g. "0.5")` / `0.5.0` → `0.6`.
+
+**Do not touch** the `exchange://` URI section's `{id}.{ext}` text or
+§"Security and Path Resolution" — those use "path" for genuine path components
+and are unrelated. Only the consumer *tool parameter* is renamed.
+
+## Part B — pvl-core implementation
+
+### B1. `SPEC_VERSION` — `src/fastmcp_pvl_core/_file_exchange_protocol.py`
+`SPEC_VERSION = "0.5"` → `SPEC_VERSION = "0.6"`.
+
+### B2. `SinkContext` — `src/fastmcp_pvl_core/file_exchange.py` (~line 292)
+Add a first-class `destination: str | None` field, directly after `origin_id`,
+mirroring it:
+
+```python
+class SinkContext(NamedTuple):
+    origin_id: str | None
+    destination: str | None
+    mime_type: str | None
+    size_bytes: int | None
+    file_ref: FileRef | None
+    params: Mapping[str, Any]
+    handle: FileExchangeHandle | None
+```
+
+Update the docstring: document `destination` as "the sink-side opaque domain
+reference — the caller's placement handle for this consumer, when supplied;
+`None` when the caller left placement to the consumer." Drop the `path` /
+`destination` examples from the `params` field's docstring (it is now caller
+*extras* only). `params` itself stays — removing it is out of scope ([#106](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/106)).
+
+### B3. `fetch_file` — `file_exchange.py` (~line 968)
+- Rename the parameter `path: str | None = None` → `destination: str | None = None`.
+- Validate it: if `destination is not None`, call `validate_reference(destination,
+  field="destination")` inside `try/except ExchangeURIError`; on failure return
+  `{"error": "invalid_input", "message": str(exc)}` — `fetch_file`'s existing
+  error envelope for malformed input (this is the concrete form of the design
+  doc's "supplied-but-invalid is an error, not a silent fallback"; `fetch_file`
+  reports bad input as `invalid_input`, distinct from `create_upload_link`'s
+  `_upload_transfer_failed` — each tool keeps its own envelope).
+- Stop putting the value into the `params` dict. Thread `destination` to the
+  downstream consume helpers as a dedicated argument (see B4).
+- Update the `fetch_file` docstring.
+
+### B4. Thread `destination` to the `SinkContext` construction sites
+`destination` must reach the three `SinkContext(...)` constructions. Add a
+`destination: str | None` parameter to `_fetch_via_url`, `_fetch_via_file_ref`,
+`_consume_exchange`, and `_consume_http`, threaded from `fetch_file` through to
+the constructors. The `params` dict continues to be threaded unchanged (it is
+now empty on the `fetch_file` path — that residue is [#106](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/106)'s concern, not this PR's).
+
+The two `fetch_file`-side `SinkContext(...)` sites (`_consume_exchange` ~1193,
+`_consume_http` ~1275) gain `destination=destination`.
+
+### B5. `http_upload` receive — `_route_sink` (`file_exchange.py` ~1700)
+`_route_sink` currently puts `record.destination` into `params["destination"]`.
+Change: pass it as the first-class field — `SinkContext(origin_id=record.origin_id,
+destination=record.destination, …)` — and drop the `params["destination"]`
+assignment (`params` becomes `{}`).
+
+## Part C — Tests
+
+Run `uv run pytest -q` for a baseline first. Then under `tests/`:
+
+- **Rename in existing tests:** every `fetch_file(..., path=...)` call →
+  `destination=...`. Grep `tests/` for `path=` in file-exchange fetch tests and
+  for `SinkContext` / `.params` assertions keyed on `path`.
+- **`SinkContext.destination` populated:** assert the sink hook receives
+  `ctx.destination` equal to the caller-supplied value — on the `fetch_file`
+  `exchange` path, the `fetch_file` `http` path, and the `http_upload` receive
+  path. Assert `ctx.origin_id` and `ctx.destination` are both first-class.
+- **Omitted `destination`:** `fetch_file` with no `destination` → `ctx.destination
+  is None`, transfer still succeeds (auto-place fallback intact).
+- **Floor violation:** `fetch_file(url=..., destination="bad\x00id")` →
+  `{"error": "invalid_input", ...}`; symmetric values (empty, edge whitespace,
+  control char) rejected.
+- **Capability version:** any test asserting the capability `version` is `"0.5"`
+  → `"0.6"` (grep `tests/` for `"0.5"` and `SPEC_VERSION`).
+- Any test that asserted the old `params["path"]` / `params["destination"]`
+  routing is rewritten to assert the first-class field.
+
+## Out of scope
+
+- Domain postprocessing surface (front matter, tagging) — downstream follow-up
+  tooling by design.
+- Removing the now-vestigial `SinkContext.params` field / its threading —
+  [#106](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/106) (SinkContext type-design).
+- `ArtifactStore` → `DownloadStore` rename — [#113](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/113).
+
+## Verification
+
+```bash
+uv sync --all-extras
+uv run pytest
+uv run ruff format --check . && uv run ruff check . && uv run mypy src
+```
+
+End-to-end checks:
+- `fetch_file` accepts `destination` and no longer accepts `path`
+  (`grep -n "def fetch_file" -A6 src/fastmcp_pvl_core/file_exchange.py`).
+- `SinkContext` has both `origin_id` and `destination` as first-class fields;
+  `destination` is populated on the `fetch_file` (`http`/`exchange`) and
+  `http_upload` sink paths.
+- `grep -rn '"0.5"' src/` shows no surviving file-exchange spec-version literal;
+  `SPEC_VERSION == "0.6"`; `docs/specs/file-exchange.md` is at v0.6.0.
+- A floor-violating `destination` on `fetch_file` yields `invalid_input`; an
+  omitted `destination` triggers the auto-place fallback.
+
+## Issue + PR
+
+Issue [#114](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/114) is filed.
+One PR carries Parts A+B+C (`Closes #114`). Branch `feat/sink-reference-symmetrization`
+already exists with the design doc + this plan committed. Run `preflight-circus`
+on the full diff before opening as draft.

--- a/docs/superpowers/specs/2026-05-17-sink-reference-symmetrization-design.md
+++ b/docs/superpowers/specs/2026-05-17-sink-reference-symmetrization-design.md
@@ -58,8 +58,9 @@ identical to `origin_id`'s v0.5 definition but sink-side:
   local path" to *the consumer auto-places per its own domain* (a
   domain-default location, a UUID-derived name, etc.; the rationale —
   "prevents LLMs hallucinating invalid directory structures" — is unchanged).
-  If `destination` is *supplied but* fails the minimal-safety floor, that is a
-  `transfer_failed`, not a silent fallback.
+  If `destination` is *supplied but* fails the minimal-safety floor,
+  `fetch_file` returns its `invalid_input` error envelope (the tool's existing
+  shape for malformed input) — surfaced, not a silent fallback.
 
 The spec enumerates, non-normatively, the range of valid downstream
 interpretations — the same freedom `origin_id` has on the source side:
@@ -168,6 +169,6 @@ breaking changes shipped.
 - The spec's consumer-tool surface has no placement parameter named `path`;
   `docs/specs/file-exchange.md` is at v0.6 and `SPEC_VERSION == "0.6"`.
 - A supplied `destination` that violates the minimal-safety floor yields
-  `transfer_failed`; an omitted `destination` triggers the auto-place
-  fallback.
+  `fetch_file`'s `invalid_input` error envelope; an omitted `destination`
+  triggers the auto-place fallback.
 - Full suite + `ruff` + `mypy` green.

--- a/docs/superpowers/specs/2026-05-17-sink-reference-symmetrization-design.md
+++ b/docs/superpowers/specs/2026-05-17-sink-reference-symmetrization-design.md
@@ -1,0 +1,173 @@
+# Design: symmetrize the file-exchange sink-side reference (`path` → `destination`)
+
+**Issue:** [#114](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/114)
+**Date:** 2026-05-17
+**Spec target:** file-exchange v0.6
+
+## Problem
+
+file-exchange's transfer surface has a *source* side and a *sink* side. The
+source side, after v0.5, has exactly one reference name — `origin_id` — used
+by every source tool (`create_download_link`, the `upload` sender,
+`make_file_ref`). It is an opaque domain reference: the producing server
+interprets it however its domain dictates; pvl-core never parses it.
+
+The sink side has **two names for one concept**:
+
+| Sink tool | Transfer method | Sink-side reference | State |
+|---|---|---|---|
+| `fetch_file` | `http`, `exchange` | `path` | filesystem-framed — spec says "auto-generate a safe **local path**" |
+| `create_upload_link` | `http_upload` | `destination` | v0.5-opaque — "path, slot, parent document key, MCP resource URI, anything" |
+
+Both parameters carry the identical role: *where and how this consuming
+server stores the received bytes, interpreted by its own domain*. The only
+difference between them is the transfer mechanism (pull vs. pushed-in) — and
+mechanism detail must not leak into a reference's name or shape.
+
+The v0.3 dual-role pass and the v0.5 `origin_id` ⇄ `destination` symmetry
+pass each *asserted* source/sink symmetry without auditing `fetch_file`'s
+`path`. It slipped through both. `SinkContext`'s own docstring records the
+split outright: "`params`: Caller-supplied parameters (e.g. `path` on
+`fetch_file`, `destination` on an upload)".
+
+## Goal
+
+Complete the symmetry: the sink side has **one** opaque domain reference,
+`destination`, mirroring `origin_id` on the source side — one name, one
+shape, across both sink tools.
+
+This is a focused spec evolution (v0.5 → v0.6). It is not a new feature; it
+finishes a job the prior two revisions left incomplete.
+
+## Design
+
+### The reference
+
+`fetch_file`'s `path` parameter becomes `destination`. `create_upload_link`
+keeps `destination` unchanged. Both are then governed by one definition,
+identical to `origin_id`'s v0.5 definition but sink-side:
+
+- **Opaque domain reference.** The consuming server interprets it however its
+  domain dictates; pvl-core never parses, splits, or derives structure from
+  it.
+- **Validated against the minimal-safety floor only** — non-empty, no null
+  bytes, no control characters U+0000–U+001F, no leading/trailing whitespace
+  (the existing `validate_reference`). No path-segment rules.
+- **Optional (`MAY`).** If omitted, the consumer auto-places — the existing
+  `fetch_file` fallback carries over, generalised from "auto-generate a safe
+  local path" to *the consumer auto-places per its own domain* (a
+  domain-default location, a UUID-derived name, etc.; the rationale —
+  "prevents LLMs hallucinating invalid directory structures" — is unchanged).
+  If `destination` is *supplied but* fails the minimal-safety floor, that is a
+  `transfer_failed`, not a silent fallback.
+
+The spec enumerates, non-normatively, the range of valid downstream
+interpretations — the same freedom `origin_id` has on the source side:
+
+- interpreted **directly** — e.g. as a path or storage slot;
+- a **handle minted by a downstream "prepare-receive" domain tool** (the
+  sink-side dual of a producer's domain tool minting an `origin_id`);
+- a **(possibly parametrized) resource URI**.
+
+pvl-core picks none of these — the consuming server does.
+
+### `SinkContext`
+
+`destination` becomes a first-class `SinkContext` field, symmetric with the
+existing first-class `origin_id` field. It is populated on every sink path —
+the `fetch_file` consume path (`http` and `exchange`) and the `http_upload`
+receive path. Today the sink reference reaches the sink hook only through the
+generic `params` dict; after this change `SinkContext` carries both
+references explicitly:
+
+- `origin_id` — the *source-side* reference (the producer's handle), when the
+  call carries one.
+- `destination` — the *sink-side* reference (this consumer's placement
+  handle), when the caller supplied one.
+
+`params` reverts to what its name says — caller extras — and its docstring
+stops citing `path`/`destination` as examples.
+
+(The `SinkContext` type is also the subject of [#106](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/106),
+type-design hardening. The `destination` field is intrinsic to *this*
+symmetrization and belongs here; #106 covers separate hardening.)
+
+### Scope boundary
+
+file-exchange's sink job ends at: *bytes received; the sink hook stored them
+at and according to `destination`.* Anything domain-rich beyond placement —
+markdown-vault-mcp stamping YAML front matter onto a received document, for
+instance — is **postprocessing performed by separate follow-up tools**, off
+file-exchange's surface.
+
+This boundary is why a fourth option once floated — domain-specific keyword
+arguments appended to `fetch_file` — stays rejected: it would re-domain-couple
+the shared tool surface and collapse the opacity of the reference. A consumer
+that needs to act on richer per-receive metadata either encodes it into the
+opaque `destination` (via its own prepare-receive tool) or applies it
+afterward with its own domain tools.
+
+The markdown-vault front-matter use case motivated this work but is **not a
+deliverable of it**: the symmetrization unblocks it (markdown-vault may mint a
+`destination` that encodes front-matter intent, or postprocess after receipt
+— its choice), and requires no further pvl-core surface.
+
+## Spec edits (`docs/specs/file-exchange.md` → v0.6)
+
+- **`http` consumer tool** (the `Consumer tool MUST accept …` bullet): the
+  optional placement parameter `path` → `destination`. Replace the
+  "auto-generate a safe local path" filesystem framing with the
+  opaque-domain-reference definition — reuse the wording of the
+  `create_upload_link` `destination` row. Keep the omitted → auto-place
+  fallback.
+- **Consuming-server requirements** section: the `SHOULD … accept … `path``
+  bullet → `destination`.
+- **Worked example / step list**: every reference to the consumer placement
+  parameter `path` → `destination`.
+- **Version** field `0.5` → `0.6`. This changes a tool-contract parameter and
+  its validation regime, which per the spec's own §"Versioning and
+  compatibility" bump-trigger checklist warrants a minor bump.
+
+The `exchange://` URI section's `{id}.{ext}` text and §"Security and Path
+Resolution" already use the word "path" for genuine path components — those
+are unrelated and unchanged. Only the consumer *tool parameter* is renamed.
+
+## Implementation (pvl-core)
+
+- `fetch_file` tool: rename the `path` parameter to `destination`; validate it
+  with `validate_reference` (the minimal-safety floor), exactly as
+  `create_upload_link` already validates its `destination`.
+- `SinkContext`: add `destination: str | None`; populate it in
+  `_consume_exchange`, `_consume_http`, and the `http_upload` receive route.
+  Update the `SinkContext` docstring; drop the `path`/`destination` examples
+  from the `params` field doc.
+- `SPEC_VERSION` → `"0.6"`; update spec-version literals/examples.
+- The `fetch_file` auto-place fallback logic is retained; it now keys off
+  `destination` being omitted.
+
+## Breaking change
+
+`fetch_file`'s `path` → `destination` is a tool-parameter rename. No
+downstream server has adopted file-exchange, so the cost is nil — it ships as
+a direct replacement with no compatibility alias, consistent with how v0.5's
+breaking changes shipped.
+
+## Out of scope
+
+- Any domain postprocessing surface (front matter, tagging, etc.) — that is
+  downstream follow-up tooling by design.
+- Broader `SinkContext` type-design hardening — [#106](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/106).
+- The `ArtifactStore` → `DownloadStore` rename — [#113](https://github.com/pvliesdonk/fastmcp-pvl-core/issues/113).
+
+## Verification
+
+- `fetch_file` accepts `destination` and no longer accepts `path`.
+- `SinkContext.destination` is populated on the `fetch_file` (`http` /
+  `exchange`) and `http_upload` sink paths; `SinkContext.origin_id` and
+  `SinkContext.destination` are both first-class fields.
+- The spec's consumer-tool surface has no placement parameter named `path`;
+  `docs/specs/file-exchange.md` is at v0.6 and `SPEC_VERSION == "0.6"`.
+- A supplied `destination` that violates the minimal-safety floor yields
+  `transfer_failed`; an omitted `destination` triggers the auto-place
+  fallback.
+- Full suite + `ruff` + `mypy` green.

--- a/src/fastmcp_pvl_core/_file_exchange_protocol.py
+++ b/src/fastmcp_pvl_core/_file_exchange_protocol.py
@@ -82,7 +82,7 @@ rejection of residuals.
 def validate_reference(value: str, *, field: str = "origin_id") -> str:
     """Validate an opaque domain reference (``origin_id`` / ``destination``).
 
-    The minimal-safety floor (spec v0.5 §"Security and Path Resolution"):
+    The minimal-safety floor (spec §"Security and Path Resolution"):
     non-empty, no null bytes, no control characters U+0000-U+001F, no
     leading or trailing whitespace. The reference is otherwise opaque —
     the owning domain server's hook validates it against its own domain
@@ -482,7 +482,7 @@ class _FileExchangeCapabilityBuilder:
     instance; the capability dict is materialised by :meth:`build` once
     every registrar has run.
 
-    Transfer methods are advertised in the v0.5 ``source``/``sink``
+    Transfer methods are advertised in the ``source``/``sink``
     role-keyed shape (spec §"Transfer Methods"): ``http`` and
     ``http_upload`` are separate top-level method keys, and each carries
     whichever of the ``source`` / ``sink`` roles the server fills.
@@ -548,7 +548,7 @@ class _FileExchangeCapabilityBuilder:
             ``None`` if no transfer method has been set (neither
             exchange nor an ``http`` role nor an ``http_upload`` role).
             Otherwise a frozen :class:`FileExchangeCapability` whose
-            ``transfer_methods`` uses the v0.5 ``source``/``sink`` shape.
+            ``transfer_methods`` uses the ``source``/``sink`` shape.
         """
         transfer_methods: dict[str, dict[str, Any]] = {}
         if self._exchange_present:

--- a/src/fastmcp_pvl_core/_file_exchange_protocol.py
+++ b/src/fastmcp_pvl_core/_file_exchange_protocol.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 #: field in the ``experimental.file_exchange`` capability declaration
 #: (spec §"Capability declaration"). Major.minor only — patch revisions
 #: are spec-internal.
-SPEC_VERSION = "0.5"
+SPEC_VERSION = "0.6"
 
 
 # ---------------------------------------------------------------------------

--- a/src/fastmcp_pvl_core/_file_exchange_runtime.py
+++ b/src/fastmcp_pvl_core/_file_exchange_runtime.py
@@ -342,7 +342,7 @@ class FileExchange:
             origin_id: Producer-chosen opaque reference. Never used
                 verbatim as a path component — the ``exchange://`` URI
                 ``{id}`` segment is derived from it via
-                :func:`_exchange_segment` (spec v0.5 §"Security and
+                :func:`_exchange_segment` (spec §"Security and
                 Path Resolution"). Validated against the minimal-safety
                 floor; otherwise used only for the debug log and as the
                 derivation input.
@@ -365,7 +365,7 @@ class FileExchange:
         ExchangeURI.validate_segment(ext, role="json_param")
         # Defence-in-depth: the producing facade validates origin_id
         # before calling here, but write_atomic is also reachable
-        # directly — enforce the spec v0.5 minimal-safety floor too.
+        # directly — enforce the spec minimal-safety floor too.
         validate_reference(origin_id, field="origin_id")
         seg = _exchange_segment(origin_id)
 

--- a/src/fastmcp_pvl_core/_token_store.py
+++ b/src/fastmcp_pvl_core/_token_store.py
@@ -382,7 +382,7 @@ class UploadRecord:
     An ``UploadRecord`` does not carry bytes — bytes arrive over the wire
     when a client ``POST``s to ``/<ns>/uploads/{token}``. The record
     carries the metadata the receiver needs to commit the bytes, modelling
-    the v0.5 spec's WHAT/WHERE split, plus the runtime guards.
+    the spec's WHAT/WHERE split, plus the runtime guards.
 
     Attributes:
         origin_id: The sender's opaque stable handle for the bytes (the

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -300,19 +300,22 @@ class SinkContext(NamedTuple):
             ``http`` or ``exchange`` alike: a bare URL carries no
             ``origin_id`` — an ``exchange://`` URL carries only the
             pvl-core-derived segment, which is not the reference.
+        destination: The sink-side opaque domain reference: the
+            caller's placement handle for this consumer when supplied,
+            ``None`` when the caller left placement to the consumer.
         mime_type: Best-known MIME type — from the file reference, the
             HTTP ``Content-Type`` header, or the upload request hint.
         size_bytes: Byte length when known up front, else ``None``.
         file_ref: The full file reference when the consumer was handed
             one; ``None`` for a bare-``url`` fetch or an upload receive.
-        params: Caller-supplied parameters (e.g. ``path`` on
-            ``fetch_file``, ``destination`` on an upload) plus extras.
+        params: Caller-supplied extras passed alongside the transfer.
         handle: The :class:`FileExchangeHandle` owning a download-side
             sink — handy for consume-then-produce chaining; ``None`` for
             the ``http_upload`` receiver sink, which has no such handle.
     """
 
     origin_id: str | None
+    destination: str | None
     mime_type: str | None
     size_bytes: int | None
     file_ref: FileRef | None
@@ -968,7 +971,7 @@ def _register_fetch_file(
     async def fetch_file(
         file_ref: dict[str, Any] | None = None,
         url: str | None = None,
-        path: str | None = None,
+        destination: str | None = None,
     ) -> dict[str, Any]:
         """Resolve a file reference (or URL) and hand the bytes to a sink.
 
@@ -978,6 +981,15 @@ def _register_fetch_file(
         in spec priority (``exchange`` before ``http``), building
         ``remaining_transfer`` on each method failure per spec
         §"Transfer Negotiation".
+
+        ``destination`` is the optional sink-side opaque domain
+        reference — the caller's placement handle for this consumer,
+        mirroring ``origin_id`` on the source side. When supplied it is
+        validated against the minimal-safety floor (spec §"Security and
+        Path Resolution") and surfaced to the sink hook as
+        :attr:`SinkContext.destination`; when omitted the consumer
+        decides placement itself. The reference is otherwise opaque to
+        pvl-core.
 
         HTTP redirects are NOT followed — producers configure
         non-redirecting download URLs (the spec mandates one-time
@@ -990,24 +1002,28 @@ def _register_fetch_file(
                 "error": "invalid_input",
                 "message": "fetch_file requires exactly one of file_ref or url",
             }
+        if destination is not None:
+            try:
+                validate_reference(destination, field="destination")
+            except ExchangeURIError as exc:
+                return {"error": "invalid_input", "message": str(exc)}
         params: dict[str, Any] = {}
-        if path is not None:
-            params["path"] = path
 
         if url is not None:
-            return await _fetch_via_url(handle, sink, url, params)
+            return await _fetch_via_url(handle, sink, url, destination, params)
 
         # url is None here (the (file_ref is None) == (url is None)
         # check above guarantees one is set).
         if file_ref is None:
             raise RuntimeError("fetch_file: input validation should have caught this")
-        return await _fetch_via_file_ref(handle, sink, file_ref, params)
+        return await _fetch_via_file_ref(handle, sink, file_ref, destination, params)
 
 
 async def _fetch_via_url(
     handle: FileExchangeHandle,
     sink: SinkHook,
     url: str,
+    destination: str | None,
     params: Mapping[str, Any],
 ) -> dict[str, Any]:
     parts = urlsplit(url)
@@ -1027,7 +1043,7 @@ async def _fetch_via_url(
             origin_id = ""
         try:
             return await _consume_exchange(
-                handle, sink, url, file_ref=None, params=params
+                handle, sink, url, file_ref=None, destination=destination, params=params
             )
         except (
             ExchangeURIError,
@@ -1044,7 +1060,9 @@ async def _fetch_via_url(
             )
     if parts.scheme in ("http", "https"):
         try:
-            return await _consume_http(handle, sink, url, file_ref=None, params=params)
+            return await _consume_http(
+                handle, sink, url, file_ref=None, destination=destination, params=params
+            )
         except FetchTransportError as exc:
             logger.warning("fetch_file http url failed: %s", exc)
             return _transfer_failed(
@@ -1074,6 +1092,7 @@ async def _fetch_via_file_ref(
     handle: FileExchangeHandle,
     sink: SinkHook,
     raw: dict[str, Any],
+    destination: str | None,
     params: Mapping[str, Any],
 ) -> dict[str, Any]:
     try:
@@ -1138,7 +1157,12 @@ async def _fetch_via_file_ref(
                 continue
             try:
                 return await _consume_exchange(
-                    handle, sink, uri, file_ref=ref, params=params
+                    handle,
+                    sink,
+                    uri,
+                    file_ref=ref,
+                    destination=destination,
+                    params=params,
                 )
             except (
                 ExchangeURIError,
@@ -1179,6 +1203,7 @@ async def _consume_exchange(
     uri: str,
     *,
     file_ref: FileRef | None,
+    destination: str | None,
     params: Mapping[str, Any],
 ) -> dict[str, Any]:
     if handle.exchange is None:
@@ -1192,6 +1217,7 @@ async def _consume_exchange(
     )
     ctx = SinkContext(
         origin_id=file_ref.origin_id if file_ref else None,
+        destination=destination,
         mime_type=file_ref.mime_type if file_ref else None,
         size_bytes=file_ref.size_bytes if file_ref else None,
         file_ref=file_ref,
@@ -1208,6 +1234,7 @@ async def _consume_http(
     url: str,
     *,
     file_ref: FileRef | None,
+    destination: str | None,
     params: Mapping[str, Any],
 ) -> dict[str, Any]:
     _ssrf_guard(url)
@@ -1274,6 +1301,7 @@ async def _consume_http(
 
     ctx = SinkContext(
         origin_id=file_ref.origin_id if file_ref else None,
+        destination=destination,
         mime_type=content_type or (file_ref.mime_type if file_ref else None),
         size_bytes=file_ref.size_bytes if file_ref else None,
         file_ref=file_ref,
@@ -1699,15 +1727,13 @@ def register_file_exchange_upload(
 
     async def _route_sink(record: UploadRecord, stream: BinaryIO) -> Mapping[str, Any]:
         """Adapt the public ``sink`` hook to the upload route's shape."""
-        params: dict[str, Any] = {}
-        if record.destination is not None:
-            params["destination"] = record.destination
         ctx = SinkContext(
             origin_id=record.origin_id,
+            destination=record.destination,
             mime_type=record.content_type,
             size_bytes=None,
             file_ref=None,
-            params=params,
+            params={},
             handle=None,
         )
         return await _invoke_sink(sink, stream, ctx)

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -1,13 +1,13 @@
 """MCP File Exchange — public facade.
 
 Single-entry-point wiring for downstream MCP servers that want to
-participate in the File Exchange convention (spec v0.5). Composes
+participate in the File Exchange convention. Composes
 the artifact store, the protocol surface, and the exchange-volume
 runtime, and registers the spec-compliant ``create_download_link``
 and ``fetch_file`` MCP tools.
 
 The ``experimental.file_exchange`` capability this module advertises
-uses the v0.5 ``transfer_methods`` shape: ``http`` and
+uses the ``transfer_methods`` shape: ``http`` and
 ``http_upload`` are separate method keys, each carrying ``source`` /
 ``sink`` role sub-objects for whichever role(s) the server fills.
 
@@ -459,7 +459,7 @@ class FileExchangeHandle:
                 ``source`` hook — pvl-core never invents one, because a
                 pvl-core-generated id would be unknown to the hook.
                 Validated only against the minimal-safety floor (spec
-                v0.5 §"Security and Path Resolution"): non-empty, no
+                §"Security and Path Resolution"): non-empty, no
                 null bytes or control characters, no leading/trailing
                 whitespace. It is otherwise opaque — the ``source`` hook
                 owns domain validation, and pvl-core derives every path
@@ -593,7 +593,7 @@ def register_file_exchange(
     source: SourceHook | None = None,
     sink: SinkHook | None = None,
 ) -> FileExchangeHandle:
-    """Wire MCP File Exchange (v0.5) onto ``mcp``.
+    """Wire MCP File Exchange onto ``mcp``.
 
     The kwarg surface is intentionally minimal — only domain hooks,
     no operator-config kwargs, no override seams. Operator config
@@ -727,7 +727,7 @@ def register_file_exchange(
     # --- Capability declaration ---
     # Push contributions into the per-FastMCP builder so that an upload
     # registrar on the same ``mcp`` can merge into one capability dict.
-    # The shape emitted is the v0.5 ``source``/``sink`` role-keyed form.
+    # The shape emitted is the ``source``/``sink`` role-keyed form.
     capability: FileExchangeCapability | None = None
     if enabled:
         builder = _get_or_create_builder(
@@ -1789,7 +1789,7 @@ def register_file_exchange_upload(
         Args:
             origin_id: The sender's opaque stable handle for the bytes
                 (the *what*). Validated against the minimal-safety floor
-                (spec v0.5 §"Security and Path Resolution"): non-empty,
+                (spec §"Security and Path Resolution"): non-empty,
                 no null bytes or control characters, no leading/trailing
                 whitespace. Otherwise opaque — the receiver validates
                 the rest per its own domain rules.
@@ -1811,7 +1811,7 @@ def register_file_exchange_upload(
             envelope.
         """
         # origin_id and destination share the minimal-safety floor (spec
-        # v0.5 §"Security and Path Resolution"): non-empty, no null bytes
+        # §"Security and Path Resolution"): non-empty, no null bytes
         # or control chars, no leading/trailing whitespace. Both are
         # otherwise opaque domain references — the receiver validates the
         # rest per its own domain rules.
@@ -1946,7 +1946,7 @@ def register_file_exchange_upload_sender(
                 ``create_upload_link`` call.
             origin_id: The sender's opaque stable handle for the bytes to
                 push. Validated against the minimal-safety floor (spec
-                v0.5 §"Security and Path Resolution"): non-empty, no null
+                §"Security and Path Resolution"): non-empty, no null
                 bytes or control characters, no leading/trailing
                 whitespace; resolved to bytes by the server's ``source``
                 hook. This ``origin_id`` is the

--- a/tests/test_file_exchange_capability_merge.py
+++ b/tests/test_file_exchange_capability_merge.py
@@ -50,7 +50,7 @@ def test_builder_http_source_only_emits_source_role() -> None:
     cap = b.build()
     assert cap is not None
     d = cap.to_capability_dict()
-    assert d["version"] == "0.5"
+    assert d["version"] == "0.6"
     assert d["transfer_methods"]["http"] == {
         "source": {"tool": "create_download_link"},
     }

--- a/tests/test_file_exchange_capability_merge.py
+++ b/tests/test_file_exchange_capability_merge.py
@@ -1,6 +1,6 @@
 """Tests for capability-merge across the http / http_upload registrars.
 
-Capability declarations use the v0.5 ``source``/``sink`` role-keyed
+Capability declarations use the ``source``/``sink`` role-keyed
 ``transfer_methods`` shape (spec §"Transfer Methods").
 """
 

--- a/tests/test_file_exchange_coverage.py
+++ b/tests/test_file_exchange_coverage.py
@@ -387,16 +387,16 @@ class TestConsumeHTTP:
 
 
 # ---------------------------------------------------------------------------
-# fetch_file ``destination`` — the sink-side opaque domain reference (v0.6)
+# fetch_file ``destination`` — the sink-side opaque domain reference
 # ---------------------------------------------------------------------------
 
 
 class TestFetchFileDestination:
     """``fetch_file(destination=...)`` threads the sink-side reference.
 
-    Spec v0.6 §"File reference" makes ``destination`` a first-class
-    :class:`SinkContext` field, mirroring ``origin_id`` on the source
-    side: it is the caller's opaque placement handle for the consumer.
+    ``destination`` is a first-class :class:`SinkContext` field,
+    mirroring ``origin_id`` on the source side: the caller's opaque
+    placement handle for the consumer.
     """
 
     async def test_http_path_populates_destination(

--- a/tests/test_file_exchange_coverage.py
+++ b/tests/test_file_exchange_coverage.py
@@ -810,7 +810,7 @@ class TestCreateDownloadLink:
     async def test_floor_violation_origin_id_returns_transfer_failed(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # v0.5: ``../escape`` is now an opaque reference, not a rejection.
+        # ``../escape`` is an opaque reference, not a rejection.
         # The minimal-safety floor still rejects control characters.
         mcp = _new_producer_mcp(monkeypatch, _src(b"PNG", "image/png"))
         out = await _call_download_link(mcp, origin_id="bad\x00id")
@@ -867,7 +867,7 @@ class TestMakeFileRef:
     async def test_make_file_ref_accepts_dotted_origin_id(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # v0.5: a leading dot is opaque data — make_file_ref accepts it
+        # a leading dot is opaque data — make_file_ref accepts it
         # and echoes it back; no segment-rule rejection.
         monkeypatch.setenv("TEST_FE_BASE_URL", "http://test.example")
         monkeypatch.setenv("TEST_FE_TRANSPORT", "http")

--- a/tests/test_file_exchange_coverage.py
+++ b/tests/test_file_exchange_coverage.py
@@ -128,6 +128,7 @@ def _sink(captured: dict[str, Any] | None = None) -> SinkHook:
             captured["data"] = data
             captured["mime_type"] = ctx.mime_type
             captured["origin_id"] = ctx.origin_id
+            captured["destination"] = ctx.destination
             captured["size_bytes"] = ctx.size_bytes
         return {"stored_at": "memory", "bytes_written": len(data)}
 
@@ -143,6 +144,7 @@ def _async_sink(captured: dict[str, Any] | None = None) -> SinkHook:
             captured["data"] = data
             captured["mime_type"] = ctx.mime_type
             captured["origin_id"] = ctx.origin_id
+            captured["destination"] = ctx.destination
             captured["size_bytes"] = ctx.size_bytes
         return {"stored_at": "memory", "bytes_written": len(data)}
 
@@ -385,6 +387,129 @@ class TestConsumeHTTP:
 
 
 # ---------------------------------------------------------------------------
+# fetch_file ``destination`` — the sink-side opaque domain reference (v0.6)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchFileDestination:
+    """``fetch_file(destination=...)`` threads the sink-side reference.
+
+    Spec v0.6 §"File reference" makes ``destination`` a first-class
+    :class:`SinkContext` field, mirroring ``origin_id`` on the source
+    side: it is the caller's opaque placement handle for the consumer.
+    """
+
+    async def test_http_path_populates_destination(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, content=b"bytes", headers={"content-type": "image/png"}
+            )
+
+        _mock_http(monkeypatch, handler)
+        mcp = _new_consumer_mcp(monkeypatch, _sink(captured))
+
+        out = await _call_fetch(
+            mcp, url="https://example.com/img.png", destination="vault/notes"
+        )
+        assert out["method"] == "http"
+        # destination is a first-class SinkContext field, not a params entry.
+        assert captured["destination"] == "vault/notes"
+
+    async def test_exchange_path_populates_destination(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("MCP_EXCHANGE_DIR", str(tmp_path))
+        from fastmcp_pvl_core import FileExchange
+
+        producer = FileExchange.from_env(default_namespace="image-mcp")
+        assert producer is not None
+        uri = str(producer.write_atomic(origin_id="abc", ext="png", content=b"img"))
+
+        captured: dict[str, Any] = {}
+        mcp = _new_consumer_mcp(monkeypatch, _sink(captured))
+
+        out = await _call_fetch(mcp, url=uri, destination="generated/test.png")
+        assert out["method"] == "exchange"
+        assert captured["destination"] == "generated/test.png"
+
+    async def test_file_ref_path_populates_destination(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # A file_ref-driven fetch over the exchange method also threads
+        # the caller-supplied destination through to the sink.
+        monkeypatch.setenv("MCP_EXCHANGE_DIR", str(tmp_path))
+        from fastmcp_pvl_core import FileExchange
+
+        producer = FileExchange.from_env(default_namespace="image-mcp")
+        assert producer is not None
+        uri = str(producer.write_atomic(origin_id="abc", ext="png", content=b"img"))
+
+        captured: dict[str, Any] = {}
+        mcp = _new_consumer_mcp(monkeypatch, _sink(captured))
+
+        ref = FileRef(
+            origin_server="image-mcp",
+            origin_id="src-ref",
+            transfer={"exchange": {"uri": uri}},
+        ).to_dict()
+        out = await _call_fetch(mcp, file_ref=ref, destination="vault/in")
+        assert out["method"] == "exchange"
+        # origin_id (source side) and destination (sink side) are both
+        # first-class SinkContext attributes.
+        assert captured["origin_id"] == "src-ref"
+        assert captured["destination"] == "vault/in"
+
+    async def test_omitted_destination_is_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No destination supplied → ctx.destination is None, transfer
+        # still succeeds (the consumer decides placement itself).
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"bytes")
+
+        _mock_http(monkeypatch, handler)
+        mcp = _new_consumer_mcp(monkeypatch, _sink(captured))
+
+        out = await _call_fetch(mcp, url="https://example.com/img")
+        assert out["method"] == "http"
+        assert out["bytes_written"] == 5
+        assert captured["destination"] is None
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",  # empty
+            " leading-space",
+            "trailing-space ",
+            "bad\x00id",  # null byte
+            "ctrl\x1fchar",  # other control character
+        ],
+    )
+    async def test_floor_violation_rejected(
+        self, monkeypatch: pytest.MonkeyPatch, bad: str
+    ) -> None:
+        # A destination violating the minimal-safety floor is rejected
+        # with the invalid_input envelope before any transfer happens.
+        sink_called = False
+
+        def sink(stream: BinaryIO, ctx: SinkContext) -> Mapping[str, Any]:
+            nonlocal sink_called
+            sink_called = True
+            return {"bytes_written": len(stream.read())}
+
+        mcp = _new_consumer_mcp(monkeypatch, sink)
+        out = await _call_fetch(mcp, url="https://example.com/img", destination=bad)
+        assert out["error"] == "invalid_input"
+        assert sink_called is False
+
+
+# ---------------------------------------------------------------------------
 # _ssrf_guard matrix
 # ---------------------------------------------------------------------------
 
@@ -543,6 +668,7 @@ class TestInvokeSink:
     def _ctx(self) -> SinkContext:
         return SinkContext(
             origin_id=None,
+            destination=None,
             mime_type=None,
             size_bytes=None,
             file_ref=None,

--- a/tests/test_file_exchange_facade.py
+++ b/tests/test_file_exchange_facade.py
@@ -406,7 +406,7 @@ class TestMakeFileRef:
     ) -> None:
         """The ``exchange://`` URI segment is a SHA-256 of the origin_id.
 
-        v0.5: a path-shaped ``origin_id`` is never embedded verbatim in
+        A path-shaped ``origin_id`` is never embedded verbatim in
         the URI, path, or filename — pvl-core derives a segment-safe
         digest. The ``file_ref`` still carries the real ``origin_id``.
         """
@@ -561,7 +561,7 @@ class TestCreateDownloadLinkTool:
     async def test_opaque_origin_id_accepted(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # v0.5: origin_id is an opaque domain reference — path-shaped and
+        # origin_id is an opaque domain reference — path-shaped and
         # URI-shaped values are passed through to the source hook, not
         # rejected by pvl-core.
         for origin_id in ("folder/to/note.md", "image://job-1/0", "../weird"):
@@ -588,7 +588,7 @@ class TestCreateDownloadLinkTool:
     async def test_resource_uri_origin_id_round_trips_to_hook(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # v0.5: a resource-URI-shaped origin_id reaches the source hook
+        # a resource-URI-shaped origin_id reaches the source hook
         # verbatim and a download URL comes back.
         seen: list[str] = []
 

--- a/tests/test_file_exchange_protocol.py
+++ b/tests/test_file_exchange_protocol.py
@@ -310,7 +310,7 @@ class TestFileExchangeCapability:
         }
 
     def test_full_round_trip_matches_spec_3_9(self) -> None:
-        # Verbatim shape from spec §3.9 producer example (v0.5 source/sink shape).
+        # Verbatim shape from spec §3.9 producer example (v0.6 source/sink shape).
         cap = FileExchangeCapability(
             namespace="image-mcp",
             exchange_id="hades-01",
@@ -323,7 +323,7 @@ class TestFileExchangeCapability:
         )
         d = cap.to_capability_dict()
         assert d == {
-            "version": "0.5",
+            "version": "0.6",
             "namespace": "image-mcp",
             "exchange_id": "hades-01",
             "produces": ["image/png", "image/webp", "image/jpeg"],

--- a/tests/test_file_exchange_protocol.py
+++ b/tests/test_file_exchange_protocol.py
@@ -255,7 +255,7 @@ class TestValidateSegment:
 
 
 class TestValidateReference:
-    """Spec v0.5 minimal-safety floor for opaque domain references."""
+    """Minimal-safety floor for opaque domain references."""
 
     @pytest.mark.parametrize(
         "value",

--- a/tests/test_file_exchange_protocol.py
+++ b/tests/test_file_exchange_protocol.py
@@ -310,7 +310,7 @@ class TestFileExchangeCapability:
         }
 
     def test_full_round_trip_matches_spec_3_9(self) -> None:
-        # Verbatim shape from spec §3.9 producer example (v0.6 source/sink shape).
+        # Verbatim shape from spec §3.9 producer example (source/sink shape).
         cap = FileExchangeCapability(
             namespace="image-mcp",
             exchange_id="hades-01",

--- a/tests/test_file_exchange_runtime.py
+++ b/tests/test_file_exchange_runtime.py
@@ -215,7 +215,7 @@ class TestWriteAtomic:
         uri = fx.write_atomic(origin_id="abc", ext="png", content=b"hello")
         assert isinstance(uri, ExchangeURI)
         # The exchange segment is the SHA-256 of the origin_id, not the
-        # raw origin_id (spec v0.5 decoupling).
+        # raw origin_id (the spec's exchange-segment decoupling).
         seg = _seg("abc")
         assert uri.id == seg
         assert str(uri) == f"exchange://hades-01/image-mcp/{seg}.png"
@@ -242,7 +242,7 @@ class TestWriteAtomic:
             fx.read_exchange_uri(f"exchange://hades-01/image-mcp/{seg}.png")
 
     def test_opaque_origin_id_accepted(self, tmp_path: Path) -> None:
-        # v0.5: origin_id is opaque — path-shaped values are no longer
+        # origin_id is opaque — path-shaped values are not
         # rejected by write_atomic; the exchange segment is derived.
         fx = _make_fx(tmp_path)
         for origin_id in ("bad/id", ".hidden", "../weird", "image://job-1/0"):
@@ -257,7 +257,7 @@ class TestWriteAtomic:
             fx.write_atomic(origin_id="abc", ext="p/g", content=b"x")
 
     def test_floor_violation_origin_id_rejected(self, tmp_path: Path) -> None:
-        # v0.5: write_atomic enforces the minimal-safety floor on
+        # write_atomic enforces the minimal-safety floor on
         # origin_id (defence-in-depth alongside the producing facade).
         fx = _make_fx(tmp_path)
         for bad in ("", " leading", "trailing ", "with\x00null", "ctl\x01"):

--- a/tests/test_file_exchange_upload_facade.py
+++ b/tests/test_file_exchange_upload_facade.py
@@ -411,7 +411,7 @@ async def test_create_upload_link_accepts_opaque_origin_id(
     origin_id: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """v0.5: ``origin_id`` is an opaque domain reference.
+    """``origin_id`` is an opaque domain reference.
 
     Path-shaped and URI-shaped values are no longer rejected — they are
     only checked against the minimal-safety floor and otherwise passed

--- a/tests/test_file_exchange_upload_facade.py
+++ b/tests/test_file_exchange_upload_facade.py
@@ -693,7 +693,7 @@ async def test_upload_post_propagates_sink_context(
 
     The ``_route_sink`` adapter maps the upload record onto a
     :class:`SinkContext`: ``origin_id`` = the record's origin_id,
-    ``mime_type`` = the record's content_type, and ``params["destination"]``
+    ``mime_type`` = the record's content_type, and ``destination``
     = the ``destination`` the ``create_upload_link`` caller passed.
     """
     monkeypatch.setenv("TEST_UPLOAD_TRANSPORT", "http")
@@ -705,7 +705,7 @@ async def test_upload_post_propagates_sink_context(
         data = stream.read()
         captured["origin_id"] = ctx.origin_id
         captured["mime_type"] = ctx.mime_type
-        captured["destination"] = ctx.params.get("destination")
+        captured["destination"] = ctx.destination
         return {"stored": True, "bytes": len(data)}
 
     mcp = FastMCP(name="test")

--- a/tests/test_file_exchange_upload_sender.py
+++ b/tests/test_file_exchange_upload_sender.py
@@ -399,7 +399,7 @@ async def test_upload_opaque_origin_id_accepted(
     origin_id: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """v0.5: path-/URI-shaped origin_id is opaque — the POST proceeds."""
+    """A path-/URI-shaped origin_id is opaque — the POST proceeds."""
     call_count: list[int] = [0]
 
     def handler(request: httpx.Request) -> httpx.Response:


### PR DESCRIPTION
## Summary

Completes file-exchange's source/sink symmetry. The *source* side has one
reference name — `origin_id` — across every source tool. The *sink* side had
two: `fetch_file` took `path` (filesystem-framed), `create_upload_link` took
`destination` (made an opaque domain reference in v0.5). Same role, two names —
a gap the v0.3 dual-role pass and the v0.5 symmetry pass both missed.

v0.6:

- **`fetch_file`'s `path` parameter becomes `destination`** — one opaque
  domain reference across both sink tools, validated against the
  minimal-safety floor, interpreted by the consuming server per its own
  domain (directly as a path/slot, a handle minted by a downstream
  prepare-receive tool, or a resource URI). Optional; if omitted the consumer
  auto-places.
- **`SinkContext` gains a first-class `destination` field**, symmetric with
  its existing `origin_id` field, populated on every sink path (`fetch_file`
  over `http`/`exchange`, and the `http_upload` receive route). The sink
  reference previously reached the hook only through the generic `params`
  dict.
- Spec `docs/specs/file-exchange.md` → **v0.6**; `SPEC_VERSION` → `"0.6"`.
- All `v0.5` prose references across `src/` and `tests/` made
  version-agnostic — a spec-version number now appears only in `SPEC_VERSION`
  and the spec doc's `Version` field.

**Scope boundary:** file-exchange's sink job ends at placement; domain
postprocessing (e.g. markdown-vault stamping front matter) is downstream
follow-up tooling, off this surface.

**Breaking change:** `fetch_file`'s `path` → `destination` is a parameter
rename. No downstream server has adopted file-exchange — clean replacement, no
alias.

Closes #114. Design doc + plan: `docs/superpowers/{specs,plans}/2026-05-17-sink-reference-symmetrization*`.

## Test plan

- [x] `uv run pytest` — 721 passed (new: `destination` populated on the
  `http` / `exchange` / `http_upload` sink paths; `origin_id` + `destination`
  both first-class; omitted `destination` → `None` + auto-place; floor
  violation → `invalid_input` with the sink not invoked; capability `version`
  `0.6`)
- [x] `uv run ruff format --check .` / `uv run ruff check .` — clean
- [x] `uv run mypy src` — clean
- [x] Local preflight review (5-lens circus + supplementary reviewers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)