### PR TITLE
build: bump fastmcp floor 3.2.4 → 3.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "MIT"}
 authors = [{name = "Peter van Liesdonk", email = "peter@liesdonk.nl"}]
 requires-python = ">=3.10"
 dependencies = [
-  "fastmcp>=3.2.4,<4",
+  "fastmcp>=3.3.1,<4",
   # httpx is used by the remote-auth provider (`_auth.py`) to fetch the
   # OIDC discovery document at startup. Kept as a hard dependency; the
   # `remote-auth` extra is retained as a backwards-compat no-op.

--- a/uv.lock
+++ b/uv.lock
@@ -572,40 +572,19 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.2.4"
+version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "authlib" },
-    { name = "cyclopts" },
-    { name = "exceptiongroup" },
-    { name = "griffelib" },
-    { name = "httpx" },
-    { name = "jsonref" },
-    { name = "jsonschema-path" },
-    { name = "mcp" },
-    { name = "openapi-pydantic" },
-    { name = "opentelemetry-api" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
-    { name = "pyperclip" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "uncalled-for" },
-    { name = "uvicorn" },
-    { name = "watchfiles" },
-    { name = "websockets" },
+    { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/a9/5c5a01b6abd5346bf60b97cfd29e4a86661940c27dd562bfcda07fd03519/fastmcp-3.3.1.tar.gz", hash = "sha256:979362ea557de42a5f40342563c7e4b236bcc8e7cd192715f50030695d1a71cd", size = 28681699, upload-time = "2026-05-15T15:50:39.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/11/6b1bdada6ccfe647d615ae63f9106f8136aec17971e9361546af01c7d38e/fastmcp-3.3.1-py3-none-any.whl", hash = "sha256:862440c5c4d281363a5995eee59d77f0f7cac1f18869038729cecf03b02fc522", size = 7903, upload-time = "2026-05-15T15:50:36.424Z" },
 ]
 
 [[package]]
 name = "fastmcp-pvl-core"
-version = "3.0.1rc2"
+version = "3.0.1rc3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -633,7 +612,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "debugpy", marker = "extra == 'debug'", specifier = ">=1.8" },
-    { name = "fastmcp", specifier = ">=3.2.4,<4" },
+    { name = "fastmcp", specifier = ">=3.3.1,<4" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.7" },
@@ -649,6 +628,54 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-cov", specifier = ">=5" },
     { name = "ruff", specifier = ">=0.6" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/a0/627103e517e1d0d6f1eec633d5662d13e776f01b45ad188e4f5f7478b438/fastmcp_slim-3.3.1.tar.gz", hash = "sha256:0957835fc59452e143ab2f4b7836d2d2df9b2d9958408edc79ba8b56232b2a88", size = 567007, upload-time = "2026-05-15T15:50:10.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ee/97047f4cc2d7b1d46670d08d8ad01a96e7a748cc01c0b4b351ad8eddbc7a/fastmcp_slim-3.3.1-py3-none-any.whl", hash = "sha256:6cf1c2d77e3adb0d409d6825ed6b0b2a999062973e00b8eea03bd48bf9b4c043", size = 738644, upload-time = "2026-05-15T15:50:08.336Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+]
+server = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pyperclip" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `fastmcp` floor in `pyproject.toml` from `>=3.2.4,<4` to `>=3.3.1,<4` and regenerates `uv.lock`.
- 3.3.0 ("Slim Reaper") brings OAuthProxy / `ResponseCachingMiddleware` hardening, full MCP-semantic-conventions OTEL coverage, `AzureB2CProvider`, `OAuthProxy.update_scopes()`, and the `run_in_thread=False` opt-out for sync tools.
- 3.3.1 hotfixes a circular import in 3.3.0 — pinning `>=3.3.1` (not `>=3.3.0`) so clean installs cannot land on the broken release.

This repo's `fastmcp` imports (`FastMCP`, `exceptions`, `server.dependencies`, `server.middleware{,.middleware}`, `utilities.logging`) are all preserved across 3.2.4 → 3.3.1 — the 3.3.0 component-import decoupling kept the old paths as compat re-exports.

Closes #119

## Test plan

- [x] `uv sync --all-extras` — clean (fastmcp 3.2.4 → 3.3.1, fastmcp-slim 3.3.1 pulled in transitively as 3.3.0's packaging split intends).
- [x] `uv run pytest` — 358/358 passing.
- [x] `uv run ruff format --check .` — 37 files already formatted.
- [x] `uv run ruff check .` — all checks passed.
- [x] `uv run mypy src` — no issues in 15 source files.
- [x] `preflight-circus` — clean (0 findings ≥80 across lenses 1–5 + `pr-review-toolkit:code-reviewer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)