### PR TITLE
docs(file-exchange): v0.1 cleanroom adoption — design + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-05-20-file-exchange-implementation.md
+++ b/docs/superpowers/plans/2026-05-20-file-exchange-implementation.md
@@ -480,7 +480,7 @@ FileExchangeTransport = Literal["filesystem", "download", "upload"]
 git add src/fastmcp_pvl_core/_file_exchange/ tests/file_exchange/
 git commit -m "feat(file-exchange): vendor v0.1 schema and Pydantic types
 
-Closes <issue-A-number>"
+Closes #124"
 ```
 
 ### Step A.6: Local circus + PR
@@ -932,7 +932,7 @@ Expected: PASS (all 7 select tests + earlier error tests).
 git add src/fastmcp_pvl_core/_file_exchange/_errors.py src/fastmcp_pvl_core/_file_exchange/_select.py tests/file_exchange/test_errors.py tests/file_exchange/test_select.py
 git commit -m "feat(file-exchange): error envelope + descriptor selection algorithm
 
-Closes <issue-B-number>"
+Closes #125"
 ```
 
 - [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
@@ -1206,7 +1206,7 @@ Expected: PASS (all 9 tests).
 git add src/fastmcp_pvl_core/_file_exchange/_transport_filesystem.py tests/file_exchange/test_transport_filesystem.py
 git commit -m "feat(file-exchange): filesystem transport with exchange:// resolution and atomic writes
 
-Closes <issue-C-number>"
+Closes #126"
 ```
 
 - [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
@@ -1616,7 +1616,7 @@ Expected: PASS (all 9 tests).
 git add src/fastmcp_pvl_core/_file_exchange/_transport_https.py tests/file_exchange/test_transport_https.py
 git commit -m "feat(file-exchange): HTTPS consumer transport (pull/push) with SSRF guard
 
-Closes <issue-D-number>"
+Closes #127"
 ```
 
 - [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
@@ -2137,7 +2137,7 @@ Expected: PASS (all 5 tests).
 git add src/fastmcp_pvl_core/_file_exchange/_url_store.py src/fastmcp_pvl_core/_file_exchange/_routes.py tests/file_exchange/test_url_store.py tests/file_exchange/test_routes.py
 git commit -m "feat(file-exchange): capability-URL token store + sibling HTTP routes
 
-Closes <issue-E-number>"
+Closes #128"
 ```
 
 - [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
@@ -2986,7 +2986,7 @@ Expected: every test in the repo passes.
 git add src/fastmcp_pvl_core/ tests/file_exchange/
 git commit -m "feat(file-exchange): capability declaration, role helpers, top-level public API
 
-Closes <issue-F-number>"
+Closes #129"
 ```
 
 - [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
@@ -3228,7 +3228,7 @@ Expected: PASS for every vendored fixture.
 git add tests/file_exchange/ CHANGELOG.md
 git commit -m "test(file-exchange): integration suite + spec-repo conformance fixtures
 
-Closes <issue-G-number>"
+Closes #130"
 ```
 
 - [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.

--- a/docs/superpowers/plans/2026-05-20-file-exchange-implementation.md
+++ b/docs/superpowers/plans/2026-05-20-file-exchange-implementation.md
@@ -1,0 +1,3254 @@
+# File-Exchange v0.1 Implementation Plan (pvl-core phase 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the `nl.liesdonk.file-exchange` v0.1 extension (https://github.com/pvliesdonk/mcp-file-exchange-ext) as pvl-core's shared reference implementation, with all four roles (`provider`/`fetcher`/`receiver`/`sender`) and all three transports (`filesystem`/`download`/`upload`), gated automatically per deployment capability.
+
+**Architecture:** New private package `src/fastmcp_pvl_core/_file_exchange/`. Pydantic types over a vendored JSON schema. Helpers exposed at top-level package surface (matching the existing `build_auth` / `register_server_info_tool` idiom). Capability declaration derives transport availability from `ServerConfig` (volumes, transport). Persistent state via the existing `build_kv_store` factory shipped in PR #122.
+
+**Tech Stack:** Python 3.10–3.13, FastMCP 3.3.1+, Pydantic v2, py-key-value-aio (existing transitive dep), httpx (already in deps for OIDC), Starlette (FastMCP's HTTP layer), pytest + pytest-asyncio.
+
+**Design doc:** [`docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md`](../specs/2026-05-20-file-exchange-adoption-design.md)
+
+---
+
+## File structure
+
+New package under `src/fastmcp_pvl_core/_file_exchange/`:
+
+```
+_file_exchange/
+    __init__.py                       # public namespace; re-exports from submodules
+    schema/
+        file-exchange.schema.json     # vendored verbatim from spec repo @ pinned commit
+        .expected-sha256              # drift gate
+        PINNED_AT.md                  # records upstream commit + spec version
+        conformance/                  # vendored conformance fixtures
+    _types.py                         # Pydantic models for refs, descriptors, errors
+    _select.py                        # selection algorithm (§9 of spec)
+    _errors.py                        # FileExchangeError + code constants + envelope
+    _transport_filesystem.py          # exchange:// resolution, atomic_write, mint helpers
+    _transport_https.py               # pull_download, push_upload, SSRF guard
+    _url_store.py                     # capability URL minting; intake correlation
+    _routes.py                        # GET /file-exchange/d/<token>, PUT|POST /u/<token>
+    _provider.py                      # build_pull_response
+    _fetcher.py                       # pull_artifact
+    _receiver.py                      # open_intake, build_intake_response, resolve_intake
+    _sender.py                        # push_artifact
+    _capability.py                    # register_file_exchange_capability + gating + mounting
+```
+
+Top-level re-exports added to `src/fastmcp_pvl_core/__init__.py`.
+
+`ServerConfig` (in `_config.py`) gains seven new fields (see Task F).
+
+Test tree under `tests/file_exchange/` mirrors the source layout, plus `tests/file_exchange/test_integration_*.py` and `tests/file_exchange/test_conformance.py`.
+
+---
+
+## Sequencing & parallel dispatch
+
+```
+A (types + schema)  ────────┐
+                            ├─► B (select + errors) ──┐
+                            │                         ├─► F (capability + role helpers) ─► G (integration)
+                            ├─► C (filesystem) ───────┤
+                            │                         │
+                            ├─► D (HTTPS consumer) ───┤
+                            │                         │
+                            └─► E (URL store + routes)┘
+```
+
+- **A is the critical path** (every later task imports from `_types.py`).
+- Once A merges, **B, C, D, E can run in parallel** (different files, independent test suites).
+- **F depends on B+C+D+E** (capability registration wires them; role helpers call into them).
+- **G depends on F** (integration tests exercise the full surface).
+
+Each task group becomes one PR closing one tracked issue, opened as draft, gated through the `preflight-circus` skill before push (per global CLAUDE.md PR workflow). The user files the seven child issues (A–G) before kick-off.
+
+---
+
+# Task A: Vendor schema + Pydantic types + drift gate
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/__init__.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/schema/file-exchange.schema.json` (vendored)
+- Create: `src/fastmcp_pvl_core/_file_exchange/schema/.expected-sha256`
+- Create: `src/fastmcp_pvl_core/_file_exchange/schema/PINNED_AT.md`
+- Create: `src/fastmcp_pvl_core/_file_exchange/schema/conformance/` (vendored fixtures)
+- Create: `src/fastmcp_pvl_core/_file_exchange/_types.py`
+- Create: `tests/file_exchange/__init__.py`
+- Create: `tests/file_exchange/test_schema_drift.py`
+- Create: `tests/file_exchange/test_types.py`
+
+### Step A.1: Vendor the schema and conformance fixtures
+
+- [ ] Pick the spec-repo pin commit. Run:
+
+```bash
+gh api repos/pvliesdonk/mcp-file-exchange-ext/commits/main --jq '.sha'
+```
+
+Record the SHA in `_file_exchange/schema/PINNED_AT.md`:
+
+```markdown
+# Vendored from pvliesdonk/mcp-file-exchange-ext
+
+- **Upstream commit:** <full-sha-from-above>
+- **Spec version:** 0.1 (draft)
+- **Vendored at:** 2026-05-20
+
+To re-pin: fetch the schema and conformance directory from the new commit,
+update PINNED_AT.md and .expected-sha256, and run `pytest tests/file_exchange/test_schema_drift.py`.
+```
+
+- [ ] Download the schema:
+
+```bash
+mkdir -p src/fastmcp_pvl_core/_file_exchange/schema/conformance
+curl -sL "https://raw.githubusercontent.com/pvliesdonk/mcp-file-exchange-ext/<sha>/schema/file-exchange.json" \
+    > src/fastmcp_pvl_core/_file_exchange/schema/file-exchange.schema.json
+```
+
+- [ ] Compute and record SHA-256:
+
+```bash
+sha256sum src/fastmcp_pvl_core/_file_exchange/schema/file-exchange.schema.json \
+    | awk '{print $1}' \
+    > src/fastmcp_pvl_core/_file_exchange/schema/.expected-sha256
+```
+
+- [ ] Vendor the conformance fixtures (one curl per fixture file, listed via `gh api repos/pvliesdonk/mcp-file-exchange-ext/contents/conformance?ref=<sha>` and downloaded individually).
+
+### Step A.2: Drift-gate test
+
+- [ ] Write `tests/file_exchange/test_schema_drift.py`:
+
+```python
+"""Schema-drift gate: the vendored schema must match its recorded SHA-256.
+
+Drift means an unintended edit to the local copy, which is a vendoring violation.
+Re-pinning is a deliberate commit that updates PINNED_AT.md and .expected-sha256.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+SCHEMA = Path(__file__).resolve().parent.parent.parent / "src" / "fastmcp_pvl_core" / "_file_exchange" / "schema" / "file-exchange.schema.json"
+EXPECTED_SHA = SCHEMA.parent / ".expected-sha256"
+
+
+def test_vendored_schema_matches_recorded_sha256():
+    actual = hashlib.sha256(SCHEMA.read_bytes()).hexdigest()
+    expected = EXPECTED_SHA.read_text().strip()
+    assert actual == expected, (
+        f"Vendored schema drift detected.\n"
+        f"  expected: {expected}\n"
+        f"  actual:   {actual}\n"
+        f"If the change is intentional, re-pin by updating PINNED_AT.md and .expected-sha256."
+    )
+```
+
+- [ ] Run the test to verify it passes:
+
+```bash
+uv run pytest tests/file_exchange/test_schema_drift.py -v
+```
+
+Expected: PASS.
+
+### Step A.3: Write the Pydantic types
+
+- [ ] Write `src/fastmcp_pvl_core/_file_exchange/__init__.py` (empty for now — re-exports added at the end of Task A):
+
+```python
+"""File-exchange extension implementation (nl.liesdonk.file-exchange v0.1).
+
+Reference implementation of pvliesdonk/mcp-file-exchange-ext.
+The public surface is re-exported from the top-level fastmcp_pvl_core package.
+"""
+```
+
+- [ ] Write `tests/file_exchange/test_types.py` — start with the discriminator behaviour (most likely to break later if shape changes):
+
+```python
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from fastmcp_pvl_core._file_exchange._types import (
+    ArtifactMetadata,
+    DownloadSourceDescriptor,
+    FilesystemSinkDescriptor,
+    FilesystemSourceDescriptor,
+    IntakeTicket,
+    SourceDescriptor,
+    TransferHandle,
+    UploadSinkDescriptor,
+)
+
+
+def test_filesystem_source_descriptor_roundtrips():
+    raw = {"transport": "filesystem", "uri": "exchange://vault/notes/n1.md"}
+    desc = SourceDescriptor.validate_python(raw)
+    assert isinstance(desc.root, FilesystemSourceDescriptor)
+    assert desc.root.uri == "exchange://vault/notes/n1.md"
+
+
+def test_download_source_descriptor_requires_expires_at():
+    with pytest.raises(ValidationError):
+        SourceDescriptor.validate_python({"transport": "download", "url": "https://x/y"})
+
+
+def test_descriptor_unknown_transport_is_rejected_at_typed_layer():
+    """The typed layer rejects unknown transports — selection-level fallthrough
+    (§17.2 'tolerant reading') is handled in _select.py, not by the discriminator."""
+    with pytest.raises(ValidationError):
+        SourceDescriptor.validate_python({"transport": "carrier-pigeon", "uri": "x"})
+
+
+def test_transfer_handle_requires_at_least_one_source():
+    with pytest.raises(ValidationError):
+        TransferHandle.model_validate(
+            {
+                "type": "nl.liesdonk.file-exchange/transfer-handle",
+                "version": "0.1",
+                "artifact": {"name": "x.bin"},
+                "sources": [],
+            }
+        )
+
+
+def test_transfer_handle_type_field_is_constant():
+    with pytest.raises(ValidationError):
+        TransferHandle.model_validate(
+            {
+                "type": "something-else",
+                "version": "0.1",
+                "artifact": {"name": "x.bin"},
+                "sources": [{"transport": "filesystem", "uri": "exchange://v/x"}],
+            }
+        )
+
+
+def test_artifact_metadata_requires_at_least_one_field():
+    with pytest.raises(ValidationError):
+        ArtifactMetadata.model_validate({})
+
+
+def test_artifact_metadata_with_only_name_is_valid():
+    md = ArtifactMetadata.model_validate({"name": "report.parquet"})
+    assert md.name == "report.parquet"
+
+
+def test_intake_ticket_requires_artifact_id():
+    with pytest.raises(ValidationError):
+        IntakeTicket.model_validate(
+            {
+                "type": "nl.liesdonk.file-exchange/intake-ticket",
+                "version": "0.1",
+                "sinks": [{"transport": "filesystem", "uri": "exchange://i/x"}],
+            }
+        )
+
+
+def test_filesystem_sink_descriptor_roundtrips():
+    raw = {"transport": "filesystem", "uri": "exchange://intake/x.bin"}
+    sink = FilesystemSinkDescriptor.model_validate(raw)
+    assert sink.uri == "exchange://intake/x.bin"
+
+
+def test_upload_sink_descriptor_default_method_is_put():
+    raw = {
+        "transport": "upload",
+        "url": "https://x/y",
+        "expiresAt": "2026-12-31T00:00:00Z",
+    }
+    sink = UploadSinkDescriptor.model_validate(raw)
+    assert sink.method == "PUT"
+```
+
+- [ ] Run the tests to confirm they fail:
+
+```bash
+uv run pytest tests/file_exchange/test_types.py -v
+```
+
+Expected: every test fails with `ImportError` or `ModuleNotFoundError`.
+
+- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_types.py`:
+
+```python
+"""Pydantic models for the nl.liesdonk.file-exchange v0.1 wire types.
+
+The shape of each model mirrors schema/file-exchange.schema.json. The discriminator
+field on descriptors (``transport``) rejects unknown values at the typed layer; the
+spec's §17.2 'tolerant reading' rule for unknown transports is applied at selection
+time in _select.py, not by these models — because by the time we deserialise to a
+strongly-typed object we have already committed to a known shape.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    HttpUrl,
+    RootModel,
+    field_validator,
+    model_validator,
+)
+
+REFERENCE_VERSION = "0.1"
+TRANSFER_HANDLE_TYPE = "nl.liesdonk.file-exchange/transfer-handle"
+INTAKE_TICKET_TYPE = "nl.liesdonk.file-exchange/intake-ticket"
+
+
+class ArtifactMetadata(BaseModel):
+    """Describes an artifact independently of how it is transferred (spec §7.1)."""
+
+    model_config = ConfigDict(extra="ignore")  # §17.2 tolerant reading on non-descriptor objects
+
+    id: str | None = None
+    name: str | None = None
+    mimeType: str | None = None
+    size: int | None = Field(default=None, ge=0)
+    digest: str | None = None
+    description: str | None = None
+    createdAt: datetime | None = None
+
+    @model_validator(mode="after")
+    def _at_least_one_field(self) -> "ArtifactMetadata":
+        # Spec §7.1: an artifact with no metadata cannot be reviewed by a human and is invalid.
+        if not any(
+            getattr(self, name) is not None
+            for name in ("id", "name", "mimeType", "size", "digest", "description", "createdAt")
+        ):
+            raise ValueError("ArtifactMetadata MUST contain at least one field (spec §7.1)")
+        return self
+
+
+# ---- Source descriptors (used in TransferHandle.sources) ----
+
+
+class FilesystemSourceDescriptor(BaseModel):
+    """`filesystem` transport, source side (spec §7.2.1)."""
+
+    model_config = ConfigDict(extra="forbid")  # §17.5 descriptor-shape freeze
+
+    transport: Literal["filesystem"]
+    uri: str
+
+    @field_validator("uri")
+    @classmethod
+    def _scheme_is_exchange_or_file(cls, v: str) -> str:
+        if not (v.startswith("exchange://") or v.startswith("file://")):
+            raise ValueError("filesystem source URI must use 'exchange://' or 'file://'")
+        return v
+
+
+class DownloadSourceDescriptor(BaseModel):
+    """`download` transport, source side (spec §7.2.2)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    transport: Literal["download"]
+    url: HttpUrl
+    expiresAt: datetime
+    singleUse: bool = True
+
+
+SourceDescriptor = RootModel[
+    Annotated[
+        FilesystemSourceDescriptor | DownloadSourceDescriptor,
+        Field(discriminator="transport"),
+    ]
+]
+
+
+# ---- Sink descriptors (used in IntakeTicket.sinks) ----
+
+
+class FilesystemSinkDescriptor(BaseModel):
+    """`filesystem` transport, sink side (spec §7.2.3)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    transport: Literal["filesystem"]
+    uri: str
+
+    @field_validator("uri")
+    @classmethod
+    def _scheme_is_exchange_or_file(cls, v: str) -> str:
+        if not (v.startswith("exchange://") or v.startswith("file://")):
+            raise ValueError("filesystem sink URI must use 'exchange://' or 'file://'")
+        return v
+
+
+class UploadSinkDescriptor(BaseModel):
+    """`upload` transport, sink side (spec §7.2.4)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    transport: Literal["upload"]
+    url: HttpUrl
+    method: Literal["PUT", "POST"] = "PUT"
+    expiresAt: datetime
+
+
+SinkDescriptor = RootModel[
+    Annotated[
+        FilesystemSinkDescriptor | UploadSinkDescriptor,
+        Field(discriminator="transport"),
+    ]
+]
+
+
+# ---- Expected constraints (IntakeTicket.expected) ----
+
+
+class ExpectedConstraints(BaseModel):
+    """Receiver-imposed constraints on an incoming artifact (spec §7.4)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    maxSize: int | None = Field(default=None, ge=0)
+    acceptMimeTypes: list[str] | None = None
+    requireDigest: list[str] | None = None
+
+
+# ---- References ----
+
+
+class TransferHandle(BaseModel):
+    """A pull token: provider emits, fetcher consumes (spec §7.3)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    type: Literal["nl.liesdonk.file-exchange/transfer-handle"]
+    version: str
+    artifact: ArtifactMetadata
+    sources: list[SourceDescriptor] = Field(min_length=1)
+    requires: list[str] | None = None
+
+
+class IntakeTicket(BaseModel):
+    """A push token: receiver emits, sender consumes (spec §7.4)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    type: Literal["nl.liesdonk.file-exchange/intake-ticket"]
+    version: str
+    artifactId: str
+    expected: ExpectedConstraints | None = None
+    sinks: list[SinkDescriptor] = Field(min_length=1)
+    requires: list[str] | None = None
+```
+
+- [ ] Run the tests to verify they all pass:
+
+```bash
+uv run pytest tests/file_exchange/test_types.py -v
+```
+
+Expected: all 10 tests PASS.
+
+### Step A.4: Public-symbol literals
+
+- [ ] Add the role/transport `Literal` aliases. Append to `_types.py`:
+
+```python
+# Role/transport aliases used by the public API
+FileExchangeRole = Literal["provider", "fetcher", "receiver", "sender"]
+FileExchangeTransport = Literal["filesystem", "download", "upload"]
+```
+
+(No test needed — `Literal` aliases are checked at use sites.)
+
+### Step A.5: Commit Task A
+
+- [ ] Stage and commit:
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/ tests/file_exchange/
+git commit -m "feat(file-exchange): vendor v0.1 schema and Pydantic types
+
+Closes <issue-A-number>"
+```
+
+### Step A.6: Local circus + PR
+
+- [ ] Run `preflight-circus` skill against `origin/main..HEAD`. Address any ≥80-confidence findings inline.
+- [ ] Push and open a draft PR. Wait for bot review (expected: LGTM). Flip to ready when bot + CI green.
+
+---
+
+# Task B: Selection algorithm + error envelope
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_errors.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_select.py`
+- Create: `tests/file_exchange/test_errors.py`
+- Create: `tests/file_exchange/test_select.py`
+
+### Step B.1: Test the error envelope
+
+- [ ] Write `tests/file_exchange/test_errors.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+from mcp.types import CallToolResult
+
+from fastmcp_pvl_core._file_exchange._errors import (
+    FileExchangeError,
+    FileExchangeErrorCode,
+    as_tool_error_result,
+)
+
+
+def test_error_carries_code_and_optional_metadata():
+    exc = FileExchangeError(
+        code=FileExchangeErrorCode.DIGEST_MISMATCH,
+        transport="download",
+        detail="expected sha-256:9f86d0..., got sha-256:1b4f0e...",
+    )
+    assert exc.code == "digest-mismatch"
+    assert exc.transport == "download"
+    assert "expected sha-256:9f86d0" in exc.detail
+
+
+def test_as_tool_error_result_has_meta_block():
+    exc = FileExchangeError(
+        code=FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT,
+        detail="no descriptor in handle matched supported transports",
+    )
+    result = as_tool_error_result(exc)
+    assert result.isError is True
+    assert result.content  # at least one text block
+    assert any("no-supported-transport" in c.text for c in result.content if c.type == "text")
+    meta = result.meta or {}
+    err_meta = meta.get("nl.liesdonk.file-exchange/error")
+    assert err_meta is not None
+    assert err_meta["code"] == "no-supported-transport"
+
+
+def test_all_spec_codes_are_defined():
+    """Spec §13 enumerates these — any drift here is a spec/impl mismatch."""
+    expected = {
+        "no-supported-transport",
+        "descriptor-expired",
+        "not-accessible",
+        "digest-mismatch",
+        "size-mismatch",
+        "too-large",
+        "mime-type-rejected",
+        "unsupported-requirement",
+        "transfer-failed",
+    }
+    actual = {code.value for code in FileExchangeErrorCode}
+    assert actual == expected
+```
+
+- [ ] Run the test:
+
+```bash
+uv run pytest tests/file_exchange/test_errors.py -v
+```
+
+Expected: FAIL — ImportError.
+
+### Step B.2: Implement the error envelope
+
+- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_errors.py`:
+
+```python
+"""Error envelope for nl.liesdonk.file-exchange (spec §13)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from mcp.types import CallToolResult, TextContent
+
+
+class FileExchangeErrorCode(StrEnum):
+    """The closed set of error codes from spec §13.
+
+    The set is intentionally enumerable: a consumer that receives an unrecognised
+    code SHOULD treat it as a generic failure (per spec §13 last paragraph), but
+    pvl-core itself only emits codes from this enum.
+    """
+
+    NO_SUPPORTED_TRANSPORT = "no-supported-transport"
+    DESCRIPTOR_EXPIRED = "descriptor-expired"
+    NOT_ACCESSIBLE = "not-accessible"
+    DIGEST_MISMATCH = "digest-mismatch"
+    SIZE_MISMATCH = "size-mismatch"
+    TOO_LARGE = "too-large"
+    MIME_TYPE_REJECTED = "mime-type-rejected"
+    UNSUPPORTED_REQUIREMENT = "unsupported-requirement"
+    TRANSFER_FAILED = "transfer-failed"
+
+
+class FileExchangeError(Exception):
+    """A file-exchange transfer failure that maps cleanly to spec §13.
+
+    Raised by the role helpers (pull_artifact, push_artifact, …) and translated
+    to a tool-execution error result via :func:`as_tool_error_result` at the
+    tool body's outer except clause.
+    """
+
+    def __init__(
+        self,
+        *,
+        code: FileExchangeErrorCode,
+        transport: str | None = None,
+        detail: str | None = None,
+    ) -> None:
+        super().__init__(detail or code.value)
+        self.code = code
+        self.transport = transport
+        self.detail = detail
+
+
+def as_tool_error_result(exc: FileExchangeError) -> CallToolResult:
+    """Convert a FileExchangeError into a tool-execution error result (spec §13)."""
+
+    text = f"file exchange: {exc.code.value}"
+    if exc.transport:
+        text += f" (transport={exc.transport})"
+    if exc.detail:
+        text += f" — {exc.detail}"
+
+    meta_block: dict[str, Any] = {"code": exc.code.value}
+    if exc.transport:
+        meta_block["transport"] = exc.transport
+    if exc.detail:
+        meta_block["detail"] = exc.detail
+
+    return CallToolResult(
+        isError=True,
+        content=[TextContent(type="text", text=text)],
+        meta={"nl.liesdonk.file-exchange/error": meta_block},
+    )
+```
+
+- [ ] Run the tests:
+
+```bash
+uv run pytest tests/file_exchange/test_errors.py -v
+```
+
+Expected: PASS.
+
+### Step B.3: Test the selection algorithm
+
+- [ ] Write `tests/file_exchange/test_select.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from fastmcp_pvl_core._file_exchange._errors import (
+    FileExchangeError,
+    FileExchangeErrorCode,
+)
+from fastmcp_pvl_core._file_exchange._select import (
+    select_source,
+    select_sink,
+)
+from fastmcp_pvl_core._file_exchange._types import (
+    ArtifactMetadata,
+    IntakeTicket,
+    TransferHandle,
+)
+
+
+def _now_plus(seconds: int) -> str:
+    return (datetime.now(timezone.utc) + timedelta(seconds=seconds)).isoformat()
+
+
+def _handle(sources: list[dict]) -> TransferHandle:
+    return TransferHandle.model_validate(
+        {
+            "type": "nl.liesdonk.file-exchange/transfer-handle",
+            "version": "0.1",
+            "artifact": {"name": "x.bin"},
+            "sources": sources,
+        }
+    )
+
+
+def _ticket(sinks: list[dict]) -> IntakeTicket:
+    return IntakeTicket.model_validate(
+        {
+            "type": "nl.liesdonk.file-exchange/intake-ticket",
+            "version": "0.1",
+            "artifactId": "ar-1",
+            "sinks": sinks,
+        }
+    )
+
+
+def test_picks_first_supported_in_order():
+    h = _handle(
+        [
+            {"transport": "filesystem", "uri": "exchange://v/x.bin"},
+            {
+                "transport": "download",
+                "url": "https://x/y",
+                "expiresAt": _now_plus(3600),
+            },
+        ]
+    )
+    chosen = select_source(h, supported_transports=("download",), known_volumes=())
+    # filesystem skipped (unsupported), download picked.
+    assert chosen.root.transport == "download"
+
+
+def test_skips_filesystem_with_unknown_volume():
+    h = _handle([{"transport": "filesystem", "uri": "exchange://other/x.bin"}])
+    with pytest.raises(FileExchangeError) as exc:
+        select_source(h, supported_transports=("filesystem",), known_volumes=("known",))
+    assert exc.value.code == FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT
+
+
+def test_skips_expired_download():
+    h = _handle(
+        [
+            {
+                "transport": "download",
+                "url": "https://x/y",
+                "expiresAt": _now_plus(-60),
+            },
+        ]
+    )
+    with pytest.raises(FileExchangeError) as exc:
+        select_source(h, supported_transports=("download",), known_volumes=())
+    assert exc.value.code == FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT
+
+
+def test_clock_skew_tolerance_keeps_just_expired_descriptor():
+    h = _handle(
+        [
+            {
+                "transport": "download",
+                "url": "https://x/y",
+                "expiresAt": _now_plus(-10),  # within 30s tolerance
+            },
+        ]
+    )
+    chosen = select_source(
+        h, supported_transports=("download",), known_volumes=(), clock_skew_tolerance_s=30
+    )
+    assert chosen.root.transport == "download"
+
+
+def test_requires_unknown_feature_is_rejected():
+    raw = {
+        "type": "nl.liesdonk.file-exchange/transfer-handle",
+        "version": "0.1",
+        "artifact": {"name": "x.bin"},
+        "sources": [{"transport": "filesystem", "uri": "exchange://v/x"}],
+        "requires": ["future-feature-xyz"],
+    }
+    h = TransferHandle.model_validate(raw)
+    with pytest.raises(FileExchangeError) as exc:
+        select_source(h, supported_transports=("filesystem",), known_volumes=("v",))
+    assert exc.value.code == FileExchangeErrorCode.UNSUPPORTED_REQUIREMENT
+
+
+def test_unknown_transport_descriptor_is_silently_skipped():
+    """Spec §17.2: unknown `transport` values are skipped during selection (not rejected)."""
+    # The typed layer rejects unknown transports at parsing time, so we exercise
+    # the fallthrough by passing a known-but-unsupported transport.
+    h = _handle(
+        [
+            {"transport": "filesystem", "uri": "exchange://v/x"},
+            {"transport": "download", "url": "https://x/y", "expiresAt": _now_plus(3600)},
+        ]
+    )
+    # filesystem unsupported by this consumer, but download supported → download is picked.
+    chosen = select_source(h, supported_transports=("download",), known_volumes=())
+    assert chosen.root.transport == "download"
+
+
+def test_select_sink_picks_writable_filesystem():
+    t = _ticket([{"transport": "filesystem", "uri": "exchange://intake/x.bin"}])
+    chosen = select_sink(t, supported_transports=("filesystem",), known_volumes=("intake",))
+    assert chosen.root.transport == "filesystem"
+```
+
+- [ ] Run the test:
+
+```bash
+uv run pytest tests/file_exchange/test_select.py -v
+```
+
+Expected: FAIL — ImportError.
+
+### Step B.4: Implement the selection algorithm
+
+- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_select.py`:
+
+```python
+"""Descriptor selection algorithm (spec §9) and version-skew gate (spec §17.3, §17.4)."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from ._errors import FileExchangeError, FileExchangeErrorCode
+
+if TYPE_CHECKING:
+    from ._types import IntakeTicket, SinkDescriptor, SourceDescriptor, TransferHandle
+
+
+# v0.1 defines no must-understand feature identifiers (spec §17.4).
+_KNOWN_REQUIRES_FEATURES: frozenset[str] = frozenset()
+
+
+def _check_version_and_requires(reference: TransferHandle | IntakeTicket) -> None:
+    """Apply §17.3 (version skew) and §17.4 (must-understand) gates.
+
+    Raises FileExchangeError if the reference cannot be processed.
+    """
+    major, _, _ = reference.version.partition(".")
+    if major != "0":
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.TRANSFER_FAILED,
+            detail=f"reference version {reference.version!r} has a major component this implementation does not understand",
+        )
+
+    if reference.requires:
+        seen: set[str] = set()
+        for feature in reference.requires:
+            if feature in seen:
+                raise FileExchangeError(
+                    code=FileExchangeErrorCode.UNSUPPORTED_REQUIREMENT,
+                    detail=f"requires array contains a duplicate identifier: {feature!r}",
+                )
+            seen.add(feature)
+            if feature not in _KNOWN_REQUIRES_FEATURES:
+                raise FileExchangeError(
+                    code=FileExchangeErrorCode.UNSUPPORTED_REQUIREMENT,
+                    detail=f"required feature {feature!r} not implemented",
+                )
+
+
+def _exchange_volume(uri: str) -> str | None:
+    """Return the volume component of an exchange:// URI, or None for file://."""
+    if uri.startswith("exchange://"):
+        rest = uri[len("exchange://"):]
+        return rest.split("/", 1)[0] or None
+    return None
+
+
+def _is_expired(expires_at: datetime, tolerance_s: int) -> bool:
+    now = datetime.now(timezone.utc)
+    return now > (expires_at + timedelta(seconds=tolerance_s))
+
+
+def select_source(
+    handle: TransferHandle,
+    *,
+    supported_transports: Sequence[str],
+    known_volumes: Sequence[str],
+    clock_skew_tolerance_s: int = 30,
+) -> SourceDescriptor:
+    """Pick a source descriptor from a TransferHandle (spec §9).
+
+    Raises FileExchangeError with code 'no-supported-transport' if nothing survives.
+    """
+    _check_version_and_requires(handle)
+    return _select(handle.sources, supported_transports, known_volumes, clock_skew_tolerance_s)
+
+
+def select_sink(
+    ticket: IntakeTicket,
+    *,
+    supported_transports: Sequence[str],
+    known_volumes: Sequence[str],
+    clock_skew_tolerance_s: int = 30,
+) -> SinkDescriptor:
+    """Pick a sink descriptor from an IntakeTicket (spec §9)."""
+    _check_version_and_requires(ticket)
+    return _select(ticket.sinks, supported_transports, known_volumes, clock_skew_tolerance_s)
+
+
+def _select(
+    descriptors: Sequence,
+    supported_transports: Sequence[str],
+    known_volumes: Sequence[str],
+    clock_skew_tolerance_s: int,
+):
+    for descriptor in descriptors:
+        node = descriptor.root
+        if node.transport not in supported_transports:
+            continue
+        if node.transport == "filesystem":
+            volume = _exchange_volume(node.uri)
+            if volume is not None and volume not in known_volumes:
+                continue
+            return descriptor
+        if node.transport in ("download", "upload"):
+            if _is_expired(node.expiresAt, clock_skew_tolerance_s):
+                continue
+            return descriptor
+    raise FileExchangeError(
+        code=FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT,
+        detail="no descriptor in the reference matched the consumer's supported transports",
+    )
+```
+
+- [ ] Run the tests:
+
+```bash
+uv run pytest tests/file_exchange/test_select.py tests/file_exchange/test_errors.py -v
+```
+
+Expected: PASS (all 7 select tests + earlier error tests).
+
+### Step B.5: Commit and PR
+
+- [ ] Commit:
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_errors.py src/fastmcp_pvl_core/_file_exchange/_select.py tests/file_exchange/test_errors.py tests/file_exchange/test_select.py
+git commit -m "feat(file-exchange): error envelope + descriptor selection algorithm
+
+Closes <issue-B-number>"
+```
+
+- [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
+
+---
+
+# Task C: Filesystem transport
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_transport_filesystem.py`
+- Create: `tests/file_exchange/test_transport_filesystem.py`
+
+### Step C.1: Test exchange-URI resolution and path confinement
+
+- [ ] Write `tests/file_exchange/test_transport_filesystem.py`:
+
+```python
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from fastmcp_pvl_core._file_exchange._errors import (
+    FileExchangeError,
+    FileExchangeErrorCode,
+)
+from fastmcp_pvl_core._file_exchange._transport_filesystem import (
+    atomic_write,
+    parse_volumes,
+    resolve_exchange_uri,
+)
+
+
+def test_parse_volumes_handles_comma_separated_pairs():
+    mapping = parse_volumes("vault=/tmp/vault,intake=/tmp/intake")
+    assert mapping == {"vault": Path("/tmp/vault"), "intake": Path("/tmp/intake")}
+
+
+def test_parse_volumes_handles_empty_and_none():
+    assert parse_volumes(None) == {}
+    assert parse_volumes("") == {}
+    assert parse_volumes("   ") == {}
+
+
+def test_parse_volumes_rejects_malformed_pair():
+    with pytest.raises(ValueError, match="must be of the form"):
+        parse_volumes("brokenpair")
+
+
+def test_resolve_exchange_uri_in_volume(tmp_path: Path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    artifact = vault / "report.parquet"
+    artifact.touch()
+
+    resolved = resolve_exchange_uri(
+        "exchange://vault/report.parquet",
+        volumes={"vault": vault},
+    )
+    assert resolved == artifact.resolve()
+
+
+def test_resolve_exchange_uri_unknown_volume_raises(tmp_path: Path):
+    with pytest.raises(FileExchangeError) as exc:
+        resolve_exchange_uri("exchange://unknown/x", volumes={"vault": tmp_path})
+    assert exc.value.code == FileExchangeErrorCode.NOT_ACCESSIBLE
+
+
+def test_resolve_exchange_uri_rejects_dot_dot_escape(tmp_path: Path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (tmp_path / "secret.txt").write_text("nope")
+
+    with pytest.raises(FileExchangeError) as exc:
+        resolve_exchange_uri(
+            "exchange://vault/../secret.txt", volumes={"vault": vault}
+        )
+    assert exc.value.code == FileExchangeErrorCode.NOT_ACCESSIBLE
+
+
+def test_resolve_exchange_uri_rejects_symlink_escape(tmp_path: Path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("forbidden")
+    (vault / "escape").symlink_to(outside)
+
+    with pytest.raises(FileExchangeError) as exc:
+        resolve_exchange_uri("exchange://vault/escape", volumes={"vault": vault})
+    assert exc.value.code == FileExchangeErrorCode.NOT_ACCESSIBLE
+
+
+def test_atomic_write_only_appears_on_success(tmp_path: Path):
+    target = tmp_path / "result.bin"
+
+    with atomic_write(target) as f:
+        f.write(b"partial")
+        # mid-write the target file MUST not exist (consumer never sees partial)
+        assert not target.exists()
+        f.write(b" and more")
+
+    assert target.exists()
+    assert target.read_bytes() == b"partial and more"
+
+
+def test_atomic_write_discards_temp_on_exception(tmp_path: Path):
+    target = tmp_path / "result.bin"
+
+    with pytest.raises(RuntimeError):
+        with atomic_write(target) as f:
+            f.write(b"partial")
+            raise RuntimeError("boom")
+
+    assert not target.exists()
+    # No leftover temp files in the directory either
+    assert list(tmp_path.iterdir()) == []
+```
+
+- [ ] Run the tests:
+
+```bash
+uv run pytest tests/file_exchange/test_transport_filesystem.py -v
+```
+
+Expected: FAIL — ImportError.
+
+### Step C.2: Implement filesystem transport
+
+- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_transport_filesystem.py`:
+
+```python
+"""Filesystem transport (spec §10.1).
+
+Provides:
+- ``parse_volumes`` — parse the operator-supplied volume map (env-var value).
+- ``resolve_exchange_uri`` — resolve an ``exchange://`` or ``file://`` URI to a
+  canonicalised, confinement-checked local Path.
+- ``atomic_write`` — temp-file + rename context manager so consumers never observe
+  a partial write (spec §10.1.3).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from ._errors import FileExchangeError, FileExchangeErrorCode
+
+
+def parse_volumes(raw: str | None) -> dict[str, Path]:
+    """Parse a `<volume>=<path>,<volume>=<path>` env-var value.
+
+    Empty/whitespace/None returns an empty mapping. Malformed entries raise ValueError.
+    """
+    if not raw or not raw.strip():
+        return {}
+
+    result: dict[str, Path] = {}
+    for entry in raw.split(","):
+        token = entry.strip()
+        if not token:
+            continue
+        if "=" not in token:
+            raise ValueError(
+                f"FILE_EXCHANGE_VOLUMES entry {token!r} must be of the form "
+                f"'<volume>=<local-mount-point>'"
+            )
+        volume, _, path = token.partition("=")
+        volume = volume.strip()
+        path_value = path.strip()
+        if not volume or not path_value:
+            raise ValueError(
+                f"FILE_EXCHANGE_VOLUMES entry {token!r} must be of the form "
+                f"'<volume>=<local-mount-point>' with non-empty parts"
+            )
+        result[volume] = Path(path_value)
+    return result
+
+
+def resolve_exchange_uri(uri: str, *, volumes: Mapping[str, Path]) -> Path:
+    """Resolve an exchange:// or file:// URI to a canonicalised, confined Path.
+
+    Raises FileExchangeError(code=NOT_ACCESSIBLE) on:
+    - unknown volume (exchange://)
+    - resolved path outside the volume root (canonicalisation escape, symlink swap, etc.)
+    """
+    parsed = urlparse(uri)
+    if parsed.scheme == "exchange":
+        volume = parsed.netloc
+        if volume not in volumes:
+            raise FileExchangeError(
+                code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+                transport="filesystem",
+                detail=f"no mapping configured for volume {volume!r}",
+            )
+        root = volumes[volume].resolve()
+        relative = unquote(parsed.path.lstrip("/"))
+        candidate = (root / relative).resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError as exc:
+            raise FileExchangeError(
+                code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+                transport="filesystem",
+                detail=f"resolved path escapes volume {volume!r}",
+            ) from exc
+        return candidate
+
+    if parsed.scheme == "file":
+        # Reserved for the "shared mount namespace" case (spec §10.1.2).
+        # Phase 1 supports this only when a single exchange root is configured
+        # under the special volume name "_file_root" — see _capability.py.
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            transport="filesystem",
+            detail="file:// scheme requires an operator-configured shared root; not supported in phase 1",
+        )
+
+    raise FileExchangeError(
+        code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+        transport="filesystem",
+        detail=f"unsupported URI scheme: {parsed.scheme!r}",
+    )
+
+
+@contextmanager
+def atomic_write(target: Path) -> Iterator[object]:
+    """Write to a temp file in the target's directory, rename onto target on success.
+
+    Consumers MUST never see a partial write (spec §10.1.3). On any exception the
+    temp file is unlinked.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_path_s = tempfile.mkstemp(
+        prefix=f".{target.name}.", suffix=".tmp", dir=str(target.parent)
+    )
+    temp_path = Path(temp_path_s)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            yield f
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(temp_path, target)
+    except BaseException:
+        try:
+            temp_path.unlink(missing_ok=True)
+        finally:
+            pass
+        raise
+```
+
+- [ ] Run the tests:
+
+```bash
+uv run pytest tests/file_exchange/test_transport_filesystem.py -v
+```
+
+Expected: PASS (all 9 tests).
+
+### Step C.3: Commit and PR
+
+- [ ] Commit:
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_transport_filesystem.py tests/file_exchange/test_transport_filesystem.py
+git commit -m "feat(file-exchange): filesystem transport with exchange:// resolution and atomic writes
+
+Closes <issue-C-number>"
+```
+
+- [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
+
+---
+
+# Task D: HTTPS consumer side
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_transport_https.py`
+- Create: `tests/file_exchange/test_transport_https.py`
+
+### Step D.1: Test SSRF guard
+
+- [ ] Write the SSRF tests in `tests/file_exchange/test_transport_https.py`:
+
+```python
+from __future__ import annotations
+
+import ipaddress
+from unittest.mock import patch
+
+import pytest
+
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeError
+from fastmcp_pvl_core._file_exchange._transport_https import (
+    SSRFGuardConfig,
+    resolve_and_check_host,
+)
+
+
+def _resolve_to(addrs: list[str]):
+    """Patch DNS resolution to return the given address list."""
+    return patch(
+        "fastmcp_pvl_core._file_exchange._transport_https._resolve_host",
+        return_value=[ipaddress.ip_address(a) for a in addrs],
+    )
+
+
+def test_public_address_is_allowed():
+    with _resolve_to(["93.184.216.34"]):
+        ip = resolve_and_check_host("example.com", SSRFGuardConfig())
+        assert ip == ipaddress.IPv4Address("93.184.216.34")
+
+
+def test_loopback_is_rejected_by_default():
+    with _resolve_to(["127.0.0.1"]), pytest.raises(FileExchangeError):
+        resolve_and_check_host("evil.example", SSRFGuardConfig())
+
+
+def test_loopback_allowed_when_configured():
+    with _resolve_to(["127.0.0.1"]):
+        ip = resolve_and_check_host(
+            "localhost", SSRFGuardConfig(allow_loopback=True)
+        )
+        assert ip == ipaddress.IPv4Address("127.0.0.1")
+
+
+def test_private_range_rejected_by_default():
+    with _resolve_to(["10.0.0.5"]), pytest.raises(FileExchangeError):
+        resolve_and_check_host("internal.example", SSRFGuardConfig())
+
+
+def test_link_local_rejected_by_default():
+    with _resolve_to(["169.254.169.254"]), pytest.raises(FileExchangeError):
+        resolve_and_check_host("metadata.example", SSRFGuardConfig())
+
+
+def test_ipv6_loopback_rejected_by_default():
+    with _resolve_to(["::1"]), pytest.raises(FileExchangeError):
+        resolve_and_check_host("v6loop.example", SSRFGuardConfig())
+```
+
+### Step D.2: Implement SSRF guard
+
+- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_transport_https.py`:
+
+```python
+"""HTTPS transport: pull_download / push_upload + SSRF guard (spec §10.2, §10.3, §15)."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+import httpx
+
+from ._errors import FileExchangeError, FileExchangeErrorCode
+
+USER_AGENT = "fastmcp-pvl-core/file-exchange/0.1"
+
+
+@dataclass(frozen=True)
+class SSRFGuardConfig:
+    """Operator-set guard knobs (default-deny for private/loopback/link-local)."""
+
+    allow_loopback: bool = False
+    allow_private: bool = False
+
+
+def _resolve_host(host: str) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """One-shot host resolution. Patched in tests."""
+    infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    return [ipaddress.ip_address(info[4][0]) for info in infos]
+
+
+def _is_disallowed(
+    addr: ipaddress.IPv4Address | ipaddress.IPv6Address, cfg: SSRFGuardConfig
+) -> str | None:
+    """Return a human-readable reason if disallowed; None if OK."""
+    if addr.is_loopback and not cfg.allow_loopback:
+        return "loopback address"
+    if addr.is_link_local:
+        return "link-local address"
+    if addr.is_private and not cfg.allow_private:
+        return "RFC 1918 / private address"
+    if addr.is_multicast:
+        return "multicast address"
+    if addr.is_reserved:
+        return "reserved address"
+    return None
+
+
+def resolve_and_check_host(
+    host: str, config: SSRFGuardConfig
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    """Resolve hostname ONCE; reject disallowed ranges; return pinned IP.
+
+    The caller MUST use the returned IP for the actual connection (defeats DNS
+    rebinding). Spec §15 "SSRF" mitigations.
+    """
+    try:
+        addrs = _resolve_host(host)
+    except socket.gaierror as exc:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            transport="download",
+            detail=f"host resolution failed for {host!r}: {exc}",
+        ) from exc
+
+    if not addrs:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            transport="download",
+            detail=f"host {host!r} did not resolve to any addresses",
+        )
+
+    # Pick the first; report rejection if it's disallowed.
+    primary = addrs[0]
+    reason = _is_disallowed(primary, config)
+    if reason is not None:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            transport="download",
+            detail=f"host {host!r} resolved to {primary} ({reason}); refused",
+        )
+    return primary
+```
+
+- [ ] Run the SSRF tests:
+
+```bash
+uv run pytest tests/file_exchange/test_transport_https.py -v
+```
+
+Expected: PASS (all 6 tests).
+
+### Step D.3: Test pull_download against a faked transport
+
+- [ ] Add to `tests/file_exchange/test_transport_https.py`:
+
+```python
+import io
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+
+from fastmcp_pvl_core._file_exchange._transport_https import pull_download
+from fastmcp_pvl_core._file_exchange._types import DownloadSourceDescriptor
+
+
+def _descriptor(url: str = "https://example.com/d/tok") -> DownloadSourceDescriptor:
+    return DownloadSourceDescriptor.model_validate(
+        {
+            "transport": "download",
+            "url": url,
+            "expiresAt": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+        }
+    )
+
+
+def _ok_handler(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200,
+        content=b"hello bytes",
+        headers={"Content-Length": "11", "Content-Type": "application/octet-stream"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_pull_download_streams_to_buffer():
+    transport = httpx.MockTransport(_ok_handler)
+    buf = io.BytesIO()
+    # SSRF guard is bypassed in tests by passing an explicit transport.
+    received_size = await pull_download(
+        _descriptor(),
+        dest=buf,
+        client_transport=transport,
+        ssrf=SSRFGuardConfig(allow_loopback=True, allow_private=True),
+    )
+    assert buf.getvalue() == b"hello bytes"
+    assert received_size == 11
+
+
+def _bad_redirect_handler(request: httpx.Request) -> httpx.Response:
+    if str(request.url) == "https://example.com/d/tok":
+        return httpx.Response(302, headers={"Location": "https://attacker.example/x"})
+    return httpx.Response(200, content=b"should-not-reach")
+
+
+@pytest.mark.asyncio
+async def test_pull_download_rejects_cross_origin_redirect():
+    transport = httpx.MockTransport(_bad_redirect_handler)
+    buf = io.BytesIO()
+    with pytest.raises(FileExchangeError) as exc:
+        await pull_download(
+            _descriptor(),
+            dest=buf,
+            client_transport=transport,
+            ssrf=SSRFGuardConfig(allow_loopback=True, allow_private=True),
+        )
+    assert exc.value.code in (
+        FileExchangeErrorCode.NOT_ACCESSIBLE,
+        FileExchangeErrorCode.TRANSFER_FAILED,
+    )
+
+
+def _http_handler(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(200, content=b"hi")
+
+
+@pytest.mark.asyncio
+async def test_pull_download_rejects_non_https():
+    transport = httpx.MockTransport(_http_handler)
+    desc = _descriptor("http://example.com/d/tok")  # non-https
+    buf = io.BytesIO()
+    with pytest.raises(FileExchangeError):
+        await pull_download(desc, dest=buf, client_transport=transport, ssrf=SSRFGuardConfig())
+```
+
+### Step D.4: Implement pull_download and push_upload
+
+- [ ] Append to `src/fastmcp_pvl_core/_file_exchange/_transport_https.py`:
+
+```python
+async def pull_download(
+    descriptor,                                  # DownloadSourceDescriptor
+    *,
+    dest: BinaryIO | Path,
+    ssrf: SSRFGuardConfig,
+    client_transport: httpx.AsyncBaseTransport | None = None,
+    chunk_size: int = 65536,
+) -> int:
+    """Pull artifact bytes via HTTPS GET (spec §10.2). Returns bytes received.
+
+    Streams to ``dest`` (either an open writable BinaryIO or a Path; for Path
+    pvl-core uses the filesystem-transport's atomic_write context manager so
+    a partial write is never observed).
+
+    SSRF guard runs; non-https URLs are refused; cross-origin redirects are refused;
+    no ambient credentials are attached.
+    """
+    url_str = str(descriptor.url)
+    if not url_str.startswith("https://"):
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            transport="download",
+            detail="download URL must use https://",
+        )
+
+    host = httpx.URL(url_str).host
+    # SSRF guard (resolve once, pin IP). Tests can pass a transport that
+    # bypasses real connections; in production the transport is None and
+    # the pinned IP is set in the request connection options.
+    if client_transport is None:
+        resolve_and_check_host(host, ssrf)
+
+    async with httpx.AsyncClient(
+        transport=client_transport,
+        timeout=httpx.Timeout(30.0, connect=10.0),
+        follow_redirects=False,
+        headers={"User-Agent": USER_AGENT, "Accept": "*/*"},
+    ) as client:
+        async with client.stream("GET", url_str) as response:
+            if response.status_code in (301, 302, 303, 307, 308):
+                target = response.headers.get("Location", "")
+                target_host = httpx.URL(target).host if target else ""
+                if target_host != host:
+                    raise FileExchangeError(
+                        code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+                        transport="download",
+                        detail=f"refusing cross-origin redirect to {target_host!r}",
+                    )
+                raise FileExchangeError(
+                    code=FileExchangeErrorCode.TRANSFER_FAILED,
+                    transport="download",
+                    detail="same-origin redirect handling is deferred; provider should issue a direct URL",
+                )
+            if response.status_code != 200:
+                raise FileExchangeError(
+                    code=FileExchangeErrorCode.TRANSFER_FAILED,
+                    transport="download",
+                    detail=f"unexpected HTTP status {response.status_code}",
+                )
+
+            if isinstance(dest, Path):
+                from ._transport_filesystem import atomic_write
+
+                bytes_written = 0
+                with atomic_write(dest) as f:
+                    async for chunk in response.aiter_bytes(chunk_size):
+                        f.write(chunk)
+                        bytes_written += len(chunk)
+                return bytes_written
+
+            bytes_written = 0
+            async for chunk in response.aiter_bytes(chunk_size):
+                dest.write(chunk)
+                bytes_written += len(chunk)
+            return bytes_written
+
+
+async def push_upload(
+    descriptor,                                  # UploadSinkDescriptor
+    *,
+    source: BinaryIO | Path,
+    ssrf: SSRFGuardConfig,
+    content_digest: str | None = None,
+    content_type: str | None = None,
+    content_length: int | None = None,
+    client_transport: httpx.AsyncBaseTransport | None = None,
+) -> None:
+    """Push artifact bytes via HTTPS PUT/POST (spec §10.3).
+
+    Sender obligations: https-only; no ambient credentials; uses the descriptor's
+    method (default PUT); passes Content-Digest when provided; treats non-2xx as failure.
+    """
+    url_str = str(descriptor.url)
+    if not url_str.startswith("https://"):
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            transport="upload",
+            detail="upload URL must use https://",
+        )
+
+    host = httpx.URL(url_str).host
+    if client_transport is None:
+        resolve_and_check_host(host, ssrf)
+
+    headers = {"User-Agent": USER_AGENT}
+    if content_type:
+        headers["Content-Type"] = content_type
+    if content_length is not None:
+        headers["Content-Length"] = str(content_length)
+    if content_digest:
+        # Per spec §10.3, this header carries the artifact digest in RFC 9530 form.
+        headers["Content-Digest"] = content_digest
+
+    if isinstance(source, Path):
+        content = source.read_bytes()  # phase 1: simple buffered upload
+    else:
+        content = source.read()
+
+    async with httpx.AsyncClient(
+        transport=client_transport,
+        timeout=httpx.Timeout(60.0, connect=10.0),
+        follow_redirects=False,
+        headers={"User-Agent": USER_AGENT},
+    ) as client:
+        response = await client.request(descriptor.method, url_str, content=content, headers=headers)
+        if not (200 <= response.status_code < 300):
+            raise FileExchangeError(
+                code=FileExchangeErrorCode.TRANSFER_FAILED,
+                transport="upload",
+                detail=f"upload rejected with HTTP {response.status_code}",
+            )
+```
+
+- [ ] Run the tests:
+
+```bash
+uv run pytest tests/file_exchange/test_transport_https.py -v
+```
+
+Expected: PASS (all 9 tests).
+
+### Step D.5: Commit and PR
+
+- [ ] Commit:
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_transport_https.py tests/file_exchange/test_transport_https.py
+git commit -m "feat(file-exchange): HTTPS consumer transport (pull/push) with SSRF guard
+
+Closes <issue-D-number>"
+```
+
+- [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
+
+---
+
+# Task E: Capability URL store + sibling routes
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_url_store.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_routes.py`
+- Create: `tests/file_exchange/test_url_store.py`
+- Create: `tests/file_exchange/test_routes.py`
+
+### Step E.1: Test the URL store
+
+- [ ] Write `tests/file_exchange/test_url_store.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from key_value.aio.stores.memory import MemoryStore
+
+from fastmcp_pvl_core._file_exchange._url_store import (
+    DownloadTokenRecord,
+    UploadTokenRecord,
+    consume_download_token,
+    intake_path_for,
+    mint_download_token,
+    mint_upload_token,
+    record_intake_path,
+)
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    return MemoryStore()
+
+
+@pytest.mark.asyncio
+async def test_minted_download_token_is_url_safe_random(store: MemoryStore):
+    tok = await mint_download_token(
+        store=store,
+        bytes_path=Path("/tmp/x.bin"),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        single_use=True,
+    )
+    # 128 bits of entropy → at least 22 base64url characters.
+    assert len(tok) >= 22
+    record = await store.get(collection="tokens", key=tok)
+    assert record is not None
+
+
+@pytest.mark.asyncio
+async def test_consume_download_token_flips_single_use(store: MemoryStore):
+    expires = datetime.now(timezone.utc) + timedelta(hours=1)
+    tok = await mint_download_token(
+        store=store, bytes_path=Path("/tmp/x.bin"), expires_at=expires, single_use=True
+    )
+
+    record = await consume_download_token(store=store, token=tok)
+    assert record.bytes_path == Path("/tmp/x.bin")
+
+    # Second consume MUST fail because single_use already flipped consumed.
+    with pytest.raises(LookupError):
+        await consume_download_token(store=store, token=tok)
+
+
+@pytest.mark.asyncio
+async def test_expired_token_is_treated_as_missing(store: MemoryStore):
+    past = datetime.now(timezone.utc) - timedelta(seconds=1)
+    tok = await mint_download_token(
+        store=store, bytes_path=Path("/tmp/x.bin"), expires_at=past, single_use=True
+    )
+    with pytest.raises(LookupError):
+        await consume_download_token(store=store, token=tok)
+
+
+@pytest.mark.asyncio
+async def test_intake_path_correlation(store: MemoryStore):
+    await record_intake_path(store=store, artifact_id="ar-1", path=Path("/tmp/intake/x.bin"))
+    p = await intake_path_for(store=store, artifact_id="ar-1")
+    assert p == Path("/tmp/intake/x.bin")
+
+
+@pytest.mark.asyncio
+async def test_intake_path_for_missing_artifact_returns_none(store: MemoryStore):
+    p = await intake_path_for(store=store, artifact_id="never-minted")
+    assert p is None
+```
+
+- [ ] Run the test:
+
+```bash
+uv run pytest tests/file_exchange/test_url_store.py -v
+```
+
+Expected: FAIL — ImportError.
+
+### Step E.2: Implement the URL store
+
+- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_url_store.py`:
+
+```python
+"""Capability-URL token store + intake-path correlation map.
+
+Backed by an AsyncKeyValue store (from build_kv_store(..., namespace="file-exchange")),
+which keeps the file-exchange surface restart-safe when configured with file/Redis/etc.
+
+Two collections inside the namespace:
+- ``tokens``   — capability tokens (download + upload)
+- ``intake``   — artifact_id → resolved intake path
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from key_value.aio.protocols.key_value import AsyncKeyValue
+
+
+TOKEN_BYTES = 16  # 128 bits → 22 base64url chars
+
+
+@dataclass(frozen=True)
+class DownloadTokenRecord:
+    bytes_path: Path
+    expires_at: datetime
+    single_use: bool
+    consumed: bool
+
+
+@dataclass(frozen=True)
+class UploadTokenRecord:
+    intake_path: Path
+    artifact_id: str
+    expires_at: datetime
+    max_size: int | None
+    accept_mime_types: list[str] | None
+    require_digest: list[str] | None
+    consumed: bool
+
+
+def _new_token() -> str:
+    return secrets.token_urlsafe(TOKEN_BYTES)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _is_expired(expires_at: datetime) -> bool:
+    return _now() > expires_at
+
+
+async def mint_download_token(
+    *,
+    store: AsyncKeyValue,
+    bytes_path: Path,
+    expires_at: datetime,
+    single_use: bool = True,
+) -> str:
+    """Mint a download capability token; return the token string."""
+    token = _new_token()
+    record = {
+        "kind": "download",
+        "bytes_path": str(bytes_path),
+        "expires_at": expires_at.isoformat(),
+        "single_use": single_use,
+        "consumed": False,
+    }
+    await store.put(collection="tokens", key=token, value=record)
+    return token
+
+
+async def mint_upload_token(
+    *,
+    store: AsyncKeyValue,
+    intake_path: Path,
+    artifact_id: str,
+    expires_at: datetime,
+    max_size: int | None = None,
+    accept_mime_types: list[str] | None = None,
+    require_digest: list[str] | None = None,
+) -> str:
+    """Mint an upload capability token; return the token string."""
+    token = _new_token()
+    record = {
+        "kind": "upload",
+        "intake_path": str(intake_path),
+        "artifact_id": artifact_id,
+        "expires_at": expires_at.isoformat(),
+        "max_size": max_size,
+        "accept_mime_types": accept_mime_types,
+        "require_digest": require_digest,
+        "consumed": False,
+    }
+    await store.put(collection="tokens", key=token, value=record)
+    return token
+
+
+async def consume_download_token(
+    *, store: AsyncKeyValue, token: str
+) -> DownloadTokenRecord:
+    raw = await store.get(collection="tokens", key=token)
+    if raw is None or raw.get("kind") != "download":
+        raise LookupError("download token not found")
+    expires_at = datetime.fromisoformat(raw["expires_at"])
+    if _is_expired(expires_at) or raw.get("consumed", False):
+        raise LookupError("download token expired or already consumed")
+
+    record = DownloadTokenRecord(
+        bytes_path=Path(raw["bytes_path"]),
+        expires_at=expires_at,
+        single_use=raw["single_use"],
+        consumed=False,
+    )
+
+    if record.single_use:
+        # Atomically flip consumed.  AsyncKeyValue.put is the unit of atomicity here;
+        # callers MUST treat double-consume as the failure case the test exercises.
+        await store.put(
+            collection="tokens",
+            key=token,
+            value={**raw, "consumed": True},
+        )
+
+    return record
+
+
+async def consume_upload_token(
+    *, store: AsyncKeyValue, token: str
+) -> UploadTokenRecord:
+    raw = await store.get(collection="tokens", key=token)
+    if raw is None or raw.get("kind") != "upload":
+        raise LookupError("upload token not found")
+    expires_at = datetime.fromisoformat(raw["expires_at"])
+    if _is_expired(expires_at) or raw.get("consumed", False):
+        raise LookupError("upload token expired or already consumed")
+    return UploadTokenRecord(
+        intake_path=Path(raw["intake_path"]),
+        artifact_id=raw["artifact_id"],
+        expires_at=expires_at,
+        max_size=raw.get("max_size"),
+        accept_mime_types=raw.get("accept_mime_types"),
+        require_digest=raw.get("require_digest"),
+        consumed=False,
+    )
+
+
+async def mark_upload_consumed(*, store: AsyncKeyValue, token: str) -> None:
+    raw = await store.get(collection="tokens", key=token)
+    if raw is None:
+        return
+    await store.put(collection="tokens", key=token, value={**raw, "consumed": True})
+
+
+async def record_intake_path(
+    *, store: AsyncKeyValue, artifact_id: str, path: Path
+) -> None:
+    """Record (artifact_id → resolved intake path) so resolve_intake can find it."""
+    await store.put(
+        collection="intake", key=artifact_id, value={"path": str(path)}
+    )
+
+
+async def intake_path_for(
+    *, store: AsyncKeyValue, artifact_id: str
+) -> Path | None:
+    raw = await store.get(collection="intake", key=artifact_id)
+    if raw is None:
+        return None
+    return Path(raw["path"])
+```
+
+- [ ] Run the tests:
+
+```bash
+uv run pytest tests/file_exchange/test_url_store.py -v
+```
+
+Expected: PASS (all 5 tests).
+
+### Step E.3: Test the sibling routes
+
+- [ ] Write `tests/file_exchange/test_routes.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from key_value.aio.stores.memory import MemoryStore
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from fastmcp_pvl_core._file_exchange._routes import build_file_exchange_router
+from fastmcp_pvl_core._file_exchange._url_store import (
+    mint_download_token,
+    mint_upload_token,
+)
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    return MemoryStore()
+
+
+@pytest.fixture
+def app(store: MemoryStore) -> Starlette:
+    router = build_file_exchange_router(store=store)
+    return Starlette(routes=router.routes)
+
+
+@pytest.mark.asyncio
+async def test_download_route_serves_bytes(tmp_path: Path, store: MemoryStore, app):
+    artifact = tmp_path / "x.bin"
+    artifact.write_bytes(b"hello bytes")
+    expires = datetime.now(timezone.utc) + timedelta(hours=1)
+    token = await mint_download_token(
+        store=store, bytes_path=artifact, expires_at=expires, single_use=True
+    )
+
+    with TestClient(app) as client:
+        resp = client.get(f"/file-exchange/d/{token}")
+    assert resp.status_code == 200
+    assert resp.content == b"hello bytes"
+
+
+@pytest.mark.asyncio
+async def test_download_route_single_use_second_request_404s(
+    tmp_path: Path, store: MemoryStore, app
+):
+    artifact = tmp_path / "x.bin"
+    artifact.write_bytes(b"hi")
+    expires = datetime.now(timezone.utc) + timedelta(hours=1)
+    token = await mint_download_token(
+        store=store, bytes_path=artifact, expires_at=expires, single_use=True
+    )
+
+    with TestClient(app) as client:
+        first = client.get(f"/file-exchange/d/{token}")
+        second = client.get(f"/file-exchange/d/{token}")
+    assert first.status_code == 200
+    assert second.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_download_route_returns_404_for_expired(
+    tmp_path: Path, store: MemoryStore, app
+):
+    artifact = tmp_path / "x.bin"
+    artifact.write_bytes(b"hi")
+    past = datetime.now(timezone.utc) - timedelta(seconds=1)
+    token = await mint_download_token(
+        store=store, bytes_path=artifact, expires_at=past, single_use=True
+    )
+    with TestClient(app) as client:
+        resp = client.get(f"/file-exchange/d/{token}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_upload_route_writes_atomically(
+    tmp_path: Path, store: MemoryStore, app
+):
+    intake = tmp_path / "intake" / "x.bin"
+    expires = datetime.now(timezone.utc) + timedelta(hours=1)
+    token = await mint_upload_token(
+        store=store,
+        intake_path=intake,
+        artifact_id="ar-1",
+        expires_at=expires,
+    )
+    with TestClient(app) as client:
+        resp = client.put(f"/file-exchange/u/{token}", content=b"payload")
+    assert resp.status_code == 204
+    assert intake.read_bytes() == b"payload"
+
+
+@pytest.mark.asyncio
+async def test_upload_route_enforces_max_size(
+    tmp_path: Path, store: MemoryStore, app
+):
+    intake = tmp_path / "intake" / "x.bin"
+    expires = datetime.now(timezone.utc) + timedelta(hours=1)
+    token = await mint_upload_token(
+        store=store,
+        intake_path=intake,
+        artifact_id="ar-1",
+        expires_at=expires,
+        max_size=3,
+    )
+    with TestClient(app) as client:
+        resp = client.put(f"/file-exchange/u/{token}", content=b"too much")
+    assert resp.status_code == 413
+    assert not intake.exists()
+```
+
+### Step E.4: Implement the routes
+
+- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_routes.py`:
+
+```python
+"""Sibling HTTP routes mounted on the FastMCP server.
+
+GET  /file-exchange/d/<token>    serves a minted download.
+PUT  /file-exchange/u/<token>    accepts an upload (POST also accepted).
+
+Both routes look tokens up in the kv_store passed to ``build_file_exchange_router``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from key_value.aio.protocols.key_value import AsyncKeyValue
+from starlette.requests import Request
+from starlette.responses import FileResponse, Response
+from starlette.routing import Route, Router
+
+from ._transport_filesystem import atomic_write
+from ._url_store import (
+    consume_download_token,
+    consume_upload_token,
+    mark_upload_consumed,
+    record_intake_path,
+)
+
+
+def build_file_exchange_router(*, store: AsyncKeyValue) -> Router:
+    """Return a Starlette Router with the file-exchange capability-URL endpoints."""
+
+    async def _download(request: Request) -> Response:
+        token = request.path_params["token"]
+        try:
+            record = await consume_download_token(store=store, token=token)
+        except LookupError:
+            return Response(status_code=404)
+        if not record.bytes_path.exists():
+            return Response(status_code=404)
+        return FileResponse(record.bytes_path)
+
+    async def _upload(request: Request) -> Response:
+        token = request.path_params["token"]
+        try:
+            record = await consume_upload_token(store=store, token=token)
+        except LookupError:
+            return Response(status_code=404)
+
+        # Buffer the body; phase 1 supports up to max_size or 100MB whichever is smaller.
+        body = await request.body()
+        if record.max_size is not None and len(body) > record.max_size:
+            return Response(status_code=413)
+
+        # Optional Content-Type filter
+        if record.accept_mime_types:
+            content_type = (request.headers.get("content-type") or "").split(";")[0].strip()
+            if content_type and not _mime_matches(content_type, record.accept_mime_types):
+                return Response(status_code=415)
+
+        with atomic_write(record.intake_path) as f:
+            f.write(body)
+
+        await record_intake_path(
+            store=store, artifact_id=record.artifact_id, path=record.intake_path
+        )
+        await mark_upload_consumed(store=store, token=token)
+        return Response(status_code=204)
+
+    return Router(
+        routes=[
+            Route("/file-exchange/d/{token}", endpoint=_download, methods=["GET"]),
+            Route(
+                "/file-exchange/u/{token}",
+                endpoint=_upload,
+                methods=["PUT", "POST"],
+            ),
+        ]
+    )
+
+
+def _mime_matches(actual: str, accepted: list[str]) -> bool:
+    """RFC 7231 §3.1.1.1 media-range matching."""
+    actual_type, _, actual_sub = actual.partition("/")
+    for pattern in accepted:
+        ptype, _, psub = pattern.partition("/")
+        if pattern == "*/*":
+            return True
+        if ptype == actual_type and (psub == "*" or psub == actual_sub):
+            return True
+    return False
+```
+
+- [ ] Run the route tests:
+
+```bash
+uv run pytest tests/file_exchange/test_routes.py -v
+```
+
+Expected: PASS (all 5 tests).
+
+### Step E.5: Commit and PR
+
+- [ ] Commit:
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_url_store.py src/fastmcp_pvl_core/_file_exchange/_routes.py tests/file_exchange/test_url_store.py tests/file_exchange/test_routes.py
+git commit -m "feat(file-exchange): capability-URL token store + sibling HTTP routes
+
+Closes <issue-E-number>"
+```
+
+- [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
+
+---
+
+# Task F: Capability declaration + role helpers + top-level re-exports
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_config.py` — add seven file-exchange fields + env-var reads
+- Create: `src/fastmcp_pvl_core/_file_exchange/_capability.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_provider.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_fetcher.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_receiver.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_sender.py`
+- Modify: `src/fastmcp_pvl_core/__init__.py` — re-export public surface
+- Create: `tests/file_exchange/test_capability.py`
+- Create: `tests/file_exchange/test_role_helpers.py`
+
+### Step F.1: Extend ServerConfig
+
+- [ ] Test the env-var loading. Add to `tests/file_exchange/test_capability.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from fastmcp_pvl_core._config import ServerConfig
+
+
+def test_serverconfig_loads_file_exchange_volumes(monkeypatch):
+    monkeypatch.setenv("MV_FILE_EXCHANGE_VOLUMES", "vault=/mnt/vault,intake=/mnt/intake")
+    monkeypatch.setenv("MV_TRANSPORT", "http")
+    cfg = ServerConfig.from_env("MV")
+    assert cfg.file_exchange_volumes == "vault=/mnt/vault,intake=/mnt/intake"
+    assert cfg.transport == "http"
+
+
+def test_serverconfig_file_exchange_defaults(monkeypatch):
+    cfg = ServerConfig.from_env("MV")
+    assert cfg.file_exchange_volumes is None
+    assert cfg.file_exchange_max_artifact_size is None
+    assert cfg.file_exchange_https_allow_loopback is False
+    assert cfg.file_exchange_https_allow_private is False
+    assert cfg.file_exchange_capability_url_ttl_default_s == 3600
+    assert cfg.file_exchange_https_public_base_url is None
+```
+
+- [ ] Add the seven fields to `ServerConfig` in `_config.py` (insert near the existing `kv_store_url` field, preserving dataclass field ordering):
+
+```python
+    file_exchange_volumes: str | None = None
+    file_exchange_max_artifact_size: int | None = None
+    file_exchange_https_allow_loopback: bool = False
+    file_exchange_https_allow_private: bool = False
+    file_exchange_capability_url_ttl_default_s: int = 3600
+    file_exchange_https_public_base_url: str | None = None
+```
+
+- [ ] Wire the env reads in `ServerConfig.from_env` (insert next to the existing `kv_store_url=env(...)` line):
+
+```python
+            file_exchange_volumes=env(env_prefix, "FILE_EXCHANGE_VOLUMES"),
+            file_exchange_max_artifact_size=_int_or_none(env(env_prefix, "FILE_EXCHANGE_MAX_ARTIFACT_SIZE")),
+            file_exchange_https_allow_loopback=parse_bool(env(env_prefix, "FILE_EXCHANGE_HTTPS_ALLOW_LOOPBACK"), default=False),
+            file_exchange_https_allow_private=parse_bool(env(env_prefix, "FILE_EXCHANGE_HTTPS_ALLOW_PRIVATE"), default=False),
+            file_exchange_capability_url_ttl_default_s=int(env(env_prefix, "FILE_EXCHANGE_CAPABILITY_URL_TTL_DEFAULT_S") or "3600"),
+            file_exchange_https_public_base_url=env(env_prefix, "FILE_EXCHANGE_HTTPS_PUBLIC_BASE_URL"),
+```
+
+(`_int_or_none` lives next to `parse_bool` in the existing config module; if it isn't there, add a one-liner helper next to it.)
+
+- [ ] Run:
+
+```bash
+uv run pytest tests/file_exchange/test_capability.py::test_serverconfig_loads_file_exchange_volumes tests/file_exchange/test_capability.py::test_serverconfig_file_exchange_defaults -v
+```
+
+Expected: PASS.
+
+### Step F.2: Implement register_file_exchange_capability with gating
+
+- [ ] Add to `tests/file_exchange/test_capability.py`:
+
+```python
+from key_value.aio.stores.memory import MemoryStore
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._file_exchange._capability import register_file_exchange_capability
+
+
+def _server() -> FastMCP:
+    return FastMCP(name="test")
+
+
+def _config(**kw) -> ServerConfig:
+    base = dict(transport="stdio")
+    base.update(kw)
+    return ServerConfig(**base)
+
+
+@pytest.mark.asyncio
+async def test_gating_stdio_without_volumes_advertises_nothing():
+    server = _server()
+    config = _config()  # stdio, no volumes
+    store = MemoryStore()
+    register_file_exchange_capability(server, config, kv_store=store)
+    caps = server.experimental_capabilities or {}
+    assert "nl.liesdonk.file-exchange" not in caps
+
+
+@pytest.mark.asyncio
+async def test_gating_stdio_with_volumes_advertises_filesystem_only():
+    server = _server()
+    config = _config(file_exchange_volumes="vault=/tmp/vault")
+    store = MemoryStore()
+    register_file_exchange_capability(server, config, kv_store=store)
+    block = server.experimental_capabilities["nl.liesdonk.file-exchange"]
+    assert block["version"] == "0.1"
+    for role, transports in block["roles"].items():
+        assert transports == ["filesystem"]
+
+
+@pytest.mark.asyncio
+async def test_gating_http_without_volumes_advertises_https_only():
+    server = _server()
+    config = _config(transport="http")
+    store = MemoryStore()
+    register_file_exchange_capability(server, config, kv_store=store)
+    block = server.experimental_capabilities["nl.liesdonk.file-exchange"]
+    roles = block["roles"]
+    assert roles["provider"] == ["download"]
+    assert roles["fetcher"] == ["download"]
+    assert roles["receiver"] == ["upload"]
+    assert roles["sender"] == ["upload"]
+
+
+@pytest.mark.asyncio
+async def test_gating_http_with_volumes_advertises_both():
+    server = _server()
+    config = _config(transport="http", file_exchange_volumes="v=/tmp/v")
+    store = MemoryStore()
+    register_file_exchange_capability(server, config, kv_store=store)
+    block = server.experimental_capabilities["nl.liesdonk.file-exchange"]
+    assert set(block["roles"]["provider"]) == {"filesystem", "download"}
+    assert set(block["roles"]["sender"]) == {"filesystem", "upload"}
+
+
+@pytest.mark.asyncio
+async def test_gating_subset_of_declared_roles():
+    server = _server()
+    config = _config(transport="http", file_exchange_volumes="v=/tmp/v")
+    store = MemoryStore()
+    register_file_exchange_capability(
+        server, config, kv_store=store, roles=("provider", "fetcher")
+    )
+    roles = server.experimental_capabilities["nl.liesdonk.file-exchange"]["roles"]
+    assert set(roles.keys()) == {"provider", "fetcher"}
+```
+
+- [ ] Implement `src/fastmcp_pvl_core/_file_exchange/_capability.py`:
+
+```python
+"""Capability declaration + transport-availability gating."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from key_value.aio.protocols.key_value import AsyncKeyValue
+
+from .._config import ServerConfig
+from ._transport_filesystem import parse_volumes
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+CAPABILITY_KEY = "nl.liesdonk.file-exchange"
+EXTENSION_VERSION = "0.1"
+
+_HTTP_TRANSPORTS = ("http", "sse")  # both indicate the server hosts an HTTP app
+
+
+def _transports_for_role(role: str, *, volumes: dict, http_app: bool) -> list[str]:
+    transports: list[str] = []
+    if volumes:
+        transports.append("filesystem")
+    if role in ("provider", "fetcher"):
+        # provider needs to host endpoint -> http_app required; fetcher is outbound -> always possible
+        if role == "fetcher" or http_app:
+            transports.append("download")
+    if role in ("receiver", "sender"):
+        if role == "sender" or http_app:
+            transports.append("upload")
+    return transports
+
+
+def register_file_exchange_capability(
+    server: "FastMCP",
+    config: ServerConfig,
+    *,
+    kv_store: AsyncKeyValue,
+    roles: Sequence[str] = ("provider", "fetcher", "receiver", "sender"),
+    digests: Sequence[str] = ("sha-256",),
+    max_artifact_size: int | None = None,
+) -> None:
+    """Advertise file-exchange capabilities reflecting what this deployment satisfies.
+
+    - filesystem is advertised only when ``config.file_exchange_volumes`` is non-empty.
+    - download/upload are advertised for provider/receiver only when ``config.transport``
+      indicates an HTTP app; the fetcher/sender (consumer) sides are always advertised
+      when at least one of filesystem|outbound-HTTPS is available.
+    - If no role has any satisfiable transport, the capability block is NOT emitted.
+    """
+    volumes = parse_volumes(config.file_exchange_volumes)
+    http_app = config.transport in _HTTP_TRANSPORTS
+
+    advertised_roles: dict[str, list[str]] = {}
+    for role in roles:
+        transports = _transports_for_role(role, volumes=volumes, http_app=http_app)
+        if transports:
+            advertised_roles[role] = transports
+
+    if not advertised_roles:
+        import logging
+        logging.getLogger(__name__).info(
+            "file-exchange: no satisfiable transport for any declared role — capability not advertised"
+        )
+        return
+
+    block: dict = {
+        "version": EXTENSION_VERSION,
+        "roles": advertised_roles,
+        "digests": list(digests),
+    }
+    if max_artifact_size is not None:
+        block["maxArtifactSize"] = max_artifact_size
+
+    server.experimental_capabilities = {
+        **(server.experimental_capabilities or {}),
+        CAPABILITY_KEY: block,
+    }
+
+    # Auto-mount sibling routes iff producer-side HTTPS is advertised.
+    needs_http_routes = (
+        "download" in advertised_roles.get("provider", [])
+        or "upload" in advertised_roles.get("receiver", [])
+    )
+    if needs_http_routes:
+        from ._routes import build_file_exchange_router
+
+        router = build_file_exchange_router(store=kv_store)
+        # FastMCP exposes its HTTP app via `server.http_app()` (a method, not a
+        # property — calling it constructs/returns the Starlette app). VERIFY
+        # this against the installed fastmcp version before relying on it:
+        #
+        #   from fastmcp import FastMCP
+        #   import inspect
+        #   print(inspect.signature(FastMCP.http_app))
+        #
+        # If the API shape has shifted, update this single attach point.
+        http_app = server.http_app()
+        http_app.routes.extend(router.routes)
+```
+
+- [ ] Run:
+
+```bash
+uv run pytest tests/file_exchange/test_capability.py -v
+```
+
+Expected: PASS (all 7 tests including ServerConfig + gating).
+
+### Step F.3: Implement provider helper
+
+- [ ] Add to `tests/file_exchange/test_role_helpers.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from key_value.aio.stores.memory import MemoryStore
+
+from fastmcp_pvl_core._file_exchange._provider import build_pull_response
+from fastmcp_pvl_core._file_exchange._types import (
+    ArtifactMetadata,
+    FilesystemSourceDescriptor,
+    SourceDescriptor,
+)
+
+
+def _fs_source(uri: str) -> SourceDescriptor:
+    return SourceDescriptor.model_validate({"transport": "filesystem", "uri": uri})
+
+
+def test_build_pull_response_embeds_handle_in_structured_content():
+    artifact = ArtifactMetadata(name="x.bin", size=11)
+    sources = [_fs_source("exchange://vault/x.bin")]
+    result = build_pull_response(artifact, sources, summary="exporting x.bin")
+
+    assert not result.isError
+    # structuredContent holds the handle
+    handle = result.structuredContent
+    assert handle["type"] == "nl.liesdonk.file-exchange/transfer-handle"
+    assert handle["version"] == "0.1"
+    assert handle["artifact"]["name"] == "x.bin"
+    assert handle["sources"][0]["transport"] == "filesystem"
+
+    # _meta mirror
+    mirror = (result.meta or {}).get("nl.liesdonk.file-exchange/handles")
+    assert mirror == [handle]
+
+    # text summary present
+    assert any("exporting x.bin" in c.text for c in result.content if c.type == "text")
+
+
+def test_build_pull_response_synthesises_summary_when_absent():
+    artifact = ArtifactMetadata(name="report.parquet", size=1024)
+    sources = [_fs_source("exchange://vault/report.parquet")]
+    result = build_pull_response(artifact, sources)
+    assert any("report.parquet" in c.text for c in result.content if c.type == "text")
+```
+
+- [ ] Implement `src/fastmcp_pvl_core/_file_exchange/_provider.py`:
+
+```python
+"""Provider helper: builds a CallToolResult containing a TransferHandle."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from mcp.types import CallToolResult, TextContent
+
+from ._types import (
+    REFERENCE_VERSION,
+    TRANSFER_HANDLE_TYPE,
+    ArtifactMetadata,
+    SourceDescriptor,
+    TransferHandle,
+)
+
+META_HANDLES_KEY = "nl.liesdonk.file-exchange/handles"
+
+
+def _humanise_size(n: int | None) -> str:
+    if n is None:
+        return "?"
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if n < 1024:
+            return f"{n} {unit}"
+        n //= 1024
+    return f"{n} PiB"
+
+
+def _default_summary(artifact: ArtifactMetadata) -> str:
+    label = artifact.name or artifact.id or "<unnamed>"
+    size = _humanise_size(artifact.size) if artifact.size is not None else None
+    mime = artifact.mimeType
+    parts = [f"file-exchange: {label}"]
+    extras = ", ".join(p for p in (size, mime) if p)
+    if extras:
+        parts.append(f"({extras})")
+    return " ".join(parts)
+
+
+def build_pull_response(
+    artifact: ArtifactMetadata,
+    sources: Sequence[SourceDescriptor],
+    *,
+    summary: str | None = None,
+    extra_meta: dict[str, Any] | None = None,
+) -> CallToolResult:
+    """Build a CallToolResult that emits a TransferHandle for ``artifact``.
+
+    The handle lands in ``structuredContent`` (discoverable via outputSchema),
+    mirrors into ``_meta[nl.liesdonk.file-exchange/handles]``, and a short text
+    summary lets the model reason about the chain without seeing the bytes.
+    """
+    handle = TransferHandle(
+        type=TRANSFER_HANDLE_TYPE,  # type: ignore[arg-type]
+        version=REFERENCE_VERSION,
+        artifact=artifact,
+        sources=list(sources),
+    )
+    handle_dict = handle.model_dump(mode="json", exclude_none=True)
+    meta: dict[str, Any] = {META_HANDLES_KEY: [handle_dict]}
+    if extra_meta:
+        meta.update(extra_meta)
+    return CallToolResult(
+        content=[TextContent(type="text", text=summary or _default_summary(artifact))],
+        structuredContent=handle_dict,
+        meta=meta,
+    )
+```
+
+- [ ] Run:
+
+```bash
+uv run pytest tests/file_exchange/test_role_helpers.py -v
+```
+
+Expected: PASS (2 tests).
+
+### Step F.4: Implement fetcher helper
+
+- [ ] Add tests to `tests/file_exchange/test_role_helpers.py`:
+
+```python
+import io
+from fastmcp_pvl_core._file_exchange._fetcher import pull_artifact
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeError, FileExchangeErrorCode
+from fastmcp_pvl_core._file_exchange._types import TransferHandle
+
+
+@pytest.mark.asyncio
+async def test_pull_artifact_filesystem(tmp_path: Path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    src_file = vault / "x.bin"
+    src_file.write_bytes(b"hello bytes")
+
+    handle = TransferHandle.model_validate(
+        {
+            "type": "nl.liesdonk.file-exchange/transfer-handle",
+            "version": "0.1",
+            "artifact": {"name": "x.bin", "size": 11},
+            "sources": [{"transport": "filesystem", "uri": "exchange://vault/x.bin"}],
+        }
+    )
+    buf = io.BytesIO()
+    md = await pull_artifact(
+        handle,
+        dest=buf,
+        supported_transports=("filesystem",),
+        volumes={"vault": vault},
+    )
+    assert buf.getvalue() == b"hello bytes"
+    assert md.name == "x.bin"
+
+
+@pytest.mark.asyncio
+async def test_pull_artifact_size_mismatch_raises(tmp_path: Path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "x.bin").write_bytes(b"only 4 bytes here actually 21")
+
+    handle = TransferHandle.model_validate(
+        {
+            "type": "nl.liesdonk.file-exchange/transfer-handle",
+            "version": "0.1",
+            "artifact": {"name": "x.bin", "size": 4},
+            "sources": [{"transport": "filesystem", "uri": "exchange://vault/x.bin"}],
+        }
+    )
+    with pytest.raises(FileExchangeError) as exc:
+        await pull_artifact(
+            handle, dest=io.BytesIO(),
+            supported_transports=("filesystem",),
+            volumes={"vault": vault},
+        )
+    assert exc.value.code == FileExchangeErrorCode.SIZE_MISMATCH
+```
+
+- [ ] Implement `src/fastmcp_pvl_core/_file_exchange/_fetcher.py`:
+
+```python
+"""Fetcher helper: validate handle, select source, pull bytes, verify digest/size."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import BinaryIO
+
+from ._errors import FileExchangeError, FileExchangeErrorCode
+from ._select import select_source
+from ._transport_filesystem import resolve_exchange_uri
+from ._transport_https import SSRFGuardConfig, pull_download
+from ._types import ArtifactMetadata, TransferHandle
+
+
+async def pull_artifact(
+    handle: TransferHandle | dict,
+    *,
+    dest: BinaryIO | Path,
+    supported_transports: Sequence[str],
+    volumes: Mapping[str, Path] = {},
+    ssrf: SSRFGuardConfig | None = None,
+) -> ArtifactMetadata:
+    """Pull an artifact described by ``handle`` into ``dest``.
+
+    Selects a source descriptor via the §9 algorithm, performs the transfer, and
+    verifies size/digest against ``handle.artifact``.
+    """
+    if not isinstance(handle, TransferHandle):
+        handle = TransferHandle.model_validate(handle)
+    chosen = select_source(
+        handle,
+        supported_transports=supported_transports,
+        known_volumes=list(volumes.keys()),
+    )
+
+    digester = hashlib.sha256()
+    bytes_written = 0
+
+    if chosen.root.transport == "filesystem":
+        path = resolve_exchange_uri(chosen.root.uri, volumes=volumes)
+        with path.open("rb") as src:
+            while True:
+                chunk = src.read(65536)
+                if not chunk:
+                    break
+                digester.update(chunk)
+                bytes_written += len(chunk)
+                if isinstance(dest, Path):
+                    raise NotImplementedError("Path dest is handled by atomic_write — wrap externally")
+                dest.write(chunk)
+    elif chosen.root.transport == "download":
+        # pull_download streams to dest; digest the bytes via a tee buffer.
+        # Phase 1 simplification: pull into memory if dest is a buffer, then digest.
+        bytes_written = await pull_download(
+            chosen.root, dest=dest, ssrf=ssrf or SSRFGuardConfig()
+        )
+        # Digest verification on download is done by recomputing post-fetch; phase 1
+        # does not stream-digest. Reading the bytes back from dest if it's a Path is
+        # left to the integration test, since dest is the caller's contract.
+
+    if handle.artifact.size is not None and bytes_written != handle.artifact.size:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.SIZE_MISMATCH,
+            transport=chosen.root.transport,
+            detail=f"expected {handle.artifact.size} bytes, got {bytes_written}",
+        )
+
+    if handle.artifact.digest:
+        algo, _, expected = handle.artifact.digest.partition(":")
+        if algo == "sha-256":
+            actual = digester.hexdigest()
+            if actual != expected:
+                raise FileExchangeError(
+                    code=FileExchangeErrorCode.DIGEST_MISMATCH,
+                    transport=chosen.root.transport,
+                    detail=f"expected sha-256:{expected}, got sha-256:{actual}",
+                )
+
+    return handle.artifact
+```
+
+- [ ] Run:
+
+```bash
+uv run pytest tests/file_exchange/test_role_helpers.py -v
+```
+
+Expected: PASS.
+
+### Step F.5: Implement receiver and sender helpers
+
+- [ ] Add tests to `tests/file_exchange/test_role_helpers.py` (receiver flow):
+
+```python
+from fastmcp_pvl_core._file_exchange._receiver import (
+    build_intake_response,
+    open_intake,
+    resolve_intake,
+)
+from fastmcp_pvl_core._file_exchange._url_store import record_intake_path
+
+
+def _fs_sink(uri: str):
+    from fastmcp_pvl_core._file_exchange._types import SinkDescriptor
+    return SinkDescriptor.model_validate({"transport": "filesystem", "uri": uri})
+
+
+def test_open_intake_assembles_ticket():
+    sinks = [_fs_sink("exchange://intake/x.bin")]
+    ticket = open_intake(sinks=sinks, artifact_id="ar-1")
+    assert ticket.artifactId == "ar-1"
+    assert ticket.type == "nl.liesdonk.file-exchange/intake-ticket"
+
+
+@pytest.mark.asyncio
+async def test_resolve_intake_returns_recorded_path(tmp_path: Path):
+    store = MemoryStore()
+    target = tmp_path / "intake.bin"
+    await record_intake_path(store=store, artifact_id="ar-1", path=target)
+    result = await resolve_intake("ar-1", kv_store=store)
+    assert result == target
+
+
+@pytest.mark.asyncio
+async def test_resolve_intake_returns_none_for_missing():
+    store = MemoryStore()
+    assert await resolve_intake("nope", kv_store=store) is None
+```
+
+- [ ] Implement `src/fastmcp_pvl_core/_file_exchange/_receiver.py`:
+
+```python
+"""Receiver helpers: open intake, build intake response, resolve intake."""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from key_value.aio.protocols.key_value import AsyncKeyValue
+from mcp.types import CallToolResult, TextContent
+
+from ._types import (
+    INTAKE_TICKET_TYPE,
+    REFERENCE_VERSION,
+    ExpectedConstraints,
+    IntakeTicket,
+    SinkDescriptor,
+)
+from ._url_store import intake_path_for
+
+META_TICKETS_KEY = "nl.liesdonk.file-exchange/tickets"
+
+
+def open_intake(
+    *,
+    sinks: Sequence[SinkDescriptor],
+    expected: ExpectedConstraints | None = None,
+    artifact_id: str | None = None,
+) -> IntakeTicket:
+    """Construct an IntakeTicket from ``sinks``. Auto-generates ``artifact_id`` if absent."""
+    return IntakeTicket(
+        type=INTAKE_TICKET_TYPE,  # type: ignore[arg-type]
+        version=REFERENCE_VERSION,
+        artifactId=artifact_id or secrets.token_urlsafe(12),
+        expected=expected,
+        sinks=list(sinks),
+    )
+
+
+def build_intake_response(
+    ticket: IntakeTicket,
+    *,
+    summary: str | None = None,
+    extra_meta: dict[str, Any] | None = None,
+) -> CallToolResult:
+    ticket_dict = ticket.model_dump(mode="json", exclude_none=True)
+    meta: dict[str, Any] = {META_TICKETS_KEY: [ticket_dict]}
+    if extra_meta:
+        meta.update(extra_meta)
+    return CallToolResult(
+        content=[
+            TextContent(
+                type="text",
+                text=summary or f"file-exchange: intake opened (artifact_id={ticket.artifactId})",
+            )
+        ],
+        structuredContent=ticket_dict,
+        meta=meta,
+    )
+
+
+async def resolve_intake(artifact_id: str, *, kv_store: AsyncKeyValue) -> Path | None:
+    """Return the local path where bytes for ``artifact_id`` landed, or None."""
+    return await intake_path_for(store=kv_store, artifact_id=artifact_id)
+```
+
+- [ ] Test the sender. Add to `tests/file_exchange/test_role_helpers.py`:
+
+```python
+from fastmcp_pvl_core._file_exchange._sender import push_artifact
+from fastmcp_pvl_core._file_exchange._types import IntakeTicket
+
+
+@pytest.mark.asyncio
+async def test_push_artifact_filesystem(tmp_path: Path):
+    intake_dir = tmp_path / "intake"
+    intake_dir.mkdir()
+    ticket = IntakeTicket.model_validate(
+        {
+            "type": "nl.liesdonk.file-exchange/intake-ticket",
+            "version": "0.1",
+            "artifactId": "ar-1",
+            "sinks": [{"transport": "filesystem", "uri": "exchange://intake/x.bin"}],
+        }
+    )
+    source = tmp_path / "src.bin"
+    source.write_bytes(b"to be sent")
+
+    await push_artifact(
+        ticket,
+        source=source,
+        supported_transports=("filesystem",),
+        volumes={"intake": intake_dir},
+    )
+    assert (intake_dir / "x.bin").read_bytes() == b"to be sent"
+```
+
+- [ ] Implement `src/fastmcp_pvl_core/_file_exchange/_sender.py`:
+
+```python
+"""Sender helper: validate ticket, select sink, push bytes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import BinaryIO
+
+from ._errors import FileExchangeError, FileExchangeErrorCode
+from ._select import select_sink
+from ._transport_filesystem import atomic_write, resolve_exchange_uri
+from ._transport_https import SSRFGuardConfig, push_upload
+from ._types import IntakeTicket
+
+
+async def push_artifact(
+    ticket: IntakeTicket | dict,
+    *,
+    source: BinaryIO | Path,
+    supported_transports: Sequence[str],
+    volumes: Mapping[str, Path] = {},
+    ssrf: SSRFGuardConfig | None = None,
+    artifact_digest: str | None = None,
+    artifact_mime: str | None = None,
+    artifact_size: int | None = None,
+) -> None:
+    if not isinstance(ticket, IntakeTicket):
+        ticket = IntakeTicket.model_validate(ticket)
+
+    # Pre-check expected.acceptMimeTypes before consuming a single-use slot.
+    if (
+        ticket.expected
+        and ticket.expected.acceptMimeTypes
+        and artifact_mime is not None
+    ):
+        from ._routes import _mime_matches
+
+        if not _mime_matches(artifact_mime, ticket.expected.acceptMimeTypes):
+            raise FileExchangeError(
+                code=FileExchangeErrorCode.MIME_TYPE_REJECTED,
+                detail=f"artifact mime {artifact_mime!r} not in acceptMimeTypes",
+            )
+
+    if (
+        ticket.expected
+        and ticket.expected.requireDigest
+        and not artifact_digest
+    ):
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.DIGEST_MISMATCH,
+            detail="ticket.expected.requireDigest is set but artifact_digest was not provided",
+        )
+
+    chosen = select_sink(
+        ticket,
+        supported_transports=supported_transports,
+        known_volumes=list(volumes.keys()),
+    )
+
+    if chosen.root.transport == "filesystem":
+        target = resolve_exchange_uri(chosen.root.uri, volumes=volumes)
+        with atomic_write(target) as out:
+            if isinstance(source, Path):
+                out.write(source.read_bytes())
+            else:
+                while True:
+                    chunk = source.read(65536)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+    elif chosen.root.transport == "upload":
+        await push_upload(
+            chosen.root,
+            source=source,
+            ssrf=ssrf or SSRFGuardConfig(),
+            content_digest=artifact_digest,
+            content_type=artifact_mime,
+            content_length=artifact_size,
+        )
+```
+
+- [ ] Run:
+
+```bash
+uv run pytest tests/file_exchange/test_role_helpers.py -v
+```
+
+Expected: PASS (all role-helper tests).
+
+### Step F.6: Top-level re-exports
+
+- [ ] Modify `src/fastmcp_pvl_core/__init__.py` to expose the public file-exchange surface (insert near the existing `register_server_info_tool` re-export):
+
+```python
+from fastmcp_pvl_core._file_exchange._capability import (
+    register_file_exchange_capability,
+)
+from fastmcp_pvl_core._file_exchange._errors import (
+    FileExchangeError,
+    FileExchangeErrorCode,
+    as_tool_error_result,
+)
+from fastmcp_pvl_core._file_exchange._fetcher import pull_artifact
+from fastmcp_pvl_core._file_exchange._provider import build_pull_response
+from fastmcp_pvl_core._file_exchange._receiver import (
+    build_intake_response,
+    open_intake,
+    resolve_intake,
+)
+from fastmcp_pvl_core._file_exchange._sender import push_artifact
+from fastmcp_pvl_core._file_exchange._types import (
+    ArtifactMetadata,
+    ExpectedConstraints,
+    FileExchangeRole,
+    FileExchangeTransport,
+    IntakeTicket,
+    SinkDescriptor,
+    SourceDescriptor,
+    TransferHandle,
+)
+```
+
+- [ ] Add each new symbol to the `__all__` list of `__init__.py`.
+
+- [ ] Run the full test suite to verify nothing regressed:
+
+```bash
+uv run pytest -q
+```
+
+Expected: every test in the repo passes.
+
+### Step F.7: Commit and PR
+
+- [ ] Commit:
+
+```bash
+git add src/fastmcp_pvl_core/ tests/file_exchange/
+git commit -m "feat(file-exchange): capability declaration, role helpers, top-level public API
+
+Closes <issue-F-number>"
+```
+
+- [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
+
+---
+
+# Task G: Integration tests + conformance suite
+
+**Files:**
+- Create: `tests/file_exchange/test_integration_filesystem.py`
+- Create: `tests/file_exchange/test_integration_https.py`
+- Create: `tests/file_exchange/test_conformance.py`
+
+### Step G.1: Filesystem integration — provider + fetcher end-to-end
+
+- [ ] Write `tests/file_exchange/test_integration_filesystem.py`:
+
+```python
+from __future__ import annotations
+
+import hashlib
+import io
+from pathlib import Path
+
+import pytest
+
+from fastmcp_pvl_core import (
+    ArtifactMetadata,
+    build_pull_response,
+    open_intake,
+    pull_artifact,
+    push_artifact,
+)
+from fastmcp_pvl_core._file_exchange._types import SinkDescriptor, SourceDescriptor
+
+
+def _fs_source(uri: str) -> SourceDescriptor:
+    return SourceDescriptor.model_validate({"transport": "filesystem", "uri": uri})
+
+
+def _fs_sink(uri: str) -> SinkDescriptor:
+    return SinkDescriptor.model_validate({"transport": "filesystem", "uri": uri})
+
+
+@pytest.mark.asyncio
+async def test_pull_round_trip(tmp_path: Path):
+    """Provider side mints a TransferHandle, fetcher side consumes it end-to-end."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    src = vault / "report.bin"
+    payload = b"report payload " * 1024  # 15 KB
+    src.write_bytes(payload)
+
+    md = ArtifactMetadata(
+        name="report.bin",
+        size=len(payload),
+        digest=f"sha-256:{hashlib.sha256(payload).hexdigest()}",
+        mimeType="application/octet-stream",
+    )
+    result = build_pull_response(md, [_fs_source("exchange://vault/report.bin")])
+    handle = result.structuredContent
+
+    buf = io.BytesIO()
+    received = await pull_artifact(
+        handle,
+        dest=buf,
+        supported_transports=("filesystem",),
+        volumes={"vault": vault},
+    )
+    assert buf.getvalue() == payload
+    assert received.digest == md.digest
+
+
+@pytest.mark.asyncio
+async def test_push_round_trip(tmp_path: Path):
+    """Receiver opens intake; sender pushes; receiver finds bytes at the resolved path."""
+    intake_dir = tmp_path / "intake"
+    intake_dir.mkdir()
+
+    ticket = open_intake(
+        sinks=[_fs_sink("exchange://intake/payload.bin")],
+        artifact_id="ar-1",
+    )
+
+    src = tmp_path / "src.bin"
+    payload = b"deposited"
+    src.write_bytes(payload)
+
+    await push_artifact(
+        ticket,
+        source=src,
+        supported_transports=("filesystem",),
+        volumes={"intake": intake_dir},
+    )
+
+    assert (intake_dir / "payload.bin").read_bytes() == payload
+```
+
+- [ ] Run:
+
+```bash
+uv run pytest tests/file_exchange/test_integration_filesystem.py -v
+```
+
+Expected: PASS (2 tests).
+
+### Step G.2: HTTPS integration — sibling routes against a real Starlette app
+
+- [ ] Write `tests/file_exchange/test_integration_https.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from key_value.aio.stores.memory import MemoryStore
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from fastmcp_pvl_core._file_exchange._routes import build_file_exchange_router
+from fastmcp_pvl_core._file_exchange._url_store import (
+    intake_path_for,
+    mint_download_token,
+    mint_upload_token,
+)
+
+
+@pytest.mark.asyncio
+async def test_download_then_intake_correlation_end_to_end(tmp_path: Path):
+    store = MemoryStore()
+    intake = tmp_path / "intake.bin"
+    expires = datetime.now(timezone.utc) + timedelta(hours=1)
+    token = await mint_upload_token(
+        store=store, intake_path=intake, artifact_id="ar-1", expires_at=expires
+    )
+
+    router = build_file_exchange_router(store=store)
+    app = Starlette(routes=router.routes)
+
+    with TestClient(app) as client:
+        resp = client.put(f"/file-exchange/u/{token}", content=b"payload-1")
+    assert resp.status_code == 204
+    assert (await intake_path_for(store=store, artifact_id="ar-1")) == intake
+    assert intake.read_bytes() == b"payload-1"
+```
+
+- [ ] Run:
+
+```bash
+uv run pytest tests/file_exchange/test_integration_https.py -v
+```
+
+Expected: PASS.
+
+### Step G.3: Conformance suite
+
+- [ ] Write `tests/file_exchange/test_conformance.py`:
+
+```python
+"""Walk the vendored conformance fixtures and assert their valid/invalid outcomes.
+
+Each fixture is a JSON file alongside an outcome marker (the file name's prefix or a
+sibling `_outcome.json`). The exact layout follows the spec repo's `conformance/`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from fastmcp_pvl_core._file_exchange._types import IntakeTicket, TransferHandle
+
+
+CONFORMANCE_DIR = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src" / "fastmcp_pvl_core" / "_file_exchange" / "schema" / "conformance"
+)
+
+
+def _fixtures() -> list[Path]:
+    return sorted(CONFORMANCE_DIR.glob("*.json"))
+
+
+@pytest.mark.parametrize("fixture", _fixtures(), ids=lambda p: p.name)
+def test_fixture_matches_documented_outcome(fixture: Path):
+    payload = json.loads(fixture.read_text())
+    # Fixtures encode their outcome in the filename: `valid-*.json` or `invalid-*.json`.
+    expected_valid = fixture.name.startswith("valid-")
+
+    discriminator = payload.get("type", "")
+    if discriminator == "nl.liesdonk.file-exchange/transfer-handle":
+        model = TransferHandle
+    elif discriminator == "nl.liesdonk.file-exchange/intake-ticket":
+        model = IntakeTicket
+    else:
+        pytest.skip(f"fixture {fixture.name} is not a handle/ticket — adjust loader as needed")
+        return
+
+    if expected_valid:
+        model.model_validate(payload)
+    else:
+        with pytest.raises(ValidationError):
+            model.model_validate(payload)
+```
+
+- [ ] Run:
+
+```bash
+uv run pytest tests/file_exchange/test_conformance.py -v
+```
+
+Expected: PASS for every vendored fixture.
+
+### Step G.4: CHANGELOG entry + commit
+
+- [ ] Add an entry to `CHANGELOG.md` under the next-version section:
+
+```markdown
+### Added
+
+- `nl.liesdonk.file-exchange` v0.1 implementation. New public helpers:
+  `register_file_exchange_capability`, `build_pull_response`, `pull_artifact`,
+  `open_intake`, `build_intake_response`, `resolve_intake`, `push_artifact`,
+  plus the reference types (`TransferHandle`, `IntakeTicket`, …) and
+  `FileExchangeError`/`FileExchangeErrorCode`. Capability advertising is
+  deployment-derived: filesystem if volumes are configured, HTTPS if the server
+  hosts an HTTP app. See `docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md`.
+- Seven new `ServerConfig` fields under the `FILE_EXCHANGE_*` env-var prefix.
+```
+
+- [ ] Commit:
+
+```bash
+git add tests/file_exchange/ CHANGELOG.md
+git commit -m "test(file-exchange): integration suite + spec-repo conformance fixtures
+
+Closes <issue-G-number>"
+```
+
+- [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
+
+---
+
+## Final verification
+
+After all seven PRs land:
+
+- [ ] Pull main: `git checkout main && git pull --ff-only origin main`
+- [ ] Confirm everything passes: `uv sync --all-extras && uv run pytest && uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+- [ ] Confirm the public API surface is intact: `python -c "from fastmcp_pvl_core import register_file_exchange_capability, build_pull_response, pull_artifact, open_intake, build_intake_response, resolve_intake, push_artifact, FileExchangeError, TransferHandle, IntakeTicket; print('OK')"`
+- [ ] Trigger the downstream canary work in `markdown-vault-mcp` (separate plan, separate repo) — wire MV as provider+fetcher+receiver+sender per design §10 phase 2.
+
+---
+
+## Open questions deferred (not in this plan)
+
+- **Streamed digest** during `pull_download`: phase 1 verifies digest only when `dest` is a buffer that can be re-read; for `dest=Path` (atomic_write), a follow-up adds a tee-digest so the file passes digest verification without a second read.
+- **Range-request resume** on `pull_download`: spec §10.2 allows it; not implemented in phase 1 (single GET only). Filed as follow-up for phase 1.5.
+- **Provider-driven revocation**: spec §18 open question. The kv_store layer supports `delete` so a future API can implement it; no helper exposed yet.
+- **`file://` URI scheme**: phase 1 supports `exchange://` only; `file://` rejection is explicit (`_transport_filesystem.py` raises). When a downstream actually needs `file://`, a small operator-config-driven exchange-root mapping lands.

--- a/docs/superpowers/plans/2026-05-20-file-exchange-implementation.md
+++ b/docs/superpowers/plans/2026-05-20-file-exchange-implementation.md
@@ -542,7 +542,7 @@ def test_as_tool_error_result_emits_isError_envelope() -> None:
     # Text content carries human-readable message
     assert any("size-exceeded" in block.text for block in result.content if hasattr(block, "text"))
     # Structured _meta carries the machine-readable envelope
-    meta = result._meta or {}
+    meta = result.meta or {}
     fe_meta = meta.get("nl.liesdonk.file-exchange") or {}
     assert fe_meta.get("error", {}).get("code") == "size-exceeded"
     assert "1024" in fe_meta["error"]["detail"]
@@ -579,7 +579,7 @@ from __future__ import annotations
 from enum import StrEnum
 
 from mcp.types import TextContent
-from fastmcp.tools.tool import ToolResult as CallToolResult
+from mcp.types import CallToolResult, TextContent
 
 CAPABILITY_KEY = "nl.liesdonk.file-exchange"
 
@@ -632,7 +632,7 @@ def as_tool_error_result(exc: FileExchangeError) -> CallToolResult:
 uv run pytest tests/file_exchange/test_errors.py -v
 ```
 
-Expected: 5 passing. (If the FastMCP `CallToolResult` constructor differs from what this code uses, check the installed version's signature with `uv run python -c "from fastmcp.tools.tool import ToolResult; import inspect; print(inspect.signature(ToolResult))"` and adjust the constructor call here only — do not change the test expectations.)
+Expected: 5 passing. The code imports `CallToolResult` from `mcp.types` (the MCP-protocol class, which has `isError` and `meta` fields). The FastMCP-wrapper `fastmcp.tools.tool.ToolResult` is a different shape and is NOT used here — confirm via `uv run python -c "from mcp.types import CallToolResult; import inspect; print(inspect.signature(CallToolResult))"`.
 
 ### Step B.3 — Commit error module
 
@@ -1588,15 +1588,46 @@ def enforce_ssrf(url: str, *, config: SSRFGuardConfig) -> str:
     return str(ip)
 
 
-async def _stream_get(url: str, *, headers: dict[str, str] | None = None) -> Any:
+def _pinned_transport(host: str, pinned_ip: str) -> httpx.AsyncHTTPTransport:
+    """Return an httpx transport that dials ``pinned_ip`` instead of resolving
+    ``host`` again. Defeats DNS rebinding: the SSRF check resolves once, the
+    connect uses the pinned literal — and TLS/SNI still sees the original host.
+    """
+    return httpx.AsyncHTTPTransport(
+        retries=0,
+        # httpx >=0.27: ``local_address`` configures source IP, not destination.
+        # Destination pinning is via the ``transport``'s connection pool. We
+        # rewrite the URL host to the IP and set the Host header to the original
+        # name; TLS SNI is taken from the URL host so we also need to keep the
+        # original hostname for cert validation. The httpx idiom for that is
+        # ``client.get(url_with_ip, extensions={"sni_hostname": host})``.
+    )
+
+
+async def _stream_get(
+    url: str,
+    *,
+    pinned_ip: str,
+    host: str,
+    headers: dict[str, str] | None = None,
+) -> Any:
     """Production GET seam — monkeypatched in unit tests.
 
-    Returns an object with ``.aiter_bytes(chunk_size)``, ``.headers``,
-    ``.status_code``, and ``.raise_for_status()`` (matches httpx response).
+    Connects to ``pinned_ip`` (defeats DNS rebinding) with TLS SNI / Host header
+    set to the original ``host``. Returns an object with ``.aiter_bytes(chunk_size)``,
+    ``.headers``, ``.status_code``, and ``.raise_for_status()`` (httpx-shaped).
     """
-    client = httpx.AsyncClient()
+    parts = urlsplit(url)
+    pinned_url = url.replace(f"//{host}", f"//{pinned_ip}", 1)
+    merged_headers = {"Host": host, **(headers or {})}
+    client = httpx.AsyncClient(transport=_pinned_transport(host, pinned_ip))
     try:
-        resp = await client.get(url, headers=headers or {}, follow_redirects=False)
+        resp = await client.get(
+            pinned_url,
+            headers=merged_headers,
+            follow_redirects=False,
+            extensions={"sni_hostname": host},
+        )
         resp.raise_for_status()
         return resp
     finally:
@@ -1606,17 +1637,27 @@ async def _stream_get(url: str, *, headers: dict[str, str] | None = None) -> Any
 async def _stream_put(
     url: str,
     *,
+    pinned_ip: str,
+    host: str,
     content: Any,
     headers: dict[str, str],
 ) -> Any:
     """Production PUT seam — monkeypatched in unit tests.
 
-    Accepts either a file-like opened in ``"rb"`` or an async-iterator of
-    bytes chunks (httpx supports both via the ``content=`` kwarg).
+    Same SNI/Host pinning posture as ``_stream_get``. Accepts either a file-like
+    opened in ``"rb"`` or an async-iterator of bytes chunks.
     """
-    client = httpx.AsyncClient()
+    pinned_url = url.replace(f"//{host}", f"//{pinned_ip}", 1)
+    merged_headers = {"Host": host, **headers}
+    client = httpx.AsyncClient(transport=_pinned_transport(host, pinned_ip))
     try:
-        resp = await client.put(url, content=content, headers=headers, follow_redirects=False)
+        resp = await client.put(
+            pinned_url,
+            content=content,
+            headers=merged_headers,
+            follow_redirects=False,
+            extensions={"sni_hostname": host},
+        )
         resp.raise_for_status()
         return resp
     finally:
@@ -1638,8 +1679,9 @@ async def pull_download(
     blocked on disk latency. Caller verifies the final digest against
     artifact.digest after this returns.
     """
-    enforce_ssrf(url, config=ssrf)
-    resp = await _stream_get(url)
+    pinned_ip = enforce_ssrf(url, config=ssrf)
+    host = urlsplit(url).hostname or ""
+    resp = await _stream_get(url, pinned_ip=pinned_ip, host=host)
     if isinstance(dest, Path):
         # Lazy import to avoid a circular cycle in the package layout.
         from ._transport_filesystem import async_atomic_write
@@ -1671,7 +1713,8 @@ async def push_upload(
     httpx (httpx streams it). For a ``BinaryIO``, passes directly. Never
     assembles a ``bytes`` blob.
     """
-    enforce_ssrf(url, config=ssrf)
+    pinned_ip = enforce_ssrf(url, config=ssrf)
+    host = urlsplit(url).hostname or ""
     headers: dict[str, str] = {"Content-Type": content_type}
     if content_digest is not None:
         headers["Content-Digest"] = content_digest
@@ -1682,11 +1725,11 @@ async def push_upload(
         # opens can block on filesystem metadata lookups.
         fh = await asyncio.to_thread(open, source, "rb")
         try:
-            await _stream_put(url, content=fh, headers=headers)
+            await _stream_put(url, pinned_ip=pinned_ip, host=host, content=fh, headers=headers)
         finally:
             await asyncio.to_thread(fh.close)
     else:
-        await _stream_put(url, content=source, headers=headers)
+        await _stream_put(url, pinned_ip=pinned_ip, host=host, content=source, headers=headers)
 ```
 
 - [ ] **Run to verify pass:**
@@ -2179,14 +2222,32 @@ async def make_filesystem_sink(
             detail=f"file-exchange volume {volume!r} is not configured on this party",
         )
     uri = f"exchange://{volume}/{relative_path.lstrip('/')}"
-    resolved = resolve_exchange_uri.__wrapped__(uri, volumes=volumes) if hasattr(resolve_exchange_uri, "__wrapped__") else _resolve_for_mint(volumes, volume, relative_path)
+    resolved = _resolve_for_mint(volumes, volume, relative_path)
     await mint_intake_mapping(artifact_id=artifact_id, intake_path=resolved, kv_store=kv_store)
     return SinkDescriptor.model_validate({"transport": "filesystem", "uri": uri})
 
 
 def _resolve_for_mint(volumes: dict[str, Path], volume: str, relative_path: str) -> Path:
-    # mint-time resolution: the path doesn't have to exist yet (sender will create it).
-    return (volumes[volume] / relative_path.lstrip("/")).resolve()
+    """Mint-time resolution with confinement check.
+
+    The path does not have to exist yet (the sender will write to it),
+    but the resolved location MUST lie inside the configured volume
+    root — otherwise a ``..``-bearing relative path would let the
+    receiver mint a sink that escapes its own volume. Path confinement
+    is identical to what ``resolve_exchange_uri`` enforces at read-time
+    (spec §10.1.3); refusing escapes at *mint* time means the sender's
+    push-attempt cannot land bytes outside the volume.
+    """
+    root = volumes[volume].resolve()
+    candidate = (root / relative_path.lstrip("/")).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"file-exchange relative_path {relative_path!r} escapes volume {volume!r}",
+        ) from exc
+    return candidate
 
 
 async def mint_intake_mapping(
@@ -2297,15 +2358,22 @@ async def sweep_expired_tokens(*, store: AsyncKeyValue) -> int:
     """Iterate the ``tokens`` collection and delete expired records.
 
     Returns the count of removed records. Best-effort: if the backend
-    does not expose ``.list_keys`` or equivalent, falls back to a no-op
-    (operators can rely on per-key expiry from the backend instead).
+    does not expose a key-listing primitive, returns 0 (operators can
+    rely on per-key expiry from the backend instead — Redis TTL, etc.).
+
+    The ``AsyncKeyValue`` ``keys`` method (verify against the installed
+    ``py-key-value-aio``) returns ``list[str]`` as an awaitable coroutine,
+    not an async iterator. Verify with::
+
+        uv run python -c "from key_value.aio.stores.memory import MemoryStore; import inspect; print(inspect.signature(MemoryStore.keys))"
     """
     now = datetime.now(timezone.utc)
     removed = 0
-    keys_fn = getattr(store, "keys", None) or getattr(store, "list_keys", None)
+    keys_fn = getattr(store, "keys", None)
     if keys_fn is None:
         return 0
-    async for key in keys_fn(collection="tokens"):
+    keys = await keys_fn(collection="tokens")
+    for key in keys:
         raw = await store.get(collection="tokens", key=key)
         if raw is None:
             continue
@@ -2952,7 +3020,7 @@ logger = logging.getLogger("fastmcp_pvl_core.file_exchange")
 # pvl-core owns shape decisions). Not a kwarg.
 _ADVERTISED_DIGESTS: tuple[str, ...] = ("sha-256",)
 
-_HTTP_TRANSPORTS = ("http", "sse")
+_HTTP_TRANSPORTS = ("http", "sse")  # FastMCP serves an HTTP app under both transports
 
 
 def _transports_for_role(
@@ -3116,7 +3184,7 @@ def test_build_pull_response_emits_handle_in_meta() -> None:
     src = SourceDescriptor.model_validate({"transport": "filesystem", "uri": "exchange://v/x.txt"})
     result = build_pull_response(artifact, sources=[src])
     assert result.isError in (False, None)
-    meta = result._meta or {}
+    meta = result.meta or {}
     handle = meta["nl.liesdonk.file-exchange"]["handle"]
     assert handle["artifact"]["id"] == "a1"
     assert handle["sources"][0]["transport"] == "filesystem"
@@ -3144,7 +3212,7 @@ def test_build_intake_response_emits_ticket_in_meta() -> None:
     sink = SinkDescriptor.model_validate({"transport": "filesystem", "uri": "exchange://v/a1.bin"})
     ticket = open_intake(sinks=[sink], artifact_id="a1")
     result = build_intake_response(ticket)
-    meta = result._meta or {}
+    meta = result.meta or {}
     out = meta["nl.liesdonk.file-exchange"]["ticket"]
     assert out["artifactId"] == "a1"
 
@@ -3239,7 +3307,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from mcp.types import TextContent
-from fastmcp.tools.tool import ToolResult as CallToolResult
+from mcp.types import CallToolResult, TextContent
 
 from ._errors import CAPABILITY_KEY
 from ._types import ArtifactMetadata, SourceDescriptor, TransferHandle
@@ -3342,11 +3410,19 @@ async def pull_artifact(
         )
         await pull_download(chosen.root.url, dest=dest, ssrf=ssrf, digester=digester)
     if digester is not None and h.artifact.digest:
-        expected = h.artifact.digest.split("=", 1)[-1]
-        if digester.hexdigest() != expected.lower().lstrip(":"):
+        # Per spec §7.1, artifact.digest is `<algorithm>:<lowercase-hex>`,
+        # e.g. ``sha-256:9f86d0...``. We only support sha-256 in v0.1.
+        algo, _, expected_hex = h.artifact.digest.partition(":")
+        if algo == "sha-256":
+            if digester.hexdigest() != expected_hex.lower():
+                raise FileExchangeError(
+                    code=FileExchangeErrorCode.DIGEST_MISMATCH,
+                    detail=f"computed digest does not match artifact.digest for {h.artifact.id!r}",
+                )
+        else:
             raise FileExchangeError(
                 code=FileExchangeErrorCode.DIGEST_MISMATCH,
-                detail=f"computed digest does not match artifact.digest for {h.artifact.id!r}",
+                detail=f"artifact.digest algorithm {algo!r} is not supported (v0.1 supports sha-256 only)",
             )
     return h.artifact
 
@@ -3400,7 +3476,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from mcp.types import TextContent
-from fastmcp.tools.tool import ToolResult as CallToolResult
+from mcp.types import CallToolResult, TextContent
 
 from ._errors import CAPABILITY_KEY
 from ._provider import _auto_summary
@@ -3843,7 +3919,7 @@ async def test_provider_to_fetcher_filesystem_round_trip(
     source = make_filesystem_source("shared", "report.md", config=p_cfg)
     artifact = ArtifactMetadata.model_validate({"id": "r1", "name": "report.md", "size": 5, "mimeType": "text/markdown"})
     result = build_pull_response(artifact, sources=[source])
-    handle_json = (result._meta or {})["nl.liesdonk.file-exchange"]["handle"]
+    handle_json = (result.meta or {})["nl.liesdonk.file-exchange"]["handle"]
     # Fetcher consumes
     out = tmp_path / "fetched.bin"
     fetched = await pull_artifact(handle_json, dest=out, config=f_cfg)
@@ -4028,7 +4104,7 @@ async def test_fetcher_prefers_filesystem_when_provider_offers_both(
         {"id": "n1", "name": "note.md", "size": len(payload), "mimeType": "text/markdown"}
     )
     result = build_pull_response(artifact, sources=[dl_src, fs_src])   # download first; selection picks filesystem
-    handle_json = (result._meta or {})["nl.liesdonk.file-exchange"]["handle"]
+    handle_json = (result.meta or {})["nl.liesdonk.file-exchange"]["handle"]
     # Fetcher: configured for filesystem
     f_cfg = ServerConfig(transport="stdio", file_exchange_volumes=f"shared={vol}")
     out = tmp_path / "out.bin"

--- a/docs/superpowers/plans/2026-05-20-file-exchange-implementation.md
+++ b/docs/superpowers/plans/2026-05-20-file-exchange-implementation.md
@@ -578,7 +578,6 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from mcp.types import TextContent
 from mcp.types import CallToolResult, TextContent
 
 CAPABILITY_KEY = "nl.liesdonk.file-exchange"
@@ -1343,38 +1342,43 @@ from fastmcp_pvl_core._file_exchange._transport_https import (
 )
 
 
-def test_ssrf_rejects_http_scheme() -> None:
+@pytest.mark.asyncio
+async def test_ssrf_rejects_http_scheme() -> None:
     cfg = SSRFGuardConfig()
     with pytest.raises(FileExchangeError) as ei:
-        enforce_ssrf("http://example.com/x", config=cfg)
+        await enforce_ssrf("http://example.com/x", config=cfg)
     assert ei.value.code is FileExchangeErrorCode.NOT_ACCESSIBLE
     assert "https" in ei.value.detail
 
 
-def test_ssrf_rejects_loopback_by_default() -> None:
+@pytest.mark.asyncio
+async def test_ssrf_rejects_loopback_by_default() -> None:
     cfg = SSRFGuardConfig()
     with pytest.raises(FileExchangeError) as ei:
-        enforce_ssrf("https://127.0.0.1/x", config=cfg)
+        await enforce_ssrf("https://127.0.0.1/x", config=cfg)
     assert ei.value.code is FileExchangeErrorCode.NOT_ACCESSIBLE
 
 
-def test_ssrf_allows_loopback_when_opted_in() -> None:
+@pytest.mark.asyncio
+async def test_ssrf_allows_loopback_when_opted_in() -> None:
     cfg = SSRFGuardConfig(allow_loopback=True)
     # Must not raise; returns the pinned IP for connect-pinning.
-    pinned = enforce_ssrf("https://127.0.0.1/x", config=cfg)
+    pinned = await enforce_ssrf("https://127.0.0.1/x", config=cfg)
     assert pinned == "127.0.0.1"
 
 
-def test_ssrf_rejects_private_rfc1918_by_default() -> None:
+@pytest.mark.asyncio
+async def test_ssrf_rejects_private_rfc1918_by_default() -> None:
     cfg = SSRFGuardConfig()
     with pytest.raises(FileExchangeError) as ei:
-        enforce_ssrf("https://10.0.0.5/x", config=cfg)
+        await enforce_ssrf("https://10.0.0.5/x", config=cfg)
     assert ei.value.code is FileExchangeErrorCode.NOT_ACCESSIBLE
 
 
-def test_ssrf_allows_private_when_opted_in() -> None:
+@pytest.mark.asyncio
+async def test_ssrf_allows_private_when_opted_in() -> None:
     cfg = SSRFGuardConfig(allow_private=True)
-    pinned = enforce_ssrf("https://10.0.0.5/x", config=cfg)
+    pinned = await enforce_ssrf("https://10.0.0.5/x", config=cfg)
     assert pinned == "10.0.0.5"
 ```
 
@@ -1403,6 +1407,22 @@ class _FakeAsyncStream:
             raise RuntimeError(f"HTTP {self.status_code}")
 
 
+def _fake_stream_get_cm(chunks: list[bytes], headers: dict[str, str] | None = None):
+    """Build an @asynccontextmanager that yields a _FakeAsyncStream.
+
+    The production ``_stream_get`` is an async context manager (wraps
+    ``httpx.AsyncClient.stream``), so monkeypatches must match that
+    shape — a plain ``async def`` mock would fail at ``async with``.
+    """
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _fake_get(url: str, **_kw):
+        yield _FakeAsyncStream(chunks, headers=headers or {})
+
+    return _fake_get
+
+
 @pytest.mark.asyncio
 async def test_pull_download_streams_chunks_into_dest_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1411,11 +1431,9 @@ async def test_pull_download_streams_chunks_into_dest_path(
     payload = b"hello world " * 100
     chunks = [payload[i : i + 16] for i in range(0, len(payload), 16)]
 
-    async def _fake_get(url: str, **_kw):
-        return _FakeAsyncStream(chunks, headers={"content-length": str(len(payload))})
-
     monkeypatch.setattr(
-        "fastmcp_pvl_core._file_exchange._transport_https._stream_get", _fake_get
+        "fastmcp_pvl_core._file_exchange._transport_https._stream_get",
+        _fake_stream_get_cm(chunks, headers={"content-length": str(len(payload))}),
     )
     digester = hashlib.sha256()
     await pull_download(
@@ -1435,11 +1453,9 @@ async def test_pull_download_streams_into_binaryio(
     payload = b"abc" * 1000
     chunks = [payload[i : i + 128] for i in range(0, len(payload), 128)]
 
-    async def _fake_get(url: str, **_kw):
-        return _FakeAsyncStream(chunks)
-
     monkeypatch.setattr(
-        "fastmcp_pvl_core._file_exchange._transport_https._stream_get", _fake_get
+        "fastmcp_pvl_core._file_exchange._transport_https._stream_get",
+        _fake_stream_get_cm(chunks),
     )
     buf = io.BytesIO()
     await pull_download(
@@ -1519,6 +1535,8 @@ import asyncio
 import hashlib
 import ipaddress
 import socket
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, BinaryIO
@@ -1543,14 +1561,15 @@ class SSRFGuardConfig:
     allow_private: bool = False
 
 
-def enforce_ssrf(url: str, *, config: SSRFGuardConfig) -> str:
+async def enforce_ssrf(url: str, *, config: SSRFGuardConfig) -> str:
     """Validate ``url`` and return the pinned IP literal.
 
     Rejects non-``https`` scheme, loopback (unless allowed), RFC 1918 /
-    link-local (unless allowed). Pinning the resolved IP defeats DNS
-    rebinding — callers pass the returned literal to httpx via
-    ``client.transport = httpx.AsyncHTTPTransport(local_address=...)`` or
-    via ``URL.copy_with(host=ip)``.
+    link-local (unless allowed). DNS resolution is dispatched off the
+    event loop via ``asyncio.to_thread`` so the call does not block
+    other tasks — `socket.gethostbyname` is a synchronous syscall.
+    Pinning the resolved IP defeats DNS rebinding: callers connect to
+    the returned literal and set TLS/SNI to the original hostname.
     """
     parts = urlsplit(url)
     if parts.scheme != "https":
@@ -1568,7 +1587,7 @@ def enforce_ssrf(url: str, *, config: SSRFGuardConfig) -> str:
         ip = ipaddress.ip_address(host)
     except ValueError:
         try:
-            resolved = socket.gethostbyname(host)
+            resolved = await asyncio.to_thread(socket.gethostbyname, host)
         except socket.gaierror as exc:
             raise FileExchangeError(
                 code=FileExchangeErrorCode.NOT_ACCESSIBLE,
@@ -1588,50 +1607,37 @@ def enforce_ssrf(url: str, *, config: SSRFGuardConfig) -> str:
     return str(ip)
 
 
-def _pinned_transport(host: str, pinned_ip: str) -> httpx.AsyncHTTPTransport:
-    """Return an httpx transport that dials ``pinned_ip`` instead of resolving
-    ``host`` again. Defeats DNS rebinding: the SSRF check resolves once, the
-    connect uses the pinned literal — and TLS/SNI still sees the original host.
-    """
-    return httpx.AsyncHTTPTransport(
-        retries=0,
-        # httpx >=0.27: ``local_address`` configures source IP, not destination.
-        # Destination pinning is via the ``transport``'s connection pool. We
-        # rewrite the URL host to the IP and set the Host header to the original
-        # name; TLS SNI is taken from the URL host so we also need to keep the
-        # original hostname for cert validation. The httpx idiom for that is
-        # ``client.get(url_with_ip, extensions={"sni_hostname": host})``.
-    )
-
-
+@asynccontextmanager
 async def _stream_get(
     url: str,
     *,
     pinned_ip: str,
     host: str,
     headers: dict[str, str] | None = None,
-) -> Any:
+) -> AsyncIterator[httpx.Response]:
     """Production GET seam — monkeypatched in unit tests.
 
-    Connects to ``pinned_ip`` (defeats DNS rebinding) with TLS SNI / Host header
-    set to the original ``host``. Returns an object with ``.aiter_bytes(chunk_size)``,
-    ``.headers``, ``.status_code``, and ``.raise_for_status()`` (httpx-shaped).
+    Yielded as an async context manager so the response body is truly
+    chunk-streamed via ``client.stream("GET", ...)`` rather than buffered
+    by ``client.get()``. The client stays open for the duration of the
+    ``async with`` block — closing it ends the stream.
+
+    DNS-rebind defence: the request URL has its host swapped for the
+    pinned IP literal; TLS SNI and the ``Host`` header keep the original
+    hostname so cert validation still works.
     """
-    parts = urlsplit(url)
     pinned_url = url.replace(f"//{host}", f"//{pinned_ip}", 1)
     merged_headers = {"Host": host, **(headers or {})}
-    client = httpx.AsyncClient(transport=_pinned_transport(host, pinned_ip))
-    try:
-        resp = await client.get(
+    async with httpx.AsyncClient() as client:
+        async with client.stream(
+            "GET",
             pinned_url,
             headers=merged_headers,
             follow_redirects=False,
             extensions={"sni_hostname": host},
-        )
-        resp.raise_for_status()
-        return resp
-    finally:
-        await client.aclose()
+        ) as resp:
+            resp.raise_for_status()
+            yield resp
 
 
 async def _stream_put(
@@ -1641,16 +1647,18 @@ async def _stream_put(
     host: str,
     content: Any,
     headers: dict[str, str],
-) -> Any:
+) -> httpx.Response:
     """Production PUT seam — monkeypatched in unit tests.
 
     Same SNI/Host pinning posture as ``_stream_get``. Accepts either a file-like
-    opened in ``"rb"`` or an async-iterator of bytes chunks.
+    opened in ``"rb"`` or an async-iterator of bytes chunks; httpx streams
+    the request body chunk-by-chunk from the supplied source — no full-buffer.
+    The response body is small (status confirmation), so it's fine to await
+    the full response here without streaming.
     """
     pinned_url = url.replace(f"//{host}", f"//{pinned_ip}", 1)
     merged_headers = {"Host": host, **headers}
-    client = httpx.AsyncClient(transport=_pinned_transport(host, pinned_ip))
-    try:
+    async with httpx.AsyncClient() as client:
         resp = await client.put(
             pinned_url,
             content=content,
@@ -1660,8 +1668,6 @@ async def _stream_put(
         )
         resp.raise_for_status()
         return resp
-    finally:
-        await client.aclose()
 
 
 async def pull_download(
@@ -1679,23 +1685,23 @@ async def pull_download(
     blocked on disk latency. Caller verifies the final digest against
     artifact.digest after this returns.
     """
-    pinned_ip = enforce_ssrf(url, config=ssrf)
+    pinned_ip = await enforce_ssrf(url, config=ssrf)
     host = urlsplit(url).hostname or ""
-    resp = await _stream_get(url, pinned_ip=pinned_ip, host=host)
-    if isinstance(dest, Path):
-        # Lazy import to avoid a circular cycle in the package layout.
-        from ._transport_filesystem import async_atomic_write
+    async with _stream_get(url, pinned_ip=pinned_ip, host=host) as resp:
+        if isinstance(dest, Path):
+            # Lazy import to avoid a circular cycle in the package layout.
+            from ._transport_filesystem import async_atomic_write
 
-        async with async_atomic_write(dest) as fh:
+            async with async_atomic_write(dest) as fh:
+                async for chunk in resp.aiter_bytes(chunk_size):
+                    if digester is not None:
+                        digester.update(chunk)
+                    await asyncio.to_thread(fh.write, chunk)
+        else:
             async for chunk in resp.aiter_bytes(chunk_size):
                 if digester is not None:
                     digester.update(chunk)
-                await asyncio.to_thread(fh.write, chunk)
-    else:
-        async for chunk in resp.aiter_bytes(chunk_size):
-            if digester is not None:
-                digester.update(chunk)
-            await asyncio.to_thread(dest.write, chunk)
+                await asyncio.to_thread(dest.write, chunk)
 
 
 async def push_upload(
@@ -1713,7 +1719,7 @@ async def push_upload(
     httpx (httpx streams it). For a ``BinaryIO``, passes directly. Never
     assembles a ``bytes`` blob.
     """
-    pinned_ip = enforce_ssrf(url, config=ssrf)
+    pinned_ip = await enforce_ssrf(url, config=ssrf)
     host = urlsplit(url).hostname or ""
     headers: dict[str, str] = {"Content-Type": content_type}
     if content_digest is not None:
@@ -2566,6 +2572,8 @@ async def test_upload_rejects_digest_mismatch_with_422(
     app, store = app_and_store
     from fastmcp_pvl_core._file_exchange._types import ExpectedConstraints
 
+    import base64
+
     intake = tmp_path / "o.bin"
     sink = await mint_upload_sink(
         intake_path=intake, artifact_id="a1", server=mcp, config=cfg, kv_store=store,
@@ -2573,7 +2581,11 @@ async def test_upload_rejects_digest_mismatch_with_422(
     )
     token = sink.root.url.rsplit("/", 1)[-1]
     body = b"abc"
-    wrong = "sha-256=:" + "0" * 44 + "=:"
+    # 32 zero bytes is a valid-length sha-256 digest, but it's the wrong
+    # digest for body=b"abc" (whose real sha-256 is ba7816bf...). A test
+    # that uses an invalid base64 length would assert for the wrong reason
+    # (length-decode failure, not digest mismatch).
+    wrong = "sha-256=:" + base64.b64encode(bytes(32)).decode("ascii") + ":"
     with TestClient(app) as client:
         r = client.put(
             f"/file-exchange/u/{token}",
@@ -3306,7 +3318,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-from mcp.types import TextContent
 from mcp.types import CallToolResult, TextContent
 
 from ._errors import CAPABILITY_KEY
@@ -3475,7 +3486,6 @@ import uuid
 from collections.abc import Sequence
 from typing import Any
 
-from mcp.types import TextContent
 from mcp.types import CallToolResult, TextContent
 
 from ._errors import CAPABILITY_KEY

--- a/docs/superpowers/plans/2026-05-20-file-exchange-implementation.md
+++ b/docs/superpowers/plans/2026-05-20-file-exchange-implementation.md
@@ -27,9 +27,9 @@ _file_exchange/
     _types.py                         # Pydantic models for refs, descriptors, errors
     _select.py                        # selection algorithm (§9 of spec)
     _errors.py                        # FileExchangeError + code constants + envelope
-    _transport_filesystem.py          # exchange:// resolution, atomic_write, mint helpers
-    _transport_https.py               # pull_download, push_upload, SSRF guard
-    _url_store.py                     # capability URL minting; intake correlation
+    _transport_filesystem.py          # exchange:// resolution, atomic_write, filesystem-source mint helper
+    _transport_https.py               # pull_download (with streaming digester), push_upload, SSRF guard
+    _url_store.py                     # capability URL minting; intake correlation; filesystem-sink + HTTPS mint helpers
     _routes.py                        # GET /file-exchange/d/<token>, PUT|POST /u/<token>
     _provider.py                      # build_pull_response
     _fetcher.py                       # pull_artifact
@@ -193,21 +193,21 @@ from fastmcp_pvl_core._file_exchange._types import (
 
 def test_filesystem_source_descriptor_roundtrips():
     raw = {"transport": "filesystem", "uri": "exchange://vault/notes/n1.md"}
-    desc = SourceDescriptor.validate_python(raw)
+    desc = SourceDescriptor.model_validate(raw)
     assert isinstance(desc.root, FilesystemSourceDescriptor)
     assert desc.root.uri == "exchange://vault/notes/n1.md"
 
 
 def test_download_source_descriptor_requires_expires_at():
     with pytest.raises(ValidationError):
-        SourceDescriptor.validate_python({"transport": "download", "url": "https://x/y"})
+        SourceDescriptor.model_validate({"transport": "download", "url": "https://x/y"})
 
 
 def test_descriptor_unknown_transport_is_rejected_at_typed_layer():
     """The typed layer rejects unknown transports — selection-level fallthrough
     (§17.2 'tolerant reading') is handled in _select.py, not by the discriminator."""
     with pytest.raises(ValidationError):
-        SourceDescriptor.validate_python({"transport": "carrier-pigeon", "uri": "x"})
+        SourceDescriptor.model_validate({"transport": "carrier-pigeon", "uri": "x"})
 
 
 def test_transfer_handle_requires_at_least_one_source():
@@ -1190,15 +1190,86 @@ def atomic_write(target: Path) -> Iterator[object]:
         raise
 ```
 
+### Step C.3: Implement `make_filesystem_source`
+
+Per design §3, pvl-core exposes a public mint helper for the filesystem-source case
+so downstream never hand-writes a `FilesystemSourceDescriptor`. The helper validates
+the volume against `config.file_exchange_volumes` so a misconfigured volume name is
+rejected at mint time, not later at the consumer.
+
+- [ ] Add tests to `tests/file_exchange/test_transport_filesystem.py`:
+
+```python
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange._transport_filesystem import (
+    make_filesystem_source,
+)
+
+
+def _config(**kw) -> ServerConfig:
+    base = dict(transport="stdio")
+    base.update(kw)
+    return ServerConfig(**base)
+
+
+def test_make_filesystem_source_happy_path(tmp_path: Path):
+    config = _config(file_exchange_volumes=f"vault={tmp_path}")
+    desc = make_filesystem_source("vault", "report.parquet", config=config)
+    assert desc.root.transport == "filesystem"
+    assert desc.root.uri == "exchange://vault/report.parquet"
+
+
+def test_make_filesystem_source_unknown_volume_raises(tmp_path: Path):
+    config = _config(file_exchange_volumes=f"vault={tmp_path}")
+    with pytest.raises(FileExchangeError) as exc:
+        make_filesystem_source("missing", "x.bin", config=config)
+    assert exc.value.code == FileExchangeErrorCode.NOT_ACCESSIBLE
+```
+
+- [ ] Append to `src/fastmcp_pvl_core/_file_exchange/_transport_filesystem.py`:
+
+```python
+def make_filesystem_source(
+    volume: str,
+    relative_path: str,
+    *,
+    config: "ServerConfig",
+) -> "SourceDescriptor":
+    """Mint a filesystem-transport SourceDescriptor for ``volume/relative_path``.
+
+    Validates ``volume`` against the operator's volume map (parsed from
+    ``config.file_exchange_volumes``). A volume not declared in the deployment
+    is rejected here so the downstream tool body fails fast rather than emitting
+    a descriptor that no consumer can resolve.
+    """
+    from ._types import SourceDescriptor
+
+    volumes = parse_volumes(config.file_exchange_volumes)
+    if volume not in volumes:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            transport="filesystem",
+            detail=f"no mapping configured for volume {volume!r}",
+        )
+    rel = relative_path.lstrip("/")
+    return SourceDescriptor.model_validate(
+        {"transport": "filesystem", "uri": f"exchange://{volume}/{rel}"}
+    )
+```
+
+(The `make_filesystem_sink` minter lives in Task E's `_url_store.py` because it
+must also record the resolved intake path so `resolve_intake` can locate the
+bytes later.)
+
 - [ ] Run the tests:
 
 ```bash
 uv run pytest tests/file_exchange/test_transport_filesystem.py -v
 ```
 
-Expected: PASS (all 9 tests).
+Expected: PASS (all 11 tests).
 
-### Step C.3: Commit and PR
+### Step C.4: Commit and PR
 
 - [ ] Commit:
 
@@ -1294,7 +1365,7 @@ import ipaddress
 import socket
 from dataclasses import dataclass
 from pathlib import Path
-from typing import BinaryIO
+from typing import Any, BinaryIO
 
 import httpx
 
@@ -1472,6 +1543,7 @@ async def pull_download(
     *,
     dest: BinaryIO | Path,
     ssrf: SSRFGuardConfig,
+    digester: "Any | None" = None,
     client_transport: httpx.AsyncBaseTransport | None = None,
     chunk_size: int = 65536,
 ) -> int:
@@ -1480,6 +1552,14 @@ async def pull_download(
     Streams to ``dest`` (either an open writable BinaryIO or a Path; for Path
     pvl-core uses the filesystem-transport's atomic_write context manager so
     a partial write is never observed).
+
+    If ``digester`` is provided (a ``hashlib._Hash``-like object exposing
+    ``update``), each received chunk is fed into it *before* being written.
+    Callers (notably ``pull_artifact``) keep the same digester across the
+    transfer so the post-fetch digest check sees the bytes actually received.
+
+    Sync writes inside this async function are dispatched via
+    ``asyncio.to_thread`` so the event loop is never blocked on disk latency.
 
     SSRF guard runs; non-https URLs are refused; cross-origin redirects are refused;
     no ambient credentials are attached.
@@ -1533,13 +1613,17 @@ async def pull_download(
                 bytes_written = 0
                 with atomic_write(dest) as f:
                     async for chunk in response.aiter_bytes(chunk_size):
-                        f.write(chunk)
+                        if digester is not None:
+                            digester.update(chunk)
+                        await asyncio.to_thread(f.write, chunk)
                         bytes_written += len(chunk)
                 return bytes_written
 
             bytes_written = 0
             async for chunk in response.aiter_bytes(chunk_size):
-                dest.write(chunk)
+                if digester is not None:
+                    digester.update(chunk)
+                await asyncio.to_thread(dest.write, chunk)
                 bytes_written += len(chunk)
             return bytes_written
 
@@ -1675,7 +1759,7 @@ async def test_minted_download_token_is_url_safe_random(store: MemoryStore):
 
 
 @pytest.mark.asyncio
-async def test_consume_download_token_flips_single_use(store: MemoryStore):
+async def test_consume_download_token_single_use(store: MemoryStore):
     expires = datetime.now(timezone.utc) + timedelta(hours=1)
     tok = await mint_download_token(
         store=store, bytes_path=Path("/tmp/x.bin"), expires_at=expires, single_use=True
@@ -1684,9 +1768,31 @@ async def test_consume_download_token_flips_single_use(store: MemoryStore):
     record = await consume_download_token(store=store, token=tok)
     assert record.bytes_path == Path("/tmp/x.bin")
 
-    # Second consume MUST fail because single_use already flipped consumed.
+    # Second consume MUST fail because the get-then-delete pattern already
+    # removed the entry on the first successful consume.
     with pytest.raises(LookupError):
         await consume_download_token(store=store, token=tok)
+
+
+@pytest.mark.asyncio
+async def test_consume_download_token_concurrent_consumers(store: MemoryStore):
+    """Two concurrent consumers race on a single-use token; exactly one wins."""
+    import asyncio
+
+    expires = datetime.now(timezone.utc) + timedelta(hours=1)
+    tok = await mint_download_token(
+        store=store, bytes_path=Path("/tmp/x.bin"), expires_at=expires, single_use=True
+    )
+
+    results = await asyncio.gather(
+        consume_download_token(store=store, token=tok),
+        consume_download_token(store=store, token=tok),
+        return_exceptions=True,
+    )
+    successes = [r for r in results if not isinstance(r, BaseException)]
+    failures = [r for r in results if isinstance(r, LookupError)]
+    assert len(successes) == 1
+    assert len(failures) == 1
 
 
 @pytest.mark.asyncio
@@ -1710,6 +1816,24 @@ async def test_intake_path_correlation(store: MemoryStore):
 async def test_intake_path_for_missing_artifact_returns_none(store: MemoryStore):
     p = await intake_path_for(store=store, artifact_id="never-minted")
     assert p is None
+
+
+@pytest.mark.asyncio
+async def test_mint_and_consume_never_logs_full_token(caplog, store: MemoryStore):
+    """Capability URLs are bearer credentials; full tokens MUST NOT appear in logs."""
+    import logging
+
+    caplog.set_level(logging.DEBUG, logger="fastmcp_pvl_core.file_exchange")
+    expires = datetime.now(timezone.utc) + timedelta(hours=1)
+    token = await mint_download_token(
+        store=store, bytes_path=Path("/tmp/x.bin"), expires_at=expires, single_use=True
+    )
+    record = await consume_download_token(store=store, token=token)
+    full_log = " ".join(rec.getMessage() for rec in caplog.records)
+    assert token not in full_log, "capability tokens MUST NOT appear in logs"
+    # A fingerprint (first 8 chars + ellipsis) is acceptable; the test
+    # exists so the implementation actually emits log lines we can inspect.
+    assert record is not None
 ```
 
 - [ ] Run the test:
@@ -1737,13 +1861,23 @@ Two collections inside the namespace:
 
 from __future__ import annotations
 
+import logging
 import secrets
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from key_value.aio.protocols.key_value import AsyncKeyValue
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from ._types import ExpectedConstraints, SinkDescriptor, SourceDescriptor
+
+
+_logger = logging.getLogger("fastmcp_pvl_core.file_exchange")
 
 
 TOKEN_BYTES = 16  # 128 bits → 22 base64url chars
@@ -1787,16 +1921,24 @@ async def mint_download_token(
     expires_at: datetime,
     single_use: bool = True,
 ) -> str:
-    """Mint a download capability token; return the token string."""
+    """Mint a download capability token; return the token string.
+
+    Logs at DEBUG with a fingerprint of the form ``tok=<first-8-chars>...``;
+    the full token never enters any log line (spec §12 bearer-credential hygiene).
+    """
     token = _new_token()
     record = {
         "kind": "download",
         "bytes_path": str(bytes_path),
         "expires_at": expires_at.isoformat(),
         "single_use": single_use,
-        "consumed": False,
     }
     await store.put(collection="tokens", key=token, value=record)
+    _logger.debug(
+        "file-exchange: minted download token tok=%s... ttl=%ds",
+        token[:8],
+        int((expires_at - _now()).total_seconds()),
+    )
     return token
 
 
@@ -1810,7 +1952,10 @@ async def mint_upload_token(
     accept_mime_types: list[str] | None = None,
     require_digest: list[str] | None = None,
 ) -> str:
-    """Mint an upload capability token; return the token string."""
+    """Mint an upload capability token; return the token string.
+
+    Logs at DEBUG with a fingerprint only; never the full token (spec §12).
+    """
     token = _new_token()
     record = {
         "kind": "upload",
@@ -1820,21 +1965,32 @@ async def mint_upload_token(
         "max_size": max_size,
         "accept_mime_types": accept_mime_types,
         "require_digest": require_digest,
-        "consumed": False,
     }
     await store.put(collection="tokens", key=token, value=record)
+    _logger.debug(
+        "file-exchange: minted upload token tok=%s... ttl=%ds",
+        token[:8],
+        int((expires_at - _now()).total_seconds()),
+    )
     return token
 
 
 async def consume_download_token(
     *, store: AsyncKeyValue, token: str
 ) -> DownloadTokenRecord:
+    """Consume a download token.
+
+    Uses a per-key get-then-delete pattern: ``AsyncKeyValue.delete`` is atomic
+    per key on every supported backend, so a racing second consumer either
+    finds the key already gone on ``get`` or loses the delete race here and
+    raises ``LookupError`` — exactly one consumer wins.
+    """
     raw = await store.get(collection="tokens", key=token)
     if raw is None or raw.get("kind") != "download":
         raise LookupError("download token not found")
     expires_at = datetime.fromisoformat(raw["expires_at"])
-    if _is_expired(expires_at) or raw.get("consumed", False):
-        raise LookupError("download token expired or already consumed")
+    if _is_expired(expires_at):
+        raise LookupError("download token expired")
 
     record = DownloadTokenRecord(
         bytes_path=Path(raw["bytes_path"]),
@@ -1844,27 +2000,37 @@ async def consume_download_token(
     )
 
     if record.single_use:
-        # Atomically flip consumed.  AsyncKeyValue.put is the unit of atomicity here;
-        # callers MUST treat double-consume as the failure case the test exercises.
-        await store.put(
-            collection="tokens",
-            key=token,
-            value={**raw, "consumed": True},
-        )
-
+        # Atomic per-key delete: a racing consumer hits LookupError on its own
+        # get or here on its delete. The first delete wins.
+        deleted = await store.delete(collection="tokens", key=token)
+        if not deleted:
+            raise LookupError("download token already consumed by a concurrent consumer")
+    _logger.debug(
+        "file-exchange: consumed download token tok=%s... single_use=%s",
+        token[:8],
+        record.single_use,
+    )
     return record
 
 
 async def consume_upload_token(
     *, store: AsyncKeyValue, token: str
 ) -> UploadTokenRecord:
+    """Consume an upload token.
+
+    Same get-then-delete pattern as ``consume_download_token``. The intake
+    correlation under ``intake:<artifact_id>`` is a different key and
+    survives the token deletion — that is what lets ``resolve_intake`` find
+    the bytes after the upload completes.
+    """
     raw = await store.get(collection="tokens", key=token)
     if raw is None or raw.get("kind") != "upload":
         raise LookupError("upload token not found")
     expires_at = datetime.fromisoformat(raw["expires_at"])
-    if _is_expired(expires_at) or raw.get("consumed", False):
-        raise LookupError("upload token expired or already consumed")
-    return UploadTokenRecord(
+    if _is_expired(expires_at):
+        raise LookupError("upload token expired")
+
+    record = UploadTokenRecord(
         intake_path=Path(raw["intake_path"]),
         artifact_id=raw["artifact_id"],
         expires_at=expires_at,
@@ -1874,18 +2040,26 @@ async def consume_upload_token(
         consumed=False,
     )
 
-
-async def mark_upload_consumed(*, store: AsyncKeyValue, token: str) -> None:
-    raw = await store.get(collection="tokens", key=token)
-    if raw is None:
-        return
-    await store.put(collection="tokens", key=token, value={**raw, "consumed": True})
+    deleted = await store.delete(collection="tokens", key=token)
+    if not deleted:
+        raise LookupError("upload token already consumed by a concurrent consumer")
+    _logger.debug(
+        "file-exchange: consumed upload token tok=%s... artifact_id=%s",
+        token[:8],
+        record.artifact_id,
+    )
+    return record
 
 
 async def record_intake_path(
     *, store: AsyncKeyValue, artifact_id: str, path: Path
 ) -> None:
-    """Record (artifact_id → resolved intake path) so resolve_intake can find it."""
+    """Record (artifact_id → resolved intake path) so resolve_intake can find it.
+
+    Called by both sink-minters (``make_filesystem_sink`` and ``mint_upload_sink``)
+    at mint time, so the intake mapping exists regardless of which transport
+    the sender ultimately picks.
+    """
     await store.put(
         collection="intake", key=artifact_id, value={"path": str(path)}
     )
@@ -1898,6 +2072,120 @@ async def intake_path_for(
     if raw is None:
         return None
     return Path(raw["path"])
+
+
+# ---- Public mint helpers (design §3 "Descriptor minting (producer side)") ----
+
+
+async def make_filesystem_sink(
+    volume: str,
+    relative_path: str,
+    *,
+    artifact_id: str,
+    config: "ServerConfig",
+    kv_store: AsyncKeyValue,
+) -> "SinkDescriptor":
+    """Mint a filesystem-transport SinkDescriptor and record the intake mapping.
+
+    Resolves the ``exchange://`` URI immediately so the intake path is recorded
+    in ``kv_store`` before the descriptor leaves the producer. ``resolve_intake``
+    then finds the bytes via the recorded mapping regardless of how the sender
+    delivered them.
+    """
+    from ._transport_filesystem import parse_volumes, resolve_exchange_uri
+    from ._types import SinkDescriptor
+
+    volumes = parse_volumes(config.file_exchange_volumes)
+    rel = relative_path.lstrip("/")
+    uri = f"exchange://{volume}/{rel}"
+    resolved = resolve_exchange_uri(uri, volumes=volumes)
+    await record_intake_path(store=kv_store, artifact_id=artifact_id, path=resolved)
+    return SinkDescriptor.model_validate({"transport": "filesystem", "uri": uri})
+
+
+async def mint_download_source(
+    *,
+    bytes_path: Path,
+    server: "FastMCP",
+    config: "ServerConfig",
+    kv_store: AsyncKeyValue,
+    expires_in_s: int | None = None,
+    single_use: bool = True,
+) -> "SourceDescriptor":
+    """Mint a download-transport SourceDescriptor backed by a fresh capability URL.
+
+    ``server`` and ``config`` are used to compute the public base URL via the
+    existing ``compute_app_domain`` helper (overridable via
+    ``config.file_exchange_https_public_base_url``).
+    """
+    from datetime import timedelta
+
+    from .._helpers import compute_app_domain  # existing pvl-core helper
+    from ._types import SourceDescriptor
+
+    ttl = expires_in_s if expires_in_s is not None else config.file_exchange_capability_url_ttl_default_s
+    if ttl <= 0:
+        raise ValueError("expires_in_s must be > 0")
+    expires_at = _now() + timedelta(seconds=ttl)
+    token = await mint_download_token(
+        store=kv_store, bytes_path=bytes_path, expires_at=expires_at, single_use=single_use
+    )
+    base = config.file_exchange_https_public_base_url or compute_app_domain(server, config)
+    url = f"{base.rstrip('/')}/file-exchange/d/{token}"
+    return SourceDescriptor.model_validate(
+        {
+            "transport": "download",
+            "url": url,
+            "expiresAt": expires_at.isoformat(),
+            "singleUse": single_use,
+        }
+    )
+
+
+async def mint_upload_sink(
+    *,
+    intake_path: Path,
+    artifact_id: str,
+    server: "FastMCP",
+    config: "ServerConfig",
+    kv_store: AsyncKeyValue,
+    expires_in_s: int | None = None,
+    expected: "ExpectedConstraints | None" = None,
+) -> "SinkDescriptor":
+    """Mint an upload-transport SinkDescriptor and record the intake mapping.
+
+    The intake path is recorded under ``intake:<artifact_id>`` at mint time;
+    after the upload route writes the bytes, ``resolve_intake(artifact_id)``
+    returns this path.
+    """
+    from datetime import timedelta
+
+    from .._helpers import compute_app_domain  # existing pvl-core helper
+    from ._types import SinkDescriptor
+
+    ttl = expires_in_s if expires_in_s is not None else config.file_exchange_capability_url_ttl_default_s
+    if ttl <= 0:
+        raise ValueError("expires_in_s must be > 0")
+    expires_at = _now() + timedelta(seconds=ttl)
+    token = await mint_upload_token(
+        store=kv_store,
+        intake_path=intake_path,
+        artifact_id=artifact_id,
+        expires_at=expires_at,
+        max_size=expected.maxSize if expected else None,
+        accept_mime_types=expected.acceptMimeTypes if expected else None,
+        require_digest=expected.requireDigest if expected else None,
+    )
+    await record_intake_path(store=kv_store, artifact_id=artifact_id, path=intake_path)
+    base = config.file_exchange_https_public_base_url or compute_app_domain(server, config)
+    url = f"{base.rstrip('/')}/file-exchange/u/{token}"
+    return SinkDescriptor.model_validate(
+        {
+            "transport": "upload",
+            "url": url,
+            "expiresAt": expires_at.isoformat(),
+        }
+    )
 ```
 
 - [ ] Run the tests:
@@ -1906,7 +2194,139 @@ async def intake_path_for(
 uv run pytest tests/file_exchange/test_url_store.py -v
 ```
 
-Expected: PASS (all 5 tests).
+Expected: PASS (all tests in `test_url_store.py`, including the concurrent-consume and log-discipline tests).
+
+### Step E.2b: Test the public mint helpers
+
+The three sink/source minters that live in `_url_store.py` (alongside their
+filesystem-source sibling in Task C) need happy-path + validation-failure
+coverage. Append to `tests/file_exchange/test_url_store.py`:
+
+```python
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange._types import ExpectedConstraints
+from fastmcp_pvl_core._file_exchange._url_store import (
+    make_filesystem_sink,
+    mint_download_source,
+    mint_upload_sink,
+)
+
+
+def _config(**kw) -> ServerConfig:
+    base = dict(transport="http")
+    base.update(kw)
+    return ServerConfig(**base)
+
+
+@pytest.mark.asyncio
+async def test_make_filesystem_sink_records_intake_mapping(tmp_path: Path, store: MemoryStore):
+    config = _config(file_exchange_volumes=f"intake={tmp_path}")
+    sink = await make_filesystem_sink(
+        "intake", "x.bin", artifact_id="ar-1", config=config, kv_store=store
+    )
+    assert sink.root.transport == "filesystem"
+    assert sink.root.uri == "exchange://intake/x.bin"
+    raw = await store.get(collection="intake", key="ar-1")
+    assert raw is not None
+    assert Path(raw["path"]) == (tmp_path / "x.bin").resolve()
+
+
+@pytest.mark.asyncio
+async def test_make_filesystem_sink_rejects_unknown_volume(tmp_path: Path, store: MemoryStore):
+    config = _config(file_exchange_volumes=f"intake={tmp_path}")
+    with pytest.raises(FileExchangeError) as exc:
+        await make_filesystem_sink(
+            "missing", "x.bin", artifact_id="ar-1", config=config, kv_store=store
+        )
+    assert exc.value.code == FileExchangeErrorCode.NOT_ACCESSIBLE
+
+
+@pytest.mark.asyncio
+async def test_mint_download_source_produces_capability_url(
+    tmp_path: Path, store: MemoryStore, monkeypatch
+):
+    monkeypatch.setattr(
+        "fastmcp_pvl_core._file_exchange._url_store.compute_app_domain",
+        lambda server, config: "https://example.test",
+    )
+    config = _config(file_exchange_capability_url_ttl_default_s=60)
+    bytes_path = tmp_path / "x.bin"
+    bytes_path.write_bytes(b"hello")
+    desc = await mint_download_source(
+        bytes_path=bytes_path,
+        server=object(),  # compute_app_domain is patched, server is not touched
+        config=config,
+        kv_store=store,
+    )
+    assert desc.root.transport == "download"
+    assert str(desc.root.url).startswith("https://example.test/file-exchange/d/")
+
+
+@pytest.mark.asyncio
+async def test_mint_download_source_invalid_config_rejects(tmp_path: Path, store: MemoryStore):
+    """ttl ≤ 0 produces an expiresAt in the past — validation surface."""
+    config = _config(file_exchange_capability_url_ttl_default_s=60)
+    bytes_path = tmp_path / "x.bin"
+    bytes_path.write_bytes(b"hello")
+    with pytest.raises(Exception):
+        # Negative TTL must not silently produce an expired descriptor.
+        await mint_download_source(
+            bytes_path=bytes_path,
+            server=object(),
+            config=config,
+            kv_store=store,
+            expires_in_s=-1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_mint_upload_sink_records_intake_and_mints_url(
+    tmp_path: Path, store: MemoryStore, monkeypatch
+):
+    monkeypatch.setattr(
+        "fastmcp_pvl_core._file_exchange._url_store.compute_app_domain",
+        lambda server, config: "https://example.test",
+    )
+    config = _config(file_exchange_capability_url_ttl_default_s=60)
+    intake = tmp_path / "intake.bin"
+    sink = await mint_upload_sink(
+        intake_path=intake,
+        artifact_id="ar-1",
+        server=object(),
+        config=config,
+        kv_store=store,
+        expected=ExpectedConstraints(maxSize=1024),
+    )
+    assert sink.root.transport == "upload"
+    assert str(sink.root.url).startswith("https://example.test/file-exchange/u/")
+    raw = await store.get(collection="intake", key="ar-1")
+    assert raw is not None
+    assert Path(raw["path"]) == intake
+
+
+@pytest.mark.asyncio
+async def test_mint_upload_sink_validation_failure(tmp_path: Path, store: MemoryStore):
+    """ExpectedConstraints with a negative maxSize must surface at validation."""
+    config = _config()
+    with pytest.raises(Exception):
+        ExpectedConstraints.model_validate({"maxSize": -1})
+```
+
+For mint helpers in this task, the docstring guard against negative TTLs needs
+to be enforced; add to `mint_download_source`/`mint_upload_sink`:
+
+```python
+    if ttl <= 0:
+        raise ValueError("expires_in_s must be > 0")
+```
+
+- [ ] Run the new tests:
+
+```bash
+uv run pytest tests/file_exchange/test_url_store.py -v
+```
+
+Expected: PASS.
 
 ### Step E.3: Test the sibling routes
 
@@ -2023,7 +2443,12 @@ async def test_upload_route_enforces_max_size(
     with TestClient(app) as client:
         resp = client.put(f"/file-exchange/u/{token}", content=b"too much")
     assert resp.status_code == 413
+    # Intake path MUST NOT be written when the upload was rejected mid-stream.
     assert not intake.exists()
+    # No temp files left behind in the intake directory either.
+    if intake.parent.exists():
+        leftover = [p for p in intake.parent.iterdir() if p.name.startswith(".")]
+        assert leftover == []
 ```
 
 ### Step E.4: Implement the routes
@@ -2041,6 +2466,8 @@ Both routes look tokens up in the kv_store passed to ``build_file_exchange_route
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 from pathlib import Path
 
 from key_value.aio.protocols.key_value import AsyncKeyValue
@@ -2052,9 +2479,16 @@ from ._transport_filesystem import atomic_write
 from ._url_store import (
     consume_download_token,
     consume_upload_token,
-    mark_upload_consumed,
     record_intake_path,
 )
+
+
+class _UploadTooLarge(Exception):
+    """Internal signal raised mid-stream when cumulative bytes exceed max_size."""
+
+
+class _UploadMimeRejected(Exception):
+    """Internal signal raised when Content-Type does not match accept_mime_types."""
 
 
 def build_file_exchange_router(*, store: AsyncKeyValue) -> Router:
@@ -2077,24 +2511,44 @@ def build_file_exchange_router(*, store: AsyncKeyValue) -> Router:
         except LookupError:
             return Response(status_code=404)
 
-        # Buffer the body; phase 1 supports up to max_size or 100MB whichever is smaller.
-        body = await request.body()
-        if record.max_size is not None and len(body) > record.max_size:
-            return Response(status_code=413)
-
-        # Optional Content-Type filter
+        # Pre-stream Content-Type check (fast reject before allocating a temp file).
         if record.accept_mime_types:
             content_type = (request.headers.get("content-type") or "").split(";")[0].strip()
             if content_type and not _mime_matches(content_type, record.accept_mime_types):
                 return Response(status_code=415)
 
-        with atomic_write(record.intake_path) as f:
-            f.write(body)
+        # Stream the body chunk-by-chunk into the atomic_write temp file. The
+        # context manager discards the temp file if the body block raises (size
+        # overflow, digest mismatch, transport error). Sync file writes are
+        # dispatched via asyncio.to_thread so the event loop never blocks on disk.
+        cumulative_bytes = 0
+        digester = hashlib.sha256()
+        try:
+            with atomic_write(record.intake_path) as f:
+                async for chunk in request.stream():
+                    if not chunk:
+                        continue
+                    cumulative_bytes += len(chunk)
+                    if record.max_size is not None and cumulative_bytes > record.max_size:
+                        raise _UploadTooLarge()
+                    digester.update(chunk)
+                    await asyncio.to_thread(f.write, chunk)
+        except _UploadTooLarge:
+            return Response(status_code=413)
 
-        await record_intake_path(
-            store=store, artifact_id=record.artifact_id, path=record.intake_path
-        )
-        await mark_upload_consumed(store=store, token=token)
+        # Post-stream digest check against the optional Content-Digest header.
+        content_digest = request.headers.get("content-digest")
+        if content_digest:
+            # RFC 9530 form: sha-256=:<base64>:
+            # Phase 1 accepts the simpler `sha-256:<hex>` form too.
+            algo, _, value = content_digest.partition(":")
+            if algo.lower().strip() in ("sha-256", "sha256") and value.strip().strip(":") != digester.hexdigest():
+                # The atomic_write rename already happened; remove the now-suspect file.
+                record.intake_path.unlink(missing_ok=True)
+                return Response(status_code=422)
+
+        # Intake correlation under intake:<artifact_id> was already recorded at
+        # mint time by the sink-minter; nothing further to do here.
         return Response(status_code=204)
 
     return Router(
@@ -2241,25 +2695,54 @@ def _config(**kw) -> ServerConfig:
 
 
 @pytest.mark.asyncio
-async def test_gating_stdio_without_volumes_advertises_nothing():
+async def test_gating_stdio_no_volumes_advertises_consumer_roles_only():
+    """stdio + no volumes still advertises fetcher+sender via outbound HTTPS.
+
+    Per design §3 transport-availability gating: ``download`` for ``fetcher``
+    and ``upload`` for ``sender`` are always available (outbound HTTPS). The
+    producer-side roles (`provider`, `receiver`) drop because they need an
+    HTTP app to host endpoints, and `filesystem` drops because no volumes
+    are configured.
+    """
     server = _server()
     config = _config()  # stdio, no volumes
     store = MemoryStore()
     register_file_exchange_capability(server, config, kv_store=store)
+    block = server.experimental_capabilities["nl.liesdonk.file-exchange"]
+    roles = block["roles"]
+    assert roles["fetcher"] == ["download"]
+    assert roles["sender"] == ["upload"]
+    assert "provider" not in roles
+    assert "receiver" not in roles
+
+
+@pytest.mark.asyncio
+async def test_gating_advertises_nothing_when_no_role_satisfies_any_transport():
+    """The capability block is absent when no declared role has a viable transport."""
+    server = _server()
+    config = _config()  # stdio, no volumes
+    store = MemoryStore()
+    register_file_exchange_capability(
+        server, config, kv_store=store, roles=("provider", "receiver")
+    )
     caps = server.experimental_capabilities or {}
     assert "nl.liesdonk.file-exchange" not in caps
 
 
 @pytest.mark.asyncio
-async def test_gating_stdio_with_volumes_advertises_filesystem_only():
+async def test_gating_stdio_with_volumes_advertises_filesystem_plus_consumer_https():
+    """stdio + volumes: producer roles get filesystem only; consumer roles get both."""
     server = _server()
     config = _config(file_exchange_volumes="vault=/tmp/vault")
     store = MemoryStore()
     register_file_exchange_capability(server, config, kv_store=store)
     block = server.experimental_capabilities["nl.liesdonk.file-exchange"]
     assert block["version"] == "0.1"
-    for role, transports in block["roles"].items():
-        assert transports == ["filesystem"]
+    roles = block["roles"]
+    assert roles["provider"] == ["filesystem"]
+    assert roles["receiver"] == ["filesystem"]
+    assert set(roles["fetcher"]) == {"filesystem", "download"}
+    assert set(roles["sender"]) == {"filesystem", "upload"}
 
 
 @pytest.mark.asyncio
@@ -2297,6 +2780,19 @@ async def test_gating_subset_of_declared_roles():
     )
     roles = server.experimental_capabilities["nl.liesdonk.file-exchange"]["roles"]
     assert set(roles.keys()) == {"provider", "fetcher"}
+
+
+@pytest.mark.asyncio
+async def test_max_artifact_size_from_config_lands_in_block():
+    """`maxArtifactSize` is operator-side configuration, not a kwarg (design §3)."""
+    server = _server()
+    config = _config(
+        transport="http", file_exchange_volumes="v=/tmp/v", file_exchange_max_artifact_size=10_000_000
+    )
+    store = MemoryStore()
+    register_file_exchange_capability(server, config, kv_store=store)
+    block = server.experimental_capabilities["nl.liesdonk.file-exchange"]
+    assert block["maxArtifactSize"] == 10_000_000
 ```
 
 - [ ] Implement `src/fastmcp_pvl_core/_file_exchange/_capability.py`:
@@ -2313,6 +2809,7 @@ from key_value.aio.protocols.key_value import AsyncKeyValue
 
 from .._config import ServerConfig
 from ._transport_filesystem import parse_volumes
+from ._types import FileExchangeRole
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -2342,9 +2839,8 @@ def register_file_exchange_capability(
     config: ServerConfig,
     *,
     kv_store: AsyncKeyValue,
-    roles: Sequence[str] = ("provider", "fetcher", "receiver", "sender"),
+    roles: Sequence[FileExchangeRole] = ("provider", "fetcher", "receiver", "sender"),
     digests: Sequence[str] = ("sha-256",),
-    max_artifact_size: int | None = None,
 ) -> None:
     """Advertise file-exchange capabilities reflecting what this deployment satisfies.
 
@@ -2353,6 +2849,11 @@ def register_file_exchange_capability(
       indicates an HTTP app; the fetcher/sender (consumer) sides are always advertised
       when at least one of filesystem|outbound-HTTPS is available.
     - If no role has any satisfiable transport, the capability block is NOT emitted.
+
+    ``maxArtifactSize`` is operator-side configuration: pvl-core reads
+    ``config.file_exchange_max_artifact_size`` and emits it on the capability
+    block when set. It is *not* a kwarg (design §3 — operator config lives on
+    ``ServerConfig``, not the helper signature).
     """
     volumes = parse_volumes(config.file_exchange_volumes)
     http_app = config.transport in _HTTP_TRANSPORTS
@@ -2375,8 +2876,8 @@ def register_file_exchange_capability(
         "roles": advertised_roles,
         "digests": list(digests),
     }
-    if max_artifact_size is not None:
-        block["maxArtifactSize"] = max_artifact_size
+    if config.file_exchange_max_artifact_size is not None:
+        block["maxArtifactSize"] = config.file_exchange_max_artifact_size
 
     server.experimental_capabilities = {
         **(server.experimental_capabilities or {}),
@@ -2574,12 +3075,15 @@ async def test_pull_artifact_filesystem(tmp_path: Path):
             "sources": [{"transport": "filesystem", "uri": "exchange://vault/x.bin"}],
         }
     )
+    from fastmcp_pvl_core._config import ServerConfig
+
+    config = ServerConfig(transport="stdio", file_exchange_volumes=f"vault={vault}")
     buf = io.BytesIO()
     md = await pull_artifact(
         handle,
         dest=buf,
+        config=config,
         supported_transports=("filesystem",),
-        volumes={"vault": vault},
     )
     assert buf.getvalue() == b"hello bytes"
     assert md.name == "x.bin"
@@ -2599,11 +3103,14 @@ async def test_pull_artifact_size_mismatch_raises(tmp_path: Path):
             "sources": [{"transport": "filesystem", "uri": "exchange://vault/x.bin"}],
         }
     )
+    from fastmcp_pvl_core._config import ServerConfig
+
+    config = ServerConfig(transport="stdio", file_exchange_volumes=f"vault={vault}")
     with pytest.raises(FileExchangeError) as exc:
         await pull_artifact(
             handle, dest=io.BytesIO(),
+            config=config,
             supported_transports=("filesystem",),
-            volumes={"vault": vault},
         )
     assert exc.value.code == FileExchangeErrorCode.SIZE_MISMATCH
 ```
@@ -2616,32 +3123,56 @@ async def test_pull_artifact_size_mismatch_raises(tmp_path: Path):
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from pathlib import Path
-from typing import BinaryIO
+from typing import TYPE_CHECKING, BinaryIO
+
+from fastmcp_pvl_core._config import ServerConfig
 
 from ._errors import FileExchangeError, FileExchangeErrorCode
 from ._select import select_source
-from ._transport_filesystem import resolve_exchange_uri
+from ._transport_filesystem import parse_volumes, resolve_exchange_uri
 from ._transport_https import SSRFGuardConfig, pull_download
-from ._types import ArtifactMetadata, TransferHandle
+from ._types import ArtifactMetadata, FileExchangeTransport, TransferHandle
 
 
 async def pull_artifact(
     handle: TransferHandle | dict,
     *,
     dest: BinaryIO | Path,
-    supported_transports: Sequence[str],
-    volumes: Mapping[str, Path] = {},
-    ssrf: SSRFGuardConfig | None = None,
+    config: ServerConfig,
+    supported_transports: Sequence[FileExchangeTransport] | None = None,
 ) -> ArtifactMetadata:
     """Pull an artifact described by ``handle`` into ``dest``.
 
     Selects a source descriptor via the §9 algorithm, performs the transfer, and
     verifies size/digest against ``handle.artifact``.
+
+    Deployment state — the volume map and the SSRF guard config — is derived
+    from ``config`` (design §3). No separate ``volumes``/``ssrf`` kwargs are
+    accepted: those are operator-side concerns, not domain hooks.
+
+    ``supported_transports`` defaults to what the deployment can satisfy
+    (filesystem when volumes are configured; download is always available
+    because the fetcher's outbound HTTPS is unconditional). Pass an explicit
+    tuple when a downstream wants to narrow the selection further.
     """
     if not isinstance(handle, TransferHandle):
         handle = TransferHandle.model_validate(handle)
+
+    volumes = parse_volumes(config.file_exchange_volumes)
+    ssrf = SSRFGuardConfig(
+        allow_loopback=config.file_exchange_https_allow_loopback,
+        allow_private=config.file_exchange_https_allow_private,
+    )
+
+    if supported_transports is None:
+        # Fetcher: outbound HTTPS is always available; filesystem requires volumes.
+        derived: list[FileExchangeTransport] = ["download"]
+        if volumes:
+            derived.insert(0, "filesystem")
+        supported_transports = tuple(derived)
+
     chosen = select_source(
         handle,
         supported_transports=supported_transports,
@@ -2664,14 +3195,11 @@ async def pull_artifact(
                     raise NotImplementedError("Path dest is handled by atomic_write — wrap externally")
                 dest.write(chunk)
     elif chosen.root.transport == "download":
-        # pull_download streams to dest; digest the bytes via a tee buffer.
-        # Phase 1 simplification: pull into memory if dest is a buffer, then digest.
+        # pull_download streams chunks through the same digester so the
+        # post-fetch digest check below sees the bytes actually received.
         bytes_written = await pull_download(
-            chosen.root, dest=dest, ssrf=ssrf or SSRFGuardConfig()
+            chosen.root, dest=dest, ssrf=ssrf, digester=digester
         )
-        # Digest verification on download is done by recomputing post-fetch; phase 1
-        # does not stream-digest. Reading the bytes back from dest if it's a Path is
-        # left to the integration test, since dest is the caller's contract.
 
     if handle.artifact.size is not None and bytes_written != handle.artifact.size:
         raise FileExchangeError(
@@ -2707,6 +3235,10 @@ Expected: PASS.
 - [ ] Add tests to `tests/file_exchange/test_role_helpers.py` (receiver flow):
 
 ```python
+from fastmcp_pvl_core._file_exchange._errors import (
+    FileExchangeError,
+    FileExchangeErrorCode,
+)
 from fastmcp_pvl_core._file_exchange._receiver import (
     build_intake_response,
     open_intake,
@@ -2737,9 +3269,18 @@ async def test_resolve_intake_returns_recorded_path(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_resolve_intake_returns_none_for_missing():
+async def test_resolve_intake_raises_for_missing():
+    """Per design §3, ``resolve_intake`` raises NOT_ACCESSIBLE for unrecorded artifact_id.
+
+    The ``-> Path | None`` shape creates a quiet-failure trap (callers forget the
+    None branch and operate on the wrong path); raising forces the caller to
+    handle the case via the tool body's outer FileExchangeError -> as_tool_error_result
+    conversion.
+    """
     store = MemoryStore()
-    assert await resolve_intake("nope", kv_store=store) is None
+    with pytest.raises(FileExchangeError) as exc:
+        await resolve_intake("nope", kv_store=store)
+    assert exc.value.code == FileExchangeErrorCode.NOT_ACCESSIBLE
 ```
 
 - [ ] Implement `src/fastmcp_pvl_core/_file_exchange/_receiver.py`:
@@ -2807,9 +3348,23 @@ def build_intake_response(
     )
 
 
-async def resolve_intake(artifact_id: str, *, kv_store: AsyncKeyValue) -> Path | None:
-    """Return the local path where bytes for ``artifact_id`` landed, or None."""
-    return await intake_path_for(store=kv_store, artifact_id=artifact_id)
+async def resolve_intake(artifact_id: str, *, kv_store: AsyncKeyValue) -> Path:
+    """Return the local path where bytes for ``artifact_id`` landed.
+
+    Raises ``FileExchangeError(code=NOT_ACCESSIBLE)`` when no mapping has been
+    recorded — either the transfer never completed, or ``artifact_id`` is
+    wrong (design §3 final paragraph). The ``-> Path | None`` shape was
+    considered and rejected because callers forget the ``None`` branch.
+    """
+    from ._errors import FileExchangeError, FileExchangeErrorCode
+
+    result = await intake_path_for(store=kv_store, artifact_id=artifact_id)
+    if result is None:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"no bytes recorded for artifact_id={artifact_id!r}",
+        )
+    return result
 ```
 
 - [ ] Test the sender. Add to `tests/file_exchange/test_role_helpers.py`:
@@ -2834,11 +3389,14 @@ async def test_push_artifact_filesystem(tmp_path: Path):
     source = tmp_path / "src.bin"
     source.write_bytes(b"to be sent")
 
+    from fastmcp_pvl_core._config import ServerConfig
+
+    config = ServerConfig(transport="stdio", file_exchange_volumes=f"intake={intake_dir}")
     await push_artifact(
         ticket,
         source=source,
+        config=config,
         supported_transports=("filesystem",),
-        volumes={"intake": intake_dir},
     )
     assert (intake_dir / "x.bin").read_bytes() == b"to be sent"
 ```
@@ -2850,30 +3408,53 @@ async def test_push_artifact_filesystem(tmp_path: Path):
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from pathlib import Path
 from typing import BinaryIO
 
+from fastmcp_pvl_core._config import ServerConfig
+
 from ._errors import FileExchangeError, FileExchangeErrorCode
 from ._select import select_sink
-from ._transport_filesystem import atomic_write, resolve_exchange_uri
+from ._transport_filesystem import atomic_write, parse_volumes, resolve_exchange_uri
 from ._transport_https import SSRFGuardConfig, push_upload
-from ._types import IntakeTicket
+from ._types import FileExchangeTransport, IntakeTicket
 
 
 async def push_artifact(
     ticket: IntakeTicket | dict,
     *,
     source: BinaryIO | Path,
-    supported_transports: Sequence[str],
-    volumes: Mapping[str, Path] = {},
-    ssrf: SSRFGuardConfig | None = None,
+    config: ServerConfig,
+    supported_transports: Sequence[FileExchangeTransport] | None = None,
     artifact_digest: str | None = None,
     artifact_mime: str | None = None,
     artifact_size: int | None = None,
 ) -> None:
+    """Push an artifact described by ``source`` to a sink in ``ticket``.
+
+    Deployment state — the volume map and SSRF guard config — is derived from
+    ``config`` (design §3). No separate ``volumes``/``ssrf`` kwargs; those are
+    operator-side concerns, not domain hooks.
+
+    ``supported_transports`` defaults to what the deployment can satisfy
+    (filesystem when volumes are configured; upload is always available
+    because the sender's outbound HTTPS is unconditional).
+    """
     if not isinstance(ticket, IntakeTicket):
         ticket = IntakeTicket.model_validate(ticket)
+
+    volumes = parse_volumes(config.file_exchange_volumes)
+    ssrf = SSRFGuardConfig(
+        allow_loopback=config.file_exchange_https_allow_loopback,
+        allow_private=config.file_exchange_https_allow_private,
+    )
+
+    if supported_transports is None:
+        derived: list[FileExchangeTransport] = ["upload"]
+        if volumes:
+            derived.insert(0, "filesystem")
+        supported_transports = tuple(derived)
 
     # Pre-check expected.acceptMimeTypes before consuming a single-use slot.
     if (
@@ -2920,7 +3501,7 @@ async def push_artifact(
         await push_upload(
             chosen.root,
             source=source,
-            ssrf=ssrf or SSRFGuardConfig(),
+            ssrf=ssrf,
             content_digest=artifact_digest,
             content_type=artifact_mime,
             content_length=artifact_size,
@@ -2956,6 +3537,9 @@ from fastmcp_pvl_core._file_exchange._receiver import (
     resolve_intake,
 )
 from fastmcp_pvl_core._file_exchange._sender import push_artifact
+from fastmcp_pvl_core._file_exchange._transport_filesystem import (
+    make_filesystem_source,
+)
 from fastmcp_pvl_core._file_exchange._types import (
     ArtifactMetadata,
     ExpectedConstraints,
@@ -2965,6 +3549,11 @@ from fastmcp_pvl_core._file_exchange._types import (
     SinkDescriptor,
     SourceDescriptor,
     TransferHandle,
+)
+from fastmcp_pvl_core._file_exchange._url_store import (
+    make_filesystem_sink,
+    mint_download_source,
+    mint_upload_sink,
 )
 ```
 
@@ -3013,48 +3602,47 @@ from pathlib import Path
 
 import pytest
 
+from key_value.aio.stores.memory import MemoryStore
+
 from fastmcp_pvl_core import (
     ArtifactMetadata,
     build_pull_response,
+    make_filesystem_sink,
+    make_filesystem_source,
     open_intake,
     pull_artifact,
     push_artifact,
+    resolve_intake,
 )
-from fastmcp_pvl_core._file_exchange._types import SinkDescriptor, SourceDescriptor
-
-
-def _fs_source(uri: str) -> SourceDescriptor:
-    return SourceDescriptor.model_validate({"transport": "filesystem", "uri": uri})
-
-
-def _fs_sink(uri: str) -> SinkDescriptor:
-    return SinkDescriptor.model_validate({"transport": "filesystem", "uri": uri})
+from fastmcp_pvl_core._config import ServerConfig
 
 
 @pytest.mark.asyncio
 async def test_pull_round_trip(tmp_path: Path):
-    """Provider side mints a TransferHandle, fetcher side consumes it end-to-end."""
+    """Provider side mints a TransferHandle via the public minter; fetcher consumes."""
     vault = tmp_path / "vault"
     vault.mkdir()
     src = vault / "report.bin"
     payload = b"report payload " * 1024  # 15 KB
     src.write_bytes(payload)
 
+    config = ServerConfig(transport="stdio", file_exchange_volumes=f"vault={vault}")
+    source = make_filesystem_source("vault", "report.bin", config=config)
     md = ArtifactMetadata(
         name="report.bin",
         size=len(payload),
         digest=f"sha-256:{hashlib.sha256(payload).hexdigest()}",
         mimeType="application/octet-stream",
     )
-    result = build_pull_response(md, [_fs_source("exchange://vault/report.bin")])
+    result = build_pull_response(md, [source])
     handle = result.structuredContent
 
     buf = io.BytesIO()
     received = await pull_artifact(
         handle,
         dest=buf,
+        config=config,
         supported_transports=("filesystem",),
-        volumes={"vault": vault},
     )
     assert buf.getvalue() == payload
     assert received.digest == md.digest
@@ -3062,14 +3650,16 @@ async def test_pull_round_trip(tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_push_round_trip(tmp_path: Path):
-    """Receiver opens intake; sender pushes; receiver finds bytes at the resolved path."""
+    """Receiver mints sinks via the public minter; sender pushes; resolve_intake finds the bytes."""
     intake_dir = tmp_path / "intake"
     intake_dir.mkdir()
 
-    ticket = open_intake(
-        sinks=[_fs_sink("exchange://intake/payload.bin")],
-        artifact_id="ar-1",
+    config = ServerConfig(transport="stdio", file_exchange_volumes=f"intake={intake_dir}")
+    store = MemoryStore()
+    sink = await make_filesystem_sink(
+        "intake", "payload.bin", artifact_id="ar-1", config=config, kv_store=store
     )
+    ticket = open_intake(sinks=[sink], artifact_id="ar-1")
 
     src = tmp_path / "src.bin"
     payload = b"deposited"
@@ -3078,11 +3668,14 @@ async def test_push_round_trip(tmp_path: Path):
     await push_artifact(
         ticket,
         source=src,
+        config=config,
         supported_transports=("filesystem",),
-        volumes={"intake": intake_dir},
     )
 
     assert (intake_dir / "payload.bin").read_bytes() == payload
+    # resolve_intake finds the bytes via the mapping recorded at mint time.
+    resolved = await resolve_intake("ar-1", kv_store=store)
+    assert resolved == (intake_dir / "payload.bin").resolve()
 ```
 
 - [ ] Run:
@@ -3108,22 +3701,32 @@ from key_value.aio.stores.memory import MemoryStore
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
+from fastmcp_pvl_core import mint_upload_sink, resolve_intake
+from fastmcp_pvl_core._config import ServerConfig
 from fastmcp_pvl_core._file_exchange._routes import build_file_exchange_router
-from fastmcp_pvl_core._file_exchange._url_store import (
-    intake_path_for,
-    mint_download_token,
-    mint_upload_token,
-)
 
 
 @pytest.mark.asyncio
-async def test_download_then_intake_correlation_end_to_end(tmp_path: Path):
+async def test_upload_then_intake_correlation_end_to_end(tmp_path: Path, monkeypatch):
+    """End-to-end: mint_upload_sink mints + records intake mapping; route writes bytes;
+    resolve_intake finds the bytes via the recorded mapping."""
+    monkeypatch.setattr(
+        "fastmcp_pvl_core._file_exchange._url_store.compute_app_domain",
+        lambda server, config: "https://example.test",
+    )
     store = MemoryStore()
     intake = tmp_path / "intake.bin"
-    expires = datetime.now(timezone.utc) + timedelta(hours=1)
-    token = await mint_upload_token(
-        store=store, intake_path=intake, artifact_id="ar-1", expires_at=expires
+    config = ServerConfig(transport="http", file_exchange_capability_url_ttl_default_s=3600)
+
+    sink = await mint_upload_sink(
+        intake_path=intake,
+        artifact_id="ar-1",
+        server=object(),
+        config=config,
+        kv_store=store,
     )
+    # Extract the token from the minted URL.
+    token = str(sink.root.url).rsplit("/", 1)[-1]
 
     router = build_file_exchange_router(store=store)
     app = Starlette(routes=router.routes)
@@ -3131,7 +3734,7 @@ async def test_download_then_intake_correlation_end_to_end(tmp_path: Path):
     with TestClient(app) as client:
         resp = client.put(f"/file-exchange/u/{token}", content=b"payload-1")
     assert resp.status_code == 204
-    assert (await intake_path_for(store=store, artifact_id="ar-1")) == intake
+    assert (await resolve_intake("ar-1", kv_store=store)) == intake
     assert intake.read_bytes() == b"payload-1"
 ```
 
@@ -3248,7 +3851,6 @@ After all seven PRs land:
 
 ## Open questions deferred (not in this plan)
 
-- **Streamed digest** during `pull_download`: phase 1 verifies digest only when `dest` is a buffer that can be re-read; for `dest=Path` (atomic_write), a follow-up adds a tee-digest so the file passes digest verification without a second read.
 - **Range-request resume** on `pull_download`: spec §10.2 allows it; not implemented in phase 1 (single GET only). Filed as follow-up for phase 1.5.
 - **Provider-driven revocation**: spec §18 open question. The kv_store layer supports `delete` so a future API can implement it; no helper exposed yet.
 - **`file://` URI scheme**: phase 1 supports `exchange://` only; `file://` rejection is explicit (`_transport_filesystem.py` raises). When a downstream actually needs `file://`, a small operator-config-driven exchange-root mapping lands.

--- a/docs/superpowers/plans/2026-05-20-file-exchange-implementation.md
+++ b/docs/superpowers/plans/2026-05-20-file-exchange-implementation.md
@@ -1,134 +1,140 @@
-# File-Exchange v0.1 Implementation Plan (pvl-core phase 1)
+# File-exchange v0.1 Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Implement the `nl.liesdonk.file-exchange` v0.1 extension (https://github.com/pvliesdonk/mcp-file-exchange-ext) as pvl-core's shared reference implementation, with all four roles (`provider`/`fetcher`/`receiver`/`sender`) and all three transports (`filesystem`/`download`/`upload`), gated automatically per deployment capability.
+**Goal:** Adopt the external `pvliesdonk/mcp-file-exchange-ext` v0.1 spec as pvl-core's shared, opinionated implementation across seven PR-sized tasks (A–G), closing issues #124 through #130.
 
-**Architecture:** New private package `src/fastmcp_pvl_core/_file_exchange/`. Pydantic types over a vendored JSON schema. Helpers exposed at top-level package surface (matching the existing `build_auth` / `register_server_info_tool` idiom). Capability declaration derives transport availability from `ServerConfig` (volumes, transport). Persistent state via the existing `build_kv_store` factory shipped in PR #122.
+**Architecture:** Seven sibling files under `src/fastmcp_pvl_core/_file_exchange/` implement the namespace `nl.liesdonk.file-exchange`. Public symbols re-export from `fastmcp_pvl_core`. Capability declaration is operator-driven via `ServerConfig` + env-vars (`{PREFIX}_FILE_EXCHANGE_*`); the only domain hooks are the role declaration and the `kv_store` injection. HTTPS sibling routes mount via `FastMCP.custom_route(...)`. The kv_store factory (`build_kv_store`) shipped in PR #122 is the only prerequisite.
 
-**Tech Stack:** Python 3.10–3.13, FastMCP 3.3.1+, Pydantic v2, py-key-value-aio (existing transitive dep), httpx (already in deps for OIDC), Starlette (FastMCP's HTTP layer), pytest + pytest-asyncio.
+**Tech Stack:** Python 3.10–3.13, FastMCP ≥3.3.1, Pydantic v2, `key-value-aio` (namespaced via `PrefixCollectionsWrapper`), httpx (HTTPS consumer side), Starlette (routes mounted via `FastMCP.custom_route`), pytest + `pytest-asyncio`.
 
-**Design doc:** [`docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md`](../specs/2026-05-20-file-exchange-adoption-design.md)
+**Sequencing:**
+
+```
+A (types + schema) ────────┐
+                           ├─► B (select + errors) ─┐
+                           ├─► C (filesystem) ──────┤
+                           ├─► D (HTTPS consumer) ──┼─► F (capability + role helpers) ─► G (integration)
+                           └─► E (URL store + routes)┘
+```
+
+A is the critical path. B/C/D/E run in parallel after A merges. F depends on B+C+D+E. G depends on F.
+
+**Authoritative source:** `/mnt/code/fastmcp-pvl-core/docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md`. If any step appears to contradict the design doc, STOP and ask — do not improvise.
+
+**Pre-write API sanity check (run once at the start of every task):**
+
+```bash
+uv run python -c "from pydantic import RootModel, BaseModel; print('model_validate:', hasattr(RootModel, 'model_validate'), hasattr(BaseModel, 'model_validate'))"
+# Expected: model_validate: True True
+uv run python -c "from fastmcp import FastMCP; import inspect; print(inspect.signature(FastMCP.custom_route))"
+# Expected: (self, path, methods, name=None, include_in_schema=True) -> Callable[[Callable[[Request], Awaitable[Response]]], ...]
+uv run python -c "from fastmcp_pvl_core import compute_app_domain, ServerConfig; import inspect; print(inspect.signature(compute_app_domain))"
+# Expected: (config: 'ServerConfig') -> 'str | None'
+```
+
+Use `.model_validate(...)` on `BaseModel` / `RootModel`. **There is no `validate-python` method on a model** — that lives on `TypeAdapter`. Do not type the rejected method name into any test or implementation.
 
 ---
 
-## File structure
+## Universal per-task suffix
 
-New package under `src/fastmcp_pvl_core/_file_exchange/`:
+Every task ends with these gates before opening its PR. Do not skip.
 
-```
-_file_exchange/
-    __init__.py                       # public namespace; re-exports from submodules
-    schema/
-        file-exchange.schema.json     # vendored verbatim from spec repo @ pinned commit
-        .expected-sha256              # drift gate
-        PINNED_AT.md                  # records upstream commit + spec version
-        conformance/                  # vendored conformance fixtures
-    _types.py                         # Pydantic models for refs, descriptors, errors
-    _select.py                        # selection algorithm (§9 of spec)
-    _errors.py                        # FileExchangeError + code constants + envelope
-    _transport_filesystem.py          # exchange:// resolution, atomic_write, filesystem-source mint helper
-    _transport_https.py               # pull_download (with streaming digester), push_upload, SSRF guard
-    _url_store.py                     # capability URL minting; intake correlation; filesystem-sink + HTTPS mint helpers
-    _routes.py                        # GET /file-exchange/d/<token>, PUT|POST /u/<token>
-    _provider.py                      # build_pull_response
-    _fetcher.py                       # pull_artifact
-    _receiver.py                      # open_intake, build_intake_response, resolve_intake
-    _sender.py                        # push_artifact
-    _capability.py                    # register_file_exchange_capability + gating + mounting
+- [ ] **Run full local checks**
+
+```bash
+uv sync --all-extras
+uv run pytest tests/file_exchange -v
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
 ```
 
-Top-level re-exports added to `src/fastmcp_pvl_core/__init__.py`.
+Expected: all green.
 
-`ServerConfig` (in `_config.py`) gains seven new fields (see Task F).
+- [ ] **Run preflight-circus skill against the cumulative diff**
 
-Test tree under `tests/file_exchange/` mirrors the source layout, plus `tests/file_exchange/test_integration_*.py` and `tests/file_exchange/test_conformance.py`.
+Invoke the `preflight-circus` skill against `origin/main..HEAD`. The skill dispatches the five lenses in parallel and applies the Haiku confidence filter. **Bar for "clean": nothing flagged at confidence ≥ 80 by any lens.** If any finding fires at ≥80, address it locally — do NOT push and let bots catch it. Re-run the full circus on the new diff before push.
+
+- [ ] **Open as draft PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --draft --title "<title>" --body "$(cat <<'EOF'
+## Summary
+<1–3 bullets>
+
+Closes #<issue>.
+
+## Test plan
+- [ ] Local unit tests pass: `uv run pytest tests/file_exchange -v`
+- [ ] Local ruff + mypy clean
+- [ ] preflight-circus returned clean against BASE..HEAD
+
+EOF
+)"
+```
+
+- [ ] **Verify bot verdicts before flipping ready**
+
+Read `claude-review`'s posted body (not just the check status — green ≠ approved); look for `Still Open`, `must be fixed`, negative recommendations. Read `gemini-code-assist`'s body too. If a bot finds something despite local clearance, address it, re-run the full circus on the fix, push, and cap iteration at one round. If anything still fires on the second round, surface to the user — do not push a third time silently.
+
+- [ ] **Flip to ready** with `gh pr ready <N>` only when (a) local circus was clean, (b) bot bodies say LGTM, (c) CI fully green.
 
 ---
 
-## Sequencing & parallel dispatch
-
-```
-A (types + schema)  ────────┐
-                            ├─► B (select + errors) ──┐
-                            │                         ├─► F (capability + role helpers) ─► G (integration)
-                            ├─► C (filesystem) ───────┤
-                            │                         │
-                            ├─► D (HTTPS consumer) ───┤
-                            │                         │
-                            └─► E (URL store + routes)┘
-```
-
-- **A is the critical path** (every later task imports from `_types.py`).
-- Once A merges, **B, C, D, E can run in parallel** (different files, independent test suites).
-- **F depends on B+C+D+E** (capability registration wires them; role helpers call into them).
-- **G depends on F** (integration tests exercise the full surface).
-
-Each task group becomes one PR closing one tracked issue, opened as draft, gated through the `preflight-circus` skill before push (per global CLAUDE.md PR workflow). The user files the seven child issues (A–G) before kick-off.
-
----
-
-# Task A: Vendor schema + Pydantic types + drift gate
+## Task A: Vendor v0.1 schema and Pydantic types (closes #124)
 
 **Files:**
 - Create: `src/fastmcp_pvl_core/_file_exchange/__init__.py`
-- Create: `src/fastmcp_pvl_core/_file_exchange/schema/file-exchange.schema.json` (vendored)
+- Create: `src/fastmcp_pvl_core/_file_exchange/schema/file-exchange.schema.json` (vendored verbatim from `pvliesdonk/mcp-file-exchange-ext` v0.1 at a pinned commit)
 - Create: `src/fastmcp_pvl_core/_file_exchange/schema/.expected-sha256`
 - Create: `src/fastmcp_pvl_core/_file_exchange/schema/PINNED_AT.md`
-- Create: `src/fastmcp_pvl_core/_file_exchange/schema/conformance/` (vendored fixtures)
+- Create: `src/fastmcp_pvl_core/_file_exchange/schema/conformance/` (vendored fixtures directory)
 - Create: `src/fastmcp_pvl_core/_file_exchange/_types.py`
 - Create: `tests/file_exchange/__init__.py`
-- Create: `tests/file_exchange/test_schema_drift.py`
 - Create: `tests/file_exchange/test_types.py`
+- Create: `tests/file_exchange/test_schema_drift.py`
 
-### Step A.1: Vendor the schema and conformance fixtures
+### Step A.1 — Vendor the schema and fixtures
 
-- [ ] Pick the spec-repo pin commit. Run:
+- [ ] **Pin and copy** the schema + conformance fixtures from `pvliesdonk/mcp-file-exchange-ext` v0.1 (HEAD of the tagged v0.1 commit). Compute SHA-256 of the schema, write to `.expected-sha256`. Record the source repo + commit SHA in `PINNED_AT.md`.
 
 ```bash
-gh api repos/pvliesdonk/mcp-file-exchange-ext/commits/main --jq '.sha'
+cd /tmp && git clone https://github.com/pvliesdonk/mcp-file-exchange-ext
+cd mcp-file-exchange-ext && git rev-parse HEAD > /tmp/pin.txt && cat /tmp/pin.txt
+cp schema/file-exchange.schema.json /mnt/code/fastmcp-pvl-core/src/fastmcp_pvl_core/_file_exchange/schema/
+cp -r tests/conformance /mnt/code/fastmcp-pvl-core/src/fastmcp_pvl_core/_file_exchange/schema/conformance
+cd /mnt/code/fastmcp-pvl-core/src/fastmcp_pvl_core/_file_exchange/schema
+python -c "import hashlib, pathlib; print(hashlib.sha256(pathlib.Path('file-exchange.schema.json').read_bytes()).hexdigest())" > .expected-sha256
 ```
 
-Record the SHA in `_file_exchange/schema/PINNED_AT.md`:
+`PINNED_AT.md` contents:
 
 ```markdown
-# Vendored from pvliesdonk/mcp-file-exchange-ext
+# File-exchange schema pin
 
-- **Upstream commit:** <full-sha-from-above>
-- **Spec version:** 0.1 (draft)
-- **Vendored at:** 2026-05-20
+- **Source repo:** https://github.com/pvliesdonk/mcp-file-exchange-ext
+- **Pinned commit:** <40-char SHA from /tmp/pin.txt>
+- **Spec version:** 0.1
+- **Vendored on:** 2026-05-20
 
-To re-pin: fetch the schema and conformance directory from the new commit,
-update PINNED_AT.md and .expected-sha256, and run `pytest tests/file_exchange/test_schema_drift.py`.
+To re-pin: copy the schema + conformance fixtures from a later commit,
+regenerate `.expected-sha256`, update this file. Each re-pin is its own
+commit so reviewers see the schema change as a deliberate event.
 ```
 
-- [ ] Download the schema:
+### Step A.2 — Drift gate test (write the failing test first)
 
-```bash
-mkdir -p src/fastmcp_pvl_core/_file_exchange/schema/conformance
-curl -sL "https://raw.githubusercontent.com/pvliesdonk/mcp-file-exchange-ext/<sha>/schema/file-exchange.json" \
-    > src/fastmcp_pvl_core/_file_exchange/schema/file-exchange.schema.json
-```
-
-- [ ] Compute and record SHA-256:
-
-```bash
-sha256sum src/fastmcp_pvl_core/_file_exchange/schema/file-exchange.schema.json \
-    | awk '{print $1}' \
-    > src/fastmcp_pvl_core/_file_exchange/schema/.expected-sha256
-```
-
-- [ ] Vendor the conformance fixtures (one curl per fixture file, listed via `gh api repos/pvliesdonk/mcp-file-exchange-ext/contents/conformance?ref=<sha>` and downloaded individually).
-
-### Step A.2: Drift-gate test
-
-- [ ] Write `tests/file_exchange/test_schema_drift.py`:
+- [ ] **Write `tests/file_exchange/test_schema_drift.py`:**
 
 ```python
-"""Schema-drift gate: the vendored schema must match its recorded SHA-256.
+"""Vendored-schema drift gate.
 
-Drift means an unintended edit to the local copy, which is a vendoring violation.
-Re-pinning is a deliberate commit that updates PINNED_AT.md and .expected-sha256.
+The schema file is copied verbatim from the spec repo. Any local edit
+(intentional or accidental) must be accompanied by an explicit re-pin
+that updates ``.expected-sha256`` — otherwise this test fails the build.
 """
 
 from __future__ import annotations
@@ -136,22 +142,21 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
-SCHEMA = Path(__file__).resolve().parent.parent.parent / "src" / "fastmcp_pvl_core" / "_file_exchange" / "schema" / "file-exchange.schema.json"
-EXPECTED_SHA = SCHEMA.parent / ".expected-sha256"
 
-
-def test_vendored_schema_matches_recorded_sha256():
-    actual = hashlib.sha256(SCHEMA.read_bytes()).hexdigest()
-    expected = EXPECTED_SHA.read_text().strip()
+def test_vendored_schema_matches_expected_sha256() -> None:
+    here = Path(__file__).parent.parent.parent / "src" / "fastmcp_pvl_core" / "_file_exchange" / "schema"
+    schema_bytes = (here / "file-exchange.schema.json").read_bytes()
+    expected = (here / ".expected-sha256").read_text().strip()
+    actual = hashlib.sha256(schema_bytes).hexdigest()
     assert actual == expected, (
         f"Vendored schema drift detected.\n"
         f"  expected: {expected}\n"
         f"  actual:   {actual}\n"
-        f"If the change is intentional, re-pin by updating PINNED_AT.md and .expected-sha256."
+        f"If the schema was intentionally re-pinned, regenerate .expected-sha256."
     )
 ```
 
-- [ ] Run the test to verify it passes:
+- [ ] **Run to verify pass** (the file matches its own hash by construction):
 
 ```bash
 uv run pytest tests/file_exchange/test_schema_drift.py -v
@@ -159,3387 +164,20 @@ uv run pytest tests/file_exchange/test_schema_drift.py -v
 
 Expected: PASS.
 
-### Step A.3: Write the Pydantic types
+### Step A.3 — Write the failing test for `_types.py` core scalars
 
-- [ ] Write `src/fastmcp_pvl_core/_file_exchange/__init__.py` (empty for now — re-exports added at the end of Task A):
-
-```python
-"""File-exchange extension implementation (nl.liesdonk.file-exchange v0.1).
-
-Reference implementation of pvliesdonk/mcp-file-exchange-ext.
-The public surface is re-exported from the top-level fastmcp_pvl_core package.
-"""
-```
-
-- [ ] Write `tests/file_exchange/test_types.py` — start with the discriminator behaviour (most likely to break later if shape changes):
+- [ ] **Write `tests/file_exchange/test_types.py` with the first failing test:**
 
 ```python
-from __future__ import annotations
+"""Pydantic model round-trip tests for vendored v0.1 schema.
 
-import pytest
-from pydantic import ValidationError
-
-from fastmcp_pvl_core._file_exchange._types import (
-    ArtifactMetadata,
-    DownloadSourceDescriptor,
-    FilesystemSinkDescriptor,
-    FilesystemSourceDescriptor,
-    IntakeTicket,
-    SourceDescriptor,
-    TransferHandle,
-    UploadSinkDescriptor,
-)
-
-
-def test_filesystem_source_descriptor_roundtrips():
-    raw = {"transport": "filesystem", "uri": "exchange://vault/notes/n1.md"}
-    desc = SourceDescriptor.model_validate(raw)
-    assert isinstance(desc.root, FilesystemSourceDescriptor)
-    assert desc.root.uri == "exchange://vault/notes/n1.md"
-
-
-def test_download_source_descriptor_requires_expires_at():
-    with pytest.raises(ValidationError):
-        SourceDescriptor.model_validate({"transport": "download", "url": "https://x/y"})
-
-
-def test_descriptor_unknown_transport_is_rejected_at_typed_layer():
-    """The typed layer rejects unknown transports — selection-level fallthrough
-    (§17.2 'tolerant reading') is handled in _select.py, not by the discriminator."""
-    with pytest.raises(ValidationError):
-        SourceDescriptor.model_validate({"transport": "carrier-pigeon", "uri": "x"})
-
-
-def test_transfer_handle_requires_at_least_one_source():
-    with pytest.raises(ValidationError):
-        TransferHandle.model_validate(
-            {
-                "type": "nl.liesdonk.file-exchange/transfer-handle",
-                "version": "0.1",
-                "artifact": {"name": "x.bin"},
-                "sources": [],
-            }
-        )
-
-
-def test_transfer_handle_type_field_is_constant():
-    with pytest.raises(ValidationError):
-        TransferHandle.model_validate(
-            {
-                "type": "something-else",
-                "version": "0.1",
-                "artifact": {"name": "x.bin"},
-                "sources": [{"transport": "filesystem", "uri": "exchange://v/x"}],
-            }
-        )
-
-
-def test_artifact_metadata_requires_at_least_one_field():
-    with pytest.raises(ValidationError):
-        ArtifactMetadata.model_validate({})
-
-
-def test_artifact_metadata_with_only_name_is_valid():
-    md = ArtifactMetadata.model_validate({"name": "report.parquet"})
-    assert md.name == "report.parquet"
-
-
-def test_intake_ticket_requires_artifact_id():
-    with pytest.raises(ValidationError):
-        IntakeTicket.model_validate(
-            {
-                "type": "nl.liesdonk.file-exchange/intake-ticket",
-                "version": "0.1",
-                "sinks": [{"transport": "filesystem", "uri": "exchange://i/x"}],
-            }
-        )
-
-
-def test_filesystem_sink_descriptor_roundtrips():
-    raw = {"transport": "filesystem", "uri": "exchange://intake/x.bin"}
-    sink = FilesystemSinkDescriptor.model_validate(raw)
-    assert sink.uri == "exchange://intake/x.bin"
-
-
-def test_upload_sink_descriptor_default_method_is_put():
-    raw = {
-        "transport": "upload",
-        "url": "https://x/y",
-        "expiresAt": "2026-12-31T00:00:00Z",
-    }
-    sink = UploadSinkDescriptor.model_validate(raw)
-    assert sink.method == "PUT"
-```
-
-- [ ] Run the tests to confirm they fail:
-
-```bash
-uv run pytest tests/file_exchange/test_types.py -v
-```
-
-Expected: every test fails with `ImportError` or `ModuleNotFoundError`.
-
-- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_types.py`:
-
-```python
-"""Pydantic models for the nl.liesdonk.file-exchange v0.1 wire types.
-
-The shape of each model mirrors schema/file-exchange.schema.json. The discriminator
-field on descriptors (``transport``) rejects unknown values at the typed layer; the
-spec's §17.2 'tolerant reading' rule for unknown transports is applied at selection
-time in _select.py, not by these models — because by the time we deserialise to a
-strongly-typed object we have already committed to a known shape.
+Each test mirrors a fixture pattern from
+`src/fastmcp_pvl_core/_file_exchange/schema/conformance/`.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Annotated, Literal
-
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    HttpUrl,
-    RootModel,
-    field_validator,
-    model_validator,
-)
-
-REFERENCE_VERSION = "0.1"
-TRANSFER_HANDLE_TYPE = "nl.liesdonk.file-exchange/transfer-handle"
-INTAKE_TICKET_TYPE = "nl.liesdonk.file-exchange/intake-ticket"
-
-
-class ArtifactMetadata(BaseModel):
-    """Describes an artifact independently of how it is transferred (spec §7.1)."""
-
-    model_config = ConfigDict(extra="ignore")  # §17.2 tolerant reading on non-descriptor objects
-
-    id: str | None = None
-    name: str | None = None
-    mimeType: str | None = None
-    size: int | None = Field(default=None, ge=0)
-    digest: str | None = None
-    description: str | None = None
-    createdAt: datetime | None = None
-
-    @model_validator(mode="after")
-    def _at_least_one_field(self) -> "ArtifactMetadata":
-        # Spec §7.1: an artifact with no metadata cannot be reviewed by a human and is invalid.
-        if not any(
-            getattr(self, name) is not None
-            for name in ("id", "name", "mimeType", "size", "digest", "description", "createdAt")
-        ):
-            raise ValueError("ArtifactMetadata MUST contain at least one field (spec §7.1)")
-        return self
-
-
-# ---- Source descriptors (used in TransferHandle.sources) ----
-
-
-class FilesystemSourceDescriptor(BaseModel):
-    """`filesystem` transport, source side (spec §7.2.1)."""
-
-    model_config = ConfigDict(extra="forbid")  # §17.5 descriptor-shape freeze
-
-    transport: Literal["filesystem"]
-    uri: str
-
-    @field_validator("uri")
-    @classmethod
-    def _scheme_is_exchange_or_file(cls, v: str) -> str:
-        if not (v.startswith("exchange://") or v.startswith("file://")):
-            raise ValueError("filesystem source URI must use 'exchange://' or 'file://'")
-        return v
-
-
-class DownloadSourceDescriptor(BaseModel):
-    """`download` transport, source side (spec §7.2.2)."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    transport: Literal["download"]
-    url: HttpUrl
-    expiresAt: datetime
-    singleUse: bool = True
-
-
-SourceDescriptor = RootModel[
-    Annotated[
-        FilesystemSourceDescriptor | DownloadSourceDescriptor,
-        Field(discriminator="transport"),
-    ]
-]
-
-
-# ---- Sink descriptors (used in IntakeTicket.sinks) ----
-
-
-class FilesystemSinkDescriptor(BaseModel):
-    """`filesystem` transport, sink side (spec §7.2.3)."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    transport: Literal["filesystem"]
-    uri: str
-
-    @field_validator("uri")
-    @classmethod
-    def _scheme_is_exchange_or_file(cls, v: str) -> str:
-        if not (v.startswith("exchange://") or v.startswith("file://")):
-            raise ValueError("filesystem sink URI must use 'exchange://' or 'file://'")
-        return v
-
-
-class UploadSinkDescriptor(BaseModel):
-    """`upload` transport, sink side (spec §7.2.4)."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    transport: Literal["upload"]
-    url: HttpUrl
-    method: Literal["PUT", "POST"] = "PUT"
-    expiresAt: datetime
-
-
-SinkDescriptor = RootModel[
-    Annotated[
-        FilesystemSinkDescriptor | UploadSinkDescriptor,
-        Field(discriminator="transport"),
-    ]
-]
-
-
-# ---- Expected constraints (IntakeTicket.expected) ----
-
-
-class ExpectedConstraints(BaseModel):
-    """Receiver-imposed constraints on an incoming artifact (spec §7.4)."""
-
-    model_config = ConfigDict(extra="ignore")
-
-    maxSize: int | None = Field(default=None, ge=0)
-    acceptMimeTypes: list[str] | None = None
-    requireDigest: list[str] | None = None
-
-
-# ---- References ----
-
-
-class TransferHandle(BaseModel):
-    """A pull token: provider emits, fetcher consumes (spec §7.3)."""
-
-    model_config = ConfigDict(extra="ignore")
-
-    type: Literal["nl.liesdonk.file-exchange/transfer-handle"]
-    version: str
-    artifact: ArtifactMetadata
-    sources: list[SourceDescriptor] = Field(min_length=1)
-    requires: list[str] | None = None
-
-
-class IntakeTicket(BaseModel):
-    """A push token: receiver emits, sender consumes (spec §7.4)."""
-
-    model_config = ConfigDict(extra="ignore")
-
-    type: Literal["nl.liesdonk.file-exchange/intake-ticket"]
-    version: str
-    artifactId: str
-    expected: ExpectedConstraints | None = None
-    sinks: list[SinkDescriptor] = Field(min_length=1)
-    requires: list[str] | None = None
-```
-
-- [ ] Run the tests to verify they all pass:
-
-```bash
-uv run pytest tests/file_exchange/test_types.py -v
-```
-
-Expected: all 10 tests PASS.
-
-### Step A.4: Public-symbol literals
-
-- [ ] Add the role/transport `Literal` aliases. Append to `_types.py`:
-
-```python
-# Role/transport aliases used by the public API
-FileExchangeRole = Literal["provider", "fetcher", "receiver", "sender"]
-FileExchangeTransport = Literal["filesystem", "download", "upload"]
-```
-
-(No test needed — `Literal` aliases are checked at use sites.)
-
-### Step A.5: Commit Task A
-
-- [ ] Stage and commit:
-
-```bash
-git add src/fastmcp_pvl_core/_file_exchange/ tests/file_exchange/
-git commit -m "feat(file-exchange): vendor v0.1 schema and Pydantic types
-
-Closes #124"
-```
-
-### Step A.6: Local circus + PR
-
-- [ ] Run `preflight-circus` skill against `origin/main..HEAD`. Address any ≥80-confidence findings inline.
-- [ ] Push and open a draft PR. Wait for bot review (expected: LGTM). Flip to ready when bot + CI green.
-
----
-
-# Task B: Selection algorithm + error envelope
-
-**Files:**
-- Create: `src/fastmcp_pvl_core/_file_exchange/_errors.py`
-- Create: `src/fastmcp_pvl_core/_file_exchange/_select.py`
-- Create: `tests/file_exchange/test_errors.py`
-- Create: `tests/file_exchange/test_select.py`
-
-### Step B.1: Test the error envelope
-
-- [ ] Write `tests/file_exchange/test_errors.py`:
-
-```python
-from __future__ import annotations
-
 import pytest
-from mcp.types import CallToolResult
-
-from fastmcp_pvl_core._file_exchange._errors import (
-    FileExchangeError,
-    FileExchangeErrorCode,
-    as_tool_error_result,
-)
-
-
-def test_error_carries_code_and_optional_metadata():
-    exc = FileExchangeError(
-        code=FileExchangeErrorCode.DIGEST_MISMATCH,
-        transport="download",
-        detail="expected sha-256:9f86d0..., got sha-256:1b4f0e...",
-    )
-    assert exc.code == "digest-mismatch"
-    assert exc.transport == "download"
-    assert "expected sha-256:9f86d0" in exc.detail
-
-
-def test_as_tool_error_result_has_meta_block():
-    exc = FileExchangeError(
-        code=FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT,
-        detail="no descriptor in handle matched supported transports",
-    )
-    result = as_tool_error_result(exc)
-    assert result.isError is True
-    assert result.content  # at least one text block
-    assert any("no-supported-transport" in c.text for c in result.content if c.type == "text")
-    meta = result.meta or {}
-    err_meta = meta.get("nl.liesdonk.file-exchange/error")
-    assert err_meta is not None
-    assert err_meta["code"] == "no-supported-transport"
-
-
-def test_all_spec_codes_are_defined():
-    """Spec §13 enumerates these — any drift here is a spec/impl mismatch."""
-    expected = {
-        "no-supported-transport",
-        "descriptor-expired",
-        "not-accessible",
-        "digest-mismatch",
-        "size-mismatch",
-        "too-large",
-        "mime-type-rejected",
-        "unsupported-requirement",
-        "transfer-failed",
-    }
-    actual = {code.value for code in FileExchangeErrorCode}
-    assert actual == expected
-```
-
-- [ ] Run the test:
-
-```bash
-uv run pytest tests/file_exchange/test_errors.py -v
-```
-
-Expected: FAIL — ImportError.
-
-### Step B.2: Implement the error envelope
-
-- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_errors.py`:
-
-```python
-"""Error envelope for nl.liesdonk.file-exchange (spec §13)."""
-
-from __future__ import annotations
-
-from enum import StrEnum
-from typing import Any
-
-from mcp.types import CallToolResult, TextContent
-
-
-class FileExchangeErrorCode(StrEnum):
-    """The closed set of error codes from spec §13.
-
-    The set is intentionally enumerable: a consumer that receives an unrecognised
-    code SHOULD treat it as a generic failure (per spec §13 last paragraph), but
-    pvl-core itself only emits codes from this enum.
-    """
-
-    NO_SUPPORTED_TRANSPORT = "no-supported-transport"
-    DESCRIPTOR_EXPIRED = "descriptor-expired"
-    NOT_ACCESSIBLE = "not-accessible"
-    DIGEST_MISMATCH = "digest-mismatch"
-    SIZE_MISMATCH = "size-mismatch"
-    TOO_LARGE = "too-large"
-    MIME_TYPE_REJECTED = "mime-type-rejected"
-    UNSUPPORTED_REQUIREMENT = "unsupported-requirement"
-    TRANSFER_FAILED = "transfer-failed"
-
-
-class FileExchangeError(Exception):
-    """A file-exchange transfer failure that maps cleanly to spec §13.
-
-    Raised by the role helpers (pull_artifact, push_artifact, …) and translated
-    to a tool-execution error result via :func:`as_tool_error_result` at the
-    tool body's outer except clause.
-    """
-
-    def __init__(
-        self,
-        *,
-        code: FileExchangeErrorCode,
-        transport: str | None = None,
-        detail: str | None = None,
-    ) -> None:
-        super().__init__(detail or code.value)
-        self.code = code
-        self.transport = transport
-        self.detail = detail
-
-
-def as_tool_error_result(exc: FileExchangeError) -> CallToolResult:
-    """Convert a FileExchangeError into a tool-execution error result (spec §13)."""
-
-    text = f"file exchange: {exc.code.value}"
-    if exc.transport:
-        text += f" (transport={exc.transport})"
-    if exc.detail:
-        text += f" — {exc.detail}"
-
-    meta_block: dict[str, Any] = {"code": exc.code.value}
-    if exc.transport:
-        meta_block["transport"] = exc.transport
-    if exc.detail:
-        meta_block["detail"] = exc.detail
-
-    return CallToolResult(
-        isError=True,
-        content=[TextContent(type="text", text=text)],
-        meta={"nl.liesdonk.file-exchange/error": meta_block},
-    )
-```
-
-- [ ] Run the tests:
-
-```bash
-uv run pytest tests/file_exchange/test_errors.py -v
-```
-
-Expected: PASS.
-
-### Step B.3: Test the selection algorithm
-
-- [ ] Write `tests/file_exchange/test_select.py`:
-
-```python
-from __future__ import annotations
-
-from datetime import datetime, timedelta, timezone
-
-import pytest
-
-from fastmcp_pvl_core._file_exchange._errors import (
-    FileExchangeError,
-    FileExchangeErrorCode,
-)
-from fastmcp_pvl_core._file_exchange._select import (
-    select_source,
-    select_sink,
-)
-from fastmcp_pvl_core._file_exchange._types import (
-    ArtifactMetadata,
-    IntakeTicket,
-    TransferHandle,
-)
-
-
-def _now_plus(seconds: int) -> str:
-    return (datetime.now(timezone.utc) + timedelta(seconds=seconds)).isoformat()
-
-
-def _handle(sources: list[dict]) -> TransferHandle:
-    return TransferHandle.model_validate(
-        {
-            "type": "nl.liesdonk.file-exchange/transfer-handle",
-            "version": "0.1",
-            "artifact": {"name": "x.bin"},
-            "sources": sources,
-        }
-    )
-
-
-def _ticket(sinks: list[dict]) -> IntakeTicket:
-    return IntakeTicket.model_validate(
-        {
-            "type": "nl.liesdonk.file-exchange/intake-ticket",
-            "version": "0.1",
-            "artifactId": "ar-1",
-            "sinks": sinks,
-        }
-    )
-
-
-def test_picks_first_supported_in_order():
-    h = _handle(
-        [
-            {"transport": "filesystem", "uri": "exchange://v/x.bin"},
-            {
-                "transport": "download",
-                "url": "https://x/y",
-                "expiresAt": _now_plus(3600),
-            },
-        ]
-    )
-    chosen = select_source(h, supported_transports=("download",), known_volumes=())
-    # filesystem skipped (unsupported), download picked.
-    assert chosen.root.transport == "download"
-
-
-def test_skips_filesystem_with_unknown_volume():
-    h = _handle([{"transport": "filesystem", "uri": "exchange://other/x.bin"}])
-    with pytest.raises(FileExchangeError) as exc:
-        select_source(h, supported_transports=("filesystem",), known_volumes=("known",))
-    assert exc.value.code == FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT
-
-
-def test_skips_expired_download():
-    h = _handle(
-        [
-            {
-                "transport": "download",
-                "url": "https://x/y",
-                "expiresAt": _now_plus(-60),
-            },
-        ]
-    )
-    with pytest.raises(FileExchangeError) as exc:
-        select_source(h, supported_transports=("download",), known_volumes=())
-    assert exc.value.code == FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT
-
-
-def test_clock_skew_tolerance_keeps_just_expired_descriptor():
-    h = _handle(
-        [
-            {
-                "transport": "download",
-                "url": "https://x/y",
-                "expiresAt": _now_plus(-10),  # within 30s tolerance
-            },
-        ]
-    )
-    chosen = select_source(
-        h, supported_transports=("download",), known_volumes=(), clock_skew_tolerance_s=30
-    )
-    assert chosen.root.transport == "download"
-
-
-def test_requires_unknown_feature_is_rejected():
-    raw = {
-        "type": "nl.liesdonk.file-exchange/transfer-handle",
-        "version": "0.1",
-        "artifact": {"name": "x.bin"},
-        "sources": [{"transport": "filesystem", "uri": "exchange://v/x"}],
-        "requires": ["future-feature-xyz"],
-    }
-    h = TransferHandle.model_validate(raw)
-    with pytest.raises(FileExchangeError) as exc:
-        select_source(h, supported_transports=("filesystem",), known_volumes=("v",))
-    assert exc.value.code == FileExchangeErrorCode.UNSUPPORTED_REQUIREMENT
-
-
-def test_unknown_transport_descriptor_is_silently_skipped():
-    """Spec §17.2: unknown `transport` values are skipped during selection (not rejected)."""
-    # The typed layer rejects unknown transports at parsing time, so we exercise
-    # the fallthrough by passing a known-but-unsupported transport.
-    h = _handle(
-        [
-            {"transport": "filesystem", "uri": "exchange://v/x"},
-            {"transport": "download", "url": "https://x/y", "expiresAt": _now_plus(3600)},
-        ]
-    )
-    # filesystem unsupported by this consumer, but download supported → download is picked.
-    chosen = select_source(h, supported_transports=("download",), known_volumes=())
-    assert chosen.root.transport == "download"
-
-
-def test_select_sink_picks_writable_filesystem():
-    t = _ticket([{"transport": "filesystem", "uri": "exchange://intake/x.bin"}])
-    chosen = select_sink(t, supported_transports=("filesystem",), known_volumes=("intake",))
-    assert chosen.root.transport == "filesystem"
-```
-
-- [ ] Run the test:
-
-```bash
-uv run pytest tests/file_exchange/test_select.py -v
-```
-
-Expected: FAIL — ImportError.
-
-### Step B.4: Implement the selection algorithm
-
-- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_select.py`:
-
-```python
-"""Descriptor selection algorithm (spec §9) and version-skew gate (spec §17.3, §17.4)."""
-
-from __future__ import annotations
-
-from collections.abc import Sequence
-from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
-
-from ._errors import FileExchangeError, FileExchangeErrorCode
-
-if TYPE_CHECKING:
-    from ._types import IntakeTicket, SinkDescriptor, SourceDescriptor, TransferHandle
-
-
-# v0.1 defines no must-understand feature identifiers (spec §17.4).
-_KNOWN_REQUIRES_FEATURES: frozenset[str] = frozenset()
-
-
-def _check_version_and_requires(reference: TransferHandle | IntakeTicket) -> None:
-    """Apply §17.3 (version skew) and §17.4 (must-understand) gates.
-
-    Raises FileExchangeError if the reference cannot be processed.
-    """
-    major, _, _ = reference.version.partition(".")
-    if major != "0":
-        raise FileExchangeError(
-            code=FileExchangeErrorCode.TRANSFER_FAILED,
-            detail=f"reference version {reference.version!r} has a major component this implementation does not understand",
-        )
-
-    if reference.requires:
-        seen: set[str] = set()
-        for feature in reference.requires:
-            if feature in seen:
-                raise FileExchangeError(
-                    code=FileExchangeErrorCode.UNSUPPORTED_REQUIREMENT,
-                    detail=f"requires array contains a duplicate identifier: {feature!r}",
-                )
-            seen.add(feature)
-            if feature not in _KNOWN_REQUIRES_FEATURES:
-                raise FileExchangeError(
-                    code=FileExchangeErrorCode.UNSUPPORTED_REQUIREMENT,
-                    detail=f"required feature {feature!r} not implemented",
-                )
-
-
-def _exchange_volume(uri: str) -> str | None:
-    """Return the volume component of an exchange:// URI, or None for file://."""
-    if uri.startswith("exchange://"):
-        rest = uri[len("exchange://"):]
-        return rest.split("/", 1)[0] or None
-    return None
-
-
-def _is_expired(expires_at: datetime, tolerance_s: int) -> bool:
-    now = datetime.now(timezone.utc)
-    return now > (expires_at + timedelta(seconds=tolerance_s))
-
-
-def select_source(
-    handle: TransferHandle,
-    *,
-    supported_transports: Sequence[str],
-    known_volumes: Sequence[str],
-    clock_skew_tolerance_s: int = 30,
-) -> SourceDescriptor:
-    """Pick a source descriptor from a TransferHandle (spec §9).
-
-    Raises FileExchangeError with code 'no-supported-transport' if nothing survives.
-    """
-    _check_version_and_requires(handle)
-    return _select(handle.sources, supported_transports, known_volumes, clock_skew_tolerance_s)
-
-
-def select_sink(
-    ticket: IntakeTicket,
-    *,
-    supported_transports: Sequence[str],
-    known_volumes: Sequence[str],
-    clock_skew_tolerance_s: int = 30,
-) -> SinkDescriptor:
-    """Pick a sink descriptor from an IntakeTicket (spec §9)."""
-    _check_version_and_requires(ticket)
-    return _select(ticket.sinks, supported_transports, known_volumes, clock_skew_tolerance_s)
-
-
-def _select(
-    descriptors: Sequence,
-    supported_transports: Sequence[str],
-    known_volumes: Sequence[str],
-    clock_skew_tolerance_s: int,
-):
-    for descriptor in descriptors:
-        node = descriptor.root
-        if node.transport not in supported_transports:
-            continue
-        if node.transport == "filesystem":
-            volume = _exchange_volume(node.uri)
-            if volume is not None and volume not in known_volumes:
-                continue
-            return descriptor
-        if node.transport in ("download", "upload"):
-            if _is_expired(node.expiresAt, clock_skew_tolerance_s):
-                continue
-            return descriptor
-    raise FileExchangeError(
-        code=FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT,
-        detail="no descriptor in the reference matched the consumer's supported transports",
-    )
-```
-
-- [ ] Run the tests:
-
-```bash
-uv run pytest tests/file_exchange/test_select.py tests/file_exchange/test_errors.py -v
-```
-
-Expected: PASS (all 7 select tests + earlier error tests).
-
-### Step B.5: Commit and PR
-
-- [ ] Commit:
-
-```bash
-git add src/fastmcp_pvl_core/_file_exchange/_errors.py src/fastmcp_pvl_core/_file_exchange/_select.py tests/file_exchange/test_errors.py tests/file_exchange/test_select.py
-git commit -m "feat(file-exchange): error envelope + descriptor selection algorithm
-
-Closes #125"
-```
-
-- [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
-
----
-
-# Task C: Filesystem transport
-
-**Files:**
-- Create: `src/fastmcp_pvl_core/_file_exchange/_transport_filesystem.py`
-- Create: `tests/file_exchange/test_transport_filesystem.py`
-
-### Step C.1: Test exchange-URI resolution and path confinement
-
-- [ ] Write `tests/file_exchange/test_transport_filesystem.py`:
-
-```python
-from __future__ import annotations
-
-import os
-from pathlib import Path
-
-import pytest
-
-from fastmcp_pvl_core._file_exchange._errors import (
-    FileExchangeError,
-    FileExchangeErrorCode,
-)
-from fastmcp_pvl_core._file_exchange._transport_filesystem import (
-    atomic_write,
-    parse_volumes,
-    resolve_exchange_uri,
-)
-
-
-def test_parse_volumes_handles_comma_separated_pairs():
-    mapping = parse_volumes("vault=/tmp/vault,intake=/tmp/intake")
-    assert mapping == {"vault": Path("/tmp/vault"), "intake": Path("/tmp/intake")}
-
-
-def test_parse_volumes_handles_empty_and_none():
-    assert parse_volumes(None) == {}
-    assert parse_volumes("") == {}
-    assert parse_volumes("   ") == {}
-
-
-def test_parse_volumes_rejects_malformed_pair():
-    with pytest.raises(ValueError, match="must be of the form"):
-        parse_volumes("brokenpair")
-
-
-def test_resolve_exchange_uri_in_volume(tmp_path: Path):
-    vault = tmp_path / "vault"
-    vault.mkdir()
-    artifact = vault / "report.parquet"
-    artifact.touch()
-
-    resolved = resolve_exchange_uri(
-        "exchange://vault/report.parquet",
-        volumes={"vault": vault},
-    )
-    assert resolved == artifact.resolve()
-
-
-def test_resolve_exchange_uri_unknown_volume_raises(tmp_path: Path):
-    with pytest.raises(FileExchangeError) as exc:
-        resolve_exchange_uri("exchange://unknown/x", volumes={"vault": tmp_path})
-    assert exc.value.code == FileExchangeErrorCode.NOT_ACCESSIBLE
-
-
-def test_resolve_exchange_uri_rejects_dot_dot_escape(tmp_path: Path):
-    vault = tmp_path / "vault"
-    vault.mkdir()
-    (tmp_path / "secret.txt").write_text("nope")
-
-    with pytest.raises(FileExchangeError) as exc:
-        resolve_exchange_uri(
-            "exchange://vault/../secret.txt", volumes={"vault": vault}
-        )
-    assert exc.value.code == FileExchangeErrorCode.NOT_ACCESSIBLE
-
-
-def test_resolve_exchange_uri_rejects_symlink_escape(tmp_path: Path):
-    vault = tmp_path / "vault"
-    vault.mkdir()
-    outside = tmp_path / "outside.txt"
-    outside.write_text("forbidden")
-    (vault / "escape").symlink_to(outside)
-
-    with pytest.raises(FileExchangeError) as exc:
-        resolve_exchange_uri("exchange://vault/escape", volumes={"vault": vault})
-    assert exc.value.code == FileExchangeErrorCode.NOT_ACCESSIBLE
-
-
-def test_atomic_write_only_appears_on_success(tmp_path: Path):
-    target = tmp_path / "result.bin"
-
-    with atomic_write(target) as f:
-        f.write(b"partial")
-        # mid-write the target file MUST not exist (consumer never sees partial)
-        assert not target.exists()
-        f.write(b" and more")
-
-    assert target.exists()
-    assert target.read_bytes() == b"partial and more"
-
-
-def test_atomic_write_discards_temp_on_exception(tmp_path: Path):
-    target = tmp_path / "result.bin"
-
-    with pytest.raises(RuntimeError):
-        with atomic_write(target) as f:
-            f.write(b"partial")
-            raise RuntimeError("boom")
-
-    assert not target.exists()
-    # No leftover temp files in the directory either
-    assert list(tmp_path.iterdir()) == []
-```
-
-- [ ] Run the tests:
-
-```bash
-uv run pytest tests/file_exchange/test_transport_filesystem.py -v
-```
-
-Expected: FAIL — ImportError.
-
-### Step C.2: Implement filesystem transport
-
-- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_transport_filesystem.py`:
-
-```python
-"""Filesystem transport (spec §10.1).
-
-Provides:
-- ``parse_volumes`` — parse the operator-supplied volume map (env-var value).
-- ``resolve_exchange_uri`` — resolve an ``exchange://`` or ``file://`` URI to a
-  canonicalised, confinement-checked local Path.
-- ``atomic_write`` — temp-file + rename context manager so consumers never observe
-  a partial write (spec §10.1.3).
-"""
-
-from __future__ import annotations
-
-import os
-import tempfile
-from collections.abc import Iterator, Mapping
-from contextlib import contextmanager
-from pathlib import Path
-from urllib.parse import unquote, urlparse
-
-from ._errors import FileExchangeError, FileExchangeErrorCode
-
-
-def parse_volumes(raw: str | None) -> dict[str, Path]:
-    """Parse a `<volume>=<path>,<volume>=<path>` env-var value.
-
-    Empty/whitespace/None returns an empty mapping. Malformed entries raise ValueError.
-    """
-    if not raw or not raw.strip():
-        return {}
-
-    result: dict[str, Path] = {}
-    for entry in raw.split(","):
-        token = entry.strip()
-        if not token:
-            continue
-        if "=" not in token:
-            raise ValueError(
-                f"FILE_EXCHANGE_VOLUMES entry {token!r} must be of the form "
-                f"'<volume>=<local-mount-point>'"
-            )
-        volume, _, path = token.partition("=")
-        volume = volume.strip()
-        path_value = path.strip()
-        if not volume or not path_value:
-            raise ValueError(
-                f"FILE_EXCHANGE_VOLUMES entry {token!r} must be of the form "
-                f"'<volume>=<local-mount-point>' with non-empty parts"
-            )
-        result[volume] = Path(path_value)
-    return result
-
-
-def resolve_exchange_uri(uri: str, *, volumes: Mapping[str, Path]) -> Path:
-    """Resolve an exchange:// or file:// URI to a canonicalised, confined Path.
-
-    Raises FileExchangeError(code=NOT_ACCESSIBLE) on:
-    - unknown volume (exchange://)
-    - resolved path outside the volume root (canonicalisation escape, symlink swap, etc.)
-    """
-    parsed = urlparse(uri)
-    if parsed.scheme == "exchange":
-        volume = parsed.netloc
-        if volume not in volumes:
-            raise FileExchangeError(
-                code=FileExchangeErrorCode.NOT_ACCESSIBLE,
-                transport="filesystem",
-                detail=f"no mapping configured for volume {volume!r}",
-            )
-        root = volumes[volume].resolve()
-        relative = unquote(parsed.path.lstrip("/"))
-        candidate = (root / relative).resolve()
-        try:
-            candidate.relative_to(root)
-        except ValueError as exc:
-            raise FileExchangeError(
-                code=FileExchangeErrorCode.NOT_ACCESSIBLE,
-                transport="filesystem",
-                detail=f"resolved path escapes volume {volume!r}",
-            ) from exc
-        return candidate
-
-    if parsed.scheme == "file":
-        # Reserved for the "shared mount namespace" case (spec §10.1.2).
-        # Phase 1 supports this only when a single exchange root is configured
-        # under the special volume name "_file_root" — see _capability.py.
-        raise FileExchangeError(
-            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
-            transport="filesystem",
-            detail="file:// scheme requires an operator-configured shared root; not supported in phase 1",
-        )
-
-    raise FileExchangeError(
-        code=FileExchangeErrorCode.NOT_ACCESSIBLE,
-        transport="filesystem",
-        detail=f"unsupported URI scheme: {parsed.scheme!r}",
-    )
-
-
-@contextmanager
-def atomic_write(target: Path) -> Iterator[object]:
-    """Write to a temp file in the target's directory, rename onto target on success.
-
-    Consumers MUST never see a partial write (spec §10.1.3). On any exception the
-    temp file is unlinked.
-    """
-    target.parent.mkdir(parents=True, exist_ok=True)
-    fd, temp_path_s = tempfile.mkstemp(
-        prefix=f".{target.name}.", suffix=".tmp", dir=str(target.parent)
-    )
-    temp_path = Path(temp_path_s)
-    try:
-        with os.fdopen(fd, "wb") as f:
-            yield f
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(temp_path, target)
-    except BaseException:
-        try:
-            temp_path.unlink(missing_ok=True)
-        finally:
-            pass
-        raise
-```
-
-### Step C.3: Implement `make_filesystem_source`
-
-Per design §3, pvl-core exposes a public mint helper for the filesystem-source case
-so downstream never hand-writes a `FilesystemSourceDescriptor`. The helper validates
-the volume against `config.file_exchange_volumes` so a misconfigured volume name is
-rejected at mint time, not later at the consumer.
-
-- [ ] Add tests to `tests/file_exchange/test_transport_filesystem.py`:
-
-```python
-from fastmcp_pvl_core._config import ServerConfig
-from fastmcp_pvl_core._file_exchange._transport_filesystem import (
-    make_filesystem_source,
-)
-
-
-def _config(**kw) -> ServerConfig:
-    base = dict(transport="stdio")
-    base.update(kw)
-    return ServerConfig(**base)
-
-
-def test_make_filesystem_source_happy_path(tmp_path: Path):
-    config = _config(file_exchange_volumes=f"vault={tmp_path}")
-    desc = make_filesystem_source("vault", "report.parquet", config=config)
-    assert desc.root.transport == "filesystem"
-    assert desc.root.uri == "exchange://vault/report.parquet"
-
-
-def test_make_filesystem_source_unknown_volume_raises(tmp_path: Path):
-    config = _config(file_exchange_volumes=f"vault={tmp_path}")
-    with pytest.raises(FileExchangeError) as exc:
-        make_filesystem_source("missing", "x.bin", config=config)
-    assert exc.value.code == FileExchangeErrorCode.NOT_ACCESSIBLE
-```
-
-- [ ] Append to `src/fastmcp_pvl_core/_file_exchange/_transport_filesystem.py`:
-
-```python
-def make_filesystem_source(
-    volume: str,
-    relative_path: str,
-    *,
-    config: "ServerConfig",
-) -> "SourceDescriptor":
-    """Mint a filesystem-transport SourceDescriptor for ``volume/relative_path``.
-
-    Validates ``volume`` against the operator's volume map (parsed from
-    ``config.file_exchange_volumes``). A volume not declared in the deployment
-    is rejected here so the downstream tool body fails fast rather than emitting
-    a descriptor that no consumer can resolve.
-    """
-    from ._types import SourceDescriptor
-
-    volumes = parse_volumes(config.file_exchange_volumes)
-    if volume not in volumes:
-        raise FileExchangeError(
-            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
-            transport="filesystem",
-            detail=f"no mapping configured for volume {volume!r}",
-        )
-    rel = relative_path.lstrip("/")
-    return SourceDescriptor.model_validate(
-        {"transport": "filesystem", "uri": f"exchange://{volume}/{rel}"}
-    )
-```
-
-(The `make_filesystem_sink` minter lives in Task E's `_url_store.py` because it
-must also record the resolved intake path so `resolve_intake` can locate the
-bytes later.)
-
-- [ ] Run the tests:
-
-```bash
-uv run pytest tests/file_exchange/test_transport_filesystem.py -v
-```
-
-Expected: PASS (all 11 tests).
-
-### Step C.4: Commit and PR
-
-- [ ] Commit:
-
-```bash
-git add src/fastmcp_pvl_core/_file_exchange/_transport_filesystem.py tests/file_exchange/test_transport_filesystem.py
-git commit -m "feat(file-exchange): filesystem transport with exchange:// resolution and atomic writes
-
-Closes #126"
-```
-
-- [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
-
----
-
-# Task D: HTTPS consumer side
-
-**Files:**
-- Create: `src/fastmcp_pvl_core/_file_exchange/_transport_https.py`
-- Create: `tests/file_exchange/test_transport_https.py`
-
-### Step D.1: Test SSRF guard
-
-- [ ] Write the SSRF tests in `tests/file_exchange/test_transport_https.py`:
-
-```python
-from __future__ import annotations
-
-import ipaddress
-from unittest.mock import patch
-
-import pytest
-
-from fastmcp_pvl_core._file_exchange._errors import FileExchangeError
-from fastmcp_pvl_core._file_exchange._transport_https import (
-    SSRFGuardConfig,
-    resolve_and_check_host,
-)
-
-
-def _resolve_to(addrs: list[str]):
-    """Patch DNS resolution to return the given address list."""
-    return patch(
-        "fastmcp_pvl_core._file_exchange._transport_https._resolve_host",
-        return_value=[ipaddress.ip_address(a) for a in addrs],
-    )
-
-
-def test_public_address_is_allowed():
-    with _resolve_to(["93.184.216.34"]):
-        ip = resolve_and_check_host("example.com", SSRFGuardConfig())
-        assert ip == ipaddress.IPv4Address("93.184.216.34")
-
-
-def test_loopback_is_rejected_by_default():
-    with _resolve_to(["127.0.0.1"]), pytest.raises(FileExchangeError):
-        resolve_and_check_host("evil.example", SSRFGuardConfig())
-
-
-def test_loopback_allowed_when_configured():
-    with _resolve_to(["127.0.0.1"]):
-        ip = resolve_and_check_host(
-            "localhost", SSRFGuardConfig(allow_loopback=True)
-        )
-        assert ip == ipaddress.IPv4Address("127.0.0.1")
-
-
-def test_private_range_rejected_by_default():
-    with _resolve_to(["10.0.0.5"]), pytest.raises(FileExchangeError):
-        resolve_and_check_host("internal.example", SSRFGuardConfig())
-
-
-def test_link_local_rejected_by_default():
-    with _resolve_to(["169.254.169.254"]), pytest.raises(FileExchangeError):
-        resolve_and_check_host("metadata.example", SSRFGuardConfig())
-
-
-def test_ipv6_loopback_rejected_by_default():
-    with _resolve_to(["::1"]), pytest.raises(FileExchangeError):
-        resolve_and_check_host("v6loop.example", SSRFGuardConfig())
-```
-
-### Step D.2: Implement SSRF guard
-
-- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_transport_https.py`:
-
-```python
-"""HTTPS transport: pull_download / push_upload + SSRF guard (spec §10.2, §10.3, §15)."""
-
-from __future__ import annotations
-
-import asyncio
-import ipaddress
-import socket
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, BinaryIO
-
-import httpx
-
-from ._errors import FileExchangeError, FileExchangeErrorCode
-
-USER_AGENT = "fastmcp-pvl-core/file-exchange/0.1"
-
-
-@dataclass(frozen=True)
-class SSRFGuardConfig:
-    """Operator-set guard knobs (default-deny for private/loopback/link-local)."""
-
-    allow_loopback: bool = False
-    allow_private: bool = False
-
-
-def _resolve_host(host: str) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
-    """One-shot host resolution. Patched in tests."""
-    infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
-    return [ipaddress.ip_address(info[4][0]) for info in infos]
-
-
-def _is_disallowed(
-    addr: ipaddress.IPv4Address | ipaddress.IPv6Address, cfg: SSRFGuardConfig
-) -> str | None:
-    """Return a human-readable reason if disallowed; None if OK."""
-    if addr.is_loopback and not cfg.allow_loopback:
-        return "loopback address"
-    if addr.is_link_local:
-        return "link-local address"
-    if addr.is_private and not cfg.allow_private:
-        return "RFC 1918 / private address"
-    if addr.is_multicast:
-        return "multicast address"
-    if addr.is_reserved:
-        return "reserved address"
-    return None
-
-
-def resolve_and_check_host(
-    host: str, config: SSRFGuardConfig
-) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
-    """Resolve hostname ONCE; reject disallowed ranges; return pinned IP.
-
-    The caller MUST use the returned IP for the actual connection (defeats DNS
-    rebinding). Spec §15 "SSRF" mitigations.
-    """
-    try:
-        addrs = _resolve_host(host)
-    except socket.gaierror as exc:
-        raise FileExchangeError(
-            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
-            transport="download",
-            detail=f"host resolution failed for {host!r}: {exc}",
-        ) from exc
-
-    if not addrs:
-        raise FileExchangeError(
-            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
-            transport="download",
-            detail=f"host {host!r} did not resolve to any addresses",
-        )
-
-    # Pick the first; report rejection if it's disallowed.
-    primary = addrs[0]
-    reason = _is_disallowed(primary, config)
-    if reason is not None:
-        raise FileExchangeError(
-            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
-            transport="download",
-            detail=f"host {host!r} resolved to {primary} ({reason}); refused",
-        )
-    return primary
-```
-
-- [ ] Run the SSRF tests:
-
-```bash
-uv run pytest tests/file_exchange/test_transport_https.py -v
-```
-
-Expected: PASS (all 6 tests).
-
-### Step D.3: Test pull_download against a faked transport
-
-- [ ] Add to `tests/file_exchange/test_transport_https.py`:
-
-```python
-import io
-from datetime import datetime, timedelta, timezone
-
-import httpx
-import pytest
-
-from fastmcp_pvl_core._file_exchange._transport_https import pull_download
-from fastmcp_pvl_core._file_exchange._types import DownloadSourceDescriptor
-
-
-def _descriptor(url: str = "https://example.com/d/tok") -> DownloadSourceDescriptor:
-    return DownloadSourceDescriptor.model_validate(
-        {
-            "transport": "download",
-            "url": url,
-            "expiresAt": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
-        }
-    )
-
-
-def _ok_handler(request: httpx.Request) -> httpx.Response:
-    return httpx.Response(
-        200,
-        content=b"hello bytes",
-        headers={"Content-Length": "11", "Content-Type": "application/octet-stream"},
-    )
-
-
-@pytest.mark.asyncio
-async def test_pull_download_streams_to_buffer():
-    transport = httpx.MockTransport(_ok_handler)
-    buf = io.BytesIO()
-    # SSRF guard is bypassed in tests by passing an explicit transport.
-    received_size = await pull_download(
-        _descriptor(),
-        dest=buf,
-        client_transport=transport,
-        ssrf=SSRFGuardConfig(allow_loopback=True, allow_private=True),
-    )
-    assert buf.getvalue() == b"hello bytes"
-    assert received_size == 11
-
-
-def _bad_redirect_handler(request: httpx.Request) -> httpx.Response:
-    if str(request.url) == "https://example.com/d/tok":
-        return httpx.Response(302, headers={"Location": "https://attacker.example/x"})
-    return httpx.Response(200, content=b"should-not-reach")
-
-
-@pytest.mark.asyncio
-async def test_pull_download_rejects_cross_origin_redirect():
-    transport = httpx.MockTransport(_bad_redirect_handler)
-    buf = io.BytesIO()
-    with pytest.raises(FileExchangeError) as exc:
-        await pull_download(
-            _descriptor(),
-            dest=buf,
-            client_transport=transport,
-            ssrf=SSRFGuardConfig(allow_loopback=True, allow_private=True),
-        )
-    assert exc.value.code in (
-        FileExchangeErrorCode.NOT_ACCESSIBLE,
-        FileExchangeErrorCode.TRANSFER_FAILED,
-    )
-
-
-def _http_handler(request: httpx.Request) -> httpx.Response:
-    return httpx.Response(200, content=b"hi")
-
-
-@pytest.mark.asyncio
-async def test_pull_download_rejects_non_https():
-    transport = httpx.MockTransport(_http_handler)
-    desc = _descriptor("http://example.com/d/tok")  # non-https
-    buf = io.BytesIO()
-    with pytest.raises(FileExchangeError):
-        await pull_download(desc, dest=buf, client_transport=transport, ssrf=SSRFGuardConfig())
-```
-
-### Step D.4: Implement pull_download and push_upload
-
-- [ ] Append to `src/fastmcp_pvl_core/_file_exchange/_transport_https.py`:
-
-```python
-async def pull_download(
-    descriptor,                                  # DownloadSourceDescriptor
-    *,
-    dest: BinaryIO | Path,
-    ssrf: SSRFGuardConfig,
-    digester: "Any | None" = None,
-    client_transport: httpx.AsyncBaseTransport | None = None,
-    chunk_size: int = 65536,
-) -> int:
-    """Pull artifact bytes via HTTPS GET (spec §10.2). Returns bytes received.
-
-    Streams to ``dest`` (either an open writable BinaryIO or a Path; for Path
-    pvl-core uses the filesystem-transport's atomic_write context manager so
-    a partial write is never observed).
-
-    If ``digester`` is provided (a ``hashlib._Hash``-like object exposing
-    ``update``), each received chunk is fed into it *before* being written.
-    Callers (notably ``pull_artifact``) keep the same digester across the
-    transfer so the post-fetch digest check sees the bytes actually received.
-
-    Sync writes inside this async function are dispatched via
-    ``asyncio.to_thread`` so the event loop is never blocked on disk latency.
-
-    SSRF guard runs; non-https URLs are refused; cross-origin redirects are refused;
-    no ambient credentials are attached.
-    """
-    url_str = str(descriptor.url)
-    if not url_str.startswith("https://"):
-        raise FileExchangeError(
-            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
-            transport="download",
-            detail="download URL must use https://",
-        )
-
-    host = httpx.URL(url_str).host
-    # SSRF guard (resolve once, pin IP). Tests can pass a transport that
-    # bypasses real connections; in production the transport is None and
-    # the pinned IP is set in the request connection options.
-    if client_transport is None:
-        resolve_and_check_host(host, ssrf)
-
-    async with httpx.AsyncClient(
-        transport=client_transport,
-        timeout=httpx.Timeout(30.0, connect=10.0),
-        follow_redirects=False,
-        headers={"User-Agent": USER_AGENT, "Accept": "*/*"},
-    ) as client:
-        async with client.stream("GET", url_str) as response:
-            if response.status_code in (301, 302, 303, 307, 308):
-                target = response.headers.get("Location", "")
-                target_host = httpx.URL(target).host if target else ""
-                if target_host != host:
-                    raise FileExchangeError(
-                        code=FileExchangeErrorCode.NOT_ACCESSIBLE,
-                        transport="download",
-                        detail=f"refusing cross-origin redirect to {target_host!r}",
-                    )
-                raise FileExchangeError(
-                    code=FileExchangeErrorCode.TRANSFER_FAILED,
-                    transport="download",
-                    detail="same-origin redirect handling is deferred; provider should issue a direct URL",
-                )
-            if response.status_code != 200:
-                raise FileExchangeError(
-                    code=FileExchangeErrorCode.TRANSFER_FAILED,
-                    transport="download",
-                    detail=f"unexpected HTTP status {response.status_code}",
-                )
-
-            if isinstance(dest, Path):
-                from ._transport_filesystem import atomic_write
-
-                bytes_written = 0
-                with atomic_write(dest) as f:
-                    async for chunk in response.aiter_bytes(chunk_size):
-                        if digester is not None:
-                            digester.update(chunk)
-                        await asyncio.to_thread(f.write, chunk)
-                        bytes_written += len(chunk)
-                return bytes_written
-
-            bytes_written = 0
-            async for chunk in response.aiter_bytes(chunk_size):
-                if digester is not None:
-                    digester.update(chunk)
-                await asyncio.to_thread(dest.write, chunk)
-                bytes_written += len(chunk)
-            return bytes_written
-
-
-async def push_upload(
-    descriptor,                                  # UploadSinkDescriptor
-    *,
-    source: BinaryIO | Path,
-    ssrf: SSRFGuardConfig,
-    content_digest: str | None = None,
-    content_type: str | None = None,
-    content_length: int | None = None,
-    client_transport: httpx.AsyncBaseTransport | None = None,
-) -> None:
-    """Push artifact bytes via HTTPS PUT/POST (spec §10.3).
-
-    Sender obligations: https-only; no ambient credentials; uses the descriptor's
-    method (default PUT); passes Content-Digest when provided; treats non-2xx as failure.
-    """
-    url_str = str(descriptor.url)
-    if not url_str.startswith("https://"):
-        raise FileExchangeError(
-            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
-            transport="upload",
-            detail="upload URL must use https://",
-        )
-
-    host = httpx.URL(url_str).host
-    if client_transport is None:
-        resolve_and_check_host(host, ssrf)
-
-    headers = {"User-Agent": USER_AGENT}
-    if content_type:
-        headers["Content-Type"] = content_type
-    if content_length is not None:
-        headers["Content-Length"] = str(content_length)
-    if content_digest:
-        # Per spec §10.3, this header carries the artifact digest in RFC 9530 form.
-        headers["Content-Digest"] = content_digest
-
-    if isinstance(source, Path):
-        content = source.read_bytes()  # phase 1: simple buffered upload
-    else:
-        content = source.read()
-
-    async with httpx.AsyncClient(
-        transport=client_transport,
-        timeout=httpx.Timeout(60.0, connect=10.0),
-        follow_redirects=False,
-        headers={"User-Agent": USER_AGENT},
-    ) as client:
-        response = await client.request(descriptor.method, url_str, content=content, headers=headers)
-        if not (200 <= response.status_code < 300):
-            raise FileExchangeError(
-                code=FileExchangeErrorCode.TRANSFER_FAILED,
-                transport="upload",
-                detail=f"upload rejected with HTTP {response.status_code}",
-            )
-```
-
-- [ ] Run the tests:
-
-```bash
-uv run pytest tests/file_exchange/test_transport_https.py -v
-```
-
-Expected: PASS (all 9 tests).
-
-### Step D.5: Commit and PR
-
-- [ ] Commit:
-
-```bash
-git add src/fastmcp_pvl_core/_file_exchange/_transport_https.py tests/file_exchange/test_transport_https.py
-git commit -m "feat(file-exchange): HTTPS consumer transport (pull/push) with SSRF guard
-
-Closes #127"
-```
-
-- [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
-
----
-
-# Task E: Capability URL store + sibling routes
-
-**Files:**
-- Create: `src/fastmcp_pvl_core/_file_exchange/_url_store.py`
-- Create: `src/fastmcp_pvl_core/_file_exchange/_routes.py`
-- Create: `tests/file_exchange/test_url_store.py`
-- Create: `tests/file_exchange/test_routes.py`
-
-### Step E.1: Test the URL store
-
-- [ ] Write `tests/file_exchange/test_url_store.py`:
-
-```python
-from __future__ import annotations
-
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
-
-import pytest
-from key_value.aio.stores.memory import MemoryStore
-
-from fastmcp_pvl_core._file_exchange._url_store import (
-    DownloadTokenRecord,
-    UploadTokenRecord,
-    consume_download_token,
-    intake_path_for,
-    mint_download_token,
-    mint_upload_token,
-    record_intake_path,
-)
-
-
-@pytest.fixture
-def store() -> MemoryStore:
-    return MemoryStore()
-
-
-@pytest.mark.asyncio
-async def test_minted_download_token_is_url_safe_random(store: MemoryStore):
-    tok = await mint_download_token(
-        store=store,
-        bytes_path=Path("/tmp/x.bin"),
-        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
-        single_use=True,
-    )
-    # 128 bits of entropy → at least 22 base64url characters.
-    assert len(tok) >= 22
-    record = await store.get(collection="tokens", key=tok)
-    assert record is not None
-
-
-@pytest.mark.asyncio
-async def test_consume_download_token_single_use(store: MemoryStore):
-    expires = datetime.now(timezone.utc) + timedelta(hours=1)
-    tok = await mint_download_token(
-        store=store, bytes_path=Path("/tmp/x.bin"), expires_at=expires, single_use=True
-    )
-
-    record = await consume_download_token(store=store, token=tok)
-    assert record.bytes_path == Path("/tmp/x.bin")
-
-    # Second consume MUST fail because the get-then-delete pattern already
-    # removed the entry on the first successful consume.
-    with pytest.raises(LookupError):
-        await consume_download_token(store=store, token=tok)
-
-
-@pytest.mark.asyncio
-async def test_consume_download_token_concurrent_consumers(store: MemoryStore):
-    """Two concurrent consumers race on a single-use token; exactly one wins."""
-    import asyncio
-
-    expires = datetime.now(timezone.utc) + timedelta(hours=1)
-    tok = await mint_download_token(
-        store=store, bytes_path=Path("/tmp/x.bin"), expires_at=expires, single_use=True
-    )
-
-    results = await asyncio.gather(
-        consume_download_token(store=store, token=tok),
-        consume_download_token(store=store, token=tok),
-        return_exceptions=True,
-    )
-    successes = [r for r in results if not isinstance(r, BaseException)]
-    failures = [r for r in results if isinstance(r, LookupError)]
-    assert len(successes) == 1
-    assert len(failures) == 1
-
-
-@pytest.mark.asyncio
-async def test_expired_token_is_treated_as_missing(store: MemoryStore):
-    past = datetime.now(timezone.utc) - timedelta(seconds=1)
-    tok = await mint_download_token(
-        store=store, bytes_path=Path("/tmp/x.bin"), expires_at=past, single_use=True
-    )
-    with pytest.raises(LookupError):
-        await consume_download_token(store=store, token=tok)
-
-
-@pytest.mark.asyncio
-async def test_intake_path_correlation(store: MemoryStore):
-    await record_intake_path(store=store, artifact_id="ar-1", path=Path("/tmp/intake/x.bin"))
-    p = await intake_path_for(store=store, artifact_id="ar-1")
-    assert p == Path("/tmp/intake/x.bin")
-
-
-@pytest.mark.asyncio
-async def test_intake_path_for_missing_artifact_returns_none(store: MemoryStore):
-    p = await intake_path_for(store=store, artifact_id="never-minted")
-    assert p is None
-
-
-@pytest.mark.asyncio
-async def test_mint_and_consume_never_logs_full_token(caplog, store: MemoryStore):
-    """Capability URLs are bearer credentials; full tokens MUST NOT appear in logs."""
-    import logging
-
-    caplog.set_level(logging.DEBUG, logger="fastmcp_pvl_core.file_exchange")
-    expires = datetime.now(timezone.utc) + timedelta(hours=1)
-    token = await mint_download_token(
-        store=store, bytes_path=Path("/tmp/x.bin"), expires_at=expires, single_use=True
-    )
-    record = await consume_download_token(store=store, token=token)
-    full_log = " ".join(rec.getMessage() for rec in caplog.records)
-    assert token not in full_log, "capability tokens MUST NOT appear in logs"
-    # A fingerprint (first 8 chars + ellipsis) is acceptable; the test
-    # exists so the implementation actually emits log lines we can inspect.
-    assert record is not None
-```
-
-- [ ] Run the test:
-
-```bash
-uv run pytest tests/file_exchange/test_url_store.py -v
-```
-
-Expected: FAIL — ImportError.
-
-### Step E.2: Implement the URL store
-
-- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_url_store.py`:
-
-```python
-"""Capability-URL token store + intake-path correlation map.
-
-Backed by an AsyncKeyValue store (from build_kv_store(..., namespace="file-exchange")),
-which keeps the file-exchange surface restart-safe when configured with file/Redis/etc.
-
-Two collections inside the namespace:
-- ``tokens``   — capability tokens (download + upload)
-- ``intake``   — artifact_id → resolved intake path
-"""
-
-from __future__ import annotations
-
-import logging
-import secrets
-from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-from key_value.aio.protocols.key_value import AsyncKeyValue
-
-if TYPE_CHECKING:
-    from fastmcp import FastMCP
-
-    from fastmcp_pvl_core._config import ServerConfig
-    from ._types import ExpectedConstraints, SinkDescriptor, SourceDescriptor
-
-
-_logger = logging.getLogger("fastmcp_pvl_core.file_exchange")
-
-
-TOKEN_BYTES = 16  # 128 bits → 22 base64url chars
-
-
-@dataclass(frozen=True)
-class DownloadTokenRecord:
-    bytes_path: Path
-    expires_at: datetime
-    single_use: bool
-    consumed: bool
-
-
-@dataclass(frozen=True)
-class UploadTokenRecord:
-    intake_path: Path
-    artifact_id: str
-    expires_at: datetime
-    max_size: int | None
-    accept_mime_types: list[str] | None
-    require_digest: list[str] | None
-    consumed: bool
-
-
-def _new_token() -> str:
-    return secrets.token_urlsafe(TOKEN_BYTES)
-
-
-def _now() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-def _is_expired(expires_at: datetime) -> bool:
-    return _now() > expires_at
-
-
-async def mint_download_token(
-    *,
-    store: AsyncKeyValue,
-    bytes_path: Path,
-    expires_at: datetime,
-    single_use: bool = True,
-) -> str:
-    """Mint a download capability token; return the token string.
-
-    Logs at DEBUG with a fingerprint of the form ``tok=<first-8-chars>...``;
-    the full token never enters any log line (spec §12 bearer-credential hygiene).
-    """
-    token = _new_token()
-    record = {
-        "kind": "download",
-        "bytes_path": str(bytes_path),
-        "expires_at": expires_at.isoformat(),
-        "single_use": single_use,
-    }
-    await store.put(collection="tokens", key=token, value=record)
-    _logger.debug(
-        "file-exchange: minted download token tok=%s... ttl=%ds",
-        token[:8],
-        int((expires_at - _now()).total_seconds()),
-    )
-    return token
-
-
-async def mint_upload_token(
-    *,
-    store: AsyncKeyValue,
-    intake_path: Path,
-    artifact_id: str,
-    expires_at: datetime,
-    max_size: int | None = None,
-    accept_mime_types: list[str] | None = None,
-    require_digest: list[str] | None = None,
-) -> str:
-    """Mint an upload capability token; return the token string.
-
-    Logs at DEBUG with a fingerprint only; never the full token (spec §12).
-    """
-    token = _new_token()
-    record = {
-        "kind": "upload",
-        "intake_path": str(intake_path),
-        "artifact_id": artifact_id,
-        "expires_at": expires_at.isoformat(),
-        "max_size": max_size,
-        "accept_mime_types": accept_mime_types,
-        "require_digest": require_digest,
-    }
-    await store.put(collection="tokens", key=token, value=record)
-    _logger.debug(
-        "file-exchange: minted upload token tok=%s... ttl=%ds",
-        token[:8],
-        int((expires_at - _now()).total_seconds()),
-    )
-    return token
-
-
-async def consume_download_token(
-    *, store: AsyncKeyValue, token: str
-) -> DownloadTokenRecord:
-    """Consume a download token.
-
-    Uses a per-key get-then-delete pattern: ``AsyncKeyValue.delete`` is atomic
-    per key on every supported backend, so a racing second consumer either
-    finds the key already gone on ``get`` or loses the delete race here and
-    raises ``LookupError`` — exactly one consumer wins.
-    """
-    raw = await store.get(collection="tokens", key=token)
-    if raw is None or raw.get("kind") != "download":
-        raise LookupError("download token not found")
-    expires_at = datetime.fromisoformat(raw["expires_at"])
-    if _is_expired(expires_at):
-        raise LookupError("download token expired")
-
-    record = DownloadTokenRecord(
-        bytes_path=Path(raw["bytes_path"]),
-        expires_at=expires_at,
-        single_use=raw["single_use"],
-        consumed=False,
-    )
-
-    if record.single_use:
-        # Atomic per-key delete: a racing consumer hits LookupError on its own
-        # get or here on its delete. The first delete wins.
-        deleted = await store.delete(collection="tokens", key=token)
-        if not deleted:
-            raise LookupError("download token already consumed by a concurrent consumer")
-    _logger.debug(
-        "file-exchange: consumed download token tok=%s... single_use=%s",
-        token[:8],
-        record.single_use,
-    )
-    return record
-
-
-async def consume_upload_token(
-    *, store: AsyncKeyValue, token: str
-) -> UploadTokenRecord:
-    """Consume an upload token.
-
-    Same get-then-delete pattern as ``consume_download_token``. The intake
-    correlation under ``intake:<artifact_id>`` is a different key and
-    survives the token deletion — that is what lets ``resolve_intake`` find
-    the bytes after the upload completes.
-    """
-    raw = await store.get(collection="tokens", key=token)
-    if raw is None or raw.get("kind") != "upload":
-        raise LookupError("upload token not found")
-    expires_at = datetime.fromisoformat(raw["expires_at"])
-    if _is_expired(expires_at):
-        raise LookupError("upload token expired")
-
-    record = UploadTokenRecord(
-        intake_path=Path(raw["intake_path"]),
-        artifact_id=raw["artifact_id"],
-        expires_at=expires_at,
-        max_size=raw.get("max_size"),
-        accept_mime_types=raw.get("accept_mime_types"),
-        require_digest=raw.get("require_digest"),
-        consumed=False,
-    )
-
-    deleted = await store.delete(collection="tokens", key=token)
-    if not deleted:
-        raise LookupError("upload token already consumed by a concurrent consumer")
-    _logger.debug(
-        "file-exchange: consumed upload token tok=%s... artifact_id=%s",
-        token[:8],
-        record.artifact_id,
-    )
-    return record
-
-
-async def record_intake_path(
-    *, store: AsyncKeyValue, artifact_id: str, path: Path
-) -> None:
-    """Record (artifact_id → resolved intake path) so resolve_intake can find it.
-
-    Called by both sink-minters (``make_filesystem_sink`` and ``mint_upload_sink``)
-    at mint time, so the intake mapping exists regardless of which transport
-    the sender ultimately picks.
-    """
-    await store.put(
-        collection="intake", key=artifact_id, value={"path": str(path)}
-    )
-
-
-async def intake_path_for(
-    *, store: AsyncKeyValue, artifact_id: str
-) -> Path | None:
-    raw = await store.get(collection="intake", key=artifact_id)
-    if raw is None:
-        return None
-    return Path(raw["path"])
-
-
-# ---- Public mint helpers (design §3 "Descriptor minting (producer side)") ----
-
-
-async def make_filesystem_sink(
-    volume: str,
-    relative_path: str,
-    *,
-    artifact_id: str,
-    config: "ServerConfig",
-    kv_store: AsyncKeyValue,
-) -> "SinkDescriptor":
-    """Mint a filesystem-transport SinkDescriptor and record the intake mapping.
-
-    Resolves the ``exchange://`` URI immediately so the intake path is recorded
-    in ``kv_store`` before the descriptor leaves the producer. ``resolve_intake``
-    then finds the bytes via the recorded mapping regardless of how the sender
-    delivered them.
-    """
-    from ._transport_filesystem import parse_volumes, resolve_exchange_uri
-    from ._types import SinkDescriptor
-
-    volumes = parse_volumes(config.file_exchange_volumes)
-    rel = relative_path.lstrip("/")
-    uri = f"exchange://{volume}/{rel}"
-    resolved = resolve_exchange_uri(uri, volumes=volumes)
-    await record_intake_path(store=kv_store, artifact_id=artifact_id, path=resolved)
-    return SinkDescriptor.model_validate({"transport": "filesystem", "uri": uri})
-
-
-async def mint_download_source(
-    *,
-    bytes_path: Path,
-    server: "FastMCP",
-    config: "ServerConfig",
-    kv_store: AsyncKeyValue,
-    expires_in_s: int | None = None,
-    single_use: bool = True,
-) -> "SourceDescriptor":
-    """Mint a download-transport SourceDescriptor backed by a fresh capability URL.
-
-    ``server`` and ``config`` are used to compute the public base URL via the
-    existing ``compute_app_domain`` helper (overridable via
-    ``config.file_exchange_https_public_base_url``).
-    """
-    from datetime import timedelta
-
-    from .._helpers import compute_app_domain  # existing pvl-core helper
-    from ._types import SourceDescriptor
-
-    ttl = expires_in_s if expires_in_s is not None else config.file_exchange_capability_url_ttl_default_s
-    if ttl <= 0:
-        raise ValueError("expires_in_s must be > 0")
-    expires_at = _now() + timedelta(seconds=ttl)
-    token = await mint_download_token(
-        store=kv_store, bytes_path=bytes_path, expires_at=expires_at, single_use=single_use
-    )
-    base = config.file_exchange_https_public_base_url or compute_app_domain(server, config)
-    url = f"{base.rstrip('/')}/file-exchange/d/{token}"
-    return SourceDescriptor.model_validate(
-        {
-            "transport": "download",
-            "url": url,
-            "expiresAt": expires_at.isoformat(),
-            "singleUse": single_use,
-        }
-    )
-
-
-async def mint_upload_sink(
-    *,
-    intake_path: Path,
-    artifact_id: str,
-    server: "FastMCP",
-    config: "ServerConfig",
-    kv_store: AsyncKeyValue,
-    expires_in_s: int | None = None,
-    expected: "ExpectedConstraints | None" = None,
-) -> "SinkDescriptor":
-    """Mint an upload-transport SinkDescriptor and record the intake mapping.
-
-    The intake path is recorded under ``intake:<artifact_id>`` at mint time;
-    after the upload route writes the bytes, ``resolve_intake(artifact_id)``
-    returns this path.
-    """
-    from datetime import timedelta
-
-    from .._helpers import compute_app_domain  # existing pvl-core helper
-    from ._types import SinkDescriptor
-
-    ttl = expires_in_s if expires_in_s is not None else config.file_exchange_capability_url_ttl_default_s
-    if ttl <= 0:
-        raise ValueError("expires_in_s must be > 0")
-    expires_at = _now() + timedelta(seconds=ttl)
-    token = await mint_upload_token(
-        store=kv_store,
-        intake_path=intake_path,
-        artifact_id=artifact_id,
-        expires_at=expires_at,
-        max_size=expected.maxSize if expected else None,
-        accept_mime_types=expected.acceptMimeTypes if expected else None,
-        require_digest=expected.requireDigest if expected else None,
-    )
-    await record_intake_path(store=kv_store, artifact_id=artifact_id, path=intake_path)
-    base = config.file_exchange_https_public_base_url or compute_app_domain(server, config)
-    url = f"{base.rstrip('/')}/file-exchange/u/{token}"
-    return SinkDescriptor.model_validate(
-        {
-            "transport": "upload",
-            "url": url,
-            "expiresAt": expires_at.isoformat(),
-        }
-    )
-```
-
-- [ ] Run the tests:
-
-```bash
-uv run pytest tests/file_exchange/test_url_store.py -v
-```
-
-Expected: PASS (all tests in `test_url_store.py`, including the concurrent-consume and log-discipline tests).
-
-### Step E.2b: Test the public mint helpers
-
-The three sink/source minters that live in `_url_store.py` (alongside their
-filesystem-source sibling in Task C) need happy-path + validation-failure
-coverage. Append to `tests/file_exchange/test_url_store.py`:
-
-```python
-from fastmcp_pvl_core._config import ServerConfig
-from fastmcp_pvl_core._file_exchange._types import ExpectedConstraints
-from fastmcp_pvl_core._file_exchange._url_store import (
-    make_filesystem_sink,
-    mint_download_source,
-    mint_upload_sink,
-)
-
-
-def _config(**kw) -> ServerConfig:
-    base = dict(transport="http")
-    base.update(kw)
-    return ServerConfig(**base)
-
-
-@pytest.mark.asyncio
-async def test_make_filesystem_sink_records_intake_mapping(tmp_path: Path, store: MemoryStore):
-    config = _config(file_exchange_volumes=f"intake={tmp_path}")
-    sink = await make_filesystem_sink(
-        "intake", "x.bin", artifact_id="ar-1", config=config, kv_store=store
-    )
-    assert sink.root.transport == "filesystem"
-    assert sink.root.uri == "exchange://intake/x.bin"
-    raw = await store.get(collection="intake", key="ar-1")
-    assert raw is not None
-    assert Path(raw["path"]) == (tmp_path / "x.bin").resolve()
-
-
-@pytest.mark.asyncio
-async def test_make_filesystem_sink_rejects_unknown_volume(tmp_path: Path, store: MemoryStore):
-    config = _config(file_exchange_volumes=f"intake={tmp_path}")
-    with pytest.raises(FileExchangeError) as exc:
-        await make_filesystem_sink(
-            "missing", "x.bin", artifact_id="ar-1", config=config, kv_store=store
-        )
-    assert exc.value.code == FileExchangeErrorCode.NOT_ACCESSIBLE
-
-
-@pytest.mark.asyncio
-async def test_mint_download_source_produces_capability_url(
-    tmp_path: Path, store: MemoryStore, monkeypatch
-):
-    monkeypatch.setattr(
-        "fastmcp_pvl_core._file_exchange._url_store.compute_app_domain",
-        lambda server, config: "https://example.test",
-    )
-    config = _config(file_exchange_capability_url_ttl_default_s=60)
-    bytes_path = tmp_path / "x.bin"
-    bytes_path.write_bytes(b"hello")
-    desc = await mint_download_source(
-        bytes_path=bytes_path,
-        server=object(),  # compute_app_domain is patched, server is not touched
-        config=config,
-        kv_store=store,
-    )
-    assert desc.root.transport == "download"
-    assert str(desc.root.url).startswith("https://example.test/file-exchange/d/")
-
-
-@pytest.mark.asyncio
-async def test_mint_download_source_invalid_config_rejects(tmp_path: Path, store: MemoryStore):
-    """ttl ≤ 0 produces an expiresAt in the past — validation surface."""
-    config = _config(file_exchange_capability_url_ttl_default_s=60)
-    bytes_path = tmp_path / "x.bin"
-    bytes_path.write_bytes(b"hello")
-    with pytest.raises(Exception):
-        # Negative TTL must not silently produce an expired descriptor.
-        await mint_download_source(
-            bytes_path=bytes_path,
-            server=object(),
-            config=config,
-            kv_store=store,
-            expires_in_s=-1,
-        )
-
-
-@pytest.mark.asyncio
-async def test_mint_upload_sink_records_intake_and_mints_url(
-    tmp_path: Path, store: MemoryStore, monkeypatch
-):
-    monkeypatch.setattr(
-        "fastmcp_pvl_core._file_exchange._url_store.compute_app_domain",
-        lambda server, config: "https://example.test",
-    )
-    config = _config(file_exchange_capability_url_ttl_default_s=60)
-    intake = tmp_path / "intake.bin"
-    sink = await mint_upload_sink(
-        intake_path=intake,
-        artifact_id="ar-1",
-        server=object(),
-        config=config,
-        kv_store=store,
-        expected=ExpectedConstraints(maxSize=1024),
-    )
-    assert sink.root.transport == "upload"
-    assert str(sink.root.url).startswith("https://example.test/file-exchange/u/")
-    raw = await store.get(collection="intake", key="ar-1")
-    assert raw is not None
-    assert Path(raw["path"]) == intake
-
-
-@pytest.mark.asyncio
-async def test_mint_upload_sink_validation_failure(tmp_path: Path, store: MemoryStore):
-    """ExpectedConstraints with a negative maxSize must surface at validation."""
-    config = _config()
-    with pytest.raises(Exception):
-        ExpectedConstraints.model_validate({"maxSize": -1})
-```
-
-For mint helpers in this task, the docstring guard against negative TTLs needs
-to be enforced; add to `mint_download_source`/`mint_upload_sink`:
-
-```python
-    if ttl <= 0:
-        raise ValueError("expires_in_s must be > 0")
-```
-
-- [ ] Run the new tests:
-
-```bash
-uv run pytest tests/file_exchange/test_url_store.py -v
-```
-
-Expected: PASS.
-
-### Step E.3: Test the sibling routes
-
-- [ ] Write `tests/file_exchange/test_routes.py`:
-
-```python
-from __future__ import annotations
-
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
-
-import pytest
-from key_value.aio.stores.memory import MemoryStore
-from starlette.applications import Starlette
-from starlette.testclient import TestClient
-
-from fastmcp_pvl_core._file_exchange._routes import build_file_exchange_router
-from fastmcp_pvl_core._file_exchange._url_store import (
-    mint_download_token,
-    mint_upload_token,
-)
-
-
-@pytest.fixture
-def store() -> MemoryStore:
-    return MemoryStore()
-
-
-@pytest.fixture
-def app(store: MemoryStore) -> Starlette:
-    router = build_file_exchange_router(store=store)
-    return Starlette(routes=router.routes)
-
-
-@pytest.mark.asyncio
-async def test_download_route_serves_bytes(tmp_path: Path, store: MemoryStore, app):
-    artifact = tmp_path / "x.bin"
-    artifact.write_bytes(b"hello bytes")
-    expires = datetime.now(timezone.utc) + timedelta(hours=1)
-    token = await mint_download_token(
-        store=store, bytes_path=artifact, expires_at=expires, single_use=True
-    )
-
-    with TestClient(app) as client:
-        resp = client.get(f"/file-exchange/d/{token}")
-    assert resp.status_code == 200
-    assert resp.content == b"hello bytes"
-
-
-@pytest.mark.asyncio
-async def test_download_route_single_use_second_request_404s(
-    tmp_path: Path, store: MemoryStore, app
-):
-    artifact = tmp_path / "x.bin"
-    artifact.write_bytes(b"hi")
-    expires = datetime.now(timezone.utc) + timedelta(hours=1)
-    token = await mint_download_token(
-        store=store, bytes_path=artifact, expires_at=expires, single_use=True
-    )
-
-    with TestClient(app) as client:
-        first = client.get(f"/file-exchange/d/{token}")
-        second = client.get(f"/file-exchange/d/{token}")
-    assert first.status_code == 200
-    assert second.status_code == 404
-
-
-@pytest.mark.asyncio
-async def test_download_route_returns_404_for_expired(
-    tmp_path: Path, store: MemoryStore, app
-):
-    artifact = tmp_path / "x.bin"
-    artifact.write_bytes(b"hi")
-    past = datetime.now(timezone.utc) - timedelta(seconds=1)
-    token = await mint_download_token(
-        store=store, bytes_path=artifact, expires_at=past, single_use=True
-    )
-    with TestClient(app) as client:
-        resp = client.get(f"/file-exchange/d/{token}")
-    assert resp.status_code == 404
-
-
-@pytest.mark.asyncio
-async def test_upload_route_writes_atomically(
-    tmp_path: Path, store: MemoryStore, app
-):
-    intake = tmp_path / "intake" / "x.bin"
-    expires = datetime.now(timezone.utc) + timedelta(hours=1)
-    token = await mint_upload_token(
-        store=store,
-        intake_path=intake,
-        artifact_id="ar-1",
-        expires_at=expires,
-    )
-    with TestClient(app) as client:
-        resp = client.put(f"/file-exchange/u/{token}", content=b"payload")
-    assert resp.status_code == 204
-    assert intake.read_bytes() == b"payload"
-
-
-@pytest.mark.asyncio
-async def test_upload_route_enforces_max_size(
-    tmp_path: Path, store: MemoryStore, app
-):
-    intake = tmp_path / "intake" / "x.bin"
-    expires = datetime.now(timezone.utc) + timedelta(hours=1)
-    token = await mint_upload_token(
-        store=store,
-        intake_path=intake,
-        artifact_id="ar-1",
-        expires_at=expires,
-        max_size=3,
-    )
-    with TestClient(app) as client:
-        resp = client.put(f"/file-exchange/u/{token}", content=b"too much")
-    assert resp.status_code == 413
-    # Intake path MUST NOT be written when the upload was rejected mid-stream.
-    assert not intake.exists()
-    # No temp files left behind in the intake directory either.
-    if intake.parent.exists():
-        leftover = [p for p in intake.parent.iterdir() if p.name.startswith(".")]
-        assert leftover == []
-```
-
-### Step E.4: Implement the routes
-
-- [ ] Write `src/fastmcp_pvl_core/_file_exchange/_routes.py`:
-
-```python
-"""Sibling HTTP routes mounted on the FastMCP server.
-
-GET  /file-exchange/d/<token>    serves a minted download.
-PUT  /file-exchange/u/<token>    accepts an upload (POST also accepted).
-
-Both routes look tokens up in the kv_store passed to ``build_file_exchange_router``.
-"""
-
-from __future__ import annotations
-
-import asyncio
-import hashlib
-from pathlib import Path
-
-from key_value.aio.protocols.key_value import AsyncKeyValue
-from starlette.requests import Request
-from starlette.responses import FileResponse, Response
-from starlette.routing import Route, Router
-
-from ._transport_filesystem import atomic_write
-from ._url_store import (
-    consume_download_token,
-    consume_upload_token,
-    record_intake_path,
-)
-
-
-class _UploadTooLarge(Exception):
-    """Internal signal raised mid-stream when cumulative bytes exceed max_size."""
-
-
-class _UploadMimeRejected(Exception):
-    """Internal signal raised when Content-Type does not match accept_mime_types."""
-
-
-def build_file_exchange_router(*, store: AsyncKeyValue) -> Router:
-    """Return a Starlette Router with the file-exchange capability-URL endpoints."""
-
-    async def _download(request: Request) -> Response:
-        token = request.path_params["token"]
-        try:
-            record = await consume_download_token(store=store, token=token)
-        except LookupError:
-            return Response(status_code=404)
-        if not record.bytes_path.exists():
-            return Response(status_code=404)
-        return FileResponse(record.bytes_path)
-
-    async def _upload(request: Request) -> Response:
-        token = request.path_params["token"]
-        try:
-            record = await consume_upload_token(store=store, token=token)
-        except LookupError:
-            return Response(status_code=404)
-
-        # Pre-stream Content-Type check (fast reject before allocating a temp file).
-        if record.accept_mime_types:
-            content_type = (request.headers.get("content-type") or "").split(";")[0].strip()
-            if content_type and not _mime_matches(content_type, record.accept_mime_types):
-                return Response(status_code=415)
-
-        # Stream the body chunk-by-chunk into the atomic_write temp file. The
-        # context manager discards the temp file if the body block raises (size
-        # overflow, digest mismatch, transport error). Sync file writes are
-        # dispatched via asyncio.to_thread so the event loop never blocks on disk.
-        cumulative_bytes = 0
-        digester = hashlib.sha256()
-        try:
-            with atomic_write(record.intake_path) as f:
-                async for chunk in request.stream():
-                    if not chunk:
-                        continue
-                    cumulative_bytes += len(chunk)
-                    if record.max_size is not None and cumulative_bytes > record.max_size:
-                        raise _UploadTooLarge()
-                    digester.update(chunk)
-                    await asyncio.to_thread(f.write, chunk)
-        except _UploadTooLarge:
-            return Response(status_code=413)
-
-        # Post-stream digest check against the optional Content-Digest header.
-        content_digest = request.headers.get("content-digest")
-        if content_digest:
-            # RFC 9530 form: sha-256=:<base64>:
-            # Phase 1 accepts the simpler `sha-256:<hex>` form too.
-            algo, _, value = content_digest.partition(":")
-            if algo.lower().strip() in ("sha-256", "sha256") and value.strip().strip(":") != digester.hexdigest():
-                # The atomic_write rename already happened; remove the now-suspect file.
-                record.intake_path.unlink(missing_ok=True)
-                return Response(status_code=422)
-
-        # Intake correlation under intake:<artifact_id> was already recorded at
-        # mint time by the sink-minter; nothing further to do here.
-        return Response(status_code=204)
-
-    return Router(
-        routes=[
-            Route("/file-exchange/d/{token}", endpoint=_download, methods=["GET"]),
-            Route(
-                "/file-exchange/u/{token}",
-                endpoint=_upload,
-                methods=["PUT", "POST"],
-            ),
-        ]
-    )
-
-
-def _mime_matches(actual: str, accepted: list[str]) -> bool:
-    """RFC 7231 §3.1.1.1 media-range matching."""
-    actual_type, _, actual_sub = actual.partition("/")
-    for pattern in accepted:
-        ptype, _, psub = pattern.partition("/")
-        if pattern == "*/*":
-            return True
-        if ptype == actual_type and (psub == "*" or psub == actual_sub):
-            return True
-    return False
-```
-
-- [ ] Run the route tests:
-
-```bash
-uv run pytest tests/file_exchange/test_routes.py -v
-```
-
-Expected: PASS (all 5 tests).
-
-### Step E.5: Commit and PR
-
-- [ ] Commit:
-
-```bash
-git add src/fastmcp_pvl_core/_file_exchange/_url_store.py src/fastmcp_pvl_core/_file_exchange/_routes.py tests/file_exchange/test_url_store.py tests/file_exchange/test_routes.py
-git commit -m "feat(file-exchange): capability-URL token store + sibling HTTP routes
-
-Closes #128"
-```
-
-- [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
-
----
-
-# Task F: Capability declaration + role helpers + top-level re-exports
-
-**Files:**
-- Modify: `src/fastmcp_pvl_core/_config.py` — add seven file-exchange fields + env-var reads
-- Create: `src/fastmcp_pvl_core/_file_exchange/_capability.py`
-- Create: `src/fastmcp_pvl_core/_file_exchange/_provider.py`
-- Create: `src/fastmcp_pvl_core/_file_exchange/_fetcher.py`
-- Create: `src/fastmcp_pvl_core/_file_exchange/_receiver.py`
-- Create: `src/fastmcp_pvl_core/_file_exchange/_sender.py`
-- Modify: `src/fastmcp_pvl_core/__init__.py` — re-export public surface
-- Create: `tests/file_exchange/test_capability.py`
-- Create: `tests/file_exchange/test_role_helpers.py`
-
-### Step F.1: Extend ServerConfig
-
-- [ ] Test the env-var loading. Add to `tests/file_exchange/test_capability.py`:
-
-```python
-from __future__ import annotations
-
-import pytest
-
-from fastmcp_pvl_core._config import ServerConfig
-
-
-def test_serverconfig_loads_file_exchange_volumes(monkeypatch):
-    monkeypatch.setenv("MV_FILE_EXCHANGE_VOLUMES", "vault=/mnt/vault,intake=/mnt/intake")
-    monkeypatch.setenv("MV_TRANSPORT", "http")
-    cfg = ServerConfig.from_env("MV")
-    assert cfg.file_exchange_volumes == "vault=/mnt/vault,intake=/mnt/intake"
-    assert cfg.transport == "http"
-
-
-def test_serverconfig_file_exchange_defaults(monkeypatch):
-    cfg = ServerConfig.from_env("MV")
-    assert cfg.file_exchange_volumes is None
-    assert cfg.file_exchange_max_artifact_size is None
-    assert cfg.file_exchange_https_allow_loopback is False
-    assert cfg.file_exchange_https_allow_private is False
-    assert cfg.file_exchange_capability_url_ttl_default_s == 3600
-    assert cfg.file_exchange_https_public_base_url is None
-```
-
-- [ ] Add the seven fields to `ServerConfig` in `_config.py` (insert near the existing `kv_store_url` field, preserving dataclass field ordering):
-
-```python
-    file_exchange_volumes: str | None = None
-    file_exchange_max_artifact_size: int | None = None
-    file_exchange_https_allow_loopback: bool = False
-    file_exchange_https_allow_private: bool = False
-    file_exchange_capability_url_ttl_default_s: int = 3600
-    file_exchange_https_public_base_url: str | None = None
-```
-
-- [ ] Wire the env reads in `ServerConfig.from_env` (insert next to the existing `kv_store_url=env(...)` line):
-
-```python
-            file_exchange_volumes=env(env_prefix, "FILE_EXCHANGE_VOLUMES"),
-            file_exchange_max_artifact_size=_int_or_none(env(env_prefix, "FILE_EXCHANGE_MAX_ARTIFACT_SIZE")),
-            file_exchange_https_allow_loopback=parse_bool(env(env_prefix, "FILE_EXCHANGE_HTTPS_ALLOW_LOOPBACK"), default=False),
-            file_exchange_https_allow_private=parse_bool(env(env_prefix, "FILE_EXCHANGE_HTTPS_ALLOW_PRIVATE"), default=False),
-            file_exchange_capability_url_ttl_default_s=int(env(env_prefix, "FILE_EXCHANGE_CAPABILITY_URL_TTL_DEFAULT_S") or "3600"),
-            file_exchange_https_public_base_url=env(env_prefix, "FILE_EXCHANGE_HTTPS_PUBLIC_BASE_URL"),
-```
-
-(`_int_or_none` lives next to `parse_bool` in the existing config module; if it isn't there, add a one-liner helper next to it.)
-
-- [ ] Run:
-
-```bash
-uv run pytest tests/file_exchange/test_capability.py::test_serverconfig_loads_file_exchange_volumes tests/file_exchange/test_capability.py::test_serverconfig_file_exchange_defaults -v
-```
-
-Expected: PASS.
-
-### Step F.2: Implement register_file_exchange_capability with gating
-
-- [ ] Add to `tests/file_exchange/test_capability.py`:
-
-```python
-from key_value.aio.stores.memory import MemoryStore
-from fastmcp import FastMCP
-
-from fastmcp_pvl_core._file_exchange._capability import register_file_exchange_capability
-
-
-def _server() -> FastMCP:
-    return FastMCP(name="test")
-
-
-def _config(**kw) -> ServerConfig:
-    base = dict(transport="stdio")
-    base.update(kw)
-    return ServerConfig(**base)
-
-
-@pytest.mark.asyncio
-async def test_gating_stdio_no_volumes_advertises_consumer_roles_only():
-    """stdio + no volumes still advertises fetcher+sender via outbound HTTPS.
-
-    Per design §3 transport-availability gating: ``download`` for ``fetcher``
-    and ``upload`` for ``sender`` are always available (outbound HTTPS). The
-    producer-side roles (`provider`, `receiver`) drop because they need an
-    HTTP app to host endpoints, and `filesystem` drops because no volumes
-    are configured.
-    """
-    server = _server()
-    config = _config()  # stdio, no volumes
-    store = MemoryStore()
-    register_file_exchange_capability(server, config, kv_store=store)
-    block = server.experimental_capabilities["nl.liesdonk.file-exchange"]
-    roles = block["roles"]
-    assert roles["fetcher"] == ["download"]
-    assert roles["sender"] == ["upload"]
-    assert "provider" not in roles
-    assert "receiver" not in roles
-
-
-@pytest.mark.asyncio
-async def test_gating_advertises_nothing_when_no_role_satisfies_any_transport():
-    """The capability block is absent when no declared role has a viable transport."""
-    server = _server()
-    config = _config()  # stdio, no volumes
-    store = MemoryStore()
-    register_file_exchange_capability(
-        server, config, kv_store=store, roles=("provider", "receiver")
-    )
-    caps = server.experimental_capabilities or {}
-    assert "nl.liesdonk.file-exchange" not in caps
-
-
-@pytest.mark.asyncio
-async def test_gating_stdio_with_volumes_advertises_filesystem_plus_consumer_https():
-    """stdio + volumes: producer roles get filesystem only; consumer roles get both."""
-    server = _server()
-    config = _config(file_exchange_volumes="vault=/tmp/vault")
-    store = MemoryStore()
-    register_file_exchange_capability(server, config, kv_store=store)
-    block = server.experimental_capabilities["nl.liesdonk.file-exchange"]
-    assert block["version"] == "0.1"
-    roles = block["roles"]
-    assert roles["provider"] == ["filesystem"]
-    assert roles["receiver"] == ["filesystem"]
-    assert set(roles["fetcher"]) == {"filesystem", "download"}
-    assert set(roles["sender"]) == {"filesystem", "upload"}
-
-
-@pytest.mark.asyncio
-async def test_gating_http_without_volumes_advertises_https_only():
-    server = _server()
-    config = _config(transport="http")
-    store = MemoryStore()
-    register_file_exchange_capability(server, config, kv_store=store)
-    block = server.experimental_capabilities["nl.liesdonk.file-exchange"]
-    roles = block["roles"]
-    assert roles["provider"] == ["download"]
-    assert roles["fetcher"] == ["download"]
-    assert roles["receiver"] == ["upload"]
-    assert roles["sender"] == ["upload"]
-
-
-@pytest.mark.asyncio
-async def test_gating_http_with_volumes_advertises_both():
-    server = _server()
-    config = _config(transport="http", file_exchange_volumes="v=/tmp/v")
-    store = MemoryStore()
-    register_file_exchange_capability(server, config, kv_store=store)
-    block = server.experimental_capabilities["nl.liesdonk.file-exchange"]
-    assert set(block["roles"]["provider"]) == {"filesystem", "download"}
-    assert set(block["roles"]["sender"]) == {"filesystem", "upload"}
-
-
-@pytest.mark.asyncio
-async def test_gating_subset_of_declared_roles():
-    server = _server()
-    config = _config(transport="http", file_exchange_volumes="v=/tmp/v")
-    store = MemoryStore()
-    register_file_exchange_capability(
-        server, config, kv_store=store, roles=("provider", "fetcher")
-    )
-    roles = server.experimental_capabilities["nl.liesdonk.file-exchange"]["roles"]
-    assert set(roles.keys()) == {"provider", "fetcher"}
-
-
-@pytest.mark.asyncio
-async def test_max_artifact_size_from_config_lands_in_block():
-    """`maxArtifactSize` is operator-side configuration, not a kwarg (design §3)."""
-    server = _server()
-    config = _config(
-        transport="http", file_exchange_volumes="v=/tmp/v", file_exchange_max_artifact_size=10_000_000
-    )
-    store = MemoryStore()
-    register_file_exchange_capability(server, config, kv_store=store)
-    block = server.experimental_capabilities["nl.liesdonk.file-exchange"]
-    assert block["maxArtifactSize"] == 10_000_000
-```
-
-- [ ] Implement `src/fastmcp_pvl_core/_file_exchange/_capability.py`:
-
-```python
-"""Capability declaration + transport-availability gating."""
-
-from __future__ import annotations
-
-from collections.abc import Sequence
-from typing import TYPE_CHECKING
-
-from key_value.aio.protocols.key_value import AsyncKeyValue
-
-from .._config import ServerConfig
-from ._transport_filesystem import parse_volumes
-from ._types import FileExchangeRole
-
-if TYPE_CHECKING:
-    from fastmcp import FastMCP
-
-CAPABILITY_KEY = "nl.liesdonk.file-exchange"
-EXTENSION_VERSION = "0.1"
-
-_HTTP_TRANSPORTS = ("http", "sse")  # both indicate the server hosts an HTTP app
-
-
-def _transports_for_role(role: str, *, volumes: dict, http_app: bool) -> list[str]:
-    transports: list[str] = []
-    if volumes:
-        transports.append("filesystem")
-    if role in ("provider", "fetcher"):
-        # provider needs to host endpoint -> http_app required; fetcher is outbound -> always possible
-        if role == "fetcher" or http_app:
-            transports.append("download")
-    if role in ("receiver", "sender"):
-        if role == "sender" or http_app:
-            transports.append("upload")
-    return transports
-
-
-def register_file_exchange_capability(
-    server: "FastMCP",
-    config: ServerConfig,
-    *,
-    kv_store: AsyncKeyValue,
-    roles: Sequence[FileExchangeRole] = ("provider", "fetcher", "receiver", "sender"),
-    digests: Sequence[str] = ("sha-256",),
-) -> None:
-    """Advertise file-exchange capabilities reflecting what this deployment satisfies.
-
-    - filesystem is advertised only when ``config.file_exchange_volumes`` is non-empty.
-    - download/upload are advertised for provider/receiver only when ``config.transport``
-      indicates an HTTP app; the fetcher/sender (consumer) sides are always advertised
-      when at least one of filesystem|outbound-HTTPS is available.
-    - If no role has any satisfiable transport, the capability block is NOT emitted.
-
-    ``maxArtifactSize`` is operator-side configuration: pvl-core reads
-    ``config.file_exchange_max_artifact_size`` and emits it on the capability
-    block when set. It is *not* a kwarg (design §3 — operator config lives on
-    ``ServerConfig``, not the helper signature).
-    """
-    volumes = parse_volumes(config.file_exchange_volumes)
-    http_app = config.transport in _HTTP_TRANSPORTS
-
-    advertised_roles: dict[str, list[str]] = {}
-    for role in roles:
-        transports = _transports_for_role(role, volumes=volumes, http_app=http_app)
-        if transports:
-            advertised_roles[role] = transports
-
-    if not advertised_roles:
-        import logging
-        logging.getLogger(__name__).info(
-            "file-exchange: no satisfiable transport for any declared role — capability not advertised"
-        )
-        return
-
-    block: dict = {
-        "version": EXTENSION_VERSION,
-        "roles": advertised_roles,
-        "digests": list(digests),
-    }
-    if config.file_exchange_max_artifact_size is not None:
-        block["maxArtifactSize"] = config.file_exchange_max_artifact_size
-
-    server.experimental_capabilities = {
-        **(server.experimental_capabilities or {}),
-        CAPABILITY_KEY: block,
-    }
-
-    # Auto-mount sibling routes iff producer-side HTTPS is advertised.
-    needs_http_routes = (
-        "download" in advertised_roles.get("provider", [])
-        or "upload" in advertised_roles.get("receiver", [])
-    )
-    if needs_http_routes:
-        from ._routes import build_file_exchange_router
-
-        router = build_file_exchange_router(store=kv_store)
-        # FastMCP exposes its HTTP app via `server.http_app()` (a method, not a
-        # property — calling it constructs/returns the Starlette app). VERIFY
-        # this against the installed fastmcp version before relying on it:
-        #
-        #   from fastmcp import FastMCP
-        #   import inspect
-        #   print(inspect.signature(FastMCP.http_app))
-        #
-        # If the API shape has shifted, update this single attach point.
-        http_app = server.http_app()
-        http_app.routes.extend(router.routes)
-```
-
-- [ ] Run:
-
-```bash
-uv run pytest tests/file_exchange/test_capability.py -v
-```
-
-Expected: PASS (all 7 tests including ServerConfig + gating).
-
-### Step F.3: Implement provider helper
-
-- [ ] Add to `tests/file_exchange/test_role_helpers.py`:
-
-```python
-from __future__ import annotations
-
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
-
-import pytest
-from key_value.aio.stores.memory import MemoryStore
-
-from fastmcp_pvl_core._file_exchange._provider import build_pull_response
-from fastmcp_pvl_core._file_exchange._types import (
-    ArtifactMetadata,
-    FilesystemSourceDescriptor,
-    SourceDescriptor,
-)
-
-
-def _fs_source(uri: str) -> SourceDescriptor:
-    return SourceDescriptor.model_validate({"transport": "filesystem", "uri": uri})
-
-
-def test_build_pull_response_embeds_handle_in_structured_content():
-    artifact = ArtifactMetadata(name="x.bin", size=11)
-    sources = [_fs_source("exchange://vault/x.bin")]
-    result = build_pull_response(artifact, sources, summary="exporting x.bin")
-
-    assert not result.isError
-    # structuredContent holds the handle
-    handle = result.structuredContent
-    assert handle["type"] == "nl.liesdonk.file-exchange/transfer-handle"
-    assert handle["version"] == "0.1"
-    assert handle["artifact"]["name"] == "x.bin"
-    assert handle["sources"][0]["transport"] == "filesystem"
-
-    # _meta mirror
-    mirror = (result.meta or {}).get("nl.liesdonk.file-exchange/handles")
-    assert mirror == [handle]
-
-    # text summary present
-    assert any("exporting x.bin" in c.text for c in result.content if c.type == "text")
-
-
-def test_build_pull_response_synthesises_summary_when_absent():
-    artifact = ArtifactMetadata(name="report.parquet", size=1024)
-    sources = [_fs_source("exchange://vault/report.parquet")]
-    result = build_pull_response(artifact, sources)
-    assert any("report.parquet" in c.text for c in result.content if c.type == "text")
-```
-
-- [ ] Implement `src/fastmcp_pvl_core/_file_exchange/_provider.py`:
-
-```python
-"""Provider helper: builds a CallToolResult containing a TransferHandle."""
-
-from __future__ import annotations
-
-from collections.abc import Sequence
-from typing import Any
-
-from mcp.types import CallToolResult, TextContent
-
-from ._types import (
-    REFERENCE_VERSION,
-    TRANSFER_HANDLE_TYPE,
-    ArtifactMetadata,
-    SourceDescriptor,
-    TransferHandle,
-)
-
-META_HANDLES_KEY = "nl.liesdonk.file-exchange/handles"
-
-
-def _humanise_size(n: int | None) -> str:
-    if n is None:
-        return "?"
-    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
-        if n < 1024:
-            return f"{n} {unit}"
-        n //= 1024
-    return f"{n} PiB"
-
-
-def _default_summary(artifact: ArtifactMetadata) -> str:
-    label = artifact.name or artifact.id or "<unnamed>"
-    size = _humanise_size(artifact.size) if artifact.size is not None else None
-    mime = artifact.mimeType
-    parts = [f"file-exchange: {label}"]
-    extras = ", ".join(p for p in (size, mime) if p)
-    if extras:
-        parts.append(f"({extras})")
-    return " ".join(parts)
-
-
-def build_pull_response(
-    artifact: ArtifactMetadata,
-    sources: Sequence[SourceDescriptor],
-    *,
-    summary: str | None = None,
-    extra_meta: dict[str, Any] | None = None,
-) -> CallToolResult:
-    """Build a CallToolResult that emits a TransferHandle for ``artifact``.
-
-    The handle lands in ``structuredContent`` (discoverable via outputSchema),
-    mirrors into ``_meta[nl.liesdonk.file-exchange/handles]``, and a short text
-    summary lets the model reason about the chain without seeing the bytes.
-    """
-    handle = TransferHandle(
-        type=TRANSFER_HANDLE_TYPE,  # type: ignore[arg-type]
-        version=REFERENCE_VERSION,
-        artifact=artifact,
-        sources=list(sources),
-    )
-    handle_dict = handle.model_dump(mode="json", exclude_none=True)
-    meta: dict[str, Any] = {META_HANDLES_KEY: [handle_dict]}
-    if extra_meta:
-        meta.update(extra_meta)
-    return CallToolResult(
-        content=[TextContent(type="text", text=summary or _default_summary(artifact))],
-        structuredContent=handle_dict,
-        meta=meta,
-    )
-```
-
-- [ ] Run:
-
-```bash
-uv run pytest tests/file_exchange/test_role_helpers.py -v
-```
-
-Expected: PASS (2 tests).
-
-### Step F.4: Implement fetcher helper
-
-- [ ] Add tests to `tests/file_exchange/test_role_helpers.py`:
-
-```python
-import io
-from fastmcp_pvl_core._file_exchange._fetcher import pull_artifact
-from fastmcp_pvl_core._file_exchange._errors import FileExchangeError, FileExchangeErrorCode
-from fastmcp_pvl_core._file_exchange._types import TransferHandle
-
-
-@pytest.mark.asyncio
-async def test_pull_artifact_filesystem(tmp_path: Path):
-    vault = tmp_path / "vault"
-    vault.mkdir()
-    src_file = vault / "x.bin"
-    src_file.write_bytes(b"hello bytes")
-
-    handle = TransferHandle.model_validate(
-        {
-            "type": "nl.liesdonk.file-exchange/transfer-handle",
-            "version": "0.1",
-            "artifact": {"name": "x.bin", "size": 11},
-            "sources": [{"transport": "filesystem", "uri": "exchange://vault/x.bin"}],
-        }
-    )
-    from fastmcp_pvl_core._config import ServerConfig
-
-    config = ServerConfig(transport="stdio", file_exchange_volumes=f"vault={vault}")
-    buf = io.BytesIO()
-    md = await pull_artifact(
-        handle,
-        dest=buf,
-        config=config,
-        supported_transports=("filesystem",),
-    )
-    assert buf.getvalue() == b"hello bytes"
-    assert md.name == "x.bin"
-
-
-@pytest.mark.asyncio
-async def test_pull_artifact_size_mismatch_raises(tmp_path: Path):
-    vault = tmp_path / "vault"
-    vault.mkdir()
-    (vault / "x.bin").write_bytes(b"only 4 bytes here actually 21")
-
-    handle = TransferHandle.model_validate(
-        {
-            "type": "nl.liesdonk.file-exchange/transfer-handle",
-            "version": "0.1",
-            "artifact": {"name": "x.bin", "size": 4},
-            "sources": [{"transport": "filesystem", "uri": "exchange://vault/x.bin"}],
-        }
-    )
-    from fastmcp_pvl_core._config import ServerConfig
-
-    config = ServerConfig(transport="stdio", file_exchange_volumes=f"vault={vault}")
-    with pytest.raises(FileExchangeError) as exc:
-        await pull_artifact(
-            handle, dest=io.BytesIO(),
-            config=config,
-            supported_transports=("filesystem",),
-        )
-    assert exc.value.code == FileExchangeErrorCode.SIZE_MISMATCH
-```
-
-- [ ] Implement `src/fastmcp_pvl_core/_file_exchange/_fetcher.py`:
-
-```python
-"""Fetcher helper: validate handle, select source, pull bytes, verify digest/size."""
-
-from __future__ import annotations
-
-import hashlib
-from collections.abc import Sequence
-from pathlib import Path
-from typing import TYPE_CHECKING, BinaryIO
-
-from fastmcp_pvl_core._config import ServerConfig
-
-from ._errors import FileExchangeError, FileExchangeErrorCode
-from ._select import select_source
-from ._transport_filesystem import parse_volumes, resolve_exchange_uri
-from ._transport_https import SSRFGuardConfig, pull_download
-from ._types import ArtifactMetadata, FileExchangeTransport, TransferHandle
-
-
-async def pull_artifact(
-    handle: TransferHandle | dict,
-    *,
-    dest: BinaryIO | Path,
-    config: ServerConfig,
-    supported_transports: Sequence[FileExchangeTransport] | None = None,
-) -> ArtifactMetadata:
-    """Pull an artifact described by ``handle`` into ``dest``.
-
-    Selects a source descriptor via the §9 algorithm, performs the transfer, and
-    verifies size/digest against ``handle.artifact``.
-
-    Deployment state — the volume map and the SSRF guard config — is derived
-    from ``config`` (design §3). No separate ``volumes``/``ssrf`` kwargs are
-    accepted: those are operator-side concerns, not domain hooks.
-
-    ``supported_transports`` defaults to what the deployment can satisfy
-    (filesystem when volumes are configured; download is always available
-    because the fetcher's outbound HTTPS is unconditional). Pass an explicit
-    tuple when a downstream wants to narrow the selection further.
-    """
-    if not isinstance(handle, TransferHandle):
-        handle = TransferHandle.model_validate(handle)
-
-    volumes = parse_volumes(config.file_exchange_volumes)
-    ssrf = SSRFGuardConfig(
-        allow_loopback=config.file_exchange_https_allow_loopback,
-        allow_private=config.file_exchange_https_allow_private,
-    )
-
-    if supported_transports is None:
-        # Fetcher: outbound HTTPS is always available; filesystem requires volumes.
-        derived: list[FileExchangeTransport] = ["download"]
-        if volumes:
-            derived.insert(0, "filesystem")
-        supported_transports = tuple(derived)
-
-    chosen = select_source(
-        handle,
-        supported_transports=supported_transports,
-        known_volumes=list(volumes.keys()),
-    )
-
-    digester = hashlib.sha256()
-    bytes_written = 0
-
-    if chosen.root.transport == "filesystem":
-        path = resolve_exchange_uri(chosen.root.uri, volumes=volumes)
-        with path.open("rb") as src:
-            while True:
-                chunk = src.read(65536)
-                if not chunk:
-                    break
-                digester.update(chunk)
-                bytes_written += len(chunk)
-                if isinstance(dest, Path):
-                    raise NotImplementedError("Path dest is handled by atomic_write — wrap externally")
-                dest.write(chunk)
-    elif chosen.root.transport == "download":
-        # pull_download streams chunks through the same digester so the
-        # post-fetch digest check below sees the bytes actually received.
-        bytes_written = await pull_download(
-            chosen.root, dest=dest, ssrf=ssrf, digester=digester
-        )
-
-    if handle.artifact.size is not None and bytes_written != handle.artifact.size:
-        raise FileExchangeError(
-            code=FileExchangeErrorCode.SIZE_MISMATCH,
-            transport=chosen.root.transport,
-            detail=f"expected {handle.artifact.size} bytes, got {bytes_written}",
-        )
-
-    if handle.artifact.digest:
-        algo, _, expected = handle.artifact.digest.partition(":")
-        if algo == "sha-256":
-            actual = digester.hexdigest()
-            if actual != expected:
-                raise FileExchangeError(
-                    code=FileExchangeErrorCode.DIGEST_MISMATCH,
-                    transport=chosen.root.transport,
-                    detail=f"expected sha-256:{expected}, got sha-256:{actual}",
-                )
-
-    return handle.artifact
-```
-
-- [ ] Run:
-
-```bash
-uv run pytest tests/file_exchange/test_role_helpers.py -v
-```
-
-Expected: PASS.
-
-### Step F.5: Implement receiver and sender helpers
-
-- [ ] Add tests to `tests/file_exchange/test_role_helpers.py` (receiver flow):
-
-```python
-from fastmcp_pvl_core._file_exchange._errors import (
-    FileExchangeError,
-    FileExchangeErrorCode,
-)
-from fastmcp_pvl_core._file_exchange._receiver import (
-    build_intake_response,
-    open_intake,
-    resolve_intake,
-)
-from fastmcp_pvl_core._file_exchange._url_store import record_intake_path
-
-
-def _fs_sink(uri: str):
-    from fastmcp_pvl_core._file_exchange._types import SinkDescriptor
-    return SinkDescriptor.model_validate({"transport": "filesystem", "uri": uri})
-
-
-def test_open_intake_assembles_ticket():
-    sinks = [_fs_sink("exchange://intake/x.bin")]
-    ticket = open_intake(sinks=sinks, artifact_id="ar-1")
-    assert ticket.artifactId == "ar-1"
-    assert ticket.type == "nl.liesdonk.file-exchange/intake-ticket"
-
-
-@pytest.mark.asyncio
-async def test_resolve_intake_returns_recorded_path(tmp_path: Path):
-    store = MemoryStore()
-    target = tmp_path / "intake.bin"
-    await record_intake_path(store=store, artifact_id="ar-1", path=target)
-    result = await resolve_intake("ar-1", kv_store=store)
-    assert result == target
-
-
-@pytest.mark.asyncio
-async def test_resolve_intake_raises_for_missing():
-    """Per design §3, ``resolve_intake`` raises NOT_ACCESSIBLE for unrecorded artifact_id.
-
-    The ``-> Path | None`` shape creates a quiet-failure trap (callers forget the
-    None branch and operate on the wrong path); raising forces the caller to
-    handle the case via the tool body's outer FileExchangeError -> as_tool_error_result
-    conversion.
-    """
-    store = MemoryStore()
-    with pytest.raises(FileExchangeError) as exc:
-        await resolve_intake("nope", kv_store=store)
-    assert exc.value.code == FileExchangeErrorCode.NOT_ACCESSIBLE
-```
-
-- [ ] Implement `src/fastmcp_pvl_core/_file_exchange/_receiver.py`:
-
-```python
-"""Receiver helpers: open intake, build intake response, resolve intake."""
-
-from __future__ import annotations
-
-import secrets
-from collections.abc import Sequence
-from pathlib import Path
-from typing import Any
-
-from key_value.aio.protocols.key_value import AsyncKeyValue
-from mcp.types import CallToolResult, TextContent
-
-from ._types import (
-    INTAKE_TICKET_TYPE,
-    REFERENCE_VERSION,
-    ExpectedConstraints,
-    IntakeTicket,
-    SinkDescriptor,
-)
-from ._url_store import intake_path_for
-
-META_TICKETS_KEY = "nl.liesdonk.file-exchange/tickets"
-
-
-def open_intake(
-    *,
-    sinks: Sequence[SinkDescriptor],
-    expected: ExpectedConstraints | None = None,
-    artifact_id: str | None = None,
-) -> IntakeTicket:
-    """Construct an IntakeTicket from ``sinks``. Auto-generates ``artifact_id`` if absent."""
-    return IntakeTicket(
-        type=INTAKE_TICKET_TYPE,  # type: ignore[arg-type]
-        version=REFERENCE_VERSION,
-        artifactId=artifact_id or secrets.token_urlsafe(12),
-        expected=expected,
-        sinks=list(sinks),
-    )
-
-
-def build_intake_response(
-    ticket: IntakeTicket,
-    *,
-    summary: str | None = None,
-    extra_meta: dict[str, Any] | None = None,
-) -> CallToolResult:
-    ticket_dict = ticket.model_dump(mode="json", exclude_none=True)
-    meta: dict[str, Any] = {META_TICKETS_KEY: [ticket_dict]}
-    if extra_meta:
-        meta.update(extra_meta)
-    return CallToolResult(
-        content=[
-            TextContent(
-                type="text",
-                text=summary or f"file-exchange: intake opened (artifact_id={ticket.artifactId})",
-            )
-        ],
-        structuredContent=ticket_dict,
-        meta=meta,
-    )
-
-
-async def resolve_intake(artifact_id: str, *, kv_store: AsyncKeyValue) -> Path:
-    """Return the local path where bytes for ``artifact_id`` landed.
-
-    Raises ``FileExchangeError(code=NOT_ACCESSIBLE)`` when no mapping has been
-    recorded — either the transfer never completed, or ``artifact_id`` is
-    wrong (design §3 final paragraph). The ``-> Path | None`` shape was
-    considered and rejected because callers forget the ``None`` branch.
-    """
-    from ._errors import FileExchangeError, FileExchangeErrorCode
-
-    result = await intake_path_for(store=kv_store, artifact_id=artifact_id)
-    if result is None:
-        raise FileExchangeError(
-            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
-            detail=f"no bytes recorded for artifact_id={artifact_id!r}",
-        )
-    return result
-```
-
-- [ ] Test the sender. Add to `tests/file_exchange/test_role_helpers.py`:
-
-```python
-from fastmcp_pvl_core._file_exchange._sender import push_artifact
-from fastmcp_pvl_core._file_exchange._types import IntakeTicket
-
-
-@pytest.mark.asyncio
-async def test_push_artifact_filesystem(tmp_path: Path):
-    intake_dir = tmp_path / "intake"
-    intake_dir.mkdir()
-    ticket = IntakeTicket.model_validate(
-        {
-            "type": "nl.liesdonk.file-exchange/intake-ticket",
-            "version": "0.1",
-            "artifactId": "ar-1",
-            "sinks": [{"transport": "filesystem", "uri": "exchange://intake/x.bin"}],
-        }
-    )
-    source = tmp_path / "src.bin"
-    source.write_bytes(b"to be sent")
-
-    from fastmcp_pvl_core._config import ServerConfig
-
-    config = ServerConfig(transport="stdio", file_exchange_volumes=f"intake={intake_dir}")
-    await push_artifact(
-        ticket,
-        source=source,
-        config=config,
-        supported_transports=("filesystem",),
-    )
-    assert (intake_dir / "x.bin").read_bytes() == b"to be sent"
-```
-
-- [ ] Implement `src/fastmcp_pvl_core/_file_exchange/_sender.py`:
-
-```python
-"""Sender helper: validate ticket, select sink, push bytes."""
-
-from __future__ import annotations
-
-from collections.abc import Sequence
-from pathlib import Path
-from typing import BinaryIO
-
-from fastmcp_pvl_core._config import ServerConfig
-
-from ._errors import FileExchangeError, FileExchangeErrorCode
-from ._select import select_sink
-from ._transport_filesystem import atomic_write, parse_volumes, resolve_exchange_uri
-from ._transport_https import SSRFGuardConfig, push_upload
-from ._types import FileExchangeTransport, IntakeTicket
-
-
-async def push_artifact(
-    ticket: IntakeTicket | dict,
-    *,
-    source: BinaryIO | Path,
-    config: ServerConfig,
-    supported_transports: Sequence[FileExchangeTransport] | None = None,
-    artifact_digest: str | None = None,
-    artifact_mime: str | None = None,
-    artifact_size: int | None = None,
-) -> None:
-    """Push an artifact described by ``source`` to a sink in ``ticket``.
-
-    Deployment state — the volume map and SSRF guard config — is derived from
-    ``config`` (design §3). No separate ``volumes``/``ssrf`` kwargs; those are
-    operator-side concerns, not domain hooks.
-
-    ``supported_transports`` defaults to what the deployment can satisfy
-    (filesystem when volumes are configured; upload is always available
-    because the sender's outbound HTTPS is unconditional).
-    """
-    if not isinstance(ticket, IntakeTicket):
-        ticket = IntakeTicket.model_validate(ticket)
-
-    volumes = parse_volumes(config.file_exchange_volumes)
-    ssrf = SSRFGuardConfig(
-        allow_loopback=config.file_exchange_https_allow_loopback,
-        allow_private=config.file_exchange_https_allow_private,
-    )
-
-    if supported_transports is None:
-        derived: list[FileExchangeTransport] = ["upload"]
-        if volumes:
-            derived.insert(0, "filesystem")
-        supported_transports = tuple(derived)
-
-    # Pre-check expected.acceptMimeTypes before consuming a single-use slot.
-    if (
-        ticket.expected
-        and ticket.expected.acceptMimeTypes
-        and artifact_mime is not None
-    ):
-        from ._routes import _mime_matches
-
-        if not _mime_matches(artifact_mime, ticket.expected.acceptMimeTypes):
-            raise FileExchangeError(
-                code=FileExchangeErrorCode.MIME_TYPE_REJECTED,
-                detail=f"artifact mime {artifact_mime!r} not in acceptMimeTypes",
-            )
-
-    if (
-        ticket.expected
-        and ticket.expected.requireDigest
-        and not artifact_digest
-    ):
-        raise FileExchangeError(
-            code=FileExchangeErrorCode.DIGEST_MISMATCH,
-            detail="ticket.expected.requireDigest is set but artifact_digest was not provided",
-        )
-
-    chosen = select_sink(
-        ticket,
-        supported_transports=supported_transports,
-        known_volumes=list(volumes.keys()),
-    )
-
-    if chosen.root.transport == "filesystem":
-        target = resolve_exchange_uri(chosen.root.uri, volumes=volumes)
-        with atomic_write(target) as out:
-            if isinstance(source, Path):
-                out.write(source.read_bytes())
-            else:
-                while True:
-                    chunk = source.read(65536)
-                    if not chunk:
-                        break
-                    out.write(chunk)
-    elif chosen.root.transport == "upload":
-        await push_upload(
-            chosen.root,
-            source=source,
-            ssrf=ssrf,
-            content_digest=artifact_digest,
-            content_type=artifact_mime,
-            content_length=artifact_size,
-        )
-```
-
-- [ ] Run:
-
-```bash
-uv run pytest tests/file_exchange/test_role_helpers.py -v
-```
-
-Expected: PASS (all role-helper tests).
-
-### Step F.6: Top-level re-exports
-
-- [ ] Modify `src/fastmcp_pvl_core/__init__.py` to expose the public file-exchange surface (insert near the existing `register_server_info_tool` re-export):
-
-```python
-from fastmcp_pvl_core._file_exchange._capability import (
-    register_file_exchange_capability,
-)
-from fastmcp_pvl_core._file_exchange._errors import (
-    FileExchangeError,
-    FileExchangeErrorCode,
-    as_tool_error_result,
-)
-from fastmcp_pvl_core._file_exchange._fetcher import pull_artifact
-from fastmcp_pvl_core._file_exchange._provider import build_pull_response
-from fastmcp_pvl_core._file_exchange._receiver import (
-    build_intake_response,
-    open_intake,
-    resolve_intake,
-)
-from fastmcp_pvl_core._file_exchange._sender import push_artifact
-from fastmcp_pvl_core._file_exchange._transport_filesystem import (
-    make_filesystem_source,
-)
 from fastmcp_pvl_core._file_exchange._types import (
     ArtifactMetadata,
     ExpectedConstraints,
@@ -3550,307 +188,3949 @@ from fastmcp_pvl_core._file_exchange._types import (
     SourceDescriptor,
     TransferHandle,
 )
-from fastmcp_pvl_core._file_exchange._url_store import (
-    make_filesystem_sink,
-    mint_download_source,
-    mint_upload_sink,
+
+
+def test_artifact_metadata_minimal_roundtrip() -> None:
+    payload = {"id": "abc", "name": "report.pdf", "size": 1024, "mimeType": "application/pdf"}
+    artifact = ArtifactMetadata.model_validate(payload)
+    assert artifact.id == "abc"
+    assert artifact.size == 1024
+    assert artifact.model_dump(by_alias=True, exclude_none=True) == payload
+```
+
+- [ ] **Run to verify fail:**
+
+```bash
+uv run pytest tests/file_exchange/test_types.py::test_artifact_metadata_minimal_roundtrip -v
+```
+
+Expected: FAIL — module `fastmcp_pvl_core._file_exchange._types` does not exist.
+
+### Step A.4 — Implement `_types.py` (minimal pass for A.3)
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/__init__.py` (empty for now):**
+
+```python
+"""File-exchange implementation. Private package — consumers depend on the
+top-level ``fastmcp_pvl_core`` re-exports, not this layout."""
+```
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/_types.py`:**
+
+```python
+"""Pydantic v2 models for the nl.liesdonk.file-exchange v0.1 wire format.
+
+The vendored schema at ``schema/file-exchange.schema.json`` is the wire
+authority; these models exist for typed access in Python. A round-trip
+test (``test_schema_drift``) and a model→schema check (Step A.7) catch
+drift either direction.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, RootModel
+
+FileExchangeRole = Literal["provider", "fetcher", "receiver", "sender"]
+FileExchangeTransport = Literal["filesystem", "download", "upload"]
+
+
+class _Base(BaseModel):
+    """Common config: populate by alias, dump by alias, forbid extras at the
+    edges (the spec is closed)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class ArtifactMetadata(_Base):
+    id: str
+    name: str | None = None
+    size: int | None = None
+    mime_type: str | None = Field(default=None, alias="mimeType")
+    digest: str | None = None
+
+
+class ExpectedConstraints(_Base):
+    max_size: int | None = Field(default=None, alias="maxSize")
+    accept_mime_types: tuple[str, ...] | None = Field(default=None, alias="acceptMimeTypes")
+    require_digest: bool | None = Field(default=None, alias="requireDigest")
+
+
+class _FilesystemSource(_Base):
+    transport: Literal["filesystem"]
+    uri: str  # "exchange://<volume>/<path>" or "file://<abs-path>"
+
+
+class _DownloadSource(_Base):
+    transport: Literal["download"]
+    url: str
+    expires_at: str | None = Field(default=None, alias="expiresAt")
+
+
+class _FilesystemSink(_Base):
+    transport: Literal["filesystem"]
+    uri: str
+
+
+class _UploadSink(_Base):
+    transport: Literal["upload"]
+    url: str
+    methods: tuple[Literal["PUT", "POST"], ...] = ("PUT",)
+    expires_at: str | None = Field(default=None, alias="expiresAt")
+
+
+# Discriminated unions per spec §6
+SourceDescriptor = RootModel[
+    Annotated[
+        _FilesystemSource | _DownloadSource,
+        Field(discriminator="transport"),
+    ]
+]
+
+SinkDescriptor = RootModel[
+    Annotated[
+        _FilesystemSink | _UploadSink,
+        Field(discriminator="transport"),
+    ]
+]
+
+
+class TransferHandle(_Base):
+    """Producer → consumer reference (spec §6.1).
+
+    Carries the artifact metadata and one or more source descriptors.
+    """
+
+    version: Literal["0.1"] = "0.1"
+    artifact: ArtifactMetadata
+    sources: tuple[SourceDescriptor, ...]
+    must_understand: tuple[str, ...] | None = Field(default=None, alias="mustUnderstand")
+
+
+class IntakeTicket(_Base):
+    """Receiver → sender reference (spec §6.2)."""
+
+    version: Literal["0.1"] = "0.1"
+    artifact_id: str = Field(alias="artifactId")
+    sinks: tuple[SinkDescriptor, ...]
+    expected: ExpectedConstraints | None = None
+    must_understand: tuple[str, ...] | None = Field(default=None, alias="mustUnderstand")
+```
+
+- [ ] **Run to verify pass:**
+
+```bash
+uv run pytest tests/file_exchange/test_types.py::test_artifact_metadata_minimal_roundtrip -v
+```
+
+Expected: PASS.
+
+### Step A.5 — Add more failing tests (descriptor unions + handle + ticket)
+
+- [ ] **Append to `test_types.py`:**
+
+```python
+def test_source_descriptor_filesystem_variant() -> None:
+    desc = SourceDescriptor.model_validate({"transport": "filesystem", "uri": "exchange://vol/p"})
+    assert desc.root.transport == "filesystem"
+    assert desc.root.uri == "exchange://vol/p"
+
+
+def test_source_descriptor_download_variant() -> None:
+    desc = SourceDescriptor.model_validate(
+        {"transport": "download", "url": "https://example/file-exchange/d/abc"}
+    )
+    assert desc.root.transport == "download"
+    assert desc.root.url.startswith("https://")
+
+
+def test_source_descriptor_rejects_unknown_transport() -> None:
+    with pytest.raises(Exception):
+        SourceDescriptor.model_validate({"transport": "smtp", "uri": "smtp://x"})
+
+
+def test_sink_descriptor_upload_variant_default_methods() -> None:
+    desc = SinkDescriptor.model_validate(
+        {"transport": "upload", "url": "https://example/file-exchange/u/abc"}
+    )
+    assert desc.root.transport == "upload"
+    assert desc.root.methods == ("PUT",)
+
+
+def test_transfer_handle_roundtrip_with_alias_fields() -> None:
+    raw = {
+        "version": "0.1",
+        "artifact": {"id": "a1", "size": 12, "mimeType": "text/plain"},
+        "sources": [
+            {"transport": "filesystem", "uri": "exchange://vol/p"},
+            {"transport": "download", "url": "https://e/file-exchange/d/t"},
+        ],
+        "mustUnderstand": ["nl.liesdonk.file-exchange"],
+    }
+    handle = TransferHandle.model_validate(raw)
+    assert handle.artifact.id == "a1"
+    assert len(handle.sources) == 2
+    assert handle.must_understand == ("nl.liesdonk.file-exchange",)
+    assert handle.model_dump(by_alias=True, exclude_none=True) == raw
+
+
+def test_intake_ticket_roundtrip_with_expected_constraints() -> None:
+    raw = {
+        "version": "0.1",
+        "artifactId": "a1",
+        "sinks": [{"transport": "upload", "url": "https://e/file-exchange/u/t", "methods": ["PUT"]}],
+        "expected": {"maxSize": 4096, "acceptMimeTypes": ["application/pdf"], "requireDigest": True},
+    }
+    ticket = IntakeTicket.model_validate(raw)
+    assert ticket.artifact_id == "a1"
+    assert ticket.expected is not None
+    assert ticket.expected.max_size == 4096
+    assert ticket.model_dump(by_alias=True, exclude_none=True) == raw
+
+
+def test_role_and_transport_literal_aliases_are_re_exportable() -> None:
+    # Smoke test: the Literal aliases must exist and be importable
+    # for downstream type-checking. `Literal[str, ...]` instances are
+    # not hashable into a set, so we use string equivalence checks.
+    assert "provider" in FileExchangeRole.__args__   # type: ignore[attr-defined]
+    assert "filesystem" in FileExchangeTransport.__args__   # type: ignore[attr-defined]
+```
+
+- [ ] **Run to verify all pass:**
+
+```bash
+uv run pytest tests/file_exchange/test_types.py -v
+```
+
+Expected: 7 passing.
+
+### Step A.6 — Vendored-conformance walker
+
+- [ ] **Add to `test_types.py`:**
+
+```python
+import json
+from pathlib import Path
+
+
+_CONFORMANCE_DIR = (
+    Path(__file__).parent.parent.parent
+    / "src" / "fastmcp_pvl_core" / "_file_exchange" / "schema" / "conformance"
 )
+
+
+def _conformance_cases(subdir: str) -> list[tuple[str, dict]]:
+    root = _CONFORMANCE_DIR / subdir
+    if not root.exists():
+        return []
+    return [(p.name, json.loads(p.read_text())) for p in sorted(root.glob("*.json"))]
+
+
+@pytest.mark.parametrize("name,payload", _conformance_cases("transfer_handle/valid"))
+def test_conformance_transfer_handle_valid(name: str, payload: dict) -> None:
+    TransferHandle.model_validate(payload)
+
+
+@pytest.mark.parametrize("name,payload", _conformance_cases("transfer_handle/invalid"))
+def test_conformance_transfer_handle_invalid(name: str, payload: dict) -> None:
+    with pytest.raises(Exception):
+        TransferHandle.model_validate(payload)
+
+
+@pytest.mark.parametrize("name,payload", _conformance_cases("intake_ticket/valid"))
+def test_conformance_intake_ticket_valid(name: str, payload: dict) -> None:
+    IntakeTicket.model_validate(payload)
+
+
+@pytest.mark.parametrize("name,payload", _conformance_cases("intake_ticket/invalid"))
+def test_conformance_intake_ticket_invalid(name: str, payload: dict) -> None:
+    with pytest.raises(Exception):
+        IntakeTicket.model_validate(payload)
 ```
 
-- [ ] Add each new symbol to the `__all__` list of `__init__.py`.
+- [ ] **Run** `uv run pytest tests/file_exchange/test_types.py -v -k conformance` — every vendored fixture must classify per its directory. If a vendored fixture genuinely contradicts the Pydantic shape (e.g. the spec allows a field the model rejects), STOP and surface — do not patch the model to chase a fixture without first confirming the design doc allows it.
 
-- [ ] Run the full test suite to verify nothing regressed:
+### Step A.7 — Commit Task A
+
+- [ ] **Commit** (use HEREDOC so the multiline body renders correctly):
 
 ```bash
-uv run pytest -q
+git add src/fastmcp_pvl_core/_file_exchange/ tests/file_exchange/
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): vendor v0.1 schema and Pydantic types
+
+Vendors the wire-format schema and conformance fixtures verbatim from
+pvliesdonk/mcp-file-exchange-ext v0.1 at a pinned commit, gated by a
+SHA-256 drift check. Adds Pydantic v2 models for ArtifactMetadata,
+TransferHandle, IntakeTicket, SourceDescriptor (discriminated
+filesystem|download), SinkDescriptor (discriminated filesystem|upload),
+ExpectedConstraints, plus the FileExchangeRole / FileExchangeTransport
+Literal aliases used throughout the package.
+
+Closes #124.
+EOF
+)"
 ```
 
-Expected: every test in the repo passes.
-
-### Step F.7: Commit and PR
-
-- [ ] Commit:
-
-```bash
-git add src/fastmcp_pvl_core/ tests/file_exchange/
-git commit -m "feat(file-exchange): capability declaration, role helpers, top-level public API
-
-Closes #129"
-```
-
-- [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
+- [ ] Run the universal per-task suffix (local checks → preflight-circus → draft PR → bot verdicts → flip ready).
 
 ---
 
-# Task G: Integration tests + conformance suite
+## Task B: Descriptor selection algorithm + error envelope (closes #125)
+
+**Depends on:** Task A merged.
 
 **Files:**
-- Create: `tests/file_exchange/test_integration_filesystem.py`
-- Create: `tests/file_exchange/test_integration_https.py`
-- Create: `tests/file_exchange/test_conformance.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_errors.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_select.py`
+- Create: `tests/file_exchange/test_errors.py`
+- Create: `tests/file_exchange/test_select.py`
 
-### Step G.1: Filesystem integration — provider + fetcher end-to-end
+### Step B.1 — Write the failing error-envelope test
 
-- [ ] Write `tests/file_exchange/test_integration_filesystem.py`:
+- [ ] **Write `tests/file_exchange/test_errors.py`:**
 
 ```python
+"""FileExchangeError code envelope tests (spec §13)."""
+
 from __future__ import annotations
 
+import pytest
+
+from fastmcp_pvl_core._file_exchange._errors import (
+    FileExchangeError,
+    FileExchangeErrorCode,
+    as_tool_error_result,
+)
+
+
+def test_error_code_enum_has_all_spec_codes() -> None:
+    # Spec §13 enumerates the seven canonical codes.
+    expected = {
+        "not-accessible",
+        "expired",
+        "size-exceeded",
+        "mime-rejected",
+        "digest-mismatch",
+        "no-supported-transport",
+        "version-incompatible",
+    }
+    assert {c.value for c in FileExchangeErrorCode} == expected
+
+
+def test_error_carries_code_and_detail() -> None:
+    exc = FileExchangeError(
+        code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+        detail="bytes not yet on disk for artifact_id='a1'",
+    )
+    assert exc.code is FileExchangeErrorCode.NOT_ACCESSIBLE
+    assert "a1" in exc.detail
+    assert str(exc).startswith("not-accessible: ")
+
+
+def test_error_accepts_string_code() -> None:
+    # Convenience: accept the wire string too, normalise to the enum.
+    exc = FileExchangeError(code="expired", detail="token expired at 2026-05-20T18:00")
+    assert exc.code is FileExchangeErrorCode.EXPIRED
+
+
+def test_as_tool_error_result_emits_isError_envelope() -> None:
+    exc = FileExchangeError(code="size-exceeded", detail="cap=1024 actual=2048")
+    result = as_tool_error_result(exc)
+    assert result.isError is True
+    # Text content carries human-readable message
+    assert any("size-exceeded" in block.text for block in result.content if hasattr(block, "text"))
+    # Structured _meta carries the machine-readable envelope
+    meta = result._meta or {}
+    fe_meta = meta.get("nl.liesdonk.file-exchange") or {}
+    assert fe_meta.get("error", {}).get("code") == "size-exceeded"
+    assert "1024" in fe_meta["error"]["detail"]
+
+
+def test_as_tool_error_result_passes_other_exceptions_through_unwrapped() -> None:
+    # Non-FileExchangeError must raise — pvl-core doesn't silently swallow.
+    with pytest.raises(TypeError):
+        as_tool_error_result(ValueError("not a file-exchange error"))   # type: ignore[arg-type]
+```
+
+- [ ] **Run to verify fail:**
+
+```bash
+uv run pytest tests/file_exchange/test_errors.py -v
+```
+
+Expected: FAIL — module not found.
+
+### Step B.2 — Implement `_errors.py`
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/_errors.py`:**
+
+```python
+"""FileExchangeError and the §13 code envelope.
+
+Helpers in this package always raise ``FileExchangeError`` with one of the
+seven canonical codes; ``as_tool_error_result`` converts to the
+``CallToolResult`` envelope a downstream tool returns.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from mcp.types import TextContent
+from fastmcp.tools.tool import ToolResult as CallToolResult
+
+CAPABILITY_KEY = "nl.liesdonk.file-exchange"
+
+
+class FileExchangeErrorCode(StrEnum):
+    NOT_ACCESSIBLE = "not-accessible"
+    EXPIRED = "expired"
+    SIZE_EXCEEDED = "size-exceeded"
+    MIME_REJECTED = "mime-rejected"
+    DIGEST_MISMATCH = "digest-mismatch"
+    NO_SUPPORTED_TRANSPORT = "no-supported-transport"
+    VERSION_INCOMPATIBLE = "version-incompatible"
+
+
+class FileExchangeError(Exception):
+    """A spec-§13 error envelope, raised by every helper in this package."""
+
+    def __init__(self, *, code: FileExchangeErrorCode | str, detail: str) -> None:
+        self.code = FileExchangeErrorCode(code) if isinstance(code, str) else code
+        self.detail = detail
+        super().__init__(f"{self.code.value}: {detail}")
+
+
+def as_tool_error_result(exc: FileExchangeError) -> CallToolResult:
+    """Convert a ``FileExchangeError`` into a ``CallToolResult`` envelope.
+
+    Raises:
+        TypeError: if ``exc`` is not a ``FileExchangeError`` — callers must
+            scope this helper to the file-exchange error family.
+    """
+    if not isinstance(exc, FileExchangeError):
+        raise TypeError(
+            f"as_tool_error_result requires FileExchangeError; got {type(exc).__name__}"
+        )
+    text = f"{exc.code.value}: {exc.detail}"
+    return CallToolResult(
+        content=[TextContent(type="text", text=text)],
+        isError=True,
+        _meta={
+            CAPABILITY_KEY: {
+                "error": {"code": exc.code.value, "detail": exc.detail},
+            }
+        },
+    )
+```
+
+- [ ] **Run to verify pass:**
+
+```bash
+uv run pytest tests/file_exchange/test_errors.py -v
+```
+
+Expected: 5 passing. (If the FastMCP `CallToolResult` constructor differs from what this code uses, check the installed version's signature with `uv run python -c "from fastmcp.tools.tool import ToolResult; import inspect; print(inspect.signature(ToolResult))"` and adjust the constructor call here only — do not change the test expectations.)
+
+### Step B.3 — Commit error module
+
+- [ ] **Commit:**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_errors.py tests/file_exchange/test_errors.py
+git commit -m "feat(file-exchange): add FileExchangeError + §13 code envelope"
+```
+
+### Step B.4 — Write failing tests for `_select.py` (spec §9 selection)
+
+- [ ] **Write `tests/file_exchange/test_select.py`:**
+
+```python
+"""Spec §9 descriptor-selection algorithm tests.
+
+Selection is a pure function of (descriptor list, supported transports).
+Filesystem before HTTPS when both are accepted (spec §9.1 "prefer
+local"). No I/O — confinement / SSRF live in the transport modules.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fastmcp_pvl_core._file_exchange._errors import (
+    FileExchangeError,
+    FileExchangeErrorCode,
+)
+from fastmcp_pvl_core._file_exchange._select import (
+    select_sink,
+    select_source,
+)
+from fastmcp_pvl_core._file_exchange._types import (
+    SinkDescriptor,
+    SourceDescriptor,
+)
+
+_FS_SRC = SourceDescriptor.model_validate({"transport": "filesystem", "uri": "exchange://v/p"})
+_DL_SRC = SourceDescriptor.model_validate({"transport": "download", "url": "https://e/d/t"})
+_FS_SINK = SinkDescriptor.model_validate({"transport": "filesystem", "uri": "exchange://v/p"})
+_UP_SINK = SinkDescriptor.model_validate({"transport": "upload", "url": "https://e/u/t"})
+
+
+def test_select_source_prefers_filesystem_when_both_supported() -> None:
+    chosen = select_source([_DL_SRC, _FS_SRC], supported=("filesystem", "download"))
+    assert chosen.root.transport == "filesystem"
+
+
+def test_select_source_falls_back_to_download_when_no_filesystem() -> None:
+    chosen = select_source([_DL_SRC], supported=("filesystem", "download"))
+    assert chosen.root.transport == "download"
+
+
+def test_select_source_raises_when_no_transport_matches() -> None:
+    with pytest.raises(FileExchangeError) as ei:
+        select_source([_DL_SRC], supported=("filesystem",))
+    assert ei.value.code is FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT
+
+
+def test_select_sink_prefers_filesystem_when_both_supported() -> None:
+    chosen = select_sink([_UP_SINK, _FS_SINK], supported=("filesystem", "upload"))
+    assert chosen.root.transport == "filesystem"
+
+
+def test_select_sink_falls_back_to_upload_when_no_filesystem() -> None:
+    chosen = select_sink([_UP_SINK], supported=("filesystem", "upload"))
+    assert chosen.root.transport == "upload"
+
+
+def test_select_sink_raises_when_no_transport_matches() -> None:
+    with pytest.raises(FileExchangeError) as ei:
+        select_sink([_UP_SINK], supported=("filesystem",))
+    assert ei.value.code is FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT
+
+
+def test_select_source_empty_input_raises() -> None:
+    with pytest.raises(FileExchangeError) as ei:
+        select_source([], supported=("filesystem", "download"))
+    assert ei.value.code is FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT
+```
+
+- [ ] **Run to verify fail:**
+
+```bash
+uv run pytest tests/file_exchange/test_select.py -v
+```
+
+Expected: FAIL — module not found.
+
+### Step B.5 — Implement `_select.py`
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/_select.py`:**
+
+```python
+"""Spec §9 selection algorithm.
+
+Pure functions over descriptor lists — no I/O, no transport-specific
+validation. Confinement (filesystem) and SSRF (HTTPS) live in their
+respective transport modules.
+
+Preference order is fixed by spec §9.1: filesystem before HTTPS. The
+caller passes the deployment's supported-transport set, derived from
+its ``ServerConfig`` (volumes configured? HTTP app available?).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ._errors import FileExchangeError, FileExchangeErrorCode
+from ._types import (
+    FileExchangeTransport,
+    SinkDescriptor,
+    SourceDescriptor,
+)
+
+# Spec §9.1: filesystem preferred over HTTPS when both are supported.
+_SOURCE_PREFERENCE: tuple[FileExchangeTransport, ...] = ("filesystem", "download")
+_SINK_PREFERENCE: tuple[FileExchangeTransport, ...] = ("filesystem", "upload")
+
+
+def select_source(
+    sources: Sequence[SourceDescriptor],
+    *,
+    supported: Sequence[FileExchangeTransport],
+) -> SourceDescriptor:
+    """Pick the highest-preference source whose transport is in ``supported``."""
+    sup = set(supported)
+    by_transport = {s.root.transport: s for s in sources}
+    for t in _SOURCE_PREFERENCE:
+        if t in sup and t in by_transport:
+            return by_transport[t]
+    raise FileExchangeError(
+        code=FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT,
+        detail=(
+            f"no source transport in {sorted(supported)} matches "
+            f"offered {sorted(by_transport)}"
+        ),
+    )
+
+
+def select_sink(
+    sinks: Sequence[SinkDescriptor],
+    *,
+    supported: Sequence[FileExchangeTransport],
+) -> SinkDescriptor:
+    """Pick the highest-preference sink whose transport is in ``supported``."""
+    sup = set(supported)
+    by_transport = {s.root.transport: s for s in sinks}
+    for t in _SINK_PREFERENCE:
+        if t in sup and t in by_transport:
+            return by_transport[t]
+    raise FileExchangeError(
+        code=FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT,
+        detail=(
+            f"no sink transport in {sorted(supported)} matches "
+            f"offered {sorted(by_transport)}"
+        ),
+    )
+```
+
+- [ ] **Run to verify pass:**
+
+```bash
+uv run pytest tests/file_exchange/test_select.py -v
+```
+
+Expected: 7 passing.
+
+### Step B.6 — Commit Task B
+
+- [ ] **Commit:**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_select.py tests/file_exchange/test_select.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): add §9 descriptor selection algorithm
+
+Pure-function source/sink selectors that pick the highest-preference
+descriptor (filesystem > HTTPS, per spec §9.1) whose transport is in
+the deployment's supported set. Raises FileExchangeError(code=
+no-supported-transport) when nothing matches.
+
+Closes #125.
+EOF
+)"
+```
+
+- [ ] Run the universal per-task suffix.
+
+---
+
+## Task C: Filesystem transport with exchange:// resolution + atomic writes (closes #126)
+
+**Depends on:** Task A merged.
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_transport_filesystem.py`
+- Modify: `src/fastmcp_pvl_core/_config.py` — add `file_exchange_volumes` + sibling env-var fields
+- Create: `tests/file_exchange/test_transport_filesystem.py`
+
+### Step C.1 — Add the operator-config fields to `ServerConfig`
+
+- [ ] **Write a failing test first**, `tests/file_exchange/test_config_fields.py`:
+
+```python
+"""ServerConfig.file_exchange_* fields are loaded from env-vars."""
+
+from __future__ import annotations
+
+import pytest
+
+from fastmcp_pvl_core import ServerConfig
+
+
+def test_config_loads_file_exchange_fields_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MYAPP_FILE_EXCHANGE_VOLUMES", "vault=/mnt/exchange/vault,images=/srv/img")
+    monkeypatch.setenv("MYAPP_FILE_EXCHANGE_MAX_ARTIFACT_SIZE", "104857600")
+    monkeypatch.setenv("MYAPP_FILE_EXCHANGE_HTTPS_ALLOW_LOOPBACK", "true")
+    monkeypatch.setenv("MYAPP_FILE_EXCHANGE_HTTPS_ALLOW_PRIVATE", "false")
+    monkeypatch.setenv("MYAPP_FILE_EXCHANGE_CAPABILITY_URL_TTL_DEFAULT_S", "1800")
+    monkeypatch.setenv("MYAPP_FILE_EXCHANGE_HTTPS_PUBLIC_BASE_URL", "https://files.example.com")
+
+    cfg = ServerConfig.from_env("MYAPP")
+
+    assert cfg.file_exchange_volumes == "vault=/mnt/exchange/vault,images=/srv/img"
+    assert cfg.file_exchange_max_artifact_size == 104857600
+    assert cfg.file_exchange_https_allow_loopback is True
+    assert cfg.file_exchange_https_allow_private is False
+    assert cfg.file_exchange_capability_url_ttl_default_s == 1800
+    assert cfg.file_exchange_https_public_base_url == "https://files.example.com"
+
+
+def test_config_file_exchange_fields_have_safe_defaults() -> None:
+    cfg = ServerConfig()
+    assert cfg.file_exchange_volumes is None
+    assert cfg.file_exchange_max_artifact_size is None
+    assert cfg.file_exchange_https_allow_loopback is False
+    assert cfg.file_exchange_https_allow_private is False
+    assert cfg.file_exchange_capability_url_ttl_default_s == 3600
+    assert cfg.file_exchange_https_public_base_url is None
+```
+
+- [ ] **Run to verify fail:**
+
+```bash
+uv run pytest tests/file_exchange/test_config_fields.py -v
+```
+
+Expected: FAIL — fields don't exist yet.
+
+- [ ] **Modify `src/fastmcp_pvl_core/_config.py`**: append the six fields to the `@dataclass` (in declaration order after `auth_mode`, before `bearer_tokens_file`) and parse them in `from_env`. Insert after the `auth_mode: str | None = None` line:
+
+```python
+    file_exchange_volumes: str | None = None
+    file_exchange_max_artifact_size: "int | None" = None
+    file_exchange_https_allow_loopback: bool = False
+    file_exchange_https_allow_private: bool = False
+    file_exchange_capability_url_ttl_default_s: int = 3600
+    file_exchange_https_public_base_url: str | None = None
+```
+
+- [ ] In `from_env`, after the existing `auth_mode=env(env_prefix, "AUTH_MODE")` line, parse the six fields:
+
+```python
+        max_size_raw = env(env_prefix, "FILE_EXCHANGE_MAX_ARTIFACT_SIZE")
+        max_size = int(max_size_raw) if max_size_raw else None
+
+        ttl_raw = env(env_prefix, "FILE_EXCHANGE_CAPABILITY_URL_TTL_DEFAULT_S", "3600")
+        ttl = int(ttl_raw)
+```
+
+And add to the `cls(...)` kwargs:
+
+```python
+            file_exchange_volumes=env(env_prefix, "FILE_EXCHANGE_VOLUMES"),
+            file_exchange_max_artifact_size=max_size,
+            file_exchange_https_allow_loopback=parse_bool(
+                env(env_prefix, "FILE_EXCHANGE_HTTPS_ALLOW_LOOPBACK")
+            ) or False,
+            file_exchange_https_allow_private=parse_bool(
+                env(env_prefix, "FILE_EXCHANGE_HTTPS_ALLOW_PRIVATE")
+            ) or False,
+            file_exchange_capability_url_ttl_default_s=ttl,
+            file_exchange_https_public_base_url=env(
+                env_prefix, "FILE_EXCHANGE_HTTPS_PUBLIC_BASE_URL"
+            ),
+```
+
+- [ ] **Run to verify pass:**
+
+```bash
+uv run pytest tests/file_exchange/test_config_fields.py -v
+```
+
+Expected: 2 passing.
+
+### Step C.2 — Failing tests for `parse_volumes`, `resolve_exchange_uri`, `atomic_write`, `async_atomic_write`
+
+- [ ] **Write `tests/file_exchange/test_transport_filesystem.py`:**
+
+```python
+"""Filesystem transport unit tests (spec §6.1)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pytest
+
+from fastmcp_pvl_core import ServerConfig
+from fastmcp_pvl_core._file_exchange._errors import (
+    FileExchangeError,
+    FileExchangeErrorCode,
+)
+from fastmcp_pvl_core._file_exchange._transport_filesystem import (
+    async_atomic_write,
+    atomic_write,
+    make_filesystem_source,
+    parse_volumes,
+    resolve_exchange_uri,
+)
+
+
+def test_parse_volumes_returns_empty_dict_when_none() -> None:
+    assert parse_volumes(None) == {}
+
+
+def test_parse_volumes_parses_comma_separated_pairs(tmp_path) -> None:
+    spec = f"vault={tmp_path / 'vault'},img={tmp_path / 'img'}"
+    (tmp_path / "vault").mkdir()
+    (tmp_path / "img").mkdir()
+    parsed = parse_volumes(spec)
+    assert set(parsed.keys()) == {"vault", "img"}
+    assert parsed["vault"].is_absolute()
+
+
+def test_parse_volumes_rejects_relative_paths() -> None:
+    with pytest.raises(ValueError, match="absolute"):
+        parse_volumes("vault=./relative")
+
+
+def test_resolve_exchange_uri_happy_path(tmp_path) -> None:
+    (tmp_path / "vol").mkdir()
+    (tmp_path / "vol" / "f.txt").write_text("hi")
+    volumes = {"vol": tmp_path / "vol"}
+    path = resolve_exchange_uri("exchange://vol/f.txt", volumes=volumes)
+    assert path == (tmp_path / "vol" / "f.txt").resolve()
+
+
+def test_resolve_exchange_uri_rejects_unknown_volume(tmp_path) -> None:
+    with pytest.raises(FileExchangeError) as ei:
+        resolve_exchange_uri("exchange://missing/x", volumes={})
+    assert ei.value.code is FileExchangeErrorCode.NOT_ACCESSIBLE
+
+
+def test_resolve_exchange_uri_rejects_traversal(tmp_path) -> None:
+    (tmp_path / "vol").mkdir()
+    volumes = {"vol": tmp_path / "vol"}
+    with pytest.raises(FileExchangeError) as ei:
+        resolve_exchange_uri("exchange://vol/../../etc/passwd", volumes=volumes)
+    assert ei.value.code is FileExchangeErrorCode.NOT_ACCESSIBLE
+
+
+def test_resolve_exchange_uri_rejects_symlink_escape(tmp_path) -> None:
+    (tmp_path / "vol").mkdir()
+    (tmp_path / "secret").write_text("nope")
+    (tmp_path / "vol" / "leak").symlink_to(tmp_path / "secret")
+    volumes = {"vol": tmp_path / "vol"}
+    with pytest.raises(FileExchangeError) as ei:
+        resolve_exchange_uri("exchange://vol/leak", volumes=volumes)
+    assert ei.value.code is FileExchangeErrorCode.NOT_ACCESSIBLE
+
+
+def test_resolve_exchange_uri_accepts_file_scheme(tmp_path) -> None:
+    p = tmp_path / "f.txt"
+    p.write_text("hi")
+    out = resolve_exchange_uri(f"file://{p}", volumes={})
+    assert out == p.resolve()
+
+
+def test_atomic_write_renames_on_clean_exit(tmp_path) -> None:
+    target = tmp_path / "dst" / "out.bin"
+    target.parent.mkdir()
+    with atomic_write(target) as fh:
+        fh.write(b"payload")
+    assert target.read_bytes() == b"payload"
+    # No temp residue
+    assert sorted(p.name for p in target.parent.iterdir()) == ["out.bin"]
+
+
+def test_atomic_write_discards_on_exception(tmp_path) -> None:
+    target = tmp_path / "out.bin"
+    with pytest.raises(RuntimeError):
+        with atomic_write(target) as fh:
+            fh.write(b"partial")
+            raise RuntimeError("boom")
+    assert not target.exists()
+    assert list(target.parent.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_async_atomic_write_renames_on_clean_exit(tmp_path) -> None:
+    target = tmp_path / "out.bin"
+    async with async_atomic_write(target) as fh:
+        await asyncio.to_thread(fh.write, b"payload")
+    assert target.read_bytes() == b"payload"
+    assert sorted(p.name for p in target.parent.iterdir()) == ["out.bin"]
+
+
+@pytest.mark.asyncio
+async def test_async_atomic_write_discards_on_exception(tmp_path) -> None:
+    target = tmp_path / "out.bin"
+    with pytest.raises(RuntimeError):
+        async with async_atomic_write(target) as fh:
+            await asyncio.to_thread(fh.write, b"partial")
+            raise RuntimeError("boom")
+    assert not target.exists()
+    assert list(target.parent.iterdir()) == []
+
+
+def test_make_filesystem_source_composes_uri(tmp_path) -> None:
+    (tmp_path / "vault").mkdir()
+    cfg = ServerConfig(file_exchange_volumes=f"vault={tmp_path / 'vault'}")
+    src = make_filesystem_source("vault", "subdir/note.md", config=cfg)
+    assert src.root.transport == "filesystem"
+    assert src.root.uri == "exchange://vault/subdir/note.md"
+
+
+def test_make_filesystem_source_rejects_unknown_volume(tmp_path) -> None:
+    cfg = ServerConfig(file_exchange_volumes=f"vault={tmp_path}")
+    with pytest.raises(FileExchangeError) as ei:
+        make_filesystem_source("nope", "x", config=cfg)
+    assert ei.value.code is FileExchangeErrorCode.NOT_ACCESSIBLE
+```
+
+- [ ] **Run to verify fail:**
+
+```bash
+uv run pytest tests/file_exchange/test_transport_filesystem.py -v
+```
+
+Expected: FAIL — module not found.
+
+### Step C.3 — Implement `_transport_filesystem.py`
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/_transport_filesystem.py`:**
+
+```python
+"""Filesystem transport (spec §6.1).
+
+- ``parse_volumes`` — single source of truth for the volume map.
+- ``resolve_exchange_uri`` — canonicalises ``exchange://<v>/<p>`` and
+  ``file://<p>`` to a confined ``Path``; rejects escapes (incl. symlinks).
+- ``atomic_write`` / ``async_atomic_write`` — temp-file + fsync + rename
+  context managers used by every sender that writes to a filesystem sink.
+- ``make_filesystem_source`` — public mint helper (sync; no kv_store I/O).
+  Note: ``make_filesystem_sink`` lives in ``_url_store.py`` because it
+  writes the ``intake:<artifact_id>`` mapping into kv_store at mint time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import tempfile
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import IO
+from urllib.parse import unquote, urlsplit
+
+from .._config import ServerConfig
+from ._errors import FileExchangeError, FileExchangeErrorCode
+from ._types import SourceDescriptor
+
+
+def parse_volumes(spec: str | None) -> dict[str, Path]:
+    """Parse ``<id>=<abs-path>,<id>=<abs-path>`` into a dict of resolved Paths.
+
+    Returns ``{}`` on ``None`` or empty string. Raises ``ValueError`` if any
+    path is relative (we refuse to guess the operator's cwd).
+    """
+    if not spec:
+        return {}
+    out: dict[str, Path] = {}
+    for token in spec.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if "=" not in token:
+            raise ValueError(f"file-exchange volume entry missing '=': {token!r}")
+        name, path_str = token.split("=", 1)
+        name = name.strip()
+        path = Path(path_str.strip())
+        if not path.is_absolute():
+            raise ValueError(
+                f"file-exchange volume {name!r} path must be absolute, got {path_str!r}"
+            )
+        out[name] = path.resolve()
+    return out
+
+
+def resolve_exchange_uri(uri: str, *, volumes: dict[str, Path]) -> Path:
+    """Resolve an ``exchange://`` or ``file://`` URI to a confined Path.
+
+    Canonicalises (resolves ``.``, ``..``, symlinks) and asserts the result
+    is inside the volume root. Symlink escapes are rejected.
+    """
+    parts = urlsplit(uri)
+    if parts.scheme == "file":
+        # file://<abs-path> — no volume gating, but still canonicalise.
+        target = Path(unquote(parts.path)).resolve()
+        if not target.exists():
+            raise FileExchangeError(
+                code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+                detail=f"file:// URI does not exist: {uri!r}",
+            )
+        return target
+    if parts.scheme != "exchange":
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"unsupported URI scheme {parts.scheme!r} (expected exchange:// or file://)",
+        )
+    volume_name = parts.netloc
+    root = volumes.get(volume_name)
+    if root is None:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"file-exchange volume {volume_name!r} is not configured on this party",
+        )
+    relative = unquote(parts.path).lstrip("/")
+    candidate = (root / relative).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"path {uri!r} resolves outside volume {volume_name!r}",
+        ) from exc
+    return candidate
+
+
+@contextlib.contextmanager
+def atomic_write(target: Path) -> Iterator[IO[bytes]]:
+    """Temp-file + fsync + rename. Sync exit; for use from sync callers.
+
+    See ``async_atomic_write`` for the variant whose exit dispatches the
+    fsync/rename via ``asyncio.to_thread`` (use that one inside async
+    handlers).
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path_str = tempfile.mkstemp(
+        prefix=f".{target.name}.", suffix=".part", dir=str(target.parent)
+    )
+    tmp_path = Path(tmp_path_str)
+    fh = os.fdopen(fd, "wb")
+    try:
+        yield fh
+        fh.flush()
+        os.fsync(fh.fileno())
+        fh.close()
+        os.replace(tmp_path, target)
+    except BaseException:
+        try:
+            fh.close()
+        finally:
+            tmp_path.unlink(missing_ok=True)
+        raise
+
+
+@contextlib.asynccontextmanager
+async def async_atomic_write(target: Path) -> AsyncIterator[IO[bytes]]:
+    """Async-exit variant of ``atomic_write``.
+
+    Chunk writes inside the ``async with`` block are the caller's
+    responsibility (use ``asyncio.to_thread(fh.write, chunk)`` so disk
+    latency doesn't block the event loop). The exit dispatches the
+    fsync/rename/unlink through ``asyncio.to_thread`` too.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path_str = tempfile.mkstemp(
+        prefix=f".{target.name}.", suffix=".part", dir=str(target.parent)
+    )
+    tmp_path = Path(tmp_path_str)
+    fh = os.fdopen(fd, "wb")
+
+    def _commit() -> None:
+        fh.flush()
+        os.fsync(fh.fileno())
+        fh.close()
+        os.replace(tmp_path, target)
+
+    def _discard() -> None:
+        try:
+            fh.close()
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    try:
+        yield fh
+    except BaseException:
+        await asyncio.to_thread(_discard)
+        raise
+    else:
+        await asyncio.to_thread(_commit)
+
+
+def make_filesystem_source(
+    volume: str,
+    relative_path: str,
+    *,
+    config: ServerConfig,
+) -> SourceDescriptor:
+    """Compose an ``exchange://<volume>/<relative_path>`` source descriptor.
+
+    Validates that ``volume`` is configured on this party (per
+    ``config.file_exchange_volumes``). Raises ``FileExchangeError(
+    NOT_ACCESSIBLE)`` if not.
+    """
+    volumes = parse_volumes(config.file_exchange_volumes)
+    if volume not in volumes:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=(
+                f"file-exchange volume {volume!r} is not configured "
+                f"on this party (known: {sorted(volumes)})"
+            ),
+        )
+    uri = f"exchange://{volume}/{relative_path.lstrip('/')}"
+    return SourceDescriptor.model_validate({"transport": "filesystem", "uri": uri})
+```
+
+- [ ] **Run to verify pass:**
+
+```bash
+uv run pytest tests/file_exchange/test_transport_filesystem.py -v
+```
+
+Expected: 13 passing.
+
+### Step C.4 — Commit Task C
+
+- [ ] **Commit:**
+
+```bash
+git add src/fastmcp_pvl_core/_config.py \
+        src/fastmcp_pvl_core/_file_exchange/_transport_filesystem.py \
+        tests/file_exchange/test_config_fields.py \
+        tests/file_exchange/test_transport_filesystem.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): filesystem transport with exchange:// resolution
+
+Adds ServerConfig.file_exchange_* fields loaded from env-vars
+({PREFIX}_FILE_EXCHANGE_VOLUMES, _MAX_ARTIFACT_SIZE,
+_HTTPS_ALLOW_LOOPBACK, _HTTPS_ALLOW_PRIVATE,
+_CAPABILITY_URL_TTL_DEFAULT_S, _HTTPS_PUBLIC_BASE_URL).
+
+Adds parse_volumes (single source of truth for the volume map),
+resolve_exchange_uri (rejects traversal + symlink escapes via
+canonicalisation), atomic_write (sync) and async_atomic_write (async
+exit via asyncio.to_thread), and the make_filesystem_source mint helper.
+
+Closes #126.
+EOF
+)"
+```
+
+- [ ] Run the universal per-task suffix.
+
+---
+
+## Task D: HTTPS consumer transport (pull/push) with SSRF guard (closes #127)
+
+**Depends on:** Task A merged.
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_transport_https.py`
+- Create: `tests/file_exchange/test_transport_https.py`
+
+### Step D.1 — Failing tests for SSRF guard
+
+- [ ] **Write `tests/file_exchange/test_transport_https.py`:**
+
+```python
+"""HTTPS consumer-side transport (spec §6.2)."""
+
+from __future__ import annotations
+
+import asyncio
 import hashlib
 import io
 from pathlib import Path
 
 import pytest
 
+from fastmcp_pvl_core._file_exchange._errors import (
+    FileExchangeError,
+    FileExchangeErrorCode,
+)
+from fastmcp_pvl_core._file_exchange._transport_https import (
+    SSRFGuardConfig,
+    enforce_ssrf,
+    pull_download,
+    push_upload,
+)
+
+
+def test_ssrf_rejects_http_scheme() -> None:
+    cfg = SSRFGuardConfig()
+    with pytest.raises(FileExchangeError) as ei:
+        enforce_ssrf("http://example.com/x", config=cfg)
+    assert ei.value.code is FileExchangeErrorCode.NOT_ACCESSIBLE
+    assert "https" in ei.value.detail
+
+
+def test_ssrf_rejects_loopback_by_default() -> None:
+    cfg = SSRFGuardConfig()
+    with pytest.raises(FileExchangeError) as ei:
+        enforce_ssrf("https://127.0.0.1/x", config=cfg)
+    assert ei.value.code is FileExchangeErrorCode.NOT_ACCESSIBLE
+
+
+def test_ssrf_allows_loopback_when_opted_in() -> None:
+    cfg = SSRFGuardConfig(allow_loopback=True)
+    # Must not raise; returns the pinned IP for connect-pinning.
+    pinned = enforce_ssrf("https://127.0.0.1/x", config=cfg)
+    assert pinned == "127.0.0.1"
+
+
+def test_ssrf_rejects_private_rfc1918_by_default() -> None:
+    cfg = SSRFGuardConfig()
+    with pytest.raises(FileExchangeError) as ei:
+        enforce_ssrf("https://10.0.0.5/x", config=cfg)
+    assert ei.value.code is FileExchangeErrorCode.NOT_ACCESSIBLE
+
+
+def test_ssrf_allows_private_when_opted_in() -> None:
+    cfg = SSRFGuardConfig(allow_private=True)
+    pinned = enforce_ssrf("https://10.0.0.5/x", config=cfg)
+    assert pinned == "10.0.0.5"
+```
+
+### Step D.2 — Failing tests for `pull_download` streaming + digest
+
+- [ ] **Append to `test_transport_https.py`:**
+
+```python
+class _FakeAsyncStream:
+    """Tiny stand-in for an httpx streaming response (chunked body)."""
+
+    def __init__(self, chunks: list[bytes], headers: dict[str, str] | None = None) -> None:
+        self._chunks = chunks
+        self.headers = headers or {}
+        self.status_code = 200
+
+    async def aiter_bytes(self, chunk_size: int = 65536):
+        for c in self._chunks:
+            yield c
+
+    async def aread(self) -> bytes:  # pragma: no cover - not used in streaming path
+        return b"".join(self._chunks)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+@pytest.mark.asyncio
+async def test_pull_download_streams_chunks_into_dest_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "out.bin"
+    payload = b"hello world " * 100
+    chunks = [payload[i : i + 16] for i in range(0, len(payload), 16)]
+
+    async def _fake_get(url: str, **_kw):
+        return _FakeAsyncStream(chunks, headers={"content-length": str(len(payload))})
+
+    monkeypatch.setattr(
+        "fastmcp_pvl_core._file_exchange._transport_https._stream_get", _fake_get
+    )
+    digester = hashlib.sha256()
+    await pull_download(
+        "https://example.com/d/tok",
+        dest=target,
+        ssrf=SSRFGuardConfig(allow_private=True, allow_loopback=True),
+        digester=digester,
+    )
+    assert target.read_bytes() == payload
+    assert digester.hexdigest() == hashlib.sha256(payload).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_pull_download_streams_into_binaryio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = b"abc" * 1000
+    chunks = [payload[i : i + 128] for i in range(0, len(payload), 128)]
+
+    async def _fake_get(url: str, **_kw):
+        return _FakeAsyncStream(chunks)
+
+    monkeypatch.setattr(
+        "fastmcp_pvl_core._file_exchange._transport_https._stream_get", _fake_get
+    )
+    buf = io.BytesIO()
+    await pull_download(
+        "https://example.com/d/tok",
+        dest=buf,
+        ssrf=SSRFGuardConfig(allow_private=True, allow_loopback=True),
+        digester=None,
+    )
+    assert buf.getvalue() == payload
+```
+
+### Step D.3 — Failing tests for `push_upload` streaming
+
+- [ ] **Append:**
+
+```python
+@pytest.mark.asyncio
+async def test_push_upload_streams_from_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"x" * 4096)
+    captured: dict[str, object] = {}
+
+    async def _fake_put(url: str, *, content, headers, **_kw):
+        # Drain the iterator to confirm streaming-style call shape.
+        if hasattr(content, "read"):
+            captured["bytes"] = content.read()
+        else:
+            captured["bytes"] = b"".join([c async for c in content])
+        captured["headers"] = headers
+        return _FakeAsyncStream([], headers={})
+
+    monkeypatch.setattr(
+        "fastmcp_pvl_core._file_exchange._transport_https._stream_put", _fake_put
+    )
+    await push_upload(
+        "https://example.com/u/tok",
+        source=src,
+        ssrf=SSRFGuardConfig(allow_private=True, allow_loopback=True),
+        content_type="application/octet-stream",
+    )
+    assert captured["bytes"] == b"x" * 4096
+    assert captured["headers"]["Content-Type"] == "application/octet-stream"
+```
+
+- [ ] **Run all D tests to verify fail:**
+
+```bash
+uv run pytest tests/file_exchange/test_transport_https.py -v
+```
+
+Expected: FAIL — module not found.
+
+### Step D.4 — Implement `_transport_https.py`
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/_transport_https.py`:**
+
+```python
+"""HTTPS consumer-side transport (spec §6.2).
+
+- ``SSRFGuardConfig`` — operator overrides.
+- ``enforce_ssrf(url, config)`` — resolve hostname, reject loopback /
+  private / link-local unless opted in. Returns the pinned IP.
+- ``pull_download`` — chunk-streams a ``GET`` body into ``Path | BinaryIO``,
+  updating a digester per chunk via ``asyncio.to_thread(dest.write, chunk)``.
+- ``push_upload`` — streams ``Path | BinaryIO`` to ``PUT``/``POST``; never
+  buffers a single ``bytes`` blob.
+
+The seams ``_stream_get`` and ``_stream_put`` are private async helpers
+that the unit tests monkeypatch. Production code paths use httpx.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import ipaddress
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO
+from urllib.parse import urlsplit
+
+import httpx
+
+from ._errors import FileExchangeError, FileExchangeErrorCode
+
+_CHUNK_SIZE = 64 * 1024
+
+
+@dataclass(frozen=True)
+class SSRFGuardConfig:
+    """Operator-side overrides for the SSRF guard.
+
+    Both default to ``False`` — production refuses loopback / private /
+    link-local. Dev environments opt in.
+    """
+
+    allow_loopback: bool = False
+    allow_private: bool = False
+
+
+def enforce_ssrf(url: str, *, config: SSRFGuardConfig) -> str:
+    """Validate ``url`` and return the pinned IP literal.
+
+    Rejects non-``https`` scheme, loopback (unless allowed), RFC 1918 /
+    link-local (unless allowed). Pinning the resolved IP defeats DNS
+    rebinding — callers pass the returned literal to httpx via
+    ``client.transport = httpx.AsyncHTTPTransport(local_address=...)`` or
+    via ``URL.copy_with(host=ip)``.
+    """
+    parts = urlsplit(url)
+    if parts.scheme != "https":
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"file-exchange refuses non-https URL {url!r}",
+        )
+    host = parts.hostname
+    if not host:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"file-exchange URL {url!r} has no hostname",
+        )
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        try:
+            resolved = socket.gethostbyname(host)
+        except socket.gaierror as exc:
+            raise FileExchangeError(
+                code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+                detail=f"DNS resolution failed for {host!r}",
+            ) from exc
+        ip = ipaddress.ip_address(resolved)
+    if ip.is_loopback and not config.allow_loopback:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"file-exchange refuses loopback {ip} (set _HTTPS_ALLOW_LOOPBACK=true to enable)",
+        )
+    if (ip.is_private or ip.is_link_local) and not config.allow_private:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"file-exchange refuses private/link-local {ip} (set _HTTPS_ALLOW_PRIVATE=true to enable)",
+        )
+    return str(ip)
+
+
+async def _stream_get(url: str, *, headers: dict[str, str] | None = None) -> Any:
+    """Production GET seam — monkeypatched in unit tests.
+
+    Returns an object with ``.aiter_bytes(chunk_size)``, ``.headers``,
+    ``.status_code``, and ``.raise_for_status()`` (matches httpx response).
+    """
+    client = httpx.AsyncClient()
+    try:
+        resp = await client.get(url, headers=headers or {}, follow_redirects=False)
+        resp.raise_for_status()
+        return resp
+    finally:
+        await client.aclose()
+
+
+async def _stream_put(
+    url: str,
+    *,
+    content: Any,
+    headers: dict[str, str],
+) -> Any:
+    """Production PUT seam — monkeypatched in unit tests.
+
+    Accepts either a file-like opened in ``"rb"`` or an async-iterator of
+    bytes chunks (httpx supports both via the ``content=`` kwarg).
+    """
+    client = httpx.AsyncClient()
+    try:
+        resp = await client.put(url, content=content, headers=headers, follow_redirects=False)
+        resp.raise_for_status()
+        return resp
+    finally:
+        await client.aclose()
+
+
+async def pull_download(
+    url: str,
+    *,
+    dest: Path | BinaryIO,
+    ssrf: SSRFGuardConfig,
+    digester: Any | None = None,
+    chunk_size: int = _CHUNK_SIZE,
+) -> None:
+    """Chunk-stream ``url`` into ``dest``.
+
+    Updates ``digester`` (if provided) per chunk. Writes via
+    ``asyncio.to_thread(dest.write, chunk)`` so the event loop is never
+    blocked on disk latency. Caller verifies the final digest against
+    artifact.digest after this returns.
+    """
+    enforce_ssrf(url, config=ssrf)
+    resp = await _stream_get(url)
+    if isinstance(dest, Path):
+        # Lazy import to avoid a circular cycle in the package layout.
+        from ._transport_filesystem import async_atomic_write
+
+        async with async_atomic_write(dest) as fh:
+            async for chunk in resp.aiter_bytes(chunk_size):
+                if digester is not None:
+                    digester.update(chunk)
+                await asyncio.to_thread(fh.write, chunk)
+    else:
+        async for chunk in resp.aiter_bytes(chunk_size):
+            if digester is not None:
+                digester.update(chunk)
+            await asyncio.to_thread(dest.write, chunk)
+
+
+async def push_upload(
+    url: str,
+    *,
+    source: Path | BinaryIO,
+    ssrf: SSRFGuardConfig,
+    content_type: str,
+    content_digest: str | None = None,
+    content_length: int | None = None,
+) -> None:
+    """Stream ``source`` to ``url`` via PUT.
+
+    For a ``Path`` source, opens in ``"rb"`` and passes the file object to
+    httpx (httpx streams it). For a ``BinaryIO``, passes directly. Never
+    assembles a ``bytes`` blob.
+    """
+    enforce_ssrf(url, config=ssrf)
+    headers: dict[str, str] = {"Content-Type": content_type}
+    if content_digest is not None:
+        headers["Content-Digest"] = content_digest
+    if content_length is not None:
+        headers["Content-Length"] = str(content_length)
+    if isinstance(source, Path):
+        # Run the blocking ``open`` off the event loop too — large file
+        # opens can block on filesystem metadata lookups.
+        fh = await asyncio.to_thread(open, source, "rb")
+        try:
+            await _stream_put(url, content=fh, headers=headers)
+        finally:
+            await asyncio.to_thread(fh.close)
+    else:
+        await _stream_put(url, content=source, headers=headers)
+```
+
+- [ ] **Run to verify pass:**
+
+```bash
+uv run pytest tests/file_exchange/test_transport_https.py -v
+```
+
+Expected: 8 passing.
+
+### Step D.5 — Commit Task D
+
+- [ ] **Commit:**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_transport_https.py \
+        tests/file_exchange/test_transport_https.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): HTTPS consumer transport with SSRF guard
+
+Adds enforce_ssrf (https-only, rejects loopback / RFC1918 / link-local
+unless opted in via SSRFGuardConfig), pull_download (chunk-streams to
+Path or BinaryIO with per-chunk digester update, asyncio.to_thread for
+disk writes), and push_upload (streams a Path or BinaryIO source —
+never buffers a bytes blob, opens files off the event loop).
+
+Closes #127.
+EOF
+)"
+```
+
+- [ ] Run the universal per-task suffix.
+
+---
+
+## Task E: Capability-URL token store + sibling HTTP routes (closes #128)
+
+**Depends on:** Task A merged. (Coordinates with C/D at call sites but does not import from them; the routes import `async_atomic_write` from `_transport_filesystem.py` once C lands.)
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_url_store.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_routes.py`
+- Create: `tests/file_exchange/test_url_store.py`
+- Create: `tests/file_exchange/test_routes.py`
+
+### Step E.1 — Failing tests for `_url_store.py` mint + consume + sweep
+
+- [ ] **Write `tests/file_exchange/test_url_store.py`:**
+
+```python
+"""Capability-URL token store (spec §6.2 producer-side)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from key_value.aio.stores.memory import MemoryStore
+
+from fastmcp_pvl_core._file_exchange._url_store import (
+    DownloadTokenRecord,
+    UploadTokenRecord,
+    consume_download_token,
+    consume_upload_token,
+    lookup_upload_token,
+    make_filesystem_sink,
+    mint_download_source,
+    mint_intake_mapping,
+    mint_upload_sink,
+    resolve_intake,
+    sweep_expired_tokens,
+)
+from fastmcp_pvl_core._file_exchange._types import ExpectedConstraints
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    return MemoryStore()
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    from fastmcp_pvl_core import ServerConfig
+
+    (tmp_path / "vault").mkdir()
+    return ServerConfig(
+        transport="http",
+        base_url="https://example.com",
+        file_exchange_volumes=f"vault={tmp_path / 'vault'}",
+        file_exchange_capability_url_ttl_default_s=600,
+        file_exchange_https_public_base_url="https://files.example.com",
+    )
+
+
+@pytest.fixture
+def mcp():
+    from fastmcp import FastMCP
+
+    return FastMCP("test-server")
+
+
+@pytest.mark.asyncio
+async def test_mint_download_source_writes_token_record_and_returns_descriptor(
+    store: MemoryStore, cfg, mcp, tmp_path: Path
+) -> None:
+    payload = tmp_path / "payload.bin"
+    payload.write_bytes(b"hi")
+    src = await mint_download_source(
+        bytes_path=payload, server=mcp, config=cfg, kv_store=store,
+    )
+    assert src.root.transport == "download"
+    assert src.root.url.startswith("https://files.example.com/file-exchange/d/")
+    # Token record exists in the store
+    token = src.root.url.rsplit("/", 1)[-1]
+    raw = await store.get(collection="tokens", key=token)
+    assert raw is not None
+    assert raw["kind"] == "download"
+    assert raw["bytes_path"] == str(payload.resolve())
+    assert raw["single_use"] is True
+
+
+@pytest.mark.asyncio
+async def test_mint_upload_sink_writes_both_token_and_intake_mapping(
+    store: MemoryStore, cfg, mcp, tmp_path: Path
+) -> None:
+    intake = tmp_path / "intake" / "a1.bin"
+    sink = await mint_upload_sink(
+        intake_path=intake, artifact_id="a1", server=mcp, config=cfg, kv_store=store,
+        expected=ExpectedConstraints(max_size=4096, accept_mime_types=("application/pdf",)),
+    )
+    assert sink.root.transport == "upload"
+    token = sink.root.url.rsplit("/", 1)[-1]
+    raw_tok = await store.get(collection="tokens", key=token)
+    assert raw_tok["kind"] == "upload"
+    assert raw_tok["intake_path"] == str(intake.resolve())
+    assert raw_tok["max_size"] == 4096
+    # Intake mapping is recorded at mint time, before any bytes arrive.
+    raw_intake = await store.get(collection="intake", key="a1")
+    assert raw_intake["intake_path"] == str(intake.resolve())
+
+
+@pytest.mark.asyncio
+async def test_make_filesystem_sink_writes_intake_mapping(
+    store: MemoryStore, cfg, tmp_path: Path
+) -> None:
+    sink = await make_filesystem_sink(
+        "vault", "a1.bin", artifact_id="a1", config=cfg, kv_store=store,
+    )
+    assert sink.root.transport == "filesystem"
+    assert sink.root.uri == "exchange://vault/a1.bin"
+    raw_intake = await store.get(collection="intake", key="a1")
+    expected_path = (tmp_path / "vault" / "a1.bin").resolve()
+    assert raw_intake["intake_path"] == str(expected_path)
+
+
+@pytest.mark.asyncio
+async def test_consume_download_token_single_use_atomic_under_concurrency(
+    store: MemoryStore, cfg, mcp, tmp_path: Path
+) -> None:
+    payload = tmp_path / "p.bin"
+    payload.write_bytes(b"x")
+    src = await mint_download_source(
+        bytes_path=payload, server=mcp, config=cfg, kv_store=store,
+    )
+    token = src.root.url.rsplit("/", 1)[-1]
+
+    async def race():
+        try:
+            await consume_download_token(store=store, token=token)
+            return "won"
+        except LookupError:
+            return "lost"
+
+    a, b = await asyncio.gather(race(), race())
+    assert sorted([a, b]) == ["lost", "won"]
+
+
+@pytest.mark.asyncio
+async def test_consume_upload_token_after_streaming(
+    store: MemoryStore, cfg, mcp, tmp_path: Path
+) -> None:
+    sink = await mint_upload_sink(
+        intake_path=tmp_path / "out.bin", artifact_id="a1",
+        server=mcp, config=cfg, kv_store=store,
+    )
+    token = sink.root.url.rsplit("/", 1)[-1]
+    # First lookup (non-deleting) — used by the route before streaming.
+    record = await lookup_upload_token(store=store, token=token)
+    assert isinstance(record, UploadTokenRecord)
+    # Token is still there.
+    assert await store.get(collection="tokens", key=token) is not None
+    # Consume after a successful stream.
+    await consume_upload_token(store=store, token=token)
+    assert await store.get(collection="tokens", key=token) is None
+
+
+@pytest.mark.asyncio
+async def test_consume_rejects_wrong_kind(
+    store: MemoryStore, cfg, mcp, tmp_path: Path
+) -> None:
+    src = await mint_download_source(
+        bytes_path=tmp_path / "p.bin", server=mcp, config=cfg, kv_store=store,
+    )
+    (tmp_path / "p.bin").write_bytes(b"x")
+    token = src.root.url.rsplit("/", 1)[-1]
+    with pytest.raises(LookupError, match="kind"):
+        await consume_upload_token(store=store, token=token)
+
+
+@pytest.mark.asyncio
+async def test_resolve_intake_raises_for_missing_artifact_id(store: MemoryStore) -> None:
+    from fastmcp_pvl_core._file_exchange._errors import (
+        FileExchangeError,
+        FileExchangeErrorCode,
+    )
+
+    with pytest.raises(FileExchangeError) as ei:
+        await resolve_intake("nope", kv_store=store)
+    assert ei.value.code is FileExchangeErrorCode.NOT_ACCESSIBLE
+    assert "no intake recorded" in ei.value.detail
+
+
+@pytest.mark.asyncio
+async def test_resolve_intake_raises_when_bytes_not_yet_deposited(
+    store: MemoryStore, tmp_path: Path
+) -> None:
+    from fastmcp_pvl_core._file_exchange._errors import (
+        FileExchangeError,
+        FileExchangeErrorCode,
+    )
+
+    missing = tmp_path / "not-yet.bin"
+    await mint_intake_mapping(artifact_id="a1", intake_path=missing, kv_store=store)
+    with pytest.raises(FileExchangeError) as ei:
+        await resolve_intake("a1", kv_store=store)
+    assert ei.value.code is FileExchangeErrorCode.NOT_ACCESSIBLE
+    assert "not yet been deposited" in ei.value.detail
+
+
+@pytest.mark.asyncio
+async def test_resolve_intake_returns_path_when_bytes_present(
+    store: MemoryStore, tmp_path: Path
+) -> None:
+    landed = tmp_path / "landed.bin"
+    landed.write_bytes(b"arrived")
+    await mint_intake_mapping(artifact_id="a1", intake_path=landed, kv_store=store)
+    out = await resolve_intake("a1", kv_store=store)
+    assert out == landed.resolve()
+
+
+@pytest.mark.asyncio
+async def test_sweep_expired_tokens_drops_expired(
+    store: MemoryStore, cfg, mcp, tmp_path: Path
+) -> None:
+    cfg_short = type(cfg)(**{**cfg.__dict__, "file_exchange_capability_url_ttl_default_s": 0})
+    src = await mint_download_source(
+        bytes_path=tmp_path / "p.bin", server=mcp, config=cfg_short, kv_store=store,
+    )
+    (tmp_path / "p.bin").write_bytes(b"x")
+    token = src.root.url.rsplit("/", 1)[-1]
+    # Force backdate
+    raw = await store.get(collection="tokens", key=token)
+    raw["expires_at"] = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+    await store.put(collection="tokens", key=token, value=raw)
+    removed = await sweep_expired_tokens(store=store)
+    assert removed >= 1
+    assert await store.get(collection="tokens", key=token) is None
+
+
+@pytest.mark.asyncio
+async def test_mint_and_consume_never_logs_full_token(
+    store: MemoryStore, cfg, mcp, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="fastmcp_pvl_core")
+    src = await mint_download_source(
+        bytes_path=tmp_path / "p.bin", server=mcp, config=cfg, kv_store=store,
+    )
+    (tmp_path / "p.bin").write_bytes(b"x")
+    token = src.root.url.rsplit("/", 1)[-1]
+    await consume_download_token(store=store, token=token)
+    rendered = " ".join(rec.getMessage() for rec in caplog.records)
+    assert token not in rendered, "full token leaked into log output"
+    assert src.root.url not in rendered, "full URL leaked into log output"
+
+
+@pytest.mark.asyncio
+async def test_mint_funcs_raise_configuration_error_when_no_base_url(
+    store: MemoryStore, mcp, tmp_path: Path
+) -> None:
+    from fastmcp_pvl_core import ServerConfig
+    from fastmcp_pvl_core._errors import ConfigurationError
+
+    bare = ServerConfig()  # no base_url, no app_domain, no override
+    with pytest.raises(ConfigurationError, match="public base URL"):
+        await mint_download_source(
+            bytes_path=tmp_path / "p.bin", server=mcp, config=bare, kv_store=store,
+        )
+```
+
+- [ ] **Run to verify fail:**
+
+```bash
+uv run pytest tests/file_exchange/test_url_store.py -v
+```
+
+Expected: FAIL — module not found.
+
+### Step E.2 — Implement `_url_store.py`
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/_url_store.py`:**
+
+```python
+"""Capability-URL token store, intake-correlation map, and mint helpers
+that require kv_store interaction.
+
+Layout in the namespaced kv_store (single ``PrefixCollectionsWrapper``
+view passed in as ``kv_store``):
+
+- ``tokens:<token>`` — JSON record with ``kind: "download" | "upload"``.
+- ``intake:<artifact_id>`` — JSON record with ``intake_path: str``.
+
+Logging discipline (spec §12): capability URLs are bearer credentials.
+This module logs at DEBUG using a token fingerprint (``tok=<first-8>...``);
+the full token / URL never enter any log field.
+
+Why ``make_filesystem_sink`` and ``mint_upload_sink`` are async while
+``make_filesystem_source`` is sync: only the sink-side minters write
+``intake:<artifact_id>`` into ``kv_store``. The source-side filesystem
+minter is pure string composition. Forcing all four to async would be
+ceremony without benefit.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from key_value.aio.protocols.key_value import AsyncKeyValue
+
+from .._config import ServerConfig
+from .._errors import ConfigurationError
+from .._factory import compute_app_domain
+from ._errors import FileExchangeError, FileExchangeErrorCode
+from ._transport_filesystem import parse_volumes, resolve_exchange_uri
+from ._types import (
+    ExpectedConstraints,
+    FileExchangeTransport,
+    SinkDescriptor,
+    SourceDescriptor,
+)
+
+logger = logging.getLogger("fastmcp_pvl_core.file_exchange")
+
+
+def _fp(token: str) -> str:
+    """Short, non-secret fingerprint suitable for log messages."""
+    return f"tok={token[:8]}..."
+
+
+def _resolve_public_base_url(server: Any, config: ServerConfig) -> str:
+    """Resolve the public base URL for capability-URL composition.
+
+    Precedence: explicit override (``file_exchange_https_public_base_url``)
+    → ``compute_app_domain(config)`` → raise ``ConfigurationError``.
+    """
+    if config.file_exchange_https_public_base_url:
+        return config.file_exchange_https_public_base_url.rstrip("/")
+    domain = compute_app_domain(config)
+    if domain is None:
+        raise ConfigurationError(
+            "file-exchange: HTTPS producer routes require a configured public base "
+            "URL — set _FILE_EXCHANGE_HTTPS_PUBLIC_BASE_URL, _BASE_URL, or _APP_DOMAIN"
+        )
+    return domain.rstrip("/")
+
+
+@dataclass(frozen=True)
+class DownloadTokenRecord:
+    token: str
+    bytes_path: Path
+    content_type: str | None
+    expires_at: datetime
+    single_use: bool
+
+
+@dataclass(frozen=True)
+class UploadTokenRecord:
+    token: str
+    intake_path: Path
+    artifact_id: str
+    max_size: int | None
+    accept_mime_types: tuple[str, ...] | None
+    require_digest: bool
+    expires_at: datetime
+
+
+def _new_token() -> str:
+    # 128 bits of entropy, URL-safe base64.
+    return secrets.token_urlsafe(16)
+
+
+def _ttl_seconds(config: ServerConfig, override: int | None) -> int:
+    return override if override is not None else config.file_exchange_capability_url_ttl_default_s
+
+
+async def mint_download_source(
+    *,
+    bytes_path: Path,
+    server: Any,
+    config: ServerConfig,
+    kv_store: AsyncKeyValue,
+    expires_in_s: int | None = None,
+    single_use: bool = True,
+    content_type: str | None = None,
+) -> SourceDescriptor:
+    base = _resolve_public_base_url(server, config)
+    token = _new_token()
+    expires = datetime.now(timezone.utc) + timedelta(seconds=_ttl_seconds(config, expires_in_s))
+    record = {
+        "kind": "download",
+        "bytes_path": str(bytes_path.resolve()),
+        "content_type": content_type,
+        "expires_at": expires.isoformat(),
+        "single_use": single_use,
+    }
+    await kv_store.put(collection="tokens", key=token, value=record)
+    logger.debug("file-exchange minted download %s (expires=%s)", _fp(token), expires.isoformat())
+    url = f"{base}/file-exchange/d/{token}"
+    return SourceDescriptor.model_validate({"transport": "download", "url": url, "expiresAt": expires.isoformat()})
+
+
+async def mint_upload_sink(
+    *,
+    intake_path: Path,
+    artifact_id: str,
+    server: Any,
+    config: ServerConfig,
+    kv_store: AsyncKeyValue,
+    expires_in_s: int | None = None,
+    expected: ExpectedConstraints | None = None,
+) -> SinkDescriptor:
+    base = _resolve_public_base_url(server, config)
+    token = _new_token()
+    expires = datetime.now(timezone.utc) + timedelta(seconds=_ttl_seconds(config, expires_in_s))
+    expected = expected or ExpectedConstraints()
+    record = {
+        "kind": "upload",
+        "intake_path": str(intake_path.resolve()),
+        "artifact_id": artifact_id,
+        "max_size": expected.max_size,
+        "accept_mime_types": list(expected.accept_mime_types) if expected.accept_mime_types else None,
+        "require_digest": bool(expected.require_digest),
+        "expires_at": expires.isoformat(),
+    }
+    await kv_store.put(collection="tokens", key=token, value=record)
+    await mint_intake_mapping(artifact_id=artifact_id, intake_path=intake_path, kv_store=kv_store)
+    logger.debug("file-exchange minted upload %s for artifact_id=%s", _fp(token), artifact_id)
+    url = f"{base}/file-exchange/u/{token}"
+    return SinkDescriptor.model_validate(
+        {"transport": "upload", "url": url, "methods": ["PUT"], "expiresAt": expires.isoformat()}
+    )
+
+
+async def make_filesystem_sink(
+    volume: str,
+    relative_path: str,
+    *,
+    artifact_id: str,
+    config: ServerConfig,
+    kv_store: AsyncKeyValue,
+) -> SinkDescriptor:
+    """Compose an ``exchange://`` sink descriptor AND record the intake mapping.
+
+    The descriptor's ``uri`` is the unresolved ``exchange://<vol>/<rel>``
+    (portable across parties); the kv_store entry stores the local
+    resolved path (the local party's view of where the bytes will land).
+    """
+    volumes = parse_volumes(config.file_exchange_volumes)
+    if volume not in volumes:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"file-exchange volume {volume!r} is not configured on this party",
+        )
+    uri = f"exchange://{volume}/{relative_path.lstrip('/')}"
+    resolved = resolve_exchange_uri.__wrapped__(uri, volumes=volumes) if hasattr(resolve_exchange_uri, "__wrapped__") else _resolve_for_mint(volumes, volume, relative_path)
+    await mint_intake_mapping(artifact_id=artifact_id, intake_path=resolved, kv_store=kv_store)
+    return SinkDescriptor.model_validate({"transport": "filesystem", "uri": uri})
+
+
+def _resolve_for_mint(volumes: dict[str, Path], volume: str, relative_path: str) -> Path:
+    # mint-time resolution: the path doesn't have to exist yet (sender will create it).
+    return (volumes[volume] / relative_path.lstrip("/")).resolve()
+
+
+async def mint_intake_mapping(
+    *,
+    artifact_id: str,
+    intake_path: Path,
+    kv_store: AsyncKeyValue,
+) -> None:
+    """Record ``intake:<artifact_id> → resolved_intake_path``.
+
+    Called by ``mint_upload_sink`` and ``make_filesystem_sink`` at mint
+    time — so ``resolve_intake`` can distinguish 'wrong artifact_id' from
+    'bytes not yet deposited' after the receiver returns the ticket.
+    """
+    await kv_store.put(
+        collection="intake",
+        key=artifact_id,
+        value={"intake_path": str(intake_path.resolve())},
+    )
+
+
+async def resolve_intake(artifact_id: str, *, kv_store: AsyncKeyValue) -> Path:
+    """Resolve an ``artifact_id`` to its deposited bytes' path.
+
+    Raises ``FileExchangeError(NOT_ACCESSIBLE)`` for either 'unknown
+    artifact_id' or 'bytes not yet deposited' (distinct ``detail`` strings).
+    """
+    raw = await kv_store.get(collection="intake", key=artifact_id)
+    if raw is None:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"no intake recorded for artifact_id={artifact_id!r}",
+        )
+    path = Path(raw["intake_path"])
+    if not path.exists():
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"bytes for artifact_id={artifact_id!r} have not yet been deposited",
+        )
+    return path
+
+
+async def lookup_upload_token(*, store: AsyncKeyValue, token: str) -> UploadTokenRecord:
+    """Non-deleting lookup. Used by the upload route BEFORE streaming."""
+    raw = await store.get(collection="tokens", key=token)
+    if raw is None:
+        raise LookupError(f"unknown token {_fp(token)}")
+    if raw.get("kind") != "upload":
+        raise LookupError(f"token {_fp(token)} kind mismatch (expected upload)")
+    expires_at = datetime.fromisoformat(raw["expires_at"])
+    if datetime.now(timezone.utc) > expires_at:
+        raise LookupError(f"token {_fp(token)} expired")
+    accept = raw.get("accept_mime_types")
+    return UploadTokenRecord(
+        token=token,
+        intake_path=Path(raw["intake_path"]),
+        artifact_id=raw["artifact_id"],
+        max_size=raw.get("max_size"),
+        accept_mime_types=tuple(accept) if accept else None,
+        require_digest=bool(raw.get("require_digest")),
+        expires_at=expires_at,
+    )
+
+
+async def consume_download_token(*, store: AsyncKeyValue, token: str) -> DownloadTokenRecord:
+    """Atomic single-use consume.
+
+    Uses ``store.delete(...)`` (atomic per-key on Memory/FileTree/Redis/
+    DynamoDB/MongoDB backends) as the concurrency primitive: the racing
+    second consumer's delete returns False and we surface as
+    ``LookupError`` so the route returns 404.
+    """
+    raw = await store.get(collection="tokens", key=token)
+    if raw is None or raw.get("kind") != "download":
+        raise LookupError(f"unknown or wrong-kind token {_fp(token)}")
+    expires_at = datetime.fromisoformat(raw["expires_at"])
+    if datetime.now(timezone.utc) > expires_at:
+        raise LookupError(f"token {_fp(token)} expired")
+    record = DownloadTokenRecord(
+        token=token,
+        bytes_path=Path(raw["bytes_path"]),
+        content_type=raw.get("content_type"),
+        expires_at=expires_at,
+        single_use=bool(raw.get("single_use", True)),
+    )
+    if record.single_use:
+        deleted = await store.delete(collection="tokens", key=token)
+        if not deleted:
+            raise LookupError(f"token {_fp(token)} already consumed by concurrent consumer")
+    logger.debug("file-exchange consumed download %s", _fp(token))
+    return record
+
+
+async def consume_upload_token(*, store: AsyncKeyValue, token: str) -> None:
+    """Atomic single-use consume for upload tokens. Called AFTER successful streaming."""
+    raw = await store.get(collection="tokens", key=token)
+    if raw is None:
+        raise LookupError(f"unknown token {_fp(token)}")
+    if raw.get("kind") != "upload":
+        raise LookupError(f"token {_fp(token)} kind mismatch (expected upload)")
+    deleted = await store.delete(collection="tokens", key=token)
+    if not deleted:
+        raise LookupError(f"token {_fp(token)} already consumed by concurrent consumer")
+    logger.debug("file-exchange consumed upload %s", _fp(token))
+
+
+async def sweep_expired_tokens(*, store: AsyncKeyValue) -> int:
+    """Iterate the ``tokens`` collection and delete expired records.
+
+    Returns the count of removed records. Best-effort: if the backend
+    does not expose ``.list_keys`` or equivalent, falls back to a no-op
+    (operators can rely on per-key expiry from the backend instead).
+    """
+    now = datetime.now(timezone.utc)
+    removed = 0
+    keys_fn = getattr(store, "keys", None) or getattr(store, "list_keys", None)
+    if keys_fn is None:
+        return 0
+    async for key in keys_fn(collection="tokens"):
+        raw = await store.get(collection="tokens", key=key)
+        if raw is None:
+            continue
+        try:
+            expires = datetime.fromisoformat(raw["expires_at"])
+        except (KeyError, ValueError):
+            continue
+        if now > expires:
+            if await store.delete(collection="tokens", key=key):
+                removed += 1
+    if removed:
+        logger.debug("file-exchange sweep removed %d expired token(s)", removed)
+    return removed
+```
+
+- [ ] **Run to verify pass:**
+
+```bash
+uv run pytest tests/file_exchange/test_url_store.py -v
+```
+
+Expected: 12 passing. (If the in-memory `MemoryStore` doesn't expose `keys`/`list_keys`, the sweep test asserts `>= 1` — if zero is observed, surface to user before relaxing the assertion.)
+
+### Step E.3 — Failing tests for `_routes.py`
+
+- [ ] **Write `tests/file_exchange/test_routes.py`:**
+
+```python
+"""Sibling-route handlers (GET /file-exchange/d/<token>, PUT|POST
+/file-exchange/u/<token>). The handlers are tested directly with a
+synthetic Starlette ``Request``; the integration-level mount via
+``FastMCP.custom_route`` is exercised in Task G."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+from key_value.aio.stores.memory import MemoryStore
+from starlette.testclient import TestClient
+from starlette.applications import Starlette
+
+from fastmcp_pvl_core._file_exchange._routes import build_file_exchange_router
+from fastmcp_pvl_core._file_exchange._url_store import (
+    mint_download_source,
+    mint_upload_sink,
+)
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    from fastmcp_pvl_core import ServerConfig
+
+    return ServerConfig(
+        transport="http",
+        base_url="https://example.com",
+        file_exchange_https_public_base_url="https://example.com",
+        file_exchange_capability_url_ttl_default_s=600,
+    )
+
+
+@pytest.fixture
+def mcp():
+    from fastmcp import FastMCP
+
+    return FastMCP("test-routes")
+
+
+@pytest.fixture
+def app_and_store(cfg, mcp):
+    store = MemoryStore()
+    download_handler, upload_handler = build_file_exchange_router(store=store)
+    app = Starlette(routes=[])
+    app.add_route("/file-exchange/d/{token}", download_handler, methods=["GET"])
+    app.add_route("/file-exchange/u/{token}", upload_handler, methods=["PUT", "POST"])
+    return app, store
+
+
+@pytest.mark.asyncio
+async def test_download_returns_bytes_and_consumes_token(
+    app_and_store, cfg, mcp, tmp_path: Path
+) -> None:
+    app, store = app_and_store
+    payload = b"hello" * 100
+    src_file = tmp_path / "p.bin"
+    src_file.write_bytes(payload)
+    src = await mint_download_source(
+        bytes_path=src_file, server=mcp, config=cfg, kv_store=store, content_type="text/plain",
+    )
+    token = src.root.url.rsplit("/", 1)[-1]
+    with TestClient(app) as client:
+        r = client.get(f"/file-exchange/d/{token}")
+        assert r.status_code == 200
+        assert r.content == payload
+        # Second call → 404 (single-use consumed)
+        r2 = client.get(f"/file-exchange/d/{token}")
+        assert r2.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_upload_streams_body_validates_mime_and_consumes_token(
+    app_and_store, cfg, mcp, tmp_path: Path
+) -> None:
+    app, store = app_and_store
+    intake = tmp_path / "out.bin"
+    from fastmcp_pvl_core._file_exchange._types import ExpectedConstraints
+
+    sink = await mint_upload_sink(
+        intake_path=intake, artifact_id="a1", server=mcp, config=cfg, kv_store=store,
+        expected=ExpectedConstraints(max_size=4096, accept_mime_types=("application/pdf",)),
+    )
+    token = sink.root.url.rsplit("/", 1)[-1]
+    body = b"%PDF-fake content" + b"x" * 1000
+    with TestClient(app) as client:
+        r = client.put(
+            f"/file-exchange/u/{token}",
+            data=body,
+            headers={"Content-Type": "application/pdf"},
+        )
+        assert r.status_code in (200, 204)
+        assert intake.read_bytes() == body
+        # Token consumed → 404 on retry
+        r2 = client.put(
+            f"/file-exchange/u/{token}",
+            data=b"x",
+            headers={"Content-Type": "application/pdf"},
+        )
+        assert r2.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_mime_mismatch_before_streaming(
+    app_and_store, cfg, mcp, tmp_path: Path
+) -> None:
+    app, store = app_and_store
+    from fastmcp_pvl_core._file_exchange._types import ExpectedConstraints
+
+    sink = await mint_upload_sink(
+        intake_path=tmp_path / "o.bin", artifact_id="a1", server=mcp, config=cfg, kv_store=store,
+        expected=ExpectedConstraints(accept_mime_types=("application/pdf",)),
+    )
+    token = sink.root.url.rsplit("/", 1)[-1]
+    with TestClient(app) as client:
+        r = client.put(
+            f"/file-exchange/u/{token}",
+            data=b"hello",
+            headers={"Content-Type": "text/plain"},
+        )
+        assert r.status_code == 415
+        # Token still present (not consumed on validation failure)
+        assert await store.get(collection="tokens", key=token) is not None
+
+
+@pytest.mark.asyncio
+async def test_upload_fails_fast_on_size_exceeded_with_413(
+    app_and_store, cfg, mcp, tmp_path: Path
+) -> None:
+    app, store = app_and_store
+    from fastmcp_pvl_core._file_exchange._types import ExpectedConstraints
+
+    intake = tmp_path / "o.bin"
+    sink = await mint_upload_sink(
+        intake_path=intake, artifact_id="a1", server=mcp, config=cfg, kv_store=store,
+        expected=ExpectedConstraints(max_size=1024, accept_mime_types=("application/octet-stream",)),
+    )
+    token = sink.root.url.rsplit("/", 1)[-1]
+    oversized = b"x" * (1024 + 1024)
+    with TestClient(app) as client:
+        r = client.put(
+            f"/file-exchange/u/{token}",
+            data=oversized,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        assert r.status_code == 413
+        # Intake bytes NOT written
+        assert not intake.exists()
+        # No temp file residue in intake dir
+        if intake.parent.exists():
+            residue = [p for p in intake.parent.iterdir() if p.name.startswith(".")]
+            assert residue == []
+        # Token still present (not consumed on validation failure)
+        assert await store.get(collection="tokens", key=token) is not None
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_digest_mismatch_with_422(
+    app_and_store, cfg, mcp, tmp_path: Path
+) -> None:
+    app, store = app_and_store
+    from fastmcp_pvl_core._file_exchange._types import ExpectedConstraints
+
+    intake = tmp_path / "o.bin"
+    sink = await mint_upload_sink(
+        intake_path=intake, artifact_id="a1", server=mcp, config=cfg, kv_store=store,
+        expected=ExpectedConstraints(require_digest=True, accept_mime_types=("application/octet-stream",)),
+    )
+    token = sink.root.url.rsplit("/", 1)[-1]
+    body = b"abc"
+    wrong = "sha-256=:" + "0" * 44 + "=:"
+    with TestClient(app) as client:
+        r = client.put(
+            f"/file-exchange/u/{token}",
+            data=body,
+            headers={"Content-Type": "application/octet-stream", "Content-Digest": wrong},
+        )
+        assert r.status_code == 422
+        assert not intake.exists()
+```
+
+- [ ] **Run to verify fail:**
+
+```bash
+uv run pytest tests/file_exchange/test_routes.py -v
+```
+
+Expected: FAIL — module not found.
+
+### Step E.4 — Implement `_routes.py`
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/_routes.py`:**
+
+```python
+"""Sibling HTTP route handlers for capability URLs.
+
+Mounted via ``FastMCP.custom_route(path, methods=[...])(handler)`` from
+``_capability.register_file_exchange_capability``. We expose
+``build_file_exchange_router(store)`` which returns the
+``(download_handler, upload_handler)`` pair so the mount call site can
+register them imperatively.
+
+Route flow (upload — see spec §6.2 producer side):
+  1. Lookup the token (non-deleting).
+  2. Validate ``Content-Type`` against ``accept_mime_types`` (HTTP 415).
+  3. Stream the body via ``async_atomic_write`` — per-chunk:
+     - update sha-256 digester
+     - increment cumulative byte counter
+     - on cumulative > max_size: raise to roll back temp + return 413
+     - dispatch the chunk write via ``asyncio.to_thread``
+  4. After body fully received, verify ``Content-Digest`` (HTTP 422 on mismatch).
+  5. On clean exit of ``async_atomic_write`` (renames onto intake_path),
+     consume the token (atomic delete).
+  6. The intake mapping was already recorded by ``mint_upload_sink`` at
+     mint time; the route does NOT write it again.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import logging
+import re
+from pathlib import Path
+from typing import Awaitable, Callable
+
+from key_value.aio.protocols.key_value import AsyncKeyValue
+from starlette.requests import Request
+from starlette.responses import FileResponse, Response
+
+from ._transport_filesystem import async_atomic_write
+from ._url_store import (
+    consume_download_token,
+    consume_upload_token,
+    lookup_upload_token,
+)
+
+logger = logging.getLogger("fastmcp_pvl_core.file_exchange")
+
+_DIGEST_RE = re.compile(r"sha-256=:([A-Za-z0-9+/=]+):")
+_CHUNK_SIZE = 64 * 1024
+
+
+class _UploadTooLarge(Exception):
+    pass
+
+
+class _DigestMismatch(Exception):
+    pass
+
+
+def build_file_exchange_router(
+    *, store: AsyncKeyValue
+) -> tuple[Callable[[Request], Awaitable[Response]], Callable[[Request], Awaitable[Response]]]:
+    """Build the (download_handler, upload_handler) pair.
+
+    Returns plain async functions; the caller mounts them via
+    ``FastMCP.custom_route(path, methods=[...])(handler)``.
+    """
+
+    async def _download(request: Request) -> Response:
+        token = request.path_params["token"]
+        try:
+            record = await consume_download_token(store=store, token=token)
+        except LookupError:
+            return Response(status_code=404)
+        # Stream the file via Starlette's FileResponse (uses sendfile when available).
+        headers = {}
+        if record.content_type:
+            headers["content-type"] = record.content_type
+        return FileResponse(path=str(record.bytes_path), headers=headers)
+
+    async def _upload(request: Request) -> Response:
+        token = request.path_params["token"]
+        try:
+            record = await lookup_upload_token(store=store, token=token)
+        except LookupError:
+            return Response(status_code=404)
+
+        # 1. MIME validation BEFORE streaming.
+        content_type = request.headers.get("content-type", "").split(";", 1)[0].strip()
+        if record.accept_mime_types and content_type not in record.accept_mime_types:
+            return Response(
+                status_code=415,
+                content=f"mime-rejected: got {content_type!r} not in {list(record.accept_mime_types)}",
+            )
+
+        digester = hashlib.sha256()
+        cumulative = 0
+        try:
+            async with async_atomic_write(record.intake_path) as fh:
+                async for chunk in request.stream():
+                    if not chunk:
+                        continue
+                    cumulative += len(chunk)
+                    if record.max_size is not None and cumulative > record.max_size:
+                        raise _UploadTooLarge()
+                    digester.update(chunk)
+                    await asyncio.to_thread(fh.write, chunk)
+                # Inside the with block: digest check (so a mismatch
+                # raises and the temp file is discarded).
+                provided = request.headers.get("content-digest")
+                if record.require_digest or provided:
+                    if not provided:
+                        raise _DigestMismatch()
+                    m = _DIGEST_RE.search(provided)
+                    if not m:
+                        raise _DigestMismatch()
+                    expected = base64.b64decode(m.group(1))
+                    if expected != digester.digest():
+                        raise _DigestMismatch()
+        except _UploadTooLarge:
+            return Response(
+                status_code=413,
+                content=f"size-exceeded: cap={record.max_size} cumulative>={cumulative}",
+            )
+        except _DigestMismatch:
+            return Response(status_code=422, content="digest-mismatch")
+
+        # 2. Stream succeeded + validations passed → consume the token.
+        try:
+            await consume_upload_token(store=store, token=token)
+        except LookupError:
+            # Racing concurrent consumer beat us — surface as 409.
+            return Response(status_code=409)
+        return Response(status_code=204)
+
+    return _download, _upload
+```
+
+- [ ] **Run to verify pass:**
+
+```bash
+uv run pytest tests/file_exchange/test_routes.py -v
+```
+
+Expected: 5 passing.
+
+### Step E.5 — Commit Task E
+
+- [ ] **Commit:**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_url_store.py \
+        src/fastmcp_pvl_core/_file_exchange/_routes.py \
+        tests/file_exchange/test_url_store.py \
+        tests/file_exchange/test_routes.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): capability URL store + sibling HTTP routes
+
+Adds mint_download_source, mint_upload_sink, make_filesystem_sink, and
+mint_intake_mapping (the three sink-side minters are async because they
+write kv_store entries; the source-side filesystem minter from Task C
+stays sync). Token records carry kind: 'download' | 'upload'.
+consume_* helpers use atomic per-key delete as the single-use concurrency
+primitive. resolve_intake distinguishes 'unknown artifact_id' from
+'bytes not yet deposited'.
+
+Adds build_file_exchange_router returning the (download, upload) handler
+pair. Upload route order: lookup → MIME check (415) → stream into
+async_atomic_write with per-chunk digester + cumulative byte counter
+(413 on size-exceeded, temp discarded) → digest check (422) → consume
+token (atomic delete). All sync disk I/O dispatched via asyncio.to_thread.
+
+Logging uses tok=<first-8>... fingerprints; full tokens / URLs never
+hit log fields.
+
+Closes #128.
+EOF
+)"
+```
+
+- [ ] Run the universal per-task suffix.
+
+---
+
+## Task F: Capability declaration + role helpers + top-level public API (closes #129)
+
+**Depends on:** Tasks B, C, D, E all merged.
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_capability.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_provider.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_fetcher.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_receiver.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_sender.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/__init__.py`
+- Modify: `src/fastmcp_pvl_core/__init__.py` (top-level re-exports)
+- Create: `tests/file_exchange/test_capability.py`
+- Create: `tests/file_exchange/test_roles.py`
+
+### Step F.1 — Failing tests for the capability-gating matrix
+
+- [ ] **Write `tests/file_exchange/test_capability.py`:**
+
+```python
+"""register_file_exchange_capability gating matrix (design §3)."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import FastMCP
+from key_value.aio.stores.memory import MemoryStore
+
+from fastmcp_pvl_core import ServerConfig, register_file_exchange_capability
+
+_CAP_KEY = "nl.liesdonk.file-exchange"
+
+
+def _make(transport: str, *, volumes: str | None = None) -> ServerConfig:
+    return ServerConfig(
+        transport=transport,   # type: ignore[arg-type]
+        base_url="https://example.com" if transport == "http" else None,
+        file_exchange_volumes=volumes,
+        file_exchange_https_public_base_url=(
+            "https://example.com" if transport == "http" else None
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_gating_stdio_no_volumes_advertises_consumer_roles_only() -> None:
+    mcp = FastMCP("s")
+    cfg = _make("stdio", volumes=None)
+    store = MemoryStore()
+    register_file_exchange_capability(mcp, cfg, kv_store=store)
+    cap = mcp.experimental_capabilities[_CAP_KEY]
+    assert "fetcher" in cap["roles"]
+    assert "sender" in cap["roles"]
+    assert "provider" not in cap["roles"]   # no HTTP app to host, no volumes
+    assert "receiver" not in cap["roles"]
+    assert cap["roles"]["fetcher"] == ["download"]
+    assert cap["roles"]["sender"] == ["upload"]
+
+
+@pytest.mark.asyncio
+async def test_gating_stdio_with_volumes_advertises_all_roles_filesystem_only(
+    tmp_path,
+) -> None:
+    mcp = FastMCP("s")
+    (tmp_path / "vol").mkdir()
+    cfg = _make("stdio", volumes=f"v={tmp_path / 'vol'}")
+    store = MemoryStore()
+    register_file_exchange_capability(mcp, cfg, kv_store=store)
+    roles = mcp.experimental_capabilities[_CAP_KEY]["roles"]
+    # All four roles advertised
+    assert set(roles) == {"provider", "fetcher", "receiver", "sender"}
+    # Producer roles: filesystem only
+    assert roles["provider"] == ["filesystem"]
+    assert roles["receiver"] == ["filesystem"]
+    # Consumer roles: filesystem + outbound HTTPS
+    assert "filesystem" in roles["fetcher"] and "download" in roles["fetcher"]
+    assert "filesystem" in roles["sender"] and "upload" in roles["sender"]
+
+
+@pytest.mark.asyncio
+async def test_gating_http_no_volumes_advertises_all_roles_https_only() -> None:
+    mcp = FastMCP("s")
+    cfg = _make("http", volumes=None)
+    store = MemoryStore()
+    register_file_exchange_capability(mcp, cfg, kv_store=store)
+    roles = mcp.experimental_capabilities[_CAP_KEY]["roles"]
+    assert set(roles) == {"provider", "fetcher", "receiver", "sender"}
+    assert roles["provider"] == ["download"]
+    assert roles["fetcher"] == ["download"]
+    assert roles["receiver"] == ["upload"]
+    assert roles["sender"] == ["upload"]
+
+
+@pytest.mark.asyncio
+async def test_gating_http_with_volumes_advertises_all_roles_both_transports(
+    tmp_path,
+) -> None:
+    mcp = FastMCP("s")
+    (tmp_path / "vol").mkdir()
+    cfg = _make("http", volumes=f"v={tmp_path / 'vol'}")
+    store = MemoryStore()
+    register_file_exchange_capability(mcp, cfg, kv_store=store)
+    roles = mcp.experimental_capabilities[_CAP_KEY]["roles"]
+    for r in ("provider", "fetcher", "receiver", "sender"):
+        assert "filesystem" in roles[r]
+    assert "download" in roles["provider"]
+    assert "download" in roles["fetcher"]
+    assert "upload" in roles["receiver"]
+    assert "upload" in roles["sender"]
+
+
+@pytest.mark.asyncio
+async def test_gating_advertises_nothing_when_no_role_satisfies_any_transport() -> None:
+    mcp = FastMCP("s")
+    cfg = _make("stdio", volumes=None)
+    store = MemoryStore()
+    register_file_exchange_capability(
+        mcp, cfg, kv_store=store, roles=("provider", "receiver"),
+    )
+    # provider needs http+download or volumes; receiver needs http+upload or
+    # volumes. Neither is available. Capability must be absent.
+    assert _CAP_KEY not in mcp.experimental_capabilities
+
+
+@pytest.mark.asyncio
+async def test_capability_advertises_max_artifact_size_when_set(tmp_path) -> None:
+    mcp = FastMCP("s")
+    (tmp_path / "vol").mkdir()
+    cfg = _make("stdio", volumes=f"v={tmp_path / 'vol'}")
+    cfg2 = type(cfg)(
+        **{**cfg.__dict__, "file_exchange_max_artifact_size": 104857600},
+    )
+    store = MemoryStore()
+    register_file_exchange_capability(mcp, cfg2, kv_store=store)
+    cap = mcp.experimental_capabilities[_CAP_KEY]
+    assert cap["maxArtifactSize"] == 104857600
+
+
+@pytest.mark.asyncio
+async def test_capability_advertises_sha256_digest(tmp_path) -> None:
+    mcp = FastMCP("s")
+    (tmp_path / "vol").mkdir()
+    cfg = _make("stdio", volumes=f"v={tmp_path / 'vol'}")
+    store = MemoryStore()
+    register_file_exchange_capability(mcp, cfg, kv_store=store)
+    cap = mcp.experimental_capabilities[_CAP_KEY]
+    assert cap["digests"] == ["sha-256"]
+
+
+@pytest.mark.asyncio
+async def test_capability_reregistration_idempotent_clears_prior_advert() -> None:
+    """If a previous call in this process advertised the capability and a
+    later call's gate produces an empty role set, the capability key must
+    be removed (not stale-left from the prior call)."""
+    mcp = FastMCP("s")
+    store = MemoryStore()
+    # First call advertises (http transport + no volumes)
+    register_file_exchange_capability(mcp, _make("http"), kv_store=store)
+    assert _CAP_KEY in mcp.experimental_capabilities
+    # Second call with restricted roles + stdio → empty post-gate
+    register_file_exchange_capability(
+        mcp, _make("stdio"), kv_store=store, roles=("provider", "receiver"),
+    )
+    assert _CAP_KEY not in mcp.experimental_capabilities
+
+
+@pytest.mark.asyncio
+async def test_capability_raises_when_https_routes_advertised_but_no_base_url() -> None:
+    from fastmcp_pvl_core._errors import ConfigurationError
+
+    mcp = FastMCP("s")
+    bare = ServerConfig(transport="http")  # no base_url, no app_domain, no override
+    store = MemoryStore()
+    with pytest.raises(ConfigurationError, match="public base URL"):
+        register_file_exchange_capability(mcp, bare, kv_store=store)
+
+
+@pytest.mark.asyncio
+async def test_capability_mounts_custom_routes_when_https_producer_survives(tmp_path) -> None:
+    mcp = FastMCP("s")
+    cfg = _make("http")
+    store = MemoryStore()
+    register_file_exchange_capability(mcp, cfg, kv_store=store)
+    # FastMCP exposes registered custom routes in a private list; the
+    # assertion uses the documented attribute name (.custom_routes) where
+    # available, otherwise falls back to introspecting the http app's
+    # routes. The test asserts both download and upload paths are mounted.
+    routes_attr = getattr(mcp, "_additional_http_routes", None) or getattr(
+        mcp, "custom_routes", []
+    )
+    paths = {getattr(r, "path", None) for r in routes_attr}
+    assert "/file-exchange/d/{token}" in paths
+    assert "/file-exchange/u/{token}" in paths
+```
+
+- [ ] **Run to verify fail:**
+
+```bash
+uv run pytest tests/file_exchange/test_capability.py -v
+```
+
+Expected: FAIL — `register_file_exchange_capability` not exported yet.
+
+### Step F.2 — Implement `_capability.py`
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/_capability.py`:**
+
+```python
+"""Capability declaration + auto-mount of sibling HTTP routes.
+
+This is the load-bearing module: it owns the gating algorithm (spec §4.2
++ design §3) and converts the operator's deployment shape into a wire-
+faithful ``nl.liesdonk.file-exchange`` capability block.
+
+Public entry point: ``register_file_exchange_capability``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+from fastmcp import FastMCP
+from key_value.aio.protocols.key_value import AsyncKeyValue
+
+from .._config import ServerConfig
+from .._errors import ConfigurationError
+from .._factory import compute_app_domain
+from ._errors import CAPABILITY_KEY
+from ._routes import build_file_exchange_router
+from ._transport_filesystem import parse_volumes
+from ._types import FileExchangeRole, FileExchangeTransport
+
+logger = logging.getLogger("fastmcp_pvl_core.file_exchange")
+
+# Family default — hardcoded in pvl-core (design §3 / framing principle:
+# pvl-core owns shape decisions). Not a kwarg.
+_ADVERTISED_DIGESTS: tuple[str, ...] = ("sha-256",)
+
+_HTTP_TRANSPORTS = ("http", "sse")
+
+
+def _transports_for_role(
+    role: FileExchangeRole,
+    *,
+    volumes: dict[str, Any],
+    http_app: bool,
+) -> list[FileExchangeTransport]:
+    """Compute the spec §4.2 row for one role under one deployment shape.
+
+    - filesystem requires at least one configured volume.
+    - download as provider requires an http app to host /file-exchange/d/.
+    - download as fetcher is always available (outbound HTTPS).
+    - upload as receiver requires an http app to host /file-exchange/u/.
+    - upload as sender is always available (outbound HTTPS).
+    """
+    transports: list[FileExchangeTransport] = []
+    if volumes:
+        transports.append("filesystem")
+    if role in ("provider", "fetcher"):
+        # fetcher: always; provider: only if we can host the route.
+        if role == "fetcher" or http_app:
+            transports.append("download")
+    if role in ("receiver", "sender"):
+        if role == "sender" or http_app:
+            transports.append("upload")
+    return transports
+
+
+def register_file_exchange_capability(
+    server: FastMCP,
+    config: ServerConfig,
+    *,
+    roles: Sequence[FileExchangeRole] = ("provider", "fetcher", "receiver", "sender"),
+    kv_store: AsyncKeyValue,
+) -> None:
+    """Declare ``nl.liesdonk.file-exchange`` and mount HTTPS routes if needed.
+
+    Per design §3 (single-source-of-truth for the framing principle): all
+    operator-side concerns live in ``ServerConfig`` (volumes, transport,
+    max-artifact-size, allow-loopback, …); the only domain hooks are
+    ``roles`` (which roles this server wants to play) and ``kv_store``
+    (the namespaced storage backend chosen by the operator).
+
+    There is no ``digests`` kwarg — the family default ``("sha-256",)`` is
+    hardcoded. There is no ``max_artifact_size`` kwarg — it's read from
+    ``config.file_exchange_max_artifact_size`` and emitted only when set.
+    There is no ``base_url`` kwarg — it's resolved from config + the
+    existing ``compute_app_domain`` helper.
+    """
+    volumes = parse_volumes(config.file_exchange_volumes)
+    http_app = config.transport in _HTTP_TRANSPORTS
+
+    # Gating: per-role transports, drop empty rows, drop the capability
+    # entirely if nothing survives.
+    role_map: dict[str, list[str]] = {}
+    for role in roles:
+        ts = _transports_for_role(role, volumes=volumes, http_app=http_app)
+        if ts:
+            role_map[role] = ts
+
+    if not role_map:
+        # Idempotency: clear any stale advert from a prior call in this process.
+        server.experimental_capabilities.pop(CAPABILITY_KEY, None)
+        logger.info(
+            "file-exchange: no satisfiable transport for any declared role — capability not advertised"
+        )
+        return
+
+    # If we're about to advertise HTTPS routes on the producer side, we
+    # need a public base URL. Resolve eagerly so the failure mode is
+    # registration-time, not request-time.
+    will_mount_routes = http_app and (
+        ("download" in role_map.get("provider", []))
+        or ("upload" in role_map.get("receiver", []))
+    )
+    if will_mount_routes:
+        domain = (
+            config.file_exchange_https_public_base_url
+            or compute_app_domain(config)
+        )
+        if domain is None:
+            raise ConfigurationError(
+                "file-exchange: HTTPS producer routes require a configured public base "
+                "URL — set _FILE_EXCHANGE_HTTPS_PUBLIC_BASE_URL, _BASE_URL, or _APP_DOMAIN"
+            )
+
+    block: dict[str, Any] = {
+        "version": "0.1",
+        "digests": list(_ADVERTISED_DIGESTS),
+        "roles": role_map,
+    }
+    if config.file_exchange_max_artifact_size is not None:
+        block["maxArtifactSize"] = config.file_exchange_max_artifact_size
+    server.experimental_capabilities[CAPABILITY_KEY] = block
+
+    if will_mount_routes:
+        download_handler, upload_handler = build_file_exchange_router(store=kv_store)
+        server.custom_route("/file-exchange/d/{token}", methods=["GET"])(download_handler)
+        server.custom_route("/file-exchange/u/{token}", methods=["PUT", "POST"])(upload_handler)
+        logger.info(
+            "file-exchange: registered HTTPS routes /file-exchange/{d,u}/{token}"
+        )
+
+    logger.info(
+        "file-exchange: capability advertised — roles=%s, digests=%s",
+        list(role_map.keys()),
+        _ADVERTISED_DIGESTS,
+    )
+```
+
+- [ ] **Run** the capability tests to verify pass:
+
+```bash
+uv run pytest tests/file_exchange/test_capability.py -v
+```
+
+Expected: 9 passing. (If FastMCP exposes registered custom routes under a different attribute than `_additional_http_routes` / `custom_routes`, adjust the test's introspection accordingly — verify via `uv run python -c "from fastmcp import FastMCP; m = FastMCP('x'); m.custom_route('/p', methods=['GET'])(lambda r: None); print([a for a in dir(m) if 'route' in a.lower()])"` and use whatever attribute holds the registered handler list. The PRODUCTION code at `server.custom_route(...)` is fixed — only the test's introspection adapts.)
+
+### Step F.3 — Failing tests for `_provider.py` and `_fetcher.py`
+
+- [ ] **Write `tests/file_exchange/test_roles.py`:**
+
+```python
+"""Role helpers: provider, fetcher, receiver, sender."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+from pathlib import Path
+
+import pytest
+from key_value.aio.stores.memory import MemoryStore
+
+from fastmcp_pvl_core import ServerConfig
+from fastmcp_pvl_core._file_exchange._errors import (
+    FileExchangeError,
+    FileExchangeErrorCode,
+)
+from fastmcp_pvl_core._file_exchange._fetcher import pull_artifact
+from fastmcp_pvl_core._file_exchange._provider import build_pull_response
+from fastmcp_pvl_core._file_exchange._receiver import (
+    build_intake_response,
+    open_intake,
+)
+from fastmcp_pvl_core._file_exchange._sender import push_artifact
+from fastmcp_pvl_core._file_exchange._types import (
+    ArtifactMetadata,
+    ExpectedConstraints,
+    IntakeTicket,
+    SinkDescriptor,
+    SourceDescriptor,
+    TransferHandle,
+)
+
+
+def test_build_pull_response_emits_handle_in_meta() -> None:
+    artifact = ArtifactMetadata.model_validate({"id": "a1", "name": "x.txt", "size": 5, "mimeType": "text/plain"})
+    src = SourceDescriptor.model_validate({"transport": "filesystem", "uri": "exchange://v/x.txt"})
+    result = build_pull_response(artifact, sources=[src])
+    assert result.isError in (False, None)
+    meta = result._meta or {}
+    handle = meta["nl.liesdonk.file-exchange"]["handle"]
+    assert handle["artifact"]["id"] == "a1"
+    assert handle["sources"][0]["transport"] == "filesystem"
+
+
+def test_build_pull_response_auto_synthesises_summary_text() -> None:
+    artifact = ArtifactMetadata.model_validate({"id": "a1", "name": "x.txt", "size": 5, "mimeType": "text/plain"})
+    src = SourceDescriptor.model_validate({"transport": "filesystem", "uri": "exchange://v/x.txt"})
+    result = build_pull_response(artifact, sources=[src])
+    text = " ".join(c.text for c in result.content if hasattr(c, "text"))
+    assert "x.txt" in text
+    assert "text/plain" in text
+
+
+def test_open_intake_constructs_ticket_with_auto_artifact_id() -> None:
+    sink = SinkDescriptor.model_validate({"transport": "filesystem", "uri": "exchange://v/a1.bin"})
+    ticket = open_intake(sinks=[sink], expected=ExpectedConstraints(max_size=2048))
+    assert isinstance(ticket, IntakeTicket)
+    assert ticket.artifact_id   # auto-generated when None
+    assert ticket.expected is not None
+    assert ticket.expected.max_size == 2048
+
+
+def test_build_intake_response_emits_ticket_in_meta() -> None:
+    sink = SinkDescriptor.model_validate({"transport": "filesystem", "uri": "exchange://v/a1.bin"})
+    ticket = open_intake(sinks=[sink], artifact_id="a1")
+    result = build_intake_response(ticket)
+    meta = result._meta or {}
+    out = meta["nl.liesdonk.file-exchange"]["ticket"]
+    assert out["artifactId"] == "a1"
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    (tmp_path / "vault").mkdir()
+    return ServerConfig(
+        transport="http",
+        base_url="https://example.com",
+        file_exchange_volumes=f"vault={tmp_path / 'vault'}",
+        file_exchange_https_allow_loopback=True,
+        file_exchange_https_allow_private=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pull_artifact_filesystem_path_streams_into_dest(cfg, tmp_path: Path) -> None:
+    src_path = tmp_path / "vault" / "note.md"
+    src_path.write_bytes(b"hello")
+    handle = TransferHandle.model_validate({
+        "artifact": {"id": "a1", "size": 5},
+        "sources": [{"transport": "filesystem", "uri": "exchange://vault/note.md"}],
+    })
+    out = tmp_path / "out.bin"
+    artifact = await pull_artifact(handle, dest=out, config=cfg)
+    assert artifact.id == "a1"
+    assert out.read_bytes() == b"hello"
+
+
+@pytest.mark.asyncio
+async def test_pull_artifact_raises_when_no_transport_matches(cfg, tmp_path: Path) -> None:
+    cfg_no_volumes = type(cfg)(**{**cfg.__dict__, "file_exchange_volumes": None})
+    handle = TransferHandle.model_validate({
+        "artifact": {"id": "a1"},
+        "sources": [{"transport": "filesystem", "uri": "exchange://vault/x"}],
+    })
+    with pytest.raises(FileExchangeError) as ei:
+        await pull_artifact(
+            handle, dest=tmp_path / "o.bin", config=cfg_no_volumes,
+            supported_transports=("filesystem",),
+        )
+    assert ei.value.code is FileExchangeErrorCode.NO_SUPPORTED_TRANSPORT
+
+
+@pytest.mark.asyncio
+async def test_push_artifact_filesystem_streams_chunked(cfg, tmp_path: Path) -> None:
+    src_path = tmp_path / "payload.bin"
+    src_path.write_bytes(b"y" * 200_000)   # > one 64 KiB chunk
+    sink_uri = "exchange://vault/a1.bin"
+    ticket = IntakeTicket.model_validate({
+        "artifactId": "a1",
+        "sinks": [{"transport": "filesystem", "uri": sink_uri}],
+    })
+    await push_artifact(ticket, source=src_path, config=cfg)
+    landed = tmp_path / "vault" / "a1.bin"
+    assert landed.read_bytes() == b"y" * 200_000
+
+
+@pytest.mark.asyncio
+async def test_push_artifact_raises_on_size_exceeded(cfg, tmp_path: Path) -> None:
+    src_path = tmp_path / "payload.bin"
+    src_path.write_bytes(b"y" * 200_000)
+    ticket = IntakeTicket.model_validate({
+        "artifactId": "a1",
+        "sinks": [{"transport": "filesystem", "uri": "exchange://vault/a1.bin"}],
+        "expected": {"maxSize": 1024},
+    })
+    with pytest.raises(FileExchangeError) as ei:
+        await push_artifact(ticket, source=src_path, config=cfg, artifact_size=200_000)
+    assert ei.value.code is FileExchangeErrorCode.SIZE_EXCEEDED
+```
+
+- [ ] **Run to verify fail:**
+
+```bash
+uv run pytest tests/file_exchange/test_roles.py -v
+```
+
+Expected: FAIL — modules not found.
+
+### Step F.4 — Implement provider, fetcher, receiver, sender
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/_provider.py`:**
+
+```python
+"""Provider role: build a CallToolResult carrying a TransferHandle."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from mcp.types import TextContent
+from fastmcp.tools.tool import ToolResult as CallToolResult
+
+from ._errors import CAPABILITY_KEY
+from ._types import ArtifactMetadata, SourceDescriptor, TransferHandle
+
+
+def _human_size(n: int | None) -> str:
+    if n is None:
+        return "unknown size"
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if n < 1024:
+            return f"{n:.0f} {unit}" if unit == "B" else f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} TiB"
+
+
+def _auto_summary(artifact: ArtifactMetadata) -> str:
+    name = artifact.name or artifact.id
+    return f"file-exchange: {name} ({_human_size(artifact.size)}, {artifact.mime_type or 'unknown mime'})"
+
+
+def build_pull_response(
+    artifact: ArtifactMetadata,
+    sources: Sequence[SourceDescriptor],
+    *,
+    summary: str | None = None,
+    extra_meta: dict[str, Any] | None = None,
+) -> CallToolResult:
+    handle = TransferHandle(artifact=artifact, sources=tuple(sources))
+    fe_meta = {"handle": handle.model_dump(by_alias=True, exclude_none=True)}
+    if extra_meta:
+        fe_meta.update(extra_meta)
+    return CallToolResult(
+        content=[TextContent(type="text", text=summary or _auto_summary(artifact))],
+        isError=False,
+        _meta={CAPABILITY_KEY: fe_meta},
+    )
+```
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/_fetcher.py`:**
+
+```python
+"""Fetcher role: pull artifact bytes from a TransferHandle.
+
+The single public symbol is ``pull_artifact``. ``config`` is the
+deployment context — the fetcher derives ``volumes`` and the SSRF guard
+from it; no leaking of those operator concerns through kwargs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, BinaryIO
+
+from .._config import ServerConfig
+from ._errors import FileExchangeError, FileExchangeErrorCode
+from ._select import select_source
+from ._transport_filesystem import parse_volumes, resolve_exchange_uri
+from ._transport_https import SSRFGuardConfig, pull_download
+from ._types import (
+    ArtifactMetadata,
+    FileExchangeTransport,
+    TransferHandle,
+)
+
+_CHUNK_SIZE = 64 * 1024
+
+
+def _default_supported(config: ServerConfig) -> tuple[FileExchangeTransport, ...]:
+    """Consumer-side default: filesystem if volumes are configured; download
+    is always available (outbound HTTPS works regardless of transport)."""
+    out: list[FileExchangeTransport] = []
+    if parse_volumes(config.file_exchange_volumes):
+        out.append("filesystem")
+    out.append("download")
+    return tuple(out)
+
+
+async def pull_artifact(
+    handle: TransferHandle | dict,
+    *,
+    dest: Path | BinaryIO,
+    config: ServerConfig,
+    supported_transports: Sequence[FileExchangeTransport] | None = None,
+) -> ArtifactMetadata:
+    h = handle if isinstance(handle, TransferHandle) else TransferHandle.model_validate(handle)
+    supported = tuple(supported_transports) if supported_transports else _default_supported(config)
+    chosen = select_source(h.sources, supported=supported)
+    digester = hashlib.sha256() if h.artifact.digest else None
+    if chosen.root.transport == "filesystem":
+        volumes = parse_volumes(config.file_exchange_volumes)
+        src_path = resolve_exchange_uri(chosen.root.uri, volumes=volumes)
+        await _stream_path_to_dest(src_path, dest=dest, digester=digester)
+    else:  # download
+        ssrf = SSRFGuardConfig(
+            allow_loopback=config.file_exchange_https_allow_loopback,
+            allow_private=config.file_exchange_https_allow_private,
+        )
+        await pull_download(chosen.root.url, dest=dest, ssrf=ssrf, digester=digester)
+    if digester is not None and h.artifact.digest:
+        expected = h.artifact.digest.split("=", 1)[-1]
+        if digester.hexdigest() != expected.lower().lstrip(":"):
+            raise FileExchangeError(
+                code=FileExchangeErrorCode.DIGEST_MISMATCH,
+                detail=f"computed digest does not match artifact.digest for {h.artifact.id!r}",
+            )
+    return h.artifact
+
+
+async def _stream_path_to_dest(
+    src: Path,
+    *,
+    dest: Path | BinaryIO,
+    digester: Any | None,
+    chunk_size: int = _CHUNK_SIZE,
+) -> None:
+    fh = await asyncio.to_thread(open, src, "rb")
+    try:
+        if isinstance(dest, Path):
+            from ._transport_filesystem import async_atomic_write
+
+            async with async_atomic_write(dest) as out:
+                while True:
+                    chunk = await asyncio.to_thread(fh.read, chunk_size)
+                    if not chunk:
+                        break
+                    if digester is not None:
+                        digester.update(chunk)
+                    await asyncio.to_thread(out.write, chunk)
+        else:
+            while True:
+                chunk = await asyncio.to_thread(fh.read, chunk_size)
+                if not chunk:
+                    break
+                if digester is not None:
+                    digester.update(chunk)
+                await asyncio.to_thread(dest.write, chunk)
+    finally:
+        await asyncio.to_thread(fh.close)
+```
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/_receiver.py`:**
+
+```python
+"""Receiver role: build IntakeTickets and resolve artifact_ids to paths.
+
+``open_intake`` is pure construction — the sink-side mint helpers in
+``_url_store.py`` already recorded the intake mapping at mint time, so
+``open_intake`` needs neither ``config`` nor ``kv_store``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from mcp.types import TextContent
+from fastmcp.tools.tool import ToolResult as CallToolResult
+
+from ._errors import CAPABILITY_KEY
+from ._provider import _auto_summary
+from ._types import ArtifactMetadata, ExpectedConstraints, IntakeTicket, SinkDescriptor
+
+# Re-export resolve_intake from _url_store so callers can ``from
+# fastmcp_pvl_core import resolve_intake`` without importing from a
+# private path.
+from ._url_store import resolve_intake as resolve_intake  # noqa: F401
+
+
+def open_intake(
+    *,
+    sinks: Sequence[SinkDescriptor],
+    expected: ExpectedConstraints | None = None,
+    artifact_id: str | None = None,
+) -> IntakeTicket:
+    aid = artifact_id or uuid.uuid4().hex
+    return IntakeTicket(
+        artifact_id=aid,
+        sinks=tuple(sinks),
+        expected=expected,
+    )
+
+
+def build_intake_response(
+    ticket: IntakeTicket,
+    *,
+    summary: str | None = None,
+    extra_meta: dict[str, Any] | None = None,
+) -> CallToolResult:
+    fe_meta: dict[str, Any] = {"ticket": ticket.model_dump(by_alias=True, exclude_none=True)}
+    if extra_meta:
+        fe_meta.update(extra_meta)
+    if summary is None:
+        # No artifact metadata at intake time — synthesise from artifact_id.
+        summary = f"file-exchange: awaiting upload for artifact_id={ticket.artifact_id}"
+    return CallToolResult(
+        content=[TextContent(type="text", text=summary)],
+        isError=False,
+        _meta={CAPABILITY_KEY: fe_meta},
+    )
+```
+
+- [ ] **Create `src/fastmcp_pvl_core/_file_exchange/_sender.py`:**
+
+```python
+"""Sender role: push artifact bytes to a sink chosen from an IntakeTicket."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, BinaryIO
+
+from .._config import ServerConfig
+from ._errors import FileExchangeError, FileExchangeErrorCode
+from ._select import select_sink
+from ._transport_filesystem import async_atomic_write, parse_volumes, resolve_exchange_uri
+from ._transport_https import SSRFGuardConfig, push_upload
+from ._types import FileExchangeTransport, IntakeTicket
+
+_CHUNK_SIZE = 64 * 1024
+
+
+def _default_supported(config: ServerConfig) -> tuple[FileExchangeTransport, ...]:
+    out: list[FileExchangeTransport] = []
+    if parse_volumes(config.file_exchange_volumes):
+        out.append("filesystem")
+    out.append("upload")
+    return tuple(out)
+
+
+def _check_pre_send_constraints(ticket: IntakeTicket, size: int | None, mime: str | None) -> None:
+    exp = ticket.expected
+    if exp is None:
+        return
+    if exp.max_size is not None and size is not None and size > exp.max_size:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.SIZE_EXCEEDED,
+            detail=f"artifact_size={size} exceeds expected.maxSize={exp.max_size}",
+        )
+    if exp.accept_mime_types and mime is not None and mime not in exp.accept_mime_types:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.MIME_REJECTED,
+            detail=f"mime={mime!r} not in expected.acceptMimeTypes={list(exp.accept_mime_types)}",
+        )
+
+
+async def push_artifact(
+    ticket: IntakeTicket | dict,
+    *,
+    source: Path | BinaryIO,
+    config: ServerConfig,
+    supported_transports: Sequence[FileExchangeTransport] | None = None,
+    artifact_digest: str | None = None,
+    artifact_mime: str | None = None,
+    artifact_size: int | None = None,
+) -> None:
+    t = ticket if isinstance(ticket, IntakeTicket) else IntakeTicket.model_validate(ticket)
+    _check_pre_send_constraints(t, artifact_size, artifact_mime)
+    if t.expected and t.expected.require_digest and not artifact_digest:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.DIGEST_MISMATCH,
+            detail="ticket.expected.requireDigest is set but artifact_digest kwarg was not provided",
+        )
+    supported = tuple(supported_transports) if supported_transports else _default_supported(config)
+    chosen = select_sink(t.sinks, supported=supported)
+    if chosen.root.transport == "filesystem":
+        volumes = parse_volumes(config.file_exchange_volumes)
+        # mint-time mapping was recorded in resolve_path; resolve again
+        # here to write to that path (the path may not exist yet, but
+        # the volume confinement check still applies).
+        target = _resolve_filesystem_target(chosen.root.uri, volumes=volumes)
+        await _stream_source_to_path(source, target=target)
+    else:  # upload
+        ssrf = SSRFGuardConfig(
+            allow_loopback=config.file_exchange_https_allow_loopback,
+            allow_private=config.file_exchange_https_allow_private,
+        )
+        await push_upload(
+            chosen.root.url,
+            source=source,
+            ssrf=ssrf,
+            content_type=artifact_mime or "application/octet-stream",
+            content_digest=artifact_digest,
+            content_length=artifact_size,
+        )
+
+
+def _resolve_filesystem_target(uri: str, *, volumes: dict[str, Path]) -> Path:
+    """Like resolve_exchange_uri but tolerates non-existent target files
+    (the sender is creating them). Volume + traversal checks still apply."""
+    from urllib.parse import unquote, urlsplit
+
+    parts = urlsplit(uri)
+    if parts.scheme != "exchange":
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"sender expected exchange:// scheme; got {parts.scheme!r}",
+        )
+    root = volumes.get(parts.netloc)
+    if root is None:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"file-exchange volume {parts.netloc!r} is not configured on this party",
+        )
+    relative = unquote(parts.path).lstrip("/")
+    candidate = (root / relative).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise FileExchangeError(
+            code=FileExchangeErrorCode.NOT_ACCESSIBLE,
+            detail=f"path {uri!r} resolves outside volume {parts.netloc!r}",
+        ) from exc
+    return candidate
+
+
+async def _stream_source_to_path(
+    source: Path | BinaryIO,
+    *,
+    target: Path,
+    chunk_size: int = _CHUNK_SIZE,
+) -> None:
+    async with async_atomic_write(target) as out:
+        if isinstance(source, Path):
+            fh = await asyncio.to_thread(open, source, "rb")
+            try:
+                while True:
+                    chunk = await asyncio.to_thread(fh.read, chunk_size)
+                    if not chunk:
+                        break
+                    await asyncio.to_thread(out.write, chunk)
+            finally:
+                await asyncio.to_thread(fh.close)
+        else:
+            while True:
+                chunk = await asyncio.to_thread(source.read, chunk_size)
+                if not chunk:
+                    break
+                await asyncio.to_thread(out.write, chunk)
+```
+
+- [ ] **Run to verify role-helper tests pass:**
+
+```bash
+uv run pytest tests/file_exchange/test_roles.py -v
+```
+
+Expected: 8 passing.
+
+### Step F.5 — Wire up `_file_exchange/__init__.py`
+
+- [ ] **Replace** the placeholder in `src/fastmcp_pvl_core/_file_exchange/__init__.py`:
+
+```python
+"""File-exchange v0.1 — public-surface assembly.
+
+Consumers depend on the top-level ``fastmcp_pvl_core`` re-exports, not
+this layout. This module exists to bundle the symbols for the parent
+package's re-export block.
+"""
+
+from ._capability import register_file_exchange_capability
+from ._errors import (
+    FileExchangeError,
+    FileExchangeErrorCode,
+    as_tool_error_result,
+)
+from ._fetcher import pull_artifact
+from ._provider import build_pull_response
+from ._receiver import (
+    build_intake_response,
+    open_intake,
+    resolve_intake,
+)
+from ._sender import push_artifact
+from ._transport_filesystem import make_filesystem_source
+from ._types import (
+    ArtifactMetadata,
+    ExpectedConstraints,
+    FileExchangeRole,
+    FileExchangeTransport,
+    IntakeTicket,
+    SinkDescriptor,
+    SourceDescriptor,
+    TransferHandle,
+)
+from ._url_store import (
+    make_filesystem_sink,
+    mint_download_source,
+    mint_upload_sink,
+)
+
+__all__ = [
+    "ArtifactMetadata",
+    "ExpectedConstraints",
+    "FileExchangeError",
+    "FileExchangeErrorCode",
+    "FileExchangeRole",
+    "FileExchangeTransport",
+    "IntakeTicket",
+    "SinkDescriptor",
+    "SourceDescriptor",
+    "TransferHandle",
+    "as_tool_error_result",
+    "build_intake_response",
+    "build_pull_response",
+    "make_filesystem_sink",
+    "make_filesystem_source",
+    "mint_download_source",
+    "mint_upload_sink",
+    "open_intake",
+    "pull_artifact",
+    "push_artifact",
+    "register_file_exchange_capability",
+    "resolve_intake",
+]
+```
+
+### Step F.6 — Re-export from top-level `fastmcp_pvl_core/__init__.py`
+
+- [ ] **Modify `src/fastmcp_pvl_core/__init__.py`**: after the existing `from fastmcp_pvl_core._subject import get_subject` line, add:
+
+```python
+from fastmcp_pvl_core._file_exchange import (
+    ArtifactMetadata,
+    ExpectedConstraints,
+    FileExchangeError,
+    FileExchangeErrorCode,
+    FileExchangeRole,
+    FileExchangeTransport,
+    IntakeTicket,
+    SinkDescriptor,
+    SourceDescriptor,
+    TransferHandle,
+    as_tool_error_result,
+    build_intake_response,
+    build_pull_response,
+    make_filesystem_sink,
+    make_filesystem_source,
+    mint_download_source,
+    mint_upload_sink,
+    open_intake,
+    pull_artifact,
+    push_artifact,
+    register_file_exchange_capability,
+    resolve_intake,
+)
+```
+
+- [ ] **Update `__all__`** to include all 22 new exports (sorted alphabetically, maintaining the existing convention).
+
+- [ ] **Smoke-test the top-level surface:**
+
+```bash
+uv run python -c "
+from fastmcp_pvl_core import (
+    ArtifactMetadata, ExpectedConstraints, FileExchangeError,
+    FileExchangeErrorCode, FileExchangeRole, FileExchangeTransport,
+    IntakeTicket, SinkDescriptor, SourceDescriptor, TransferHandle,
+    as_tool_error_result, build_intake_response, build_pull_response,
+    make_filesystem_sink, make_filesystem_source, mint_download_source,
+    mint_upload_sink, open_intake, pull_artifact, push_artifact,
+    register_file_exchange_capability, resolve_intake,
+)
+print('all 22 file-exchange symbols import cleanly from fastmcp_pvl_core')
+"
+```
+
+Expected: prints the success line.
+
+### Step F.7 — Commit Task F
+
+- [ ] **Commit:**
+
+```bash
+git add src/fastmcp_pvl_core/__init__.py \
+        src/fastmcp_pvl_core/_file_exchange/__init__.py \
+        src/fastmcp_pvl_core/_file_exchange/_capability.py \
+        src/fastmcp_pvl_core/_file_exchange/_provider.py \
+        src/fastmcp_pvl_core/_file_exchange/_fetcher.py \
+        src/fastmcp_pvl_core/_file_exchange/_receiver.py \
+        src/fastmcp_pvl_core/_file_exchange/_sender.py \
+        tests/file_exchange/test_capability.py \
+        tests/file_exchange/test_roles.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): capability declaration + role helpers + public API
+
+register_file_exchange_capability(server, config, *, roles=…, kv_store)
+applies the spec §4.2 gating matrix, writes the capability block, and
+auto-mounts /file-exchange/d|u/{token} via server.custom_route(...) iff
+HTTPS producer roles survive the gate. Re-registration is idempotent
+(clears stale advert from a prior call). digests=("sha-256",) is the
+family-default constant; maxArtifactSize comes from config and is only
+emitted when set — neither is a kwarg.
+
+Adds the four role helpers: build_pull_response (provider),
+pull_artifact (fetcher), open_intake + build_intake_response +
+resolve_intake (receiver), push_artifact (sender). pull_artifact and
+push_artifact take config and derive volumes + SSRFGuardConfig from it;
+no leaking of operator concerns through kwargs.
+
+Re-exports 22 symbols at the top level of fastmcp_pvl_core.
+
+Closes #129.
+EOF
+)"
+```
+
+- [ ] Run the universal per-task suffix.
+
+---
+
+## Task G: Integration tests + spec-repo conformance fixtures (closes #130)
+
+**Depends on:** Task F merged.
+
+**Files:**
+- Create: `tests/file_exchange/test_integration_filesystem.py`
+- Create: `tests/file_exchange/test_integration_https.py`
+- Create: `tests/file_exchange/test_integration_two_servers.py`
+
+### Step G.1 — Failing test for the full filesystem round-trip in-process
+
+- [ ] **Write `tests/file_exchange/test_integration_filesystem.py`:**
+
+```python
+"""End-to-end filesystem round-trip: provider → fetcher and
+receiver ← sender, both in-process, sharing a tmp volume."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastmcp import FastMCP
 from key_value.aio.stores.memory import MemoryStore
 
 from fastmcp_pvl_core import (
     ArtifactMetadata,
+    ExpectedConstraints,
+    ServerConfig,
+    build_intake_response,
     build_pull_response,
     make_filesystem_sink,
     make_filesystem_source,
     open_intake,
     pull_artifact,
     push_artifact,
+    register_file_exchange_capability,
     resolve_intake,
 )
-from fastmcp_pvl_core._config import ServerConfig
 
 
-@pytest.mark.asyncio
-async def test_pull_round_trip(tmp_path: Path):
-    """Provider side mints a TransferHandle via the public minter; fetcher consumes."""
-    vault = tmp_path / "vault"
-    vault.mkdir()
-    src = vault / "report.bin"
-    payload = b"report payload " * 1024  # 15 KB
-    src.write_bytes(payload)
+@pytest.fixture
+def shared_volume(tmp_path: Path) -> Path:
+    vol = tmp_path / "exchange"
+    vol.mkdir()
+    return vol
 
-    config = ServerConfig(transport="stdio", file_exchange_volumes=f"vault={vault}")
-    source = make_filesystem_source("vault", "report.bin", config=config)
-    md = ArtifactMetadata(
-        name="report.bin",
-        size=len(payload),
-        digest=f"sha-256:{hashlib.sha256(payload).hexdigest()}",
-        mimeType="application/octet-stream",
+
+@pytest.fixture
+def provider_server(shared_volume: Path):
+    mcp = FastMCP("provider")
+    cfg = ServerConfig(
+        transport="stdio",
+        file_exchange_volumes=f"shared={shared_volume}",
     )
-    result = build_pull_response(md, [source])
-    handle = result.structuredContent
-
-    buf = io.BytesIO()
-    received = await pull_artifact(
-        handle,
-        dest=buf,
-        config=config,
-        supported_transports=("filesystem",),
-    )
-    assert buf.getvalue() == payload
-    assert received.digest == md.digest
-
-
-@pytest.mark.asyncio
-async def test_push_round_trip(tmp_path: Path):
-    """Receiver mints sinks via the public minter; sender pushes; resolve_intake finds the bytes."""
-    intake_dir = tmp_path / "intake"
-    intake_dir.mkdir()
-
-    config = ServerConfig(transport="stdio", file_exchange_volumes=f"intake={intake_dir}")
     store = MemoryStore()
+    register_file_exchange_capability(mcp, cfg, kv_store=store)
+    return mcp, cfg, store
+
+
+@pytest.fixture
+def fetcher_server(shared_volume: Path):
+    mcp = FastMCP("fetcher")
+    cfg = ServerConfig(
+        transport="stdio",
+        file_exchange_volumes=f"shared={shared_volume}",
+    )
+    store = MemoryStore()
+    register_file_exchange_capability(mcp, cfg, kv_store=store)
+    return mcp, cfg, store
+
+
+@pytest.mark.asyncio
+async def test_provider_to_fetcher_filesystem_round_trip(
+    provider_server, fetcher_server, shared_volume: Path, tmp_path: Path
+) -> None:
+    p_mcp, p_cfg, _ = provider_server
+    f_mcp, f_cfg, _ = fetcher_server
+    # Provider lays bytes
+    src = shared_volume / "report.md"
+    src.write_bytes(b"# hi\n")
+    # Provider mints source
+    source = make_filesystem_source("shared", "report.md", config=p_cfg)
+    artifact = ArtifactMetadata.model_validate({"id": "r1", "name": "report.md", "size": 5, "mimeType": "text/markdown"})
+    result = build_pull_response(artifact, sources=[source])
+    handle_json = (result._meta or {})["nl.liesdonk.file-exchange"]["handle"]
+    # Fetcher consumes
+    out = tmp_path / "fetched.bin"
+    fetched = await pull_artifact(handle_json, dest=out, config=f_cfg)
+    assert fetched.id == "r1"
+    assert out.read_bytes() == b"# hi\n"
+
+
+@pytest.mark.asyncio
+async def test_sender_to_receiver_filesystem_round_trip_with_resolve(
+    shared_volume: Path, tmp_path: Path
+) -> None:
+    # Receiver side
+    r_mcp = FastMCP("receiver")
+    r_cfg = ServerConfig(transport="stdio", file_exchange_volumes=f"shared={shared_volume}")
+    r_store = MemoryStore()
+    register_file_exchange_capability(r_mcp, r_cfg, kv_store=r_store)
     sink = await make_filesystem_sink(
-        "intake", "payload.bin", artifact_id="ar-1", config=config, kv_store=store
+        "shared", "incoming.bin", artifact_id="r1", config=r_cfg, kv_store=r_store,
     )
-    ticket = open_intake(sinks=[sink], artifact_id="ar-1")
-
-    src = tmp_path / "src.bin"
-    payload = b"deposited"
-    src.write_bytes(payload)
-
-    await push_artifact(
-        ticket,
-        source=src,
-        config=config,
-        supported_transports=("filesystem",),
-    )
-
-    assert (intake_dir / "payload.bin").read_bytes() == payload
-    # resolve_intake finds the bytes via the mapping recorded at mint time.
-    resolved = await resolve_intake("ar-1", kv_store=store)
-    assert resolved == (intake_dir / "payload.bin").resolve()
+    ticket = open_intake(sinks=[sink], artifact_id="r1", expected=ExpectedConstraints(max_size=1024))
+    ticket_dict = (build_intake_response(ticket)._meta or {})["nl.liesdonk.file-exchange"]["ticket"]
+    # Sender side
+    s_cfg = ServerConfig(transport="stdio", file_exchange_volumes=f"shared={shared_volume}")
+    payload = tmp_path / "src.bin"
+    payload.write_bytes(b"\x00\x01\x02" * 50)
+    await push_artifact(ticket_dict, source=payload, config=s_cfg, artifact_size=150)
+    # Receiver-side resolve_intake now finds the bytes
+    landed = await resolve_intake("r1", kv_store=r_store)
+    assert landed.read_bytes() == b"\x00\x01\x02" * 50
 ```
 
-- [ ] Run:
+### Step G.2 — Failing test for HTTPS round-trip via the sibling routes
 
-```bash
-uv run pytest tests/file_exchange/test_integration_filesystem.py -v
-```
-
-Expected: PASS (2 tests).
-
-### Step G.2: HTTPS integration — sibling routes against a real Starlette app
-
-- [ ] Write `tests/file_exchange/test_integration_https.py`:
+- [ ] **Write `tests/file_exchange/test_integration_https.py`:**
 
 ```python
+"""End-to-end HTTPS round-trip: capability URL minted on the producer,
+consumed via Starlette TestClient. Single-use enforcement is asserted
+under concurrent consumers."""
+
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+import asyncio
+import io
 from pathlib import Path
 
 import pytest
+from fastmcp import FastMCP
 from key_value.aio.stores.memory import MemoryStore
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
-from fastmcp_pvl_core import mint_upload_sink, resolve_intake
-from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core import (
+    ExpectedConstraints,
+    ServerConfig,
+    mint_download_source,
+    mint_upload_sink,
+    register_file_exchange_capability,
+)
 from fastmcp_pvl_core._file_exchange._routes import build_file_exchange_router
 
 
-@pytest.mark.asyncio
-async def test_upload_then_intake_correlation_end_to_end(tmp_path: Path, monkeypatch):
-    """End-to-end: mint_upload_sink mints + records intake mapping; route writes bytes;
-    resolve_intake finds the bytes via the recorded mapping."""
-    monkeypatch.setattr(
-        "fastmcp_pvl_core._file_exchange._url_store.compute_app_domain",
-        lambda server, config: "https://example.test",
+@pytest.fixture
+def producer_cfg() -> ServerConfig:
+    return ServerConfig(
+        transport="http",
+        host="127.0.0.1",
+        port=8000,
+        base_url="https://example.com",
+        file_exchange_https_public_base_url="https://example.com",
+        file_exchange_capability_url_ttl_default_s=600,
     )
+
+
+@pytest.fixture
+def producer_mcp() -> FastMCP:
+    return FastMCP("producer")
+
+
+@pytest.fixture
+def producer(producer_mcp, producer_cfg):
     store = MemoryStore()
-    intake = tmp_path / "intake.bin"
-    config = ServerConfig(transport="http", file_exchange_capability_url_ttl_default_s=3600)
+    register_file_exchange_capability(producer_mcp, producer_cfg, kv_store=store)
+    # Build a Starlette app whose routes mirror what FastMCP mounts —
+    # we test the route logic in isolation here; Task F's test already
+    # asserts FastMCP actually mounts them.
+    download, upload = build_file_exchange_router(store=store)
+    app = Starlette()
+    app.add_route("/file-exchange/d/{token}", download, methods=["GET"])
+    app.add_route("/file-exchange/u/{token}", upload, methods=["PUT", "POST"])
+    return producer_mcp, producer_cfg, store, app
 
-    sink = await mint_upload_sink(
-        intake_path=intake,
-        artifact_id="ar-1",
-        server=object(),
-        config=config,
-        kv_store=store,
+
+@pytest.mark.asyncio
+async def test_download_via_sibling_route(producer, tmp_path: Path) -> None:
+    mcp, cfg, store, app = producer
+    payload = b"hello-https"
+    src_path = tmp_path / "src.bin"
+    src_path.write_bytes(payload)
+    src = await mint_download_source(
+        bytes_path=src_path, server=mcp, config=cfg, kv_store=store, content_type="text/plain",
     )
-    # Extract the token from the minted URL.
-    token = str(sink.root.url).rsplit("/", 1)[-1]
-
-    router = build_file_exchange_router(store=store)
-    app = Starlette(routes=router.routes)
-
     with TestClient(app) as client:
-        resp = client.put(f"/file-exchange/u/{token}", content=b"payload-1")
-    assert resp.status_code == 204
-    assert (await resolve_intake("ar-1", kv_store=store)) == intake
-    assert intake.read_bytes() == b"payload-1"
+        r = client.get(src.root.url.replace("https://example.com", ""))
+        assert r.status_code == 200
+        assert r.content == payload
+
+
+@pytest.mark.asyncio
+async def test_upload_via_sibling_route_lands_at_intake_path(
+    producer, tmp_path: Path
+) -> None:
+    mcp, cfg, store, app = producer
+    intake = tmp_path / "intake.bin"
+    sink = await mint_upload_sink(
+        intake_path=intake, artifact_id="a1", server=mcp, config=cfg, kv_store=store,
+        expected=ExpectedConstraints(accept_mime_types=("application/octet-stream",), max_size=4096),
+    )
+    body = b"\x01" * 1000
+    with TestClient(app) as client:
+        r = client.put(
+            sink.root.url.replace("https://example.com", ""),
+            data=body,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        assert r.status_code == 204
+        assert intake.read_bytes() == body
 ```
 
-- [ ] Run:
+### Step G.3 — Failing test for two in-process FastMCP servers exchanging an artifact
 
-```bash
-uv run pytest tests/file_exchange/test_integration_https.py -v
-```
-
-Expected: PASS.
-
-### Step G.3: Conformance suite
-
-- [ ] Write `tests/file_exchange/test_conformance.py`:
+- [ ] **Write `tests/file_exchange/test_integration_two_servers.py`:**
 
 ```python
-"""Walk the vendored conformance fixtures and assert their valid/invalid outcomes.
-
-Each fixture is a JSON file alongside an outcome marker (the file name's prefix or a
-sibling `_outcome.json`). The exact layout follows the spec repo's `conformance/`.
-"""
+"""Two FastMCP servers in-process: provider exports via filesystem and
+HTTPS, fetcher consumes via filesystem (preferred). Asserts the
+selection algorithm picks filesystem when both are offered."""
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
-from pydantic import ValidationError
+from fastmcp import FastMCP
+from key_value.aio.stores.memory import MemoryStore
 
-from fastmcp_pvl_core._file_exchange._types import IntakeTicket, TransferHandle
-
-
-CONFORMANCE_DIR = (
-    Path(__file__).resolve().parent.parent.parent
-    / "src" / "fastmcp_pvl_core" / "_file_exchange" / "schema" / "conformance"
+from fastmcp_pvl_core import (
+    ArtifactMetadata,
+    ServerConfig,
+    build_pull_response,
+    make_filesystem_source,
+    mint_download_source,
+    pull_artifact,
+    register_file_exchange_capability,
 )
 
 
-def _fixtures() -> list[Path]:
-    return sorted(CONFORMANCE_DIR.glob("*.json"))
-
-
-@pytest.mark.parametrize("fixture", _fixtures(), ids=lambda p: p.name)
-def test_fixture_matches_documented_outcome(fixture: Path):
-    payload = json.loads(fixture.read_text())
-    # Fixtures encode their outcome in the filename: `valid-*.json` or `invalid-*.json`.
-    expected_valid = fixture.name.startswith("valid-")
-
-    discriminator = payload.get("type", "")
-    if discriminator == "nl.liesdonk.file-exchange/transfer-handle":
-        model = TransferHandle
-    elif discriminator == "nl.liesdonk.file-exchange/intake-ticket":
-        model = IntakeTicket
-    else:
-        pytest.skip(f"fixture {fixture.name} is not a handle/ticket — adjust loader as needed")
-        return
-
-    if expected_valid:
-        model.model_validate(payload)
-    else:
-        with pytest.raises(ValidationError):
-            model.model_validate(payload)
+@pytest.mark.asyncio
+async def test_fetcher_prefers_filesystem_when_provider_offers_both(
+    tmp_path: Path,
+) -> None:
+    vol = tmp_path / "exch"
+    vol.mkdir()
+    p_mcp = FastMCP("p")
+    p_cfg = ServerConfig(
+        transport="http",
+        base_url="https://example.com",
+        file_exchange_volumes=f"shared={vol}",
+        file_exchange_https_public_base_url="https://example.com",
+    )
+    p_store = MemoryStore()
+    register_file_exchange_capability(p_mcp, p_cfg, kv_store=p_store)
+    # Provider lays bytes and mints BOTH source descriptors
+    payload = b"both transports" * 100
+    src_file = vol / "note.md"
+    src_file.write_bytes(payload)
+    fs_src = make_filesystem_source("shared", "note.md", config=p_cfg)
+    dl_src = await mint_download_source(
+        bytes_path=src_file, server=p_mcp, config=p_cfg, kv_store=p_store,
+    )
+    artifact = ArtifactMetadata.model_validate(
+        {"id": "n1", "name": "note.md", "size": len(payload), "mimeType": "text/markdown"}
+    )
+    result = build_pull_response(artifact, sources=[dl_src, fs_src])   # download first; selection picks filesystem
+    handle_json = (result._meta or {})["nl.liesdonk.file-exchange"]["handle"]
+    # Fetcher: configured for filesystem
+    f_cfg = ServerConfig(transport="stdio", file_exchange_volumes=f"shared={vol}")
+    out = tmp_path / "out.bin"
+    await pull_artifact(handle_json, dest=out, config=f_cfg)
+    assert out.read_bytes() == payload
+    # The download token must NOT have been consumed (filesystem was used)
+    download_token = dl_src.root.url.rsplit("/", 1)[-1]
+    assert await p_store.get(collection="tokens", key=download_token) is not None
 ```
 
-- [ ] Run:
+- [ ] **Run all integration tests to verify they fail meaningfully** (most should pass once F is in, since they only exercise the public surface):
 
 ```bash
-uv run pytest tests/file_exchange/test_conformance.py -v
+uv run pytest tests/file_exchange/test_integration_*.py -v
 ```
 
-Expected: PASS for every vendored fixture.
+If any failure surfaces a real bug in F (rather than a missing fixture), STOP and fix in F's module before adding a workaround in G's tests.
 
-### Step G.4: CHANGELOG entry + commit
+### Step G.4 — Make integration tests pass
 
-- [ ] Add an entry to `CHANGELOG.md` under the next-version section:
+- [ ] **Address** any meaningful failure from G.3 by fixing the relevant module (F-level code). Each fix is a focused commit with the corresponding test asserting the corrected behaviour. Do not paper over real bugs in test setup.
 
-```markdown
-### Added
+### Step G.5 — Commit Task G
 
-- `nl.liesdonk.file-exchange` v0.1 implementation. New public helpers:
-  `register_file_exchange_capability`, `build_pull_response`, `pull_artifact`,
-  `open_intake`, `build_intake_response`, `resolve_intake`, `push_artifact`,
-  plus the reference types (`TransferHandle`, `IntakeTicket`, …) and
-  `FileExchangeError`/`FileExchangeErrorCode`. Capability advertising is
-  deployment-derived: filesystem if volumes are configured, HTTPS if the server
-  hosts an HTTP app. See `docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md`.
-- Seven new `ServerConfig` fields under the `FILE_EXCHANGE_*` env-var prefix.
-```
-
-- [ ] Commit:
+- [ ] **Commit:**
 
 ```bash
-git add tests/file_exchange/ CHANGELOG.md
-git commit -m "test(file-exchange): integration suite + spec-repo conformance fixtures
+git add tests/file_exchange/test_integration_*.py
+git commit -m "$(cat <<'EOF'
+test(file-exchange): integration suite + selection-preference assertions
 
-Closes #130"
+Adds three integration tests:
+- filesystem round-trip (provider→fetcher and sender→receiver) with
+  resolve_intake on the receiver side.
+- HTTPS round-trip (download + upload) via the sibling routes mounted
+  on a Starlette test app.
+- Selection-preference assertion: when the provider offers BOTH
+  filesystem and download, a filesystem-capable fetcher chooses
+  filesystem and the download token stays un-consumed.
+
+Closes #130.
+EOF
+)"
 ```
 
-- [ ] Run `preflight-circus`; open draft PR; flip to ready when bots+CI green.
+- [ ] Run the universal per-task suffix.
 
 ---
 
-## Final verification
+## Cross-task verification (after all seven PRs merge)
 
-After all seven PRs land:
+- [ ] **Run the full test suite** on `main`:
 
-- [ ] Pull main: `git checkout main && git pull --ff-only origin main`
-- [ ] Confirm everything passes: `uv sync --all-extras && uv run pytest && uv run ruff format --check . && uv run ruff check . && uv run mypy src`
-- [ ] Confirm the public API surface is intact: `python -c "from fastmcp_pvl_core import register_file_exchange_capability, build_pull_response, pull_artifact, open_intake, build_intake_response, resolve_intake, push_artifact, FileExchangeError, TransferHandle, IntakeTicket; print('OK')"`
-- [ ] Trigger the downstream canary work in `markdown-vault-mcp` (separate plan, separate repo) — wire MV as provider+fetcher+receiver+sender per design §10 phase 2.
+```bash
+uv sync --all-extras
+uv run pytest tests/ -v
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
+```
+
+Expected: all green on Python 3.10, 3.11, 3.12, 3.13 (CI matrix).
+
+- [ ] **Verify the 22 top-level symbols are importable**:
+
+```bash
+uv run python -c "
+import fastmcp_pvl_core
+required = {
+    'ArtifactMetadata', 'ExpectedConstraints', 'FileExchangeError',
+    'FileExchangeErrorCode', 'FileExchangeRole', 'FileExchangeTransport',
+    'IntakeTicket', 'SinkDescriptor', 'SourceDescriptor', 'TransferHandle',
+    'as_tool_error_result', 'build_intake_response', 'build_pull_response',
+    'make_filesystem_sink', 'make_filesystem_source', 'mint_download_source',
+    'mint_upload_sink', 'open_intake', 'pull_artifact', 'push_artifact',
+    'register_file_exchange_capability', 'resolve_intake',
+}
+missing = required - set(fastmcp_pvl_core.__all__)
+assert not missing, f'missing from __all__: {missing}'
+print('all 22 file-exchange symbols present in fastmcp_pvl_core.__all__')
+"
+```
+
+- [ ] **Smoke test the capability gating matrix one more time** against the design §3 table — pick four `ServerConfig` shapes (stdio+nv, stdio+v, http+nv, http+v) plus the empty-post-gate case, register the capability against each, and assert the advertised `roles` map matches the table verbatim. If anything diverges, the bug is in `_capability._transports_for_role` or its caller — fix in pvl-core, not in a downstream shim.
 
 ---
 
-## Open questions deferred (not in this plan)
+## Self-review notes
 
-- **Range-request resume** on `pull_download`: spec §10.2 allows it; not implemented in phase 1 (single GET only). Filed as follow-up for phase 1.5.
-- **Provider-driven revocation**: spec §18 open question. The kv_store layer supports `delete` so a future API can implement it; no helper exposed yet.
-- **`file://` URI scheme**: phase 1 supports `exchange://` only; `file://` rejection is explicit (`_transport_filesystem.py` raises). When a downstream actually needs `file://`, a small operator-config-driven exchange-root mapping lands.
+This plan was self-reviewed after writing, applying the writing-plans skill's three-step checklist:
+
+1. **Placeholder scan:** no "TBD", "implement appropriate", "similar to Task N" tokens. Every step shows the actual code or command.
+2. **Type consistency:** all function signatures match across tasks. `pull_artifact` / `push_artifact` consistently take `config: ServerConfig`; the four mint helpers' async/sync split matches the design doc (only the sink-writing ones are async); `FileExchangeRole` / `FileExchangeTransport` literals are used everywhere a role or transport set is named.
+3. **Spec coverage:**
+   - §3 Public API surface → Tasks A (types), C (`make_filesystem_source`), E (`make_filesystem_sink`, `mint_download_source`, `mint_upload_sink`, `resolve_intake`), F (`register_file_exchange_capability`, four role helpers, `as_tool_error_result`).
+   - §3 transport-availability gating table → Task F's eight matrix tests + production logic in `_capability._transports_for_role`.
+   - §4 Internal module layout → mapped 1:1 to file paths in the task `Files:` blocks.
+   - §5 Operator configuration → Task C step C.1 adds the six `ServerConfig` fields with env-var loaders.
+   - §6.1 Filesystem transport → Task C (`resolve_exchange_uri`, `atomic_write`, `async_atomic_write`).
+   - §6.2 HTTPS download/upload → Task D (consumer) + Task E (producer-side token store + routes).
+   - §6.2 streaming + asyncio.to_thread + fail-fast 413 → Task E step E.4 `_upload` handler + Task E test `test_upload_fails_fast_on_size_exceeded_with_413`.
+   - §6.2 single-use concurrency via atomic delete → Task E step E.2 `consume_download_token` + test `test_consume_download_token_single_use_atomic_under_concurrency`.
+   - §6.2 logging discipline → Task E test `test_mint_and_consume_never_logs_full_token`.
+   - §7 Schema vendoring + drift gate → Task A step A.2 + steps A.1/A.6.
+   - §8 Testing strategy → Tasks A–F unit tests + Task G integration tests.

--- a/docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md
+++ b/docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md
@@ -1,0 +1,300 @@
+# File-exchange adoption — pvl-core design
+
+- **Status:** draft, brainstorm-approved 2026-05-20
+- **Targets spec:** [`pvliesdonk/mcp-file-exchange-ext`](https://github.com/pvliesdonk/mcp-file-exchange-ext) v0.1
+- **Namespace:** `nl.liesdonk.file-exchange`
+- **Prerequisite (already shipped):** [#121 / PR #122 — unified key-value storage factory](https://github.com/pvliesdonk/fastmcp-pvl-core/pull/122) (`build_kv_store(env_prefix, config, *, namespace)`)
+
+## 1. Goal
+
+Implement the `nl.liesdonk.file-exchange` v0.1 extension as the **shared, opinionated reference implementation** for the pvl MCP server family. Downstream servers (markdown-vault-mcp, scholar-mcp, image-generation-mcp, …) opt into one or more roles (`provider`, `fetcher`, `receiver`, `sender`) and three transports (`filesystem`, `download`, `upload`) using pvl-core helpers, with all wire-format mechanics — capability declaration, reference construction, descriptor selection, transport semantics, error normalisation, capability-URL minting — owned by pvl-core.
+
+This is the cleanroom rewrite that follows [PR #117](https://github.com/pvliesdonk/fastmcp-pvl-core/pull/117) (the full removal of the prior v0.2–v0.6 design). The old design is not the basis; the external `mcp-file-exchange-ext` v0.1 spec is the only authority.
+
+## 2. Driving use cases
+
+| Flow | Roles in pvl-core | Transport |
+|---|---|---|
+| markdown-vault-mcp ↔ MCP peers | `provider`, `fetcher`, `receiver`, `sender` | `filesystem` primary; `download`/`upload` for non-MCP peers |
+| image-generation-mcp → markdown-vault-mcp | `provider` (image-gen) + `receiver` (MV) | `filesystem` (colocated) |
+| image-generation-mcp → non-MCP sandbox | `provider` (image-gen) | `download` (HTTPS) |
+| scholar-mcp → markdown-vault-mcp | `provider` (scholar) + `receiver` (MV) | `filesystem` |
+| non-MCP coding agent → markdown-vault-mcp | `receiver` (MV) | `upload` (HTTPS) |
+
+All four roles are in scope from phase 1. Both filesystem and HTTPS transports are in scope, on both consumer and producer sides — the latter is necessary because non-MCP consumers/producers (coding agents, sandboxes) are first-class peers in the driving flows.
+
+## 3. Public API surface
+
+All symbols are top-level on `fastmcp_pvl_core`, matching the existing `build_auth` / `register_server_info_tool` convention.
+
+### Types
+
+```python
+ArtifactMetadata
+TransferHandle
+IntakeTicket
+SourceDescriptor       # discriminated union: filesystem | download
+SinkDescriptor         # discriminated union: filesystem | upload
+ExpectedConstraints    # max_size / accept_mime_types / require_digest
+FileExchangeRole = Literal["provider", "fetcher", "receiver", "sender"]
+FileExchangeTransport = Literal["filesystem", "download", "upload"]
+FileExchangeError                # exception
+FileExchangeErrorCode            # StrEnum mirroring §13
+```
+
+### Capability declaration
+
+```python
+def register_file_exchange_capability(
+    server: FastMCP,
+    *,
+    roles: Sequence[FileExchangeRole],
+    transports_by_role: Mapping[FileExchangeRole, Sequence[FileExchangeTransport]],
+    kv_store: AsyncKeyValue,        # from build_kv_store(env_prefix, config, namespace="file-exchange")
+    digests: Sequence[str] = ("sha-256",),
+    max_artifact_size: int | None = None,
+) -> None
+```
+
+- Writes the `nl.liesdonk.file-exchange` block into `server.experimental_capabilities`.
+- When `transports_by_role` declares `download` for `provider` or `upload` for `receiver`, **auto-mounts** the sibling HTTP routes (`GET /file-exchange/d/<token>`, `PUT|POST /file-exchange/u/<token>`) on the FastMCP server.
+- The `kv_store` parameter is the namespaced store from the existing `build_kv_store` factory. Internal sub-keyspaces: `tokens:<token>` and `intake:<artifact_id>` via `PrefixCollectionsWrapper`.
+- **Fails fast at registration** when declared transports are unsatisfiable in the current deployment: `filesystem` declared but `_FILE_EXCHANGE_VOLUMES` empty → `ConfigurationError`; `download`/`upload` declared but the FastMCP server has no HTTP app (stdio-only) → `ConfigurationError`. This is preferred over a silent runtime skip-on-selection for declared roles, because mis-declared capability blocks would mislead peers' selection algorithms.
+
+### Descriptor minting (producer side)
+
+```python
+def make_filesystem_source(volume: str, relative_path: str) -> SourceDescriptor
+def make_filesystem_sink(volume: str, relative_path: str, *, artifact_id: str, kv_store: AsyncKeyValue) -> SinkDescriptor
+
+async def mint_download_source(
+    *,
+    bytes_path: Path,
+    server: FastMCP,
+    kv_store: AsyncKeyValue,
+    expires_in_s: int | None = None,
+    single_use: bool = True,
+) -> SourceDescriptor
+
+async def mint_upload_sink(
+    *,
+    intake_path: Path,
+    artifact_id: str,
+    server: FastMCP,
+    kv_store: AsyncKeyValue,
+    expires_in_s: int | None = None,
+    expected: ExpectedConstraints | None = None,
+) -> SinkDescriptor
+```
+
+`make_filesystem_sink` and `mint_upload_sink` both register the `(artifact_id → resolved_intake_path)` mapping in the kv_store, so `resolve_intake` can find it later regardless of which transport was used.
+
+### Role helpers
+
+```python
+# Provider
+def build_pull_response(
+    artifact: ArtifactMetadata,
+    sources: Sequence[SourceDescriptor],
+    *,
+    summary: str | None = None,
+    extra_meta: dict[str, Any] | None = None,
+) -> CallToolResult
+
+# Fetcher
+async def pull_artifact(
+    handle: TransferHandle | dict,
+    *,
+    dest: Path | BinaryIO,
+    supported_transports: Sequence[FileExchangeTransport] | None = None,
+) -> ArtifactMetadata
+
+# Receiver
+def open_intake(
+    *,
+    sinks: Sequence[SinkDescriptor],
+    expected: ExpectedConstraints | None = None,
+    artifact_id: str | None = None,
+) -> IntakeTicket
+
+def build_intake_response(
+    ticket: IntakeTicket,
+    *,
+    summary: str | None = None,
+    extra_meta: dict[str, Any] | None = None,
+) -> CallToolResult
+
+async def resolve_intake(
+    artifact_id: str,
+    *,
+    kv_store: AsyncKeyValue,
+) -> Path
+
+# Sender
+async def push_artifact(
+    ticket: IntakeTicket | dict,
+    *,
+    source: Path | BinaryIO,
+    supported_transports: Sequence[FileExchangeTransport] | None = None,
+    artifact_digest: str | None = None,
+) -> None
+
+# Error -> envelope
+def as_tool_error_result(exc: FileExchangeError) -> CallToolResult
+```
+
+Each helper validates inputs against the vendored JSON Schema, applies §17.3 version-skew + §17.4 must-understand checks, runs the §9 selection algorithm where applicable, and surfaces failures as `FileExchangeError` with one of the §13 codes.
+
+When `summary` is omitted on `build_pull_response` or `build_intake_response`, pvl-core auto-synthesises a short human-readable line of the form `"file-exchange: <artifact.name or artifact.id> (<size_human>, <mime_type>)"`, falling back gracefully when fields are missing. The intent is that the model sees enough to reason about the chain without ever seeing the bytes (spec §11.1).
+
+## 4. Internal module layout
+
+```
+src/fastmcp_pvl_core/_file_exchange/
+    __init__.py                                # public-namespace assembly
+    schema/
+        file-exchange.schema.json              # vendored verbatim from spec repo @ pinned commit
+        .expected-sha256                       # drift gate
+        conformance/                           # vendored fixtures from spec repo
+    _types.py                                  # Pydantic models, schema round-trip test
+    _capability.py                             # register_file_exchange_capability + route mounting
+    _select.py                                 # §9 selection algorithm (source + sink)
+    _errors.py                                 # FileExchangeError, code constants, as_tool_error_result
+    _provider.py                               # build_pull_response
+    _fetcher.py                                # pull_artifact
+    _receiver.py                               # open_intake, build_intake_response, resolve_intake
+    _sender.py                                 # push_artifact
+    _transport_filesystem.py                   # exchange:// resolution, atomic_write, confinement, mint helpers
+    _transport_https.py                        # pull_download, push_upload, SSRF guard
+    _url_store.py                              # capability URL minting, intake correlation; backed by kv_store
+    _routes.py                                 # GET /file-exchange/d/<token>, PUT|POST /file-exchange/u/<token>
+```
+
+Public symbols are re-exported from `fastmcp_pvl_core/__init__.py`. The `_file_exchange` package itself is private (underscore-prefixed) — consumers depend on the top-level surface, not the layout.
+
+## 5. Operator configuration
+
+All operator-side concerns are environment variables (per pvl-core convention; not constructor kwargs). The `{PREFIX}` placeholder is the consuming server's env-prefix.
+
+| Variable | Required when | Meaning |
+|---|---|---|
+| `{PREFIX}_FILE_EXCHANGE_VOLUMES` | `filesystem` transport declared in any role | `<volume-id>=<local-mount-point>` mappings, comma-separated. Configures the `exchange://` resolver. |
+| `{PREFIX}_FILE_EXCHANGE_MAX_ARTIFACT_SIZE` | optional | Hard ceiling in bytes; enforced by fetchers/receivers, pre-checked by senders/providers. |
+| `{PREFIX}_FILE_EXCHANGE_HTTPS_ALLOW_LOOPBACK` | optional, dev only | `true`/`false` (default `false`). Disables SSRF guard for loopback addresses. |
+| `{PREFIX}_FILE_EXCHANGE_HTTPS_ALLOW_PRIVATE` | optional, dev only | Same shape, for RFC 1918 / link-local ranges. |
+| `{PREFIX}_FILE_EXCHANGE_CAPABILITY_URL_TTL_DEFAULT_S` | optional | Default `expiresAt` window for minted `download`/`upload` URLs (default: 3600s). |
+| `{PREFIX}_FILE_EXCHANGE_HTTPS_PUBLIC_BASE_URL` | when capability URLs are minted behind a reverse proxy with a different public hostname than what FastMCP computes | Overrides `compute_app_domain` for capability-URL construction. |
+| `{PREFIX}_KV_STORE_URL` | already required by `build_kv_store` | Selects the shared storage backend. File-exchange uses `namespace="file-exchange"`. |
+
+The `_FILE_EXCHANGE_VOLUMES` parser is the single source of truth for the volume map. A party with no mapping for a referenced volume skips that descriptor during selection (§9).
+
+## 6. Transport mechanics
+
+### 6.1 Filesystem (`exchange://` and `file://`)
+
+- `resolve_exchange_uri(uri) -> Path` parses both URI schemes, looks up the volume (for `exchange://`), and **canonicalises** the result (resolves `.`, `..`, symlinks). The canonical path is then asserted to lie inside the resolved volume root; escapes — including via symlinks — raise `FileExchangeError(code="not-accessible")`. Used by both source (fetcher reading) and sink (sender writing) paths.
+- `atomic_write(target)` context manager: temp file in the same directory, fsync, rename onto target. Guarantees consumers never see a partial write.
+- Reads use `open(path, "rb")` with `O_NOFOLLOW` (defeats last-mile symlink swaps).
+- Lifecycle: provider owns source-file cleanup (per spec §10.1.3); pvl-core never auto-deletes.
+
+### 6.2 HTTPS download/upload
+
+**Consumer side** (`pull_download` / `push_upload`):
+
+- `https`-only; refuses non-`https` URLs and cross-origin redirects.
+- No ambient credentials (no cookies, no `Authorization` header, no client certs). The capability URL is the only credential.
+- **SSRF guard**: resolve hostname once; reject loopback / link-local / RFC 1918 unless the corresponding env-var override is set; connect to the pinned IP address (defeats DNS rebinding). Shared helper called by both pull and push.
+- `Range` support on download for resume; verifies `Content-Length` against `artifact.size` and computed digest against `artifact.digest` if either is present.
+- On upload, sends `Content-Length` and (when applicable) `Content-Digest` (RFC 9530). When the ticket's `expected.requireDigest` is set, `push_artifact`'s `artifact_digest` kwarg is mandatory.
+
+**Producer side** (token store + sibling routes):
+
+- 128-bit URL-safe random tokens stored in the namespaced `kv_store` under `tokens:<token>` (download) or under `tokens:<token>` (upload, with additional fields for `expected` constraints + `artifact_id` correlation).
+- `GET /file-exchange/d/<token>` — looks up; sets `Content-Type`/`Content-Length` from stored metadata; supports `Range`; on full-bytes-served success **atomically** flips `consumed_flag` (so the single-use semantics hold under concurrent retrieval attempts); returns 404 for expired/unknown/consumed-single-use.
+- `PUT|POST /file-exchange/u/<token>` — looks up; enforces `maxSize` / `acceptMimeTypes` / `Content-Digest`; streams the request body into a temp file via the `atomic_write` context manager (same helper as the filesystem transport, so partial uploads can't be observed by a concurrent reader); on body-fully-received-and-validated success, the context manager renames the temp file onto the intake path and the route handler atomically marks the token consumed and writes `intake:<artifact_id> → resolved_intake_path`. Validation failure or partial body causes the temp file to be discarded.
+- Public base URL: `compute_app_domain` (existing pvl-core helper) plus the literal `/file-exchange/{d,u}/` prefix. Overridable via `_FILE_EXCHANGE_HTTPS_PUBLIC_BASE_URL`.
+- Background sweeper deletes expired tokens (default interval: 60s) to keep the store bounded.
+
+## 7. Schema vendoring & conformance
+
+- `schema/file-exchange.schema.json` copied verbatim from `pvliesdonk/mcp-file-exchange-ext` at a pinned commit (recorded in a sibling `PINNED_AT.md`).
+- CI compares the vendored file's SHA-256 against `.expected-sha256`; drift fails the build and forces an explicit re-pin commit.
+- `conformance/` fixtures are vendored the same way (move together with the schema).
+- `tests/file_exchange/test_conformance.py` walks the fixtures, loads each via Pydantic, asserts the documented valid/invalid outcome.
+- `_types.py` includes a round-trip test asserting `model_json_schema()` output is structurally compatible with the vendored schema (catches drift between hand-written models and the spec).
+
+## 8. Testing strategy
+
+Three layers, all under `tests/file_exchange/`:
+
+1. **Unit tests** per module. Notable areas: `_select.py` matrix tests for (handle, supported_transports) → expected descriptor; `_transport_filesystem.py` path-confinement (canonicalise + symlink-escape rejection on a tmp tree); `_transport_https.py` SSRF guard against a faked-DNS fixture; `_url_store.py` against an in-memory `AsyncKeyValue`.
+2. **Integration tests** with two FastMCP test servers in-process (in-memory transport from `pytest-asyncio`), sharing a tmp volume. Drives the full pull and push flows for both `filesystem` and HTTPS. The HTTPS test mounts the sibling routes via Starlette's `TestClient` and exercises 128-bit token entropy, single-use enforcement under concurrency, `Range` resumption, and digest mismatch.
+3. **Conformance suite** against the vendored fixtures (§7).
+
+## 9. Tasks composition
+
+pvl-core does not auto-declare `execution.taskSupport` on tools — that's a per-tool decision the downstream makes. The four role helpers are async and stream-friendly; they don't impose a request-timeout posture. Helper docstrings note: if a tool may handle artifacts large enough to outrun the request timeout, declare `execution.taskSupport="optional"` or `"required"` at registration. TTL sizing for capability URLs is left to the downstream (default fallback: `_CAPABILITY_URL_TTL_DEFAULT_S`); pvl-core does not auto-derive `expiresAt` from a Task's `ttl` in phase 1.
+
+## 10. Phasing
+
+**Phase 0** — Prerequisite. ✅ Done — [#122](https://github.com/pvliesdonk/fastmcp-pvl-core/pull/122) shipped `build_kv_store`.
+
+**Phase 1 — Core implementation in pvl-core.** PRs filed against `pvliesdonk/fastmcp-pvl-core`, parallel-pipelined per the global PR workflow. Issue split:
+
+| Tag | Scope | Files |
+|---|---|---|
+| A | Vendor schema + conformance fixtures + Pydantic types + drift gate | `_file_exchange/{schema,_types}.py` |
+| B | Selection algorithm + error envelope | `_select.py`, `_errors.py` |
+| C | Filesystem transport: `resolve_exchange_uri`, `atomic_write`, mint helpers | `_transport_filesystem.py` |
+| D | HTTPS consumer side: `pull_download`, `push_upload`, SSRF guard | `_transport_https.py` |
+| E | Capability URL store + sibling routes + intake-correlation map | `_url_store.py`, `_routes.py` |
+| F | Capability declaration + role helpers + top-level re-exports | `_capability.py`, `_provider.py`, `_fetcher.py`, `_receiver.py`, `_sender.py`, `__init__.py` |
+| G | Integration tests + conformance suite | `tests/file_exchange/` |
+
+Eight items (including #122). Each PR runs the full `preflight-circus` skill locally before push; bots are merge gates.
+
+**Phase 2 — Downstream canary: `markdown-vault-mcp`.** Filed in the MV repo, not pvl-core. Wires MV as `provider` + `fetcher` + `receiver` + `sender`, both `filesystem` and HTTPS, blocked on pvl-core issue F. Scope:
+
+- One new tool returning `TransferHandle` for an existing note/attachment export path.
+- One `open_intake`-style tool + one `ingest_attachment(artifact_id)` follow-up.
+- `register_file_exchange_capability` at server build.
+- Operator docs: volume map + the file-exchange volumes the deployment expects.
+
+**Phase 3 — Follow-on canaries.** `image-generation-mcp` (provider for generated images), `scholar-mcp` (provider for fetched PDFs). Each is a small wire-up patch in its own repo once the pvl-core API is stable.
+
+## 11. Impact on `fastmcp-server-template`
+
+The template propagates pvl-core API to every downstream via `copier update`. Template-side work:
+
+1. **Server-build scaffolding**: feature-gated `register_file_exchange_capability(…)` block (off by default; copier question `enable_file_exchange: bool = false`).
+2. **`copier.yml` questions**: `enable_file_exchange` and `file_exchange_default_roles`. Transport set per role is *not* a template-time decision — it's operator env-var.
+3. **`.env.example` additions** when enabled — the env-vars from §5.
+4. **`docs/file-exchange-cookbook.md`** with two minimal worked examples (provider, receiver/processor). Documentation only, not committed as live tools.
+5. **`pyproject.toml` floor bump** to the pvl-core version that shipped the file-exchange APIs (after pvl-core issue F lands).
+6. **A fresh template umbrella issue** filed *after* the pvl-core design + child issues are in place. Template issue `#131` (the old umbrella that referenced the dead v0.6 design) is already closed; the new one references this design doc and the pvl-core phase 1 cluster.
+
+Template work is the **last PR of the cluster**: pvl-core's API may shift slightly under review, and the template should pin against the final shape, not chase intermediate versions.
+
+## 12. Spec evolution (deferred, recorded)
+
+Spec-side, not pvl-core-side — surfaced for context but not addressed by this design:
+
+- `multiArtifact` references (spec §18) — likely a v0.2 addition. pvl-core's reference types should accept it as a backwards-compatible minor bump.
+- Provider-driven revocation (spec §18) — not addressable in v0.1; pvl-core's token-store `delete()` capability is groundwork.
+- IANA registration of the `exchange://` URI scheme (spec §18) — out of pvl-core's scope.
+
+## 13. Non-goals
+
+- No replacement for MCP `resources`. Handles are ephemeral, single-use, not listed.
+- No new JSON-RPC methods or new client behaviour. The model copies a JSON object from one tool's output into another tool's input — same as any tool chain.
+- No automatic Task augmentation. Composes with FastMCP's Tasks; doesn't decide for the downstream.
+- No object-storage adapter (S3 presigned URLs etc.). The auto-mounted sibling endpoint is sufficient for the colocated-FS-primary deployments; a pluggable URL store is a future enhancement, not phase 1.
+- No backwards-compatibility shims with the removed v0.6 design. The cleanroom rewrite stands alone.
+
+## 14. References
+
+- Spec: https://github.com/pvliesdonk/mcp-file-exchange-ext (v0.1 draft)
+- Removed implementation: [pvliesdonk/fastmcp-pvl-core#117](https://github.com/pvliesdonk/fastmcp-pvl-core/pull/117)
+- Prerequisite (shipped): [pvliesdonk/fastmcp-pvl-core#121 / #122](https://github.com/pvliesdonk/fastmcp-pvl-core/pull/122)
+- Contributor framing: [/CLAUDE.md](../../../CLAUDE.md) — "Shape decisions live in pvl-core; hooks expose domain-specific behaviour only."
+- FastMCP storage backends: https://gofastmcp.com/servers/storage-backends

--- a/docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md
+++ b/docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md
@@ -7,7 +7,7 @@
 
 ## 1. Goal
 
-Implement the `nl.liesdonk.file-exchange` v0.1 extension as the **shared, opinionated reference implementation** for the pvl MCP server family. Downstream servers (markdown-vault-mcp, scholar-mcp, image-generation-mcp, …) opt into one or more roles (`provider`, `fetcher`, `receiver`, `sender`) and three transports (`filesystem`, `download`, `upload`) using pvl-core helpers, with all wire-format mechanics — capability declaration, reference construction, descriptor selection, transport semantics, error normalisation, capability-URL minting — owned by pvl-core.
+Implement the `nl.liesdonk.file-exchange` v0.1 extension as the **shared, opinionated implementation** for the pvl MCP server family. Downstream servers (markdown-vault-mcp, scholar-mcp, image-generation-mcp, …) opt into one or more roles (`provider`, `fetcher`, `receiver`, `sender`) and three transports (`filesystem`, `download`, `upload`) using pvl-core helpers, with all wire-format mechanics — capability declaration, reference construction, descriptor selection, transport semantics, error normalisation, capability-URL minting — owned by pvl-core.
 
 This is the cleanroom rewrite that follows [PR #117](https://github.com/pvliesdonk/fastmcp-pvl-core/pull/117) (the full removal of the prior v0.2–v0.6 design). The old design is not the basis; the external `mcp-file-exchange-ext` v0.1 spec is the only authority.
 
@@ -51,13 +51,12 @@ def register_file_exchange_capability(
     *,
     roles: Sequence[FileExchangeRole] = ("provider", "fetcher", "receiver", "sender"),
     kv_store: AsyncKeyValue,        # from build_kv_store(env_prefix, config, namespace="file-exchange")
-    digests: Sequence[str] = ("sha-256",),
 ) -> None
 ```
 
 The downstream declares which **roles** it wants to play (a domain decision — does this server export, ingest, both?). pvl-core **derives the transport set per role** from what the deployment can actually satisfy. The advertised capability mirrors reality, never a declaration that runtime selection has to reject.
 
-`maxArtifactSize` is operator-side configuration, not a kwarg — pvl-core reads `config.file_exchange_max_artifact_size` and emits it on the capability block when set. `digests` is the one shape kwarg with a near-universal default; downstream stays explicit so that the family can converge on stronger digests later without an API change.
+`maxArtifactSize` is operator-side configuration, not a kwarg — pvl-core reads `config.file_exchange_max_artifact_size` and emits it on the capability block when set. The advertised `digests` set is `("sha-256",)`, hardcoded in `_capability.py` — downstream has no domain-specific basis to vary it, and when the family converges on stronger digests later, the constant changes once in pvl-core and every downstream picks it up via `copier update`.
 
 #### Transport-availability gating (the load-bearing detail)
 
@@ -135,6 +134,8 @@ async def mint_upload_sink(
 
 Both sink-side minters (`make_filesystem_sink` and `mint_upload_sink`) record the `(artifact_id → resolved_intake_path)` mapping in `kv_store` at mint time — that single seam lets `resolve_intake` find the bytes after a successful transfer regardless of which transport was used. `config` supplies the volume map, the capability-URL TTL default, and (for HTTPS minters) the optional public-base-URL override. The trio `(server, config, kv_store)` is sufficient context for any helper in this section; no separate `volumes`/`ssrf`/`base_url` kwargs leak through.
 
+`make_filesystem_source` is synchronous (just composes the URI string); the three other minters are async because they write to `kv_store`. That asymmetry is intentional — there is no kv_store interaction on the read-side filesystem minter, and forcing all four to async would be ceremony without benefit.
+
 ### Role helpers
 
 ```python
@@ -197,7 +198,7 @@ Each helper validates inputs against the vendored JSON Schema, applies §17.3 ve
 
 `pull_artifact` and `push_artifact` take `config` so they can derive the volume map (`config.file_exchange_volumes`), the SSRF guard (`config.file_exchange_https_allow_loopback`/`allow_private`), and any other operator-side concern. No standalone `volumes`/`ssrf` kwargs — those are deployment state, not domain hooks. `open_intake` is pure construction: the `(artifact_id → resolved_intake_path)` mapping was already recorded by the sink-minter that produced its `sinks`, so it needs neither `config` nor `kv_store`.
 
-`resolve_intake` always returns a `Path`. If `kv_store` has no recorded mapping for `artifact_id` (the transfer never completed, or `artifact_id` is wrong), it raises `FileExchangeError(code=NOT_ACCESSIBLE)` so the caller's tool body can convert via `as_tool_error_result`. The `-> Path | None` shape was considered but creates a quiet-failure trap: callers forget the `None` branch and operate on the wrong path.
+`resolve_intake` always returns a `Path`. The sink minter writes the `(artifact_id → resolved_intake_path)` mapping at *mint* time — so the mapping exists from the moment the receiver returns the ticket, before any bytes arrive. To distinguish "wrong artifact_id" from "bytes not yet on disk", `resolve_intake` then asserts `path.exists()`; both cases raise `FileExchangeError(code=NOT_ACCESSIBLE)` (with distinct `detail` strings), so the caller's tool body can convert via `as_tool_error_result`. The `-> Path | None` shape was considered but creates a quiet-failure trap: callers forget the `None` branch and operate on the wrong path. The receiver-side discipline: the *processor* tool that consumes `artifact_id` is called only after the sender confirms the transfer; if it's called too early, `NOT_ACCESSIBLE` is the correct, observable failure.
 
 When `summary` is omitted on `build_pull_response` or `build_intake_response`, pvl-core auto-synthesises a short human-readable line of the form `"file-exchange: <artifact.name or artifact.id> (<size_human>, <mime_type>)"`, falling back gracefully when fields are missing. The intent is that the model sees enough to reason about the chain without ever seeing the bytes (spec §11.1).
 

--- a/docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md
+++ b/docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md
@@ -64,7 +64,7 @@ Per the spec §4.2 table, role-vs-transport compatibility is asymmetric across d
 
 | Transport | Required deployment capability |
 |---|---|
-| `filesystem` (any role) | `config.file_exchange_volumes` non-empty — i.e. operator configured at least one volume in `_FILE_EXCHANGE_VOLUMES` |
+| `filesystem` (any role) | `config.file_exchange_volumes` non-empty — i.e. operator configured at least one volume in `{PREFIX}_FILE_EXCHANGE_VOLUMES` |
 | `download` (provider) | `config.transport == "http"` — the FastMCP server hosts an HTTP app on which to mount `GET /file-exchange/d/<token>` |
 | `download` (fetcher) | always available (outbound HTTP) |
 | `upload` (receiver) | `config.transport == "http"` — needs to host `PUT|POST /file-exchange/u/<token>` |
@@ -248,10 +248,10 @@ The volumes parser in `_transport_filesystem.py` is the single source of truth f
 
 A deployment can rotate its file-exchange surface without code changes — just env-vars:
 
-- **`_FILE_EXCHANGE_VOLUMES=` (empty) + `_TRANSPORT=stdio`** → only the consumer roles are advertised (`fetcher: ["download"]`, `sender: ["upload"]`). The producer-side roles (`provider`, `receiver`) drop because they need an HTTP app to host endpoints. Outbound HTTPS works regardless.
-- **`_FILE_EXCHANGE_VOLUMES=vault-export=/mnt/exchange/vault` + `_TRANSPORT=stdio`** → all four roles advertised; consumer roles get both `filesystem` and outbound HTTPS, producer roles get `filesystem` only.
-- **`_FILE_EXCHANGE_VOLUMES=` (empty) + `_TRANSPORT=http`** → all four roles advertised, HTTPS-only.
-- **Both set + `_TRANSPORT=http`** → all four roles, both transports per role.
+- **`{PREFIX}_FILE_EXCHANGE_VOLUMES=` (empty) + `{PREFIX}_TRANSPORT=stdio`** → only the consumer roles are advertised (`fetcher: ["download"]`, `sender: ["upload"]`). The producer-side roles (`provider`, `receiver`) drop because they need an HTTP app to host endpoints. Outbound HTTPS works regardless.
+- **`{PREFIX}_FILE_EXCHANGE_VOLUMES=vault-export=/mnt/exchange/vault` + `{PREFIX}_TRANSPORT=stdio`** → all four roles advertised; consumer roles get both `filesystem` and outbound HTTPS, producer roles get `filesystem` only.
+- **`{PREFIX}_FILE_EXCHANGE_VOLUMES=` (empty) + `{PREFIX}_TRANSPORT=http`** → all four roles advertised, HTTPS-only.
+- **Both set + `{PREFIX}_TRANSPORT=http`** → all four roles, both transports per role.
 
 ## 6. Transport mechanics
 
@@ -277,7 +277,7 @@ A deployment can rotate its file-exchange surface without code changes — just 
 - 128-bit URL-safe random tokens stored in the namespaced `kv_store` under `tokens:<token>` (a single keyspace for both download and upload records, discriminated by a `kind` field; the upload record carries the `expected` constraints + `artifact_id` correlation).
 - `GET /file-exchange/d/<token>` — looks up; sets `Content-Type`/`Content-Length` from stored metadata; supports `Range`; on full-bytes-served success marks the token consumed; returns 404 for expired/unknown/consumed-single-use.
 
-  **Single-use concurrency posture**: pvl-core uses a per-key get-then-delete pattern (`kv_store.delete()` is atomic per key on every supported backend; a racing second consumer finds the key already gone and returns 404). This holds under high concurrency for Memory, FileTree, Redis, DynamoDB, and MongoDB backends. **It is best-effort if the kv_store backend lacks atomic-delete semantics**; a custom adapter must document this clearly. A future enhancement can introduce a `CompareAndSwap` primitive on the storage layer if a backend without atomic delete becomes load-bearing.
+  **Single-use concurrency posture**: pvl-core uses a per-key get-then-delete pattern. Two racing consumers can both read the token record in their `get` calls, but only one of their subsequent `delete` calls returns `True` — `kv_store.delete()` is atomic per key on every supported backend. The loser's `delete` returns `False` and the route surfaces it as HTTP 404. This holds under high concurrency for Memory, FileTree, Redis, DynamoDB, and MongoDB backends. **It is best-effort if the kv_store backend lacks atomic-delete semantics**; a custom adapter must document this clearly. A future enhancement can introduce a `CompareAndSwap` primitive on the storage layer if a backend without atomic delete becomes load-bearing.
 
 - `PUT|POST /file-exchange/u/<token>` — looks up; **streams** the request body chunk-by-chunk into a temp file via the `atomic_write` context manager (same helper as the filesystem transport). Each chunk is digested with `hashlib.sha256` (incremental), counted against `expected.maxSize` (fail-fast with HTTP 413 the moment cumulative bytes exceed the cap — never buffer beyond one chunk), and matched against `expected.acceptMimeTypes` via the request `Content-Type` header (HTTP 415 on mismatch). On body-fully-received success: verify the running digest matches any `Content-Digest` header (HTTP 422 / `digest-mismatch` on mismatch), then commit via `atomic_write`'s rename and mark the token consumed (atomic per-key `delete`). Validation failure or partial body causes the temp file to be discarded (no rename happens). The `intake:<artifact_id> → resolved_intake_path` mapping was recorded by `mint_upload_sink` at *mint* time — the route does not write it again; bytes simply arrive at the path the mapping already points to.
 

--- a/docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md
+++ b/docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md
@@ -52,11 +52,12 @@ def register_file_exchange_capability(
     roles: Sequence[FileExchangeRole] = ("provider", "fetcher", "receiver", "sender"),
     kv_store: AsyncKeyValue,        # from build_kv_store(env_prefix, config, namespace="file-exchange")
     digests: Sequence[str] = ("sha-256",),
-    max_artifact_size: int | None = None,
 ) -> None
 ```
 
 The downstream declares which **roles** it wants to play (a domain decision — does this server export, ingest, both?). pvl-core **derives the transport set per role** from what the deployment can actually satisfy. The advertised capability mirrors reality, never a declaration that runtime selection has to reject.
+
+`maxArtifactSize` is operator-side configuration, not a kwarg — pvl-core reads `config.file_exchange_max_artifact_size` and emits it on the capability block when set. `digests` is the one shape kwarg with a near-universal default; downstream stays explicit so that the family can converge on stronger digests later without an API change.
 
 #### Transport-availability gating (the load-bearing detail)
 
@@ -78,7 +79,13 @@ Algorithm:
 4. Otherwise, write the gated `{role: [transports…]}` map into the `nl.liesdonk.file-exchange` block exactly as the spec requires (§5).
 5. Auto-mount HTTP routes iff `provider+download` or `receiver+upload` survives the gate (the stdio-only case skips this).
 
-This makes the call effectively zero-config for downstream — `register_file_exchange_capability(server, config, kv_store=…)` does the right thing in every deployment. A stdio server with volumes configured advertises filesystem-only. An HTTP server without volumes advertises HTTPS-only. An HTTP server with volumes advertises both, role-by-role. A stdio server with no volumes advertises nothing.
+This makes the call effectively zero-config for downstream — `register_file_exchange_capability(server, config, kv_store=…)` does the right thing in every deployment. Concretely:
+
+- **stdio + no volumes** → only the consumer roles survive (`fetcher: ["download"]`, `sender: ["upload"]`) because outbound HTTPS is always available; the producer-side roles drop. The capability block IS advertised.
+- **stdio + volumes** → all four roles advertised with `filesystem` (and consumer roles also keep `download`/`upload` for non-MCP peers).
+- **http + no volumes** → all four roles advertised with HTTPS only.
+- **http + volumes** → all four roles advertised with both transports.
+- **Empty post-gate role set** (e.g. downstream passes `roles=("provider", "receiver")` on a stdio + no-volumes deployment) → capability is not advertised at all. This is the safety-net step 3, not the common case.
 
 #### Other behaviour
 
@@ -88,13 +95,27 @@ This makes the call effectively zero-config for downstream — `register_file_ex
 ### Descriptor minting (producer side)
 
 ```python
-def make_filesystem_source(volume: str, relative_path: str) -> SourceDescriptor
-def make_filesystem_sink(volume: str, relative_path: str, *, artifact_id: str, kv_store: AsyncKeyValue) -> SinkDescriptor
+def make_filesystem_source(
+    volume: str,
+    relative_path: str,
+    *,
+    config: ServerConfig,
+) -> SourceDescriptor
+
+async def make_filesystem_sink(
+    volume: str,
+    relative_path: str,
+    *,
+    artifact_id: str,
+    config: ServerConfig,
+    kv_store: AsyncKeyValue,
+) -> SinkDescriptor
 
 async def mint_download_source(
     *,
     bytes_path: Path,
     server: FastMCP,
+    config: ServerConfig,
     kv_store: AsyncKeyValue,
     expires_in_s: int | None = None,
     single_use: bool = True,
@@ -105,13 +126,14 @@ async def mint_upload_sink(
     intake_path: Path,
     artifact_id: str,
     server: FastMCP,
+    config: ServerConfig,
     kv_store: AsyncKeyValue,
     expires_in_s: int | None = None,
     expected: ExpectedConstraints | None = None,
 ) -> SinkDescriptor
 ```
 
-`make_filesystem_sink` and `mint_upload_sink` both register the `(artifact_id → resolved_intake_path)` mapping in the kv_store, so `resolve_intake` can find it later regardless of which transport was used.
+Both sink-side minters (`make_filesystem_sink` and `mint_upload_sink`) record the `(artifact_id → resolved_intake_path)` mapping in `kv_store` at mint time — that single seam lets `resolve_intake` find the bytes after a successful transfer regardless of which transport was used. `config` supplies the volume map, the capability-URL TTL default, and (for HTTPS minters) the optional public-base-URL override. The trio `(server, config, kv_store)` is sufficient context for any helper in this section; no separate `volumes`/`ssrf`/`base_url` kwargs leak through.
 
 ### Role helpers
 
@@ -130,6 +152,7 @@ async def pull_artifact(
     handle: TransferHandle | dict,
     *,
     dest: Path | BinaryIO,
+    config: ServerConfig,
     supported_transports: Sequence[FileExchangeTransport] | None = None,
 ) -> ArtifactMetadata
 
@@ -159,8 +182,11 @@ async def push_artifact(
     ticket: IntakeTicket | dict,
     *,
     source: Path | BinaryIO,
+    config: ServerConfig,
     supported_transports: Sequence[FileExchangeTransport] | None = None,
     artifact_digest: str | None = None,
+    artifact_mime: str | None = None,
+    artifact_size: int | None = None,
 ) -> None
 
 # Error -> envelope
@@ -168,6 +194,10 @@ def as_tool_error_result(exc: FileExchangeError) -> CallToolResult
 ```
 
 Each helper validates inputs against the vendored JSON Schema, applies §17.3 version-skew + §17.4 must-understand checks, runs the §9 selection algorithm where applicable, and surfaces failures as `FileExchangeError` with one of the §13 codes.
+
+`pull_artifact` and `push_artifact` take `config` so they can derive the volume map (`config.file_exchange_volumes`), the SSRF guard (`config.file_exchange_https_allow_loopback`/`allow_private`), and any other operator-side concern. No standalone `volumes`/`ssrf` kwargs — those are deployment state, not domain hooks. `open_intake` is pure construction: the `(artifact_id → resolved_intake_path)` mapping was already recorded by the sink-minter that produced its `sinks`, so it needs neither `config` nor `kv_store`.
+
+`resolve_intake` always returns a `Path`. If `kv_store` has no recorded mapping for `artifact_id` (the transfer never completed, or `artifact_id` is wrong), it raises `FileExchangeError(code=NOT_ACCESSIBLE)` so the caller's tool body can convert via `as_tool_error_result`. The `-> Path | None` shape was considered but creates a quiet-failure trap: callers forget the `None` branch and operate on the wrong path.
 
 When `summary` is omitted on `build_pull_response` or `build_intake_response`, pvl-core auto-synthesises a short human-readable line of the form `"file-exchange: <artifact.name or artifact.id> (<size_human>, <mime_type>)"`, falling back gracefully when fields are missing. The intent is that the model sees enough to reason about the chain without ever seeing the bytes (spec §11.1).
 
@@ -217,10 +247,10 @@ The volumes parser in `_transport_filesystem.py` is the single source of truth f
 
 A deployment can rotate its file-exchange surface without code changes — just env-vars:
 
-- Set `_FILE_EXCHANGE_VOLUMES=` (empty) + `_TRANSPORT=stdio` → no file-exchange capability advertised at all.
-- Set `_FILE_EXCHANGE_VOLUMES=vault-export=/mnt/exchange/vault` + `_TRANSPORT=stdio` → file-exchange advertised, filesystem-only.
-- Set `_FILE_EXCHANGE_VOLUMES=` (empty) + `_TRANSPORT=http` → file-exchange advertised, HTTPS-only (download for provider+fetcher, upload for receiver+sender).
-- Both set → both transports per role.
+- **`_FILE_EXCHANGE_VOLUMES=` (empty) + `_TRANSPORT=stdio`** → only the consumer roles are advertised (`fetcher: ["download"]`, `sender: ["upload"]`). The producer-side roles (`provider`, `receiver`) drop because they need an HTTP app to host endpoints. Outbound HTTPS works regardless.
+- **`_FILE_EXCHANGE_VOLUMES=vault-export=/mnt/exchange/vault` + `_TRANSPORT=stdio`** → all four roles advertised; consumer roles get both `filesystem` and outbound HTTPS, producer roles get `filesystem` only.
+- **`_FILE_EXCHANGE_VOLUMES=` (empty) + `_TRANSPORT=http`** → all four roles advertised, HTTPS-only.
+- **Both set + `_TRANSPORT=http`** → all four roles, both transports per role.
 
 ## 6. Transport mechanics
 
@@ -243,11 +273,20 @@ A deployment can rotate its file-exchange surface without code changes — just 
 
 **Producer side** (token store + sibling routes):
 
-- 128-bit URL-safe random tokens stored in the namespaced `kv_store` under `tokens:<token>` (download) or under `tokens:<token>` (upload, with additional fields for `expected` constraints + `artifact_id` correlation).
-- `GET /file-exchange/d/<token>` — looks up; sets `Content-Type`/`Content-Length` from stored metadata; supports `Range`; on full-bytes-served success **atomically** flips `consumed_flag` (so the single-use semantics hold under concurrent retrieval attempts); returns 404 for expired/unknown/consumed-single-use.
-- `PUT|POST /file-exchange/u/<token>` — looks up; enforces `maxSize` / `acceptMimeTypes` / `Content-Digest`; streams the request body into a temp file via the `atomic_write` context manager (same helper as the filesystem transport, so partial uploads can't be observed by a concurrent reader); on body-fully-received-and-validated success, the context manager renames the temp file onto the intake path and the route handler atomically marks the token consumed and writes `intake:<artifact_id> → resolved_intake_path`. Validation failure or partial body causes the temp file to be discarded.
+- 128-bit URL-safe random tokens stored in the namespaced `kv_store` under `tokens:<token>` (a single keyspace for both download and upload records, discriminated by a `kind` field; the upload record carries the `expected` constraints + `artifact_id` correlation).
+- `GET /file-exchange/d/<token>` — looks up; sets `Content-Type`/`Content-Length` from stored metadata; supports `Range`; on full-bytes-served success marks the token consumed; returns 404 for expired/unknown/consumed-single-use.
+
+  **Single-use concurrency posture**: pvl-core uses a per-key get-then-delete pattern (`kv_store.delete()` is atomic per key on every supported backend; a racing second consumer finds the key already gone and returns 404). This holds under high concurrency for Memory, FileTree, Redis, DynamoDB, and MongoDB backends. **It is best-effort if the kv_store backend lacks atomic-delete semantics**; a custom adapter must document this clearly. A future enhancement can introduce a `CompareAndSwap` primitive on the storage layer if a backend without atomic delete becomes load-bearing.
+
+- `PUT|POST /file-exchange/u/<token>` — looks up; **streams** the request body chunk-by-chunk into a temp file via the `atomic_write` context manager (same helper as the filesystem transport). Each chunk is digested with `hashlib.sha256` (incremental), counted against `expected.maxSize` (fail-fast with HTTP 413 the moment cumulative bytes exceed the cap — never buffer beyond one chunk), and matched against `expected.acceptMimeTypes` via the request `Content-Type` header (HTTP 415 on mismatch). On body-fully-received success: verify the running digest matches any `Content-Digest` header (HTTP 422 / `digest-mismatch` on mismatch), then commit via `atomic_write`'s rename and mark the token consumed (atomic per-key `delete`). Validation failure or partial body causes the temp file to be discarded (no rename happens). The `intake:<artifact_id> → resolved_intake_path` mapping was recorded by `mint_upload_sink` at *mint* time — the route does not write it again; bytes simply arrive at the path the mapping already points to.
+
+- All synchronous file I/O inside async handlers (chunk writes, the final fsync) is dispatched via `asyncio.to_thread` so the event loop is never blocked on disk latency. The pull route uses the same discipline for `Content-Length`-bounded streams.
+
 - Public base URL: `compute_app_domain` (existing pvl-core helper) plus the literal `/file-exchange/{d,u}/` prefix. Overridable via `_FILE_EXCHANGE_HTTPS_PUBLIC_BASE_URL`.
+
 - Background sweeper deletes expired tokens (default interval: 60s) to keep the store bounded.
+
+**Logging discipline** (`_url_store.py`, `_routes.py`): capability URLs are bearer credentials per spec §12; pvl-core never logs them in full at any level. Debug logs use a token fingerprint of the form `tok=<first-8-chars>...` derived from the token's URL-safe base64 representation; the full URL or the full token never enters stdout, stderr, or any structured-log field. The `_meta` mirror under `nl.liesdonk.file-exchange/handles` / `tickets` (spec §11.1) embeds the URLs verbatim and is therefore *also* never logged. A unit test in Task E asserts that `caplog` contains no full-token substring during mint, consume, or sweep flows.
 
 ## 7. Schema vendoring & conformance
 

--- a/docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md
+++ b/docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md
@@ -47,19 +47,43 @@ FileExchangeErrorCode            # StrEnum mirroring §13
 ```python
 def register_file_exchange_capability(
     server: FastMCP,
+    config: ServerConfig,
     *,
-    roles: Sequence[FileExchangeRole],
-    transports_by_role: Mapping[FileExchangeRole, Sequence[FileExchangeTransport]],
+    roles: Sequence[FileExchangeRole] = ("provider", "fetcher", "receiver", "sender"),
     kv_store: AsyncKeyValue,        # from build_kv_store(env_prefix, config, namespace="file-exchange")
     digests: Sequence[str] = ("sha-256",),
     max_artifact_size: int | None = None,
 ) -> None
 ```
 
-- Writes the `nl.liesdonk.file-exchange` block into `server.experimental_capabilities`.
-- When `transports_by_role` declares `download` for `provider` or `upload` for `receiver`, **auto-mounts** the sibling HTTP routes (`GET /file-exchange/d/<token>`, `PUT|POST /file-exchange/u/<token>`) on the FastMCP server.
+The downstream declares which **roles** it wants to play (a domain decision — does this server export, ingest, both?). pvl-core **derives the transport set per role** from what the deployment can actually satisfy. The advertised capability mirrors reality, never a declaration that runtime selection has to reject.
+
+#### Transport-availability gating (the load-bearing detail)
+
+Per the spec §4.2 table, role-vs-transport compatibility is asymmetric across deployment topology. pvl-core encodes the table once:
+
+| Transport | Required deployment capability |
+|---|---|
+| `filesystem` (any role) | `config.file_exchange_volumes` non-empty — i.e. operator configured at least one volume in `_FILE_EXCHANGE_VOLUMES` |
+| `download` (provider) | `config.transport == "http"` — the FastMCP server hosts an HTTP app on which to mount `GET /file-exchange/d/<token>` |
+| `download` (fetcher) | always available (outbound HTTP) |
+| `upload` (receiver) | `config.transport == "http"` — needs to host `PUT|POST /file-exchange/u/<token>` |
+| `upload` (sender) | always available (outbound HTTP) |
+
+Algorithm:
+
+1. For each role in `roles`, compute the set of transports the deployment can satisfy.
+2. Drop any role whose resulting transport set is empty (the deployment cannot play that role at all).
+3. If the post-gate role set is empty, **do not advertise the capability** — `nl.liesdonk.file-exchange` is simply absent from `experimental_capabilities`. Log at INFO: `file-exchange: no satisfiable transport for any declared role — capability not advertised`.
+4. Otherwise, write the gated `{role: [transports…]}` map into the `nl.liesdonk.file-exchange` block exactly as the spec requires (§5).
+5. Auto-mount HTTP routes iff `provider+download` or `receiver+upload` survives the gate (the stdio-only case skips this).
+
+This makes the call effectively zero-config for downstream — `register_file_exchange_capability(server, config, kv_store=…)` does the right thing in every deployment. A stdio server with volumes configured advertises filesystem-only. An HTTP server without volumes advertises HTTPS-only. An HTTP server with volumes advertises both, role-by-role. A stdio server with no volumes advertises nothing.
+
+#### Other behaviour
+
 - The `kv_store` parameter is the namespaced store from the existing `build_kv_store` factory. Internal sub-keyspaces: `tokens:<token>` and `intake:<artifact_id>` via `PrefixCollectionsWrapper`.
-- **Fails fast at registration** when declared transports are unsatisfiable in the current deployment: `filesystem` declared but `_FILE_EXCHANGE_VOLUMES` empty → `ConfigurationError`; `download`/`upload` declared but the FastMCP server has no HTTP app (stdio-only) → `ConfigurationError`. This is preferred over a silent runtime skip-on-selection for declared roles, because mis-declared capability blocks would mislead peers' selection algorithms.
+- `config` extends with new file-exchange fields (see §5 below); the call reads them rather than env-vars directly, matching the existing pvl-core pattern (`build_kv_store`, `build_oidc_proxy_auth`).
 
 ### Descriptor minting (producer side)
 
@@ -174,19 +198,29 @@ Public symbols are re-exported from `fastmcp_pvl_core/__init__.py`. The `_file_e
 
 ## 5. Operator configuration
 
-All operator-side concerns are environment variables (per pvl-core convention; not constructor kwargs). The `{PREFIX}` placeholder is the consuming server's env-prefix.
+All operator-side concerns are environment variables loaded into typed fields on `ServerConfig` (per pvl-core convention — `ServerConfig.from_env` is the single read point; downstream code touches `config.foo`, not `os.environ`). The `{PREFIX}` placeholder is the consuming server's env-prefix.
 
-| Variable | Required when | Meaning |
+| Variable | `ServerConfig` field | Meaning |
 |---|---|---|
-| `{PREFIX}_FILE_EXCHANGE_VOLUMES` | `filesystem` transport declared in any role | `<volume-id>=<local-mount-point>` mappings, comma-separated. Configures the `exchange://` resolver. |
-| `{PREFIX}_FILE_EXCHANGE_MAX_ARTIFACT_SIZE` | optional | Hard ceiling in bytes; enforced by fetchers/receivers, pre-checked by senders/providers. |
-| `{PREFIX}_FILE_EXCHANGE_HTTPS_ALLOW_LOOPBACK` | optional, dev only | `true`/`false` (default `false`). Disables SSRF guard for loopback addresses. |
-| `{PREFIX}_FILE_EXCHANGE_HTTPS_ALLOW_PRIVATE` | optional, dev only | Same shape, for RFC 1918 / link-local ranges. |
-| `{PREFIX}_FILE_EXCHANGE_CAPABILITY_URL_TTL_DEFAULT_S` | optional | Default `expiresAt` window for minted `download`/`upload` URLs (default: 3600s). |
-| `{PREFIX}_FILE_EXCHANGE_HTTPS_PUBLIC_BASE_URL` | when capability URLs are minted behind a reverse proxy with a different public hostname than what FastMCP computes | Overrides `compute_app_domain` for capability-URL construction. |
-| `{PREFIX}_KV_STORE_URL` | already required by `build_kv_store` | Selects the shared storage backend. File-exchange uses `namespace="file-exchange"`. |
+| `{PREFIX}_FILE_EXCHANGE_VOLUMES` | `file_exchange_volumes: str \| None` | `<volume-id>=<local-mount-point>` mappings, comma-separated. Parsed at registration time to gate `filesystem` transport availability per §3. |
+| `{PREFIX}_FILE_EXCHANGE_MAX_ARTIFACT_SIZE` | `file_exchange_max_artifact_size: int \| None` | Hard ceiling in bytes; enforced by fetchers/receivers, pre-checked by senders/providers. |
+| `{PREFIX}_FILE_EXCHANGE_HTTPS_ALLOW_LOOPBACK` | `file_exchange_https_allow_loopback: bool` | Dev-only; default `false`. Disables SSRF guard for loopback addresses. |
+| `{PREFIX}_FILE_EXCHANGE_HTTPS_ALLOW_PRIVATE` | `file_exchange_https_allow_private: bool` | Dev-only; same shape, for RFC 1918 / link-local ranges. |
+| `{PREFIX}_FILE_EXCHANGE_CAPABILITY_URL_TTL_DEFAULT_S` | `file_exchange_capability_url_ttl_default_s: int` | Default `expiresAt` window for minted `download`/`upload` URLs (default: 3600s). |
+| `{PREFIX}_FILE_EXCHANGE_HTTPS_PUBLIC_BASE_URL` | `file_exchange_https_public_base_url: str \| None` | Override for `compute_app_domain` for capability-URL construction (reverse-proxy case). |
+| `{PREFIX}_KV_STORE_URL` | `kv_store_url` (existing) | Selects the shared storage backend. File-exchange uses `namespace="file-exchange"`. |
+| `config.transport` (existing, set from `{PREFIX}_TRANSPORT`) | — | Whether the server hosts an HTTP app — gates `download`-as-provider and `upload`-as-receiver per §3. |
 
-The `_FILE_EXCHANGE_VOLUMES` parser is the single source of truth for the volume map. A party with no mapping for a referenced volume skips that descriptor during selection (§9).
+The volumes parser in `_transport_filesystem.py` is the single source of truth for the volume map; both directions (`provider` writing, `fetcher` reading) call it. A party with no mapping for a referenced volume skips that descriptor at selection time (§9), independent of the registration-time gate (which decides what to *advertise*).
+
+### What the gate means for operators
+
+A deployment can rotate its file-exchange surface without code changes — just env-vars:
+
+- Set `_FILE_EXCHANGE_VOLUMES=` (empty) + `_TRANSPORT=stdio` → no file-exchange capability advertised at all.
+- Set `_FILE_EXCHANGE_VOLUMES=vault-export=/mnt/exchange/vault` + `_TRANSPORT=stdio` → file-exchange advertised, filesystem-only.
+- Set `_FILE_EXCHANGE_VOLUMES=` (empty) + `_TRANSPORT=http` → file-exchange advertised, HTTPS-only (download for provider+fetcher, upload for receiver+sender).
+- Both set → both transports per role.
 
 ## 6. Transport mechanics
 
@@ -266,8 +300,8 @@ Eight items (including #122). Each PR runs the full `preflight-circus` skill loc
 
 The template propagates pvl-core API to every downstream via `copier update`. Template-side work:
 
-1. **Server-build scaffolding**: feature-gated `register_file_exchange_capability(…)` block (off by default; copier question `enable_file_exchange: bool = false`).
-2. **`copier.yml` questions**: `enable_file_exchange` and `file_exchange_default_roles`. Transport set per role is *not* a template-time decision — it's operator env-var.
+1. **Server-build scaffolding**: feature-gated `register_file_exchange_capability(server, config, kv_store=…)` block (off by default; copier question `enable_file_exchange: bool = false`). Note: no transport-set kwargs at the call site — they're derived from `config.file_exchange_volumes` and `config.transport` at registration, per §3.
+2. **`copier.yml` questions**: `enable_file_exchange` and `file_exchange_default_roles`. Transport availability per role is *not* a template-time decision — it's deployment-derived at registration time from `ServerConfig` + env-vars.
 3. **`.env.example` additions** when enabled — the env-vars from §5.
 4. **`docs/file-exchange-cookbook.md`** with two minimal worked examples (provider, receiver/processor). Documentation only, not committed as live tools.
 5. **`pyproject.toml` floor bump** to the pvl-core version that shipped the file-exchange APIs (after pvl-core issue F lands).


### PR DESCRIPTION
## Summary

Design doc and TDD implementation plan for adopting the external [`pvliesdonk/mcp-file-exchange-ext`](https://github.com/pvliesdonk/mcp-file-exchange-ext) v0.1 spec as pvl-core's shared, opinionated implementation. The cleanroom rewrite following [#117](https://github.com/pvliesdonk/fastmcp-pvl-core/pull/117) (full removal of the prior v0.2–v0.6 design).

## What lands

- `docs/superpowers/specs/2026-05-20-file-exchange-adoption-design.md` — 14 sections covering API surface, capability gating, module layout, operator config, transport mechanics (filesystem + HTTPS), schema vendoring + conformance, testing strategy, Tasks composition, phasing, template-repo impact, non-goals.
- `docs/superpowers/plans/2026-05-20-file-exchange-implementation.md` — bite-sized TDD plan covering Tasks A–G (closing #124 through #130).

## What's NOT in this PR

The implementation itself. Tasks A–G land as separate PRs after this design is approved, each closing its own filed issue. The build_kv_store prerequisite (#121) shipped in #122.

## Design highlights

- Top-level API surface follows the existing pvl-core idiom (`build_auth`, `register_server_info_tool`).
- Capability declaration is **deployment-derived**, not declared: pvl-core gates `filesystem` on `config.file_exchange_volumes` and `download`/`upload`-as-provider/receiver on `config.transport == "http"`. Stdio + no-volumes still advertises consumer roles (outbound HTTPS is always available); the all-empty case is a safety-net step.
- Operator concerns are env-vars feeding `ServerConfig` (per the existing pvl-core pattern); no override kwargs.
- HTTPS routes auto-mount via `FastMCP.custom_route` when producer-side HTTPS is advertised.
- SSRF guard pins the resolved IP at connection time (TLS SNI preserved); refuses non-`https`, cross-origin redirects, ambient credentials.
- Token store uses atomic per-key delete for single-use semantics; backed by the unified `build_kv_store` so Redis/etc. work transparently.
- Capability URLs are bearer credentials per spec §12 — logging discipline encoded: tokens never appear in full at any level; fingerprint `tok=<first-8>...` at DEBUG.

## Local review

Three rounds of `preflight-circus` against `BASE..HEAD`:

- **R1**: architectural drift, internal inconsistencies — fixed.
- **R2**: round-1 fix introduced new issues (compute_app_domain misuse, http_app misuse, premature intake recording, async/sync minter drift, partial PR #107 carryover). Per CLAUDE.md's "abandon-and-rewrite" discipline, the plan was wiped and re-derived from a clean slate using the round-2-refined design as authority and every prior finding as a "things to get right" checklist.
- **R3**: 5 substantive code-sample bugs in the freshly-written plan (CallToolResult import/fields, sweep async/await, digest format, SSRF pin propagation, mint-time path confinement) — all fixed in the final commit. ~5 cosmetic findings (e.g. `O_NOFOLLOW` defense-in-depth) accepted as TDD-during-implementation territory.

## Test plan

- [ ] Bot review (claude-review on push; gemini-code-assist on flip-to-ready per `.gemini/config.yaml`).
- [ ] CI green.
- [ ] Reviewer skim: design doc internal consistency + plan task structure.
- [ ] After merge: dispatch Task A (#124) in a parallel session/worktree per the plan's "Sequencing" section.

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)