### PR TITLE
feat: mechanism-agnostic artifact source/sink hook contracts (#142)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-file-exchange-142-hooks.md
+++ b/docs/superpowers/plans/2026-05-23-file-exchange-142-hooks.md
@@ -1,0 +1,468 @@
+# File-Exchange #142 — Artifact Source/Sink Hooks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Define the mechanism-agnostic `ArtifactSource` / `ArtifactSink` hook protocols downstream servers implement, plus a transport-agnostic `atomic_write` helper, plus a test that statically proves no transport name leaks into a hook signature.
+
+**Architecture:** Two `@runtime_checkable` `typing.Protocol` classes in a new `_file_exchange/_hooks.py`, each with one `async def` method over a single sync `BinaryIO`; an `atomic_write(target, source)` helper added to the existing filesystem-utilities module `_file_exchange/_paths.py`; both re-exported through `file_exchange.py` and the subpackage `__init__.py`. The transport (filesystem in #143, HTTP later) lives entirely behind the hooks.
+
+**Tech Stack:** Python 3.10+, `typing.Protocol`, `pytest` (`asyncio_mode = "auto"`), the existing `_file_exchange._wire.ArtifactMetadata`.
+
+**Design doc:** `docs/superpowers/specs/2026-05-23-file-exchange-142-hooks-design.md`
+
+---
+
+## File structure
+
+- **Create** `src/fastmcp_pvl_core/_file_exchange/_hooks.py` — the two Protocol contracts (`ArtifactSource`, `ArtifactSink`). Sole responsibility: the hook contracts.
+- **Modify** `src/fastmcp_pvl_core/_file_exchange/_paths.py` — add the `atomic_write` helper (co-located with the other filesystem utilities).
+- **Modify** `src/fastmcp_pvl_core/_file_exchange/__init__.py` and `src/fastmcp_pvl_core/file_exchange.py` — re-export `ArtifactSource`, `ArtifactSink`, `atomic_write`.
+- **Create** `tests/_file_exchange/test_hooks.py` — protocol behavior + the no-transport-name introspection guard.
+- **Modify** `tests/_file_exchange/test_paths.py` — `atomic_write` tests.
+- **Modify** `tests/test_file_exchange_namespace.py` — assert the three new symbols are exposed.
+
+Run the full local gate after each task: `uv run pytest -q && uv run ruff format --check . && uv run ruff check . && uv run mypy src`. The repo supports Python 3.10–3.13; if a change is version-sensitive, also run `uv run --python 3.13 pytest tests/_file_exchange -q`.
+
+---
+
+### Task 1: The two hook protocols
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_hooks.py`
+- Test: `tests/_file_exchange/test_hooks.py`
+
+- [ ] **Step 1: Write the failing tests** (`tests/_file_exchange/test_hooks.py`)
+
+```python
+"""Tests for the mechanism-agnostic artifact source/sink hook protocols."""
+
+from __future__ import annotations
+
+import asyncio
+from io import BytesIO
+
+from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+
+class _DummySource:
+    async def open_artifact(self, key):  # noqa: ANN001, ANN202
+        return BytesIO(b"hello"), ArtifactMetadata(name="a.bin")
+
+
+class _DummySink:
+    def __init__(self):
+        self.stored: bytes | None = None
+
+    async def store_artifact(self, artifact_id, metadata, stream):  # noqa: ANN001, ANN202
+        self.stored = stream.read()
+
+
+def test_source_runtime_checkable_matches_conforming():
+    assert isinstance(_DummySource(), ArtifactSource)
+
+
+def test_sink_runtime_checkable_matches_conforming():
+    assert isinstance(_DummySink(), ArtifactSink)
+
+
+def test_runtime_checkable_rejects_nonconforming():
+    assert not isinstance(object(), ArtifactSource)
+    assert not isinstance(object(), ArtifactSink)
+
+
+async def test_source_returns_stream_and_metadata():
+    stream, meta = await _DummySource().open_artifact("k")
+    assert stream.read() == b"hello"
+    assert meta.name == "a.bin"
+
+
+async def test_sink_reads_stream_and_returns_none():
+    sink = _DummySink()
+    result = await sink.store_artifact("id-1", ArtifactMetadata(name="x"), BytesIO(b"payload"))
+    assert result is None
+    assert sink.stored == b"payload"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/_file_exchange/test_hooks.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'fastmcp_pvl_core._file_exchange._hooks'`.
+
+- [ ] **Step 3: Create the protocols** (`src/fastmcp_pvl_core/_file_exchange/_hooks.py`)
+
+```python
+"""Mechanism-agnostic artifact byte-source / byte-sink hook protocols.
+
+Downstream servers implement these to produce and deposit artifact bytes.
+The transport that carries the bytes (a shared filesystem volume, an HTTPS
+download/upload, ...) lives entirely behind the hook and MUST NOT appear in
+its signature — a hook cannot tell which transport is in use. The two
+protocols are exact mirrors over one synchronous BinaryIO.
+"""
+
+from __future__ import annotations
+
+from typing import BinaryIO, Protocol, runtime_checkable
+
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+
+@runtime_checkable
+class ArtifactSource(Protocol):
+    """Downstream hook: produce the bytes for an artifact this server offers.
+
+    Mechanism-agnostic. pvl-core bridges this to whatever transport carries
+    the bytes; the transport never appears here.
+    """
+
+    async def open_artifact(self, key: str) -> tuple[BinaryIO, ArtifactMetadata]:
+        """Return a readable byte stream plus the metadata the server knows.
+
+        ``key`` is the server's own opaque identifier for the artifact it is
+        offering (a domain key, not a wire field). The caller (pvl-core)
+        reads the stream to completion and closes it, and computes/records
+        size + digest itself — so the returned ``ArtifactMetadata`` need
+        only carry what the server knows (e.g. name, mimeType). Raise on
+        failure.
+        """
+        ...
+
+
+@runtime_checkable
+class ArtifactSink(Protocol):
+    """Downstream hook: deposit the bytes for an artifact this server receives.
+
+    The exact mirror of :class:`ArtifactSource`. Mechanism-agnostic.
+    """
+
+    async def store_artifact(
+        self, artifact_id: str, metadata: ArtifactMetadata, stream: BinaryIO
+    ) -> None:
+        """Read ``stream`` to completion and deposit its bytes durably.
+
+        ``artifact_id`` is the wire id of the artifact being received (an
+        ``IntakeTicket.artifactId`` on the push side, or a
+        ``TransferHandle.artifact.id`` on the pull side). The caller
+        (pvl-core) owns ``stream`` — it may hand the sink a counting/hashing
+        wrapper so it can verify size + digest as the sink reads — so the
+        sink reads but does **not** close it. Return ``None`` on success;
+        raise on failure.
+        """
+        ...
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/_file_exchange/test_hooks.py -q`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_hooks.py tests/_file_exchange/test_hooks.py
+git commit -m "feat(_hooks): ArtifactSource/ArtifactSink mechanism-agnostic hook protocols"
+```
+
+---
+
+### Task 2: No-transport-name introspection guard
+
+The headline #142 deliverable: a test that statically proves no transport/mechanism name leaks into any hook signature, with a negative control proving the check has teeth. It iterates the Protocol classes *defined in* `_hooks.py` so a future hook is auto-covered.
+
+**Files:**
+- Modify: `tests/_file_exchange/test_hooks.py`
+
+- [ ] **Step 1: Add the introspection guard tests** (append to `tests/_file_exchange/test_hooks.py`)
+
+```python
+import inspect
+
+import pytest
+
+from fastmcp_pvl_core._file_exchange import _hooks
+
+# Transport / mechanism names that must never appear in a hook signature.
+_FORBIDDEN_TOKENS = (
+    "filesystem",
+    "download",
+    "upload",
+    "http",
+    "https",
+    "exchange",
+    "url",
+    "volume",
+)
+
+# Protocol classes defined in _hooks (not imported ones like ArtifactMetadata):
+_HOOK_PROTOCOLS = [
+    obj
+    for _name, obj in inspect.getmembers(_hooks, inspect.isclass)
+    if obj.__module__ == _hooks.__name__
+]
+
+
+def _signature_tokens(method) -> list[str]:  # noqa: ANN001
+    """Param names + annotation reprs + return annotation, as strings."""
+    sig = inspect.signature(method)
+    tokens: list[str] = []
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        tokens.append(name)
+        tokens.append(str(param.annotation))
+    tokens.append(str(sig.return_annotation))
+    return tokens
+
+
+def _public_methods(cls):  # noqa: ANN001, ANN202
+    return [
+        m
+        for name, m in inspect.getmembers(cls, inspect.isfunction)
+        if not name.startswith("_")
+    ]
+
+
+def test_hook_protocols_discovered():
+    # Guard the guard: if discovery breaks (0 protocols), the test below
+    # would pass vacuously. Pin that both hooks are found.
+    names = {p.__name__ for p in _HOOK_PROTOCOLS}
+    assert names == {"ArtifactSource", "ArtifactSink"}
+
+
+@pytest.mark.parametrize("proto", _HOOK_PROTOCOLS, ids=lambda p: p.__name__)
+def test_no_transport_name_in_hook_signatures(proto):
+    for method in _public_methods(proto):
+        for token in _signature_tokens(method):
+            low = token.lower()
+            for forbidden in _FORBIDDEN_TOKENS:
+                assert forbidden not in low, (
+                    f"{proto.__name__}.{method.__name__}: transport token "
+                    f"{forbidden!r} leaked into the signature ({token!r})"
+                )
+
+
+def test_introspection_guard_has_teeth():
+    # Negative control: a signature carrying a transport token is detectable
+    # by the same token extraction, so a real leak could not pass silently.
+    def bad(self, http_url: str) -> None: ...  # noqa: ANN001
+
+    tokens = [t.lower() for t in _signature_tokens(bad)]
+    assert any("http" in t for t in tokens)
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `uv run pytest tests/_file_exchange/test_hooks.py -q`
+Expected: PASS — `test_hook_protocols_discovered`, both parametrized `test_no_transport_name_in_hook_signatures[ArtifactSource]` / `[ArtifactSink]`, and `test_introspection_guard_has_teeth` all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/_file_exchange/test_hooks.py
+git commit -m "test(_hooks): static no-transport-name guard for hook signatures (+ negative control)"
+```
+
+---
+
+### Task 3: `atomic_write` helper
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_paths.py`
+- Test: `tests/_file_exchange/test_paths.py`
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/_file_exchange/test_paths.py`)
+
+```python
+# --- atomic_write ---
+
+
+def test_atomic_write_writes_content(tmp_path):
+    target = tmp_path / "out.bin"
+    from io import BytesIO
+
+    atomic_write(target, BytesIO(b"hello"))
+    assert target.read_bytes() == b"hello"
+
+
+def test_atomic_write_overwrites_existing(tmp_path):
+    target = tmp_path / "out.bin"
+    target.write_bytes(b"old")
+    from io import BytesIO
+
+    atomic_write(target, BytesIO(b"new"))
+    assert target.read_bytes() == b"new"
+
+
+def test_atomic_write_cleans_up_and_leaves_target_absent_on_source_error(tmp_path):
+    class _Boom:
+        def read(self, *_a):
+            raise RuntimeError("boom")
+
+    target = tmp_path / "out.bin"
+    with pytest.raises(RuntimeError, match="boom"):
+        atomic_write(target, _Boom())
+    assert not target.exists()
+    # no temp file left behind in the directory
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_atomic_write_does_not_clobber_existing_on_source_error(tmp_path):
+    target = tmp_path / "out.bin"
+    target.write_bytes(b"keep")
+
+    class _Boom:
+        def read(self, *_a):
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        atomic_write(target, _Boom())
+    assert target.read_bytes() == b"keep"
+    assert list(tmp_path.iterdir()) == [target]
+
+
+def test_atomic_write_requires_existing_parent(tmp_path):
+    from io import BytesIO
+
+    target = tmp_path / "missing" / "out.bin"
+    with pytest.raises(FileNotFoundError):
+        atomic_write(target, BytesIO(b"x"))
+```
+
+Add `atomic_write` to the existing top-of-file import in `tests/_file_exchange/test_paths.py`:
+
+```python
+from fastmcp_pvl_core._file_exchange._paths import (
+    _parse_fs_uri,
+    _parse_volume_map,
+    atomic_write,
+    canonicalize_and_confine,
+    load_volume_map,
+    resolve_filesystem_uri,
+)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/_file_exchange/test_paths.py -k atomic_write -q`
+Expected: FAIL — `ImportError: cannot import name 'atomic_write'`.
+
+- [ ] **Step 3: Add the helper** (`src/fastmcp_pvl_core/_file_exchange/_paths.py`)
+
+Extend the imports at the top of the module:
+
+```python
+import contextlib
+import logging
+import os
+import shutil
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import BinaryIO, Literal
+from urllib.parse import urlsplit
+```
+
+(Keep the existing `from fastmcp_pvl_core._env import env` / `from fastmcp_pvl_core._errors import ConfigurationError` lines.)
+
+Add the helper (place it after `canonicalize_and_confine`, before `resolve_filesystem_uri`):
+
+```python
+def atomic_write(target: Path, source: BinaryIO) -> None:
+    """Write ``source``'s bytes to ``target`` atomically.
+
+    Streams into a temp file in ``target``'s own directory (so the final
+    ``os.replace`` is a same-filesystem atomic rename), flushes + fsyncs it,
+    then ``os.replace``s it into place — a concurrent reader never observes
+    a partial file (§10.1.3 "made visible atomically: write to a temporary
+    path, then rename into place"). The parent directory must already exist.
+    On any error the temp file is removed, leaving ``target`` untouched.
+
+    Sync (pure file I/O); an async transport hook runs it via
+    ``asyncio.to_thread`` so it never blocks the event loop.
+    """
+    target = Path(target)
+    fd, tmp_name = tempfile.mkstemp(dir=target.parent)
+    try:
+        with os.fdopen(fd, "wb") as tmp:
+            shutil.copyfileobj(source, tmp)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp_name, target)
+    except BaseException:
+        # copy/fsync/replace failed — the temp may still exist (it is only
+        # gone after a successful os.replace). Remove it so no partial
+        # deposit and no orphan temp is left; target is untouched.
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp_name)
+        raise
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/_file_exchange/test_paths.py -k atomic_write -q`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_paths.py tests/_file_exchange/test_paths.py
+git commit -m "feat(_paths): atomic_write helper (temp + fsync + os.replace), fail-safe"
+```
+
+---
+
+### Task 4: Public re-exports + namespace test
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/__init__.py`
+- Modify: `src/fastmcp_pvl_core/file_exchange.py`
+- Test: `tests/test_file_exchange_namespace.py`
+
+- [ ] **Step 1: Write the failing namespace test** (append to `tests/test_file_exchange_namespace.py`)
+
+```python
+def test_hook_helpers_exposed():
+    from fastmcp_pvl_core import file_exchange
+
+    # Protocols are classes; atomic_write is callable.
+    assert isinstance(file_exchange.ArtifactSource, type)
+    assert isinstance(file_exchange.ArtifactSink, type)
+    assert callable(file_exchange.atomic_write)
+    for name in ("ArtifactSource", "ArtifactSink", "atomic_write"):
+        assert name in file_exchange.__all__
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_file_exchange_namespace.py::test_hook_helpers_exposed -q`
+Expected: FAIL — `AttributeError: module 'fastmcp_pvl_core.file_exchange' has no attribute 'ArtifactSource'`.
+
+- [ ] **Step 3: Add the re-exports**
+
+In `src/fastmcp_pvl_core/_file_exchange/__init__.py`: import `ArtifactSink`, `ArtifactSource` from `._hooks` and `atomic_write` from `._paths` (the module already imports other names from `._paths`; add `atomic_write` to that import, keeping it alphabetical), and add `"ArtifactSink"`, `"ArtifactSource"`, `"atomic_write"` to `__all__` in alphabetical position.
+
+In `src/fastmcp_pvl_core/file_exchange.py`: mirror the same three imports and the same three `__all__` entries, keeping both lists alphabetical and identical in membership to the subpackage `__init__.py` (the established convention).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_file_exchange_namespace.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Full gate + commit**
+
+Run: `uv run pytest -q && uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: all green.
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/__init__.py src/fastmcp_pvl_core/file_exchange.py tests/test_file_exchange_namespace.py
+git commit -m "feat(file_exchange): expose ArtifactSource/ArtifactSink/atomic_write in public namespace"
+```
+
+---
+
+## Notes for the implementer
+
+- **`from __future__ import annotations`** is required at the top of `_hooks.py` and `test_hooks.py` — it makes the introspection guard read string annotations directly (no runtime resolution), and matches the repo's style.
+- **Do not** add new exception types, a `describe()` method, a `DepositResult`, or any transport-aware branching — the contracts are deliberately minimal (YAGNI; see the design doc's error-handling and shape notes).
+- **mypy:** the `Protocol` methods with `...` bodies and the `tuple[BinaryIO, ArtifactMetadata]` return type are valid; if mypy flags an unused-annotation or self-type issue, do not "fix" it by widening the signature — the signatures are load-bearing for the introspection guard.

--- a/docs/superpowers/specs/2026-05-23-file-exchange-142-hooks-design.md
+++ b/docs/superpowers/specs/2026-05-23-file-exchange-142-hooks-design.md
@@ -1,0 +1,188 @@
+# File-Exchange #142 — mechanism-agnostic byte-source / byte-sink hook contracts
+
+> **Status:** Contemporaneous design record for issue #142 (4/10 of EPIC
+> #138). The implementation in the same PR is the source of truth; this
+> captures the shape agreed before implementation. This is **not** a wire
+> spec — #142 is pvl-core's own internal abstraction, governed by
+> `CLAUDE.md` and the project's framing principle, not by
+> `mcp-file-exchange-ext`. No `docs/specs/` wire-format file is touched.
+
+**Goal:** Define the two public hook protocols downstream servers implement
+to produce and deposit artifact bytes — `ArtifactSource` and
+`ArtifactSink` — plus a transport-agnostic atomic write-then-rename helper,
+and a test that statically proves no transport name leaks into a hook
+signature.
+
+## The load-bearing principle: hooks are mechanism-agnostic
+
+A downstream server implements these hooks to answer one domain question
+each: *"where do the bytes for an artifact I offer come from?"* and *"where
+do the bytes for an artifact I receive go?"* The **transport** that carries
+those bytes between two parties — a shared filesystem volume (#143), an
+HTTPS download/upload (#145/#146) — lives **entirely behind** the hook and
+**MUST NOT** appear in its signature. A hook cannot tell which transport is
+in use; everything pvl-core does to bridge a hook to a transport (staging a
+volume file, serving an HTTP route, spooling a body, computing a digest) is
+pvl-core-internal.
+
+The two hooks are exact mirrors over a single byte carrier.
+
+## Byte carrier and sync/async shape (decided up front)
+
+- **Byte carrier:** one type — a synchronous `typing.BinaryIO`. Streaming
+  (not in-memory `bytes`) so large artifacts never fully materialise, and so
+  pvl-core can compute size+digest while copying.
+- **Hook methods:** `async def`. pvl-core's data plane is async (FastMCP);
+  always-await is the clean shape and keeps the protocol typing simple. This
+  is a contract-cleanliness choice for an async-native server, **not**
+  transport projection — the byte payload itself stays a *sync* `BinaryIO`;
+  only the hook *method* is async. (This supersedes an earlier
+  sync-or-async stance from the now-removed v0.x design.)
+
+## The two contracts
+
+New module `src/fastmcp_pvl_core/_file_exchange/_hooks.py`.
+
+```python
+@runtime_checkable
+class ArtifactSource(Protocol):
+    """Downstream hook: produce the bytes for an artifact this server offers.
+
+    Mechanism-agnostic. pvl-core bridges this to whatever transport carries
+    the bytes; the transport never appears here.
+    """
+
+    async def open_artifact(self, key: str) -> tuple[BinaryIO, ArtifactMetadata]:
+        """Return a readable byte stream plus the metadata the server knows.
+
+        ``key`` is the server's own opaque identifier for the artifact it is
+        offering (a domain key, not a wire field). The caller (pvl-core)
+        reads the stream to completion and closes it, and computes/records
+        size+digest itself — so the returned ``ArtifactMetadata`` need only
+        carry what the server knows (e.g. name, mimeType). Raise on failure.
+        """
+
+
+@runtime_checkable
+class ArtifactSink(Protocol):
+    """Downstream hook: deposit the bytes for an artifact this server receives.
+
+    The exact mirror of :class:`ArtifactSource`. Mechanism-agnostic.
+    """
+
+    async def store_artifact(
+        self, artifact_id: str, metadata: ArtifactMetadata, stream: BinaryIO
+    ) -> None:
+        """Read ``stream`` to completion and deposit its bytes durably.
+
+        ``artifact_id`` is the wire id of the artifact being received (an
+        ``IntakeTicket.artifactId`` on the push side, or a
+        ``TransferHandle.artifact.id`` on the pull side). The caller
+        (pvl-core) owns ``stream`` — it may hand the sink a counting/hashing
+        wrapper so it can verify size+digest as the sink reads — so the sink
+        reads but does **not** close it. Return ``None`` on success; raise
+        on failure.
+        """
+```
+
+**Notes on the shape:**
+
+- **Mirrors over one stream.** Source produces `(stream, metadata)`; sink
+  consumes `(id, metadata, stream)`. The source returns metadata *with* the
+  stream because pvl-core uses both together at provide-time (copy bytes
+  into the transport while computing size+digest for the handle), so no
+  separate `describe()` method is needed.
+- **Naming asymmetry is intentional.** The source takes the server's own
+  *domain* `key`; the sink takes the *wire* `artifact_id`. They are
+  different namespaces, and the names say so.
+- **Stream ownership.** Source: pvl-core reads and **closes** the returned
+  stream. Sink: pvl-core owns the passed stream (the sink reads, does not
+  close); pvl-core may wrap it to compute size+digest.
+- **size/digest are pvl-core's job**, computed once via stream-wrapping —
+  not reimplemented per downstream or per transport.
+
+## Atomic write-then-rename helper
+
+A single-purpose utility for any transport that deposits bytes to a local
+path (the filesystem sink in #143; a download cache later). Added to
+`_paths.py` — the existing filesystem-utilities home
+(`canonicalize_and_confine`, URI resolution) — to co-locate filesystem
+operations rather than spawn a one-function module.
+
+```python
+def atomic_write(target: Path, source: BinaryIO) -> None:
+    """Write ``source``'s bytes to ``target`` atomically.
+
+    Streams into a temp file in ``target``'s own directory (so the final
+    ``os.replace`` is a same-filesystem atomic rename), flushes +
+    ``os.fsync``es the temp file, then ``os.replace``s it into place — so a
+    concurrent reader never observes a partial file (§10.1.3 "made visible
+    atomically: write to a temporary path, then rename into place"). The
+    parent directory must already exist. On any error the temp file is
+    removed, leaving ``target`` untouched.
+
+    Sync (pure file I/O); an async transport hook runs it via
+    ``asyncio.to_thread`` so it never blocks the event loop.
+    """
+```
+
+- **Behavior:** `NamedTemporaryFile(dir=target.parent, delete=False)` →
+  `shutil.copyfileobj(source, tmp)` → `tmp.flush()` +
+  `os.fsync(tmp.fileno())` → `os.replace(tmp.name, target)`; a
+  `try/except` unlinks the temp on any failure and re-raises.
+- **Directory-fsync** (crash-durability of the rename itself) is a
+  reasonable hardening left to the implementation plan; the spec mandates
+  atomic *visibility*, which `os.replace` provides.
+- **Single purpose:** it does **not** compute size/digest — that stays in
+  pvl-core's stream-wrapping, so digest logic is not duplicated per
+  transport.
+
+## Error handling
+
+The hooks **raise on failure** (any exception). #142 deliberately defines
+**no new exception types**: mapping a hook exception to the §13
+`TransferError` envelope is the data plane's responsibility (#143+), and
+`_errors.py` already owns that mapping. `atomic_write` is fail-safe — it
+cleans up the temp file and re-raises, never leaving a partial deposit.
+
+## Testing (`tests/_file_exchange/test_hooks.py`)
+
+1. **No-transport-name introspection test (the headline guard).** Iterate
+   the `Protocol` classes defined in `_hooks.py` (so a *future* hook is
+   auto-covered, not just today's two); for each public async method,
+   collect parameter names, each parameter's annotation repr, and the
+   return annotation; assert none contains a forbidden token
+   (case-insensitive): `filesystem`, `download`, `upload`, `http`, `https`,
+   `exchange`, `url`, `volume`. A **negative control** — checking a
+   deliberately-misnamed dummy signature (e.g. a `http_url` parameter) does
+   fire — proves the check can't silently pass.
+2. **`@runtime_checkable` behavior.** A conforming dummy `isinstance`-matches
+   each Protocol; a non-conforming object does not.
+3. **Implementability round-trip.** A dummy `ArtifactSource` returns a
+   `BytesIO` + `ArtifactMetadata`; a dummy `ArtifactSink` reads a stream and
+   records its bytes — both awaited — proving the async contracts are
+   implementable as written.
+4. **`atomic_write`.** Correct content end-to-end; on a source that raises
+   mid-copy, the temp is cleaned up and `target` is absent; parent-must-exist.
+5. **Namespace re-export.** `ArtifactSource`, `ArtifactSink`, `atomic_write`
+   reachable via `fastmcp_pvl_core.file_exchange` (the established
+   convention; both `__all__` lists updated, mirrored and alphabetical).
+
+## Public surface
+
+Re-exported via `src/fastmcp_pvl_core/file_exchange.py` and the subpackage
+`__init__.py` (both `__all__`s updated):
+
+- `ArtifactSource` — Protocol
+- `ArtifactSink` — Protocol
+- `atomic_write` — helper
+
+## References
+
+- EPIC #138 (adopt mcp-file-exchange-ext v0.1); this is 4/10.
+- #143 (5/10) — the first consumer: binds these hooks to the filesystem
+  transport and uses `atomic_write` for the sink.
+- `CLAUDE.md` — "Hooks expose domain-specific behaviour only"; the framing
+  principle that governs this abstraction.
+- Wire types consumed: `ArtifactMetadata` (§7.1) from
+  `_file_exchange/_wire.py`. This document is **not** a wire spec.

--- a/src/fastmcp_pvl_core/_file_exchange/__init__.py
+++ b/src/fastmcp_pvl_core/_file_exchange/__init__.py
@@ -19,8 +19,13 @@ from fastmcp_pvl_core._file_exchange._codes import (
 from fastmcp_pvl_core._file_exchange._errors import (
     build_file_exchange_error,
 )
+from fastmcp_pvl_core._file_exchange._hooks import (
+    ArtifactSink,
+    ArtifactSource,
+)
 from fastmcp_pvl_core._file_exchange._paths import (
     VolumeMap,
+    atomic_write,
     canonicalize_and_confine,
     load_volume_map,
     resolve_filesystem_uri,
@@ -62,6 +67,8 @@ from fastmcp_pvl_core._file_exchange._wire import (
 
 __all__ = [
     "ArtifactConstraints",
+    "ArtifactSink",
+    "ArtifactSource",
     "ArtifactMetadata",
     "DownloadSource",
     "FileExchangeCapability",
@@ -87,6 +94,7 @@ __all__ = [
     "VERSION_PATTERN",
     "VolumeMap",
     "WireFormatError",
+    "atomic_write",
     "build_file_exchange_error",
     "canonicalize_and_confine",
     "capability_declaration",

--- a/src/fastmcp_pvl_core/_file_exchange/__init__.py
+++ b/src/fastmcp_pvl_core/_file_exchange/__init__.py
@@ -67,9 +67,9 @@ from fastmcp_pvl_core._file_exchange._wire import (
 
 __all__ = [
     "ArtifactConstraints",
+    "ArtifactMetadata",
     "ArtifactSink",
     "ArtifactSource",
-    "ArtifactMetadata",
     "DownloadSource",
     "FileExchangeCapability",
     "FilesystemSink",

--- a/src/fastmcp_pvl_core/_file_exchange/_hooks.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_hooks.py
@@ -1,0 +1,58 @@
+"""Mechanism-agnostic artifact byte-source / byte-sink hook protocols.
+
+Downstream servers implement these to produce and deposit artifact bytes.
+The transport that carries the bytes (a shared filesystem volume, an HTTPS
+download/upload, ...) lives entirely behind the hook and MUST NOT appear in
+its signature — a hook cannot tell which transport is in use. The two
+protocols are exact mirrors over one synchronous BinaryIO.
+"""
+
+from __future__ import annotations
+
+from typing import BinaryIO, Protocol, runtime_checkable
+
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+
+@runtime_checkable
+class ArtifactSource(Protocol):
+    """Downstream hook: produce the bytes for an artifact this server offers.
+
+    Mechanism-agnostic. pvl-core bridges this to whatever transport carries
+    the bytes; the transport never appears here.
+    """
+
+    async def open_artifact(self, key: str) -> tuple[BinaryIO, ArtifactMetadata]:
+        """Return a readable byte stream plus the metadata the server knows.
+
+        ``key`` is the server's own opaque identifier for the artifact it is
+        offering (a domain key, not a wire field). The caller (pvl-core)
+        reads the stream to completion and closes it, and computes/records
+        size + digest itself — so the returned ``ArtifactMetadata`` need
+        only carry what the server knows (e.g. name, mimeType). Raise on
+        failure.
+        """
+        ...
+
+
+@runtime_checkable
+class ArtifactSink(Protocol):
+    """Downstream hook: deposit the bytes for an artifact this server receives.
+
+    The exact mirror of :class:`ArtifactSource`. Mechanism-agnostic.
+    """
+
+    async def store_artifact(
+        self, artifact_id: str, metadata: ArtifactMetadata, stream: BinaryIO
+    ) -> None:
+        """Read ``stream`` to completion and deposit its bytes durably.
+
+        ``artifact_id`` is the wire id of the artifact being received (an
+        ``IntakeTicket.artifactId`` on the push side, or a
+        ``TransferHandle.artifact.id`` on the pull side). The caller
+        (pvl-core) owns ``stream`` — it may hand the sink a counting/hashing
+        wrapper so it can verify size + digest as the sink reads — so the
+        sink reads but does **not** close it. Return ``None`` on success;
+        raise on failure.
+        """
+        ...

--- a/src/fastmcp_pvl_core/_file_exchange/_hooks.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_hooks.py
@@ -26,8 +26,10 @@ class ArtifactSource(Protocol):
         """Return a readable byte stream plus the metadata the server knows.
 
         ``key`` is the server's own opaque identifier for the artifact it is
-        offering (a domain key, not a wire field). The caller (pvl-core)
-        reads the stream to completion and closes it, and computes/records
+        offering (a domain key, not a wire field). The returned stream MUST be
+        positioned at the first byte to transfer (typically the start): the
+        caller reads it from its *current* position to completion and does not
+        seek. The caller (pvl-core) closes the stream and computes/records
         size + digest itself — so the returned ``ArtifactMetadata`` need
         only carry what the server knows (e.g. name, mimeType). Raise on
         failure.

--- a/src/fastmcp_pvl_core/_file_exchange/_paths.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_paths.py
@@ -141,8 +141,8 @@ def atomic_write(target: Path, source: BinaryIO) -> None:
     path, then rename into place"). The parent directory must already exist.
     On any error the temp file is removed, leaving ``target`` untouched.
 
-    Sync (pure file I/O); an async transport hook runs it via
-    ``asyncio.to_thread`` so it never blocks the event loop.
+    Sync, blocking file I/O — async callers should run it via
+    ``asyncio.to_thread`` so it does not block the event loop.
     """
     target = Path(target)
     fd, tmp_name = tempfile.mkstemp(dir=target.parent)

--- a/src/fastmcp_pvl_core/_file_exchange/_paths.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_paths.py
@@ -149,15 +149,23 @@ def atomic_write(target: Path, source: BinaryIO) -> None:
     fd, tmp_name = tempfile.mkstemp(dir=target.parent)
     try:
         with os.fdopen(fd, "wb") as tmp:
+            fd = -1  # fdopen took ownership; its __exit__ closes the fd now
             shutil.copyfileobj(source, tmp)
             tmp.flush()
             os.fsync(tmp.fileno())
         os.replace(tmp_name, target)
     except BaseException:
-        # copy/fsync/replace failed — the temp may still exist (it is only
-        # gone after a successful os.replace). Remove it so no partial
-        # deposit and no orphan temp is left; target is untouched.
-        # Suppress any OSError so a cleanup failure can't mask the original error.
+        # fdopen/copy/fsync/replace failed. If os.fdopen itself raised, the raw
+        # fd was never wrapped, so close it here (fd != -1); once fdopen
+        # succeeded the with-block already closed it, so closing again would
+        # risk killing an unrelated fd that reused the number. The temp may
+        # still exist (only gone after a successful os.replace), so remove it —
+        # no partial deposit, no orphan temp; target is untouched. Suppress
+        # OSError on each cleanup step so a cleanup failure can't mask the
+        # original error.
+        if fd != -1:
+            with contextlib.suppress(OSError):
+                os.close(fd)
         with contextlib.suppress(OSError):
             os.unlink(tmp_name)
         raise

--- a/src/fastmcp_pvl_core/_file_exchange/_paths.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_paths.py
@@ -148,6 +148,13 @@ def atomic_write(target: Path, source: BinaryIO) -> None:
     path, then rename into place"). The parent directory must already exist.
     On any error the temp file is removed, leaving ``target`` untouched.
 
+    The deposited file carries ``tempfile.mkstemp``'s ``0o600`` (owner-only)
+    mode, which ``os.replace`` preserves — overwriting an existing ``target``
+    also resets it to ``0o600``. A caller needing broader access (e.g. a
+    different-uid reader on a shared volume) must ``chmod`` ``target`` itself;
+    the deposit-permission policy for the filesystem sink is the consumer's to
+    define (#143, tracked in #155), not this primitive's.
+
     Sync, blocking file I/O — async callers should run it via
     ``asyncio.to_thread`` so it does not block the event loop.
     """

--- a/src/fastmcp_pvl_core/_file_exchange/_paths.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_paths.py
@@ -17,10 +17,14 @@ only the volume id (``exchange://``) or nothing identifying (``file://``)
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import os
+import shutil
+import tempfile
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Literal
+from typing import BinaryIO, Literal
 from urllib.parse import urlsplit
 
 from fastmcp_pvl_core._env import env
@@ -125,6 +129,36 @@ def canonicalize_and_confine(candidate: Path | str, root: Path | str) -> Path | 
     if resolved_candidate.is_relative_to(resolved_root):
         return resolved_candidate
     return None
+
+
+def atomic_write(target: Path, source: BinaryIO) -> None:
+    """Write ``source``'s bytes to ``target`` atomically.
+
+    Streams into a temp file in ``target``'s own directory (so the final
+    ``os.replace`` is a same-filesystem atomic rename), flushes + fsyncs it,
+    then ``os.replace``s it into place — a concurrent reader never observes
+    a partial file (§10.1.3 "made visible atomically: write to a temporary
+    path, then rename into place"). The parent directory must already exist.
+    On any error the temp file is removed, leaving ``target`` untouched.
+
+    Sync (pure file I/O); an async transport hook runs it via
+    ``asyncio.to_thread`` so it never blocks the event loop.
+    """
+    target = Path(target)
+    fd, tmp_name = tempfile.mkstemp(dir=target.parent)
+    try:
+        with os.fdopen(fd, "wb") as tmp:
+            shutil.copyfileobj(source, tmp)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp_name, target)
+    except BaseException:
+        # copy/fsync/replace failed — the temp may still exist (it is only
+        # gone after a successful os.replace). Remove it so no partial
+        # deposit and no orphan temp is left; target is untouched.
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp_name)
+        raise
 
 
 def resolve_filesystem_uri(uri: str, *, volume_map: VolumeMap) -> Path | None:

--- a/src/fastmcp_pvl_core/_file_exchange/_paths.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_paths.py
@@ -132,7 +132,7 @@ def canonicalize_and_confine(candidate: Path | str, root: Path | str) -> Path | 
     return None
 
 
-def atomic_write(target: Path, source: BinaryIO) -> None:
+def atomic_write(target: Path | str, source: BinaryIO) -> None:
     """Write ``source``'s bytes to ``target`` atomically.
 
     Reads ``source`` from its *current* position to EOF — it does not seek, so

--- a/src/fastmcp_pvl_core/_file_exchange/_paths.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_paths.py
@@ -135,6 +135,12 @@ def canonicalize_and_confine(candidate: Path | str, root: Path | str) -> Path | 
 def atomic_write(target: Path, source: BinaryIO) -> None:
     """Write ``source``'s bytes to ``target`` atomically.
 
+    Reads ``source`` from its *current* position to EOF — it does not seek, so
+    a non-zero start position transfers only the bytes from there on (and an
+    already-exhausted stream writes an empty file). Callers pass a stream
+    positioned at the first byte to write; this keeps non-seekable streams
+    (pipes, sockets) usable.
+
     Streams into a temp file in ``target``'s own directory (so the final
     ``os.replace`` is a same-filesystem atomic rename), flushes + fsyncs it,
     then ``os.replace``s it into place — a concurrent reader never observes

--- a/src/fastmcp_pvl_core/_file_exchange/_paths.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_paths.py
@@ -8,6 +8,7 @@ Security-critical. Turns an untrusted ``filesystem`` descriptor ``uri``
 - :func:`resolve_filesystem_uri` — parse ``exchange://`` / ``file://``,
   look up the volume, confine.
 - :func:`load_volume_map` — env-driven volume-to-mount-point config.
+- :func:`atomic_write` — atomic write-then-rename of a stream to a local path.
 
 All non-usable outcomes return ``None`` (the §9 "skip this descriptor"
 signal); a confinement failure additionally logs a ``WARNING`` carrying
@@ -156,7 +157,8 @@ def atomic_write(target: Path, source: BinaryIO) -> None:
         # copy/fsync/replace failed — the temp may still exist (it is only
         # gone after a successful os.replace). Remove it so no partial
         # deposit and no orphan temp is left; target is untouched.
-        with contextlib.suppress(FileNotFoundError):
+        # Suppress any OSError so a cleanup failure can't mask the original error.
+        with contextlib.suppress(OSError):
             os.unlink(tmp_name)
         raise
 

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -59,9 +59,9 @@ from fastmcp_pvl_core._file_exchange import (
 
 __all__ = [
     "ArtifactConstraints",
+    "ArtifactMetadata",
     "ArtifactSink",
     "ArtifactSource",
-    "ArtifactMetadata",
     "DownloadSource",
     "FileExchangeCapability",
     "FilesystemSink",

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -25,6 +25,8 @@ from fastmcp_pvl_core._file_exchange import (
     VERSION_PATTERN,
     ArtifactConstraints,
     ArtifactMetadata,
+    ArtifactSink,
+    ArtifactSource,
     DownloadSource,
     FileExchangeCapability,
     FilesystemSink,
@@ -42,6 +44,7 @@ from fastmcp_pvl_core._file_exchange import (
     UploadSink,
     VolumeMap,
     WireFormatError,
+    atomic_write,
     build_file_exchange_error,
     canonicalize_and_confine,
     capability_declaration,
@@ -56,6 +59,8 @@ from fastmcp_pvl_core._file_exchange import (
 
 __all__ = [
     "ArtifactConstraints",
+    "ArtifactSink",
+    "ArtifactSource",
     "ArtifactMetadata",
     "DownloadSource",
     "FileExchangeCapability",
@@ -81,6 +86,7 @@ __all__ = [
     "VERSION_PATTERN",
     "VolumeMap",
     "WireFormatError",
+    "atomic_write",
     "build_file_exchange_error",
     "canonicalize_and_confine",
     "capability_declaration",

--- a/tests/_file_exchange/test_hooks.py
+++ b/tests/_file_exchange/test_hooks.py
@@ -1,0 +1,49 @@
+"""Tests for the mechanism-agnostic artifact source/sink hook protocols."""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+
+class _DummySource:
+    async def open_artifact(self, key):  # noqa: ANN001, ANN202
+        return BytesIO(b"hello"), ArtifactMetadata(name="a.bin")
+
+
+class _DummySink:
+    def __init__(self):
+        self.stored: bytes | None = None
+
+    async def store_artifact(self, artifact_id, metadata, stream):  # noqa: ANN001, ANN202
+        self.stored = stream.read()
+
+
+def test_source_runtime_checkable_matches_conforming():
+    assert isinstance(_DummySource(), ArtifactSource)
+
+
+def test_sink_runtime_checkable_matches_conforming():
+    assert isinstance(_DummySink(), ArtifactSink)
+
+
+def test_runtime_checkable_rejects_nonconforming():
+    assert not isinstance(object(), ArtifactSource)
+    assert not isinstance(object(), ArtifactSink)
+
+
+async def test_source_returns_stream_and_metadata():
+    stream, meta = await _DummySource().open_artifact("k")
+    assert stream.read() == b"hello"
+    assert meta.name == "a.bin"
+
+
+async def test_sink_reads_stream_and_returns_none():
+    sink = _DummySink()
+    result = await sink.store_artifact(
+        "id-1", ArtifactMetadata(name="x"), BytesIO(b"payload")
+    )
+    assert result is None
+    assert sink.stored == b"payload"

--- a/tests/_file_exchange/test_hooks.py
+++ b/tests/_file_exchange/test_hooks.py
@@ -103,7 +103,11 @@ def test_hook_protocols_discovered():
 
 @pytest.mark.parametrize("proto", _HOOK_PROTOCOLS, ids=lambda p: p.__name__)
 def test_no_transport_name_in_hook_signatures(proto):
-    for method in _public_methods(proto):
+    methods = _public_methods(proto)
+    # Guard the guard: a protocol with zero discovered methods would make the
+    # token scan below iterate zero times and pass vacuously.
+    assert methods, f"{proto.__name__}: no public methods found; guard is toothless"
+    for method in methods:
         for token in _signature_tokens(method):
             low = token.lower()
             for forbidden in _FORBIDDEN_TOKENS:

--- a/tests/_file_exchange/test_hooks.py
+++ b/tests/_file_exchange/test_hooks.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import inspect
 from io import BytesIO
 
+import pytest
+
+from fastmcp_pvl_core._file_exchange import _hooks
 from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
 from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
 
@@ -47,3 +51,72 @@ async def test_sink_reads_stream_and_returns_none():
     )
     assert result is None
     assert sink.stored == b"payload"
+
+
+# Transport / mechanism names that must never appear in a hook signature.
+_FORBIDDEN_TOKENS = (
+    "filesystem",
+    "download",
+    "upload",
+    "http",
+    "https",
+    "exchange",
+    "url",
+    "volume",
+)
+
+# Protocol classes defined in _hooks (not imported ones like ArtifactMetadata):
+_HOOK_PROTOCOLS = [
+    obj
+    for _name, obj in inspect.getmembers(_hooks, inspect.isclass)
+    if obj.__module__ == _hooks.__name__
+]
+
+
+def _signature_tokens(method) -> list[str]:  # noqa: ANN001
+    """Param names + annotation reprs + return annotation, as strings."""
+    sig = inspect.signature(method)
+    tokens: list[str] = []
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        tokens.append(name)
+        tokens.append(str(param.annotation))
+    tokens.append(str(sig.return_annotation))
+    return tokens
+
+
+def _public_methods(cls):  # noqa: ANN001, ANN202
+    return [
+        m
+        for name, m in inspect.getmembers(cls, inspect.isfunction)
+        if not name.startswith("_")
+    ]
+
+
+def test_hook_protocols_discovered():
+    # Guard the guard: if discovery breaks (0 protocols), the parametrized
+    # test below would pass vacuously. Pin that both hooks are found.
+    names = {p.__name__ for p in _HOOK_PROTOCOLS}
+    assert names == {"ArtifactSource", "ArtifactSink"}
+
+
+@pytest.mark.parametrize("proto", _HOOK_PROTOCOLS, ids=lambda p: p.__name__)
+def test_no_transport_name_in_hook_signatures(proto):
+    for method in _public_methods(proto):
+        for token in _signature_tokens(method):
+            low = token.lower()
+            for forbidden in _FORBIDDEN_TOKENS:
+                assert forbidden not in low, (
+                    f"{proto.__name__}.{method.__name__}: transport token "
+                    f"{forbidden!r} leaked into the signature ({token!r})"
+                )
+
+
+def test_introspection_guard_has_teeth():
+    # Negative control: a signature carrying a transport token is detectable
+    # by the same token extraction, so a real leak could not pass silently.
+    def bad(self, http_url: str) -> None: ...  # noqa: ANN001
+
+    tokens = [t.lower() for t in _signature_tokens(bad)]
+    assert any("http" in t for t in tokens)

--- a/tests/_file_exchange/test_paths.py
+++ b/tests/_file_exchange/test_paths.py
@@ -693,3 +693,36 @@ def test_atomic_write_requires_existing_parent(tmp_path):
     target = tmp_path / "missing" / "out.bin"
     with pytest.raises(FileNotFoundError):
         atomic_write(target, BytesIO(b"x"))
+
+
+def test_atomic_write_closes_fd_when_fdopen_fails(tmp_path, monkeypatch):
+    # If os.fdopen raises, the raw fd from mkstemp must still be closed (and the
+    # temp removed) — otherwise it leaks for the life of the process.
+    import tempfile as _tempfile
+    from io import BytesIO
+
+    captured: dict[str, int] = {}
+    real_mkstemp = _tempfile.mkstemp
+
+    def spy_mkstemp(*args, **kwargs):
+        fd, name = real_mkstemp(*args, **kwargs)
+        captured["fd"] = fd
+        return fd, name
+
+    monkeypatch.setattr(_tempfile, "mkstemp", spy_mkstemp)
+
+    def boom_fdopen(*_a, **_k):
+        raise OSError("fdopen failed")
+
+    monkeypatch.setattr(os, "fdopen", boom_fdopen)
+
+    target = tmp_path / "out.bin"
+    with pytest.raises(OSError, match="fdopen failed"):
+        atomic_write(target, BytesIO(b"x"))
+
+    # The captured fd must no longer be open (fstat raises on a closed fd),
+    # and no temp file or target may be left behind.
+    with pytest.raises(OSError):
+        os.fstat(captured["fd"])
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []

--- a/tests/_file_exchange/test_paths.py
+++ b/tests/_file_exchange/test_paths.py
@@ -15,6 +15,7 @@ from fastmcp_pvl_core import ConfigurationError
 from fastmcp_pvl_core._file_exchange._paths import (
     _parse_fs_uri,
     _parse_volume_map,
+    atomic_write,
     canonicalize_and_confine,
     load_volume_map,
     resolve_filesystem_uri,
@@ -638,3 +639,57 @@ def test_resolve_file_sibling_with_shared_prefix_returns_none(tmp_path):
     (archive / "secret").write_text("x")
     uri = "file://" + str(archive / "secret")
     assert resolve_filesystem_uri(uri, volume_map={"docs": docs}) is None
+
+
+# --- atomic_write ---
+
+
+def test_atomic_write_writes_content(tmp_path):
+    from io import BytesIO
+
+    target = tmp_path / "out.bin"
+    atomic_write(target, BytesIO(b"hello"))
+    assert target.read_bytes() == b"hello"
+
+
+def test_atomic_write_overwrites_existing(tmp_path):
+    from io import BytesIO
+
+    target = tmp_path / "out.bin"
+    target.write_bytes(b"old")
+    atomic_write(target, BytesIO(b"new"))
+    assert target.read_bytes() == b"new"
+
+
+def test_atomic_write_cleans_up_and_leaves_target_absent_on_source_error(tmp_path):
+    class _Boom:
+        def read(self, *_a):
+            raise RuntimeError("boom")
+
+    target = tmp_path / "out.bin"
+    with pytest.raises(RuntimeError, match="boom"):
+        atomic_write(target, _Boom())
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_atomic_write_does_not_clobber_existing_on_source_error(tmp_path):
+    target = tmp_path / "out.bin"
+    target.write_bytes(b"keep")
+
+    class _Boom:
+        def read(self, *_a):
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        atomic_write(target, _Boom())
+    assert target.read_bytes() == b"keep"
+    assert list(tmp_path.iterdir()) == [target]
+
+
+def test_atomic_write_requires_existing_parent(tmp_path):
+    from io import BytesIO
+
+    target = tmp_path / "missing" / "out.bin"
+    with pytest.raises(FileNotFoundError):
+        atomic_write(target, BytesIO(b"x"))

--- a/tests/_file_exchange/test_paths.py
+++ b/tests/_file_exchange/test_paths.py
@@ -737,3 +737,16 @@ def test_atomic_write_reads_from_current_position(tmp_path):
     src.seek(4)  # past "skip"
     atomic_write(tmp_path / "out.bin", src)
     assert (tmp_path / "out.bin").read_bytes() == b"keep"
+
+
+def test_atomic_write_deposits_owner_only_mode(tmp_path):
+    # Pins the documented current behavior: deposits inherit mkstemp's 0o600,
+    # preserved by os.replace, on both create and overwrite. The deposit
+    # permission policy is the filesystem sink's to define (#143, tracked #155).
+    from io import BytesIO
+
+    target = tmp_path / "out.bin"
+    target.write_bytes(b"old")
+    target.chmod(0o644)
+    atomic_write(target, BytesIO(b"new"))
+    assert target.stat().st_mode & 0o777 == 0o600

--- a/tests/_file_exchange/test_paths.py
+++ b/tests/_file_exchange/test_paths.py
@@ -739,6 +739,15 @@ def test_atomic_write_reads_from_current_position(tmp_path):
     assert (tmp_path / "out.bin").read_bytes() == b"keep"
 
 
+def test_atomic_write_accepts_str_target(tmp_path):
+    # Pins the widened Path | str contract — the body coerces via Path(target).
+    from io import BytesIO
+
+    target = tmp_path / "out.bin"
+    atomic_write(str(target), BytesIO(b"hi"))
+    assert target.read_bytes() == b"hi"
+
+
 def test_atomic_write_deposits_owner_only_mode(tmp_path):
     # Pins the documented current behavior: deposits inherit mkstemp's 0o600,
     # preserved by os.replace, on both create and overwrite. The deposit

--- a/tests/_file_exchange/test_paths.py
+++ b/tests/_file_exchange/test_paths.py
@@ -726,3 +726,14 @@ def test_atomic_write_closes_fd_when_fdopen_fails(tmp_path, monkeypatch):
         os.fstat(captured["fd"])
     assert not target.exists()
     assert list(tmp_path.iterdir()) == []
+
+
+def test_atomic_write_reads_from_current_position(tmp_path):
+    # atomic_write must NOT seek to 0 — it transfers from the stream's current
+    # position so non-seekable streams stay usable and partial transfers work.
+    from io import BytesIO
+
+    src = BytesIO(b"skip" + b"keep")
+    src.seek(4)  # past "skip"
+    atomic_write(tmp_path / "out.bin", src)
+    assert (tmp_path / "out.bin").read_bytes() == b"keep"

--- a/tests/test_file_exchange_namespace.py
+++ b/tests/test_file_exchange_namespace.py
@@ -115,3 +115,14 @@ def test_path_helpers_exposed():
     assert callable(file_exchange.resolve_filesystem_uri)
     assert callable(file_exchange.load_volume_map)
     assert hasattr(file_exchange, "VolumeMap")
+
+
+def test_hook_helpers_exposed():
+    from fastmcp_pvl_core import file_exchange
+
+    # Protocols are classes; atomic_write is callable.
+    assert isinstance(file_exchange.ArtifactSource, type)
+    assert isinstance(file_exchange.ArtifactSink, type)
+    assert callable(file_exchange.atomic_write)
+    for name in ("ArtifactSource", "ArtifactSink", "atomic_write"):
+        assert name in file_exchange.__all__


### PR DESCRIPTION
## Summary

Closes #142 (4/10 of the mcp-file-exchange-ext v0.1 adoption EPIC #138).

Defines the two public hook protocols downstream servers implement to produce and deposit artifact bytes, plus a transport-agnostic atomic write helper:

- **`ArtifactSource`** / **`ArtifactSink`** — `@runtime_checkable` `typing.Protocol` classes (`src/fastmcp_pvl_core/_file_exchange/_hooks.py`). One async method each over a single sync `BinaryIO` carrier. They answer one domain question each ("where do the bytes come from / go?"); the transport that carries the bytes lives **entirely behind** the hook and never appears in the signature. pvl-core computes size/digest itself, so the hook returns only the metadata the server already knows.
- **`atomic_write(target, source)`** — added to `_paths.py` (the filesystem-utilities home). Streams into a temp file in `target`'s own directory, `flush` + `os.fsync`, then `os.replace` for atomic visibility (§10.1.3). Fail-safe: on any error it closes the fd (only when `os.fdopen` itself raised — guarded against double-close) and unlinks the temp, leaving `target` untouched.
- Re-exported via `fastmcp_pvl_core.file_exchange` and the subpackage `__init__.py` (both `__all__`s mirrored + alphabetized).

The mechanism-agnostic discipline is **mechanically enforced**: `tests/_file_exchange/test_hooks.py` includes a static introspection guard that fails if any forbidden transport token (`filesystem`/`download`/`upload`/`http`/`https`/`exchange`/`url`/`volume`) leaks into a hook signature — with a negative-control teeth test and a discovery guard so it can't pass vacuously.

No `docs/specs/` wire-format file is touched — this is pvl-core's own internal abstraction. Design record + implementation plan under `docs/superpowers/`.

## Test plan

- [ ] `uv run pytest` — 758 passed / 1 skipped (3.10)
- [ ] `uv run --python 3.13 pytest tests/_file_exchange` — 359 passed (max matrix version)
- [ ] `uv run ruff format --check .` — clean
- [ ] `uv run ruff check .` — clean
- [ ] `uv run mypy src` — clean
- [ ] Hook protocols: runtime_checkable conformance (match + reject), awaited source/sink round-trip
- [ ] Introspection guard: discovery guard + negative control prove it has teeth
- [ ] `atomic_write`: content correctness, overwrite, cleanup-on-source-error (target absent + dir empty), no-clobber-existing-on-error, missing-parent, fd-closed-when-fdopen-fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)