### PR TITLE
feat(file-exchange): SSRF + DNS-rebind guard for outbound HTTP

### DIFF
--- a/docs/superpowers/plans/2026-05-24-file-exchange-147-ssrf-guard.md
+++ b/docs/superpowers/plans/2026-05-24-file-exchange-147-ssrf-guard.md
@@ -1,0 +1,910 @@
+# File-Exchange #147 — SSRF + DNS-rebind guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the package-internal outbound-HTTP guard (`guarded_stream`) that the download fetcher (#145) and upload sender (#146) issue every request through, enforcing the §15 SSRF + DNS-rebind mitigations.
+
+**Architecture:** A thin async-context-manager primitive in a new module `_file_exchange/_outbound.py`. It enforces https-only, deny-all-non-global address refusal (with a CIDR allowlist), resolve-once-pin-IP via httpx's `sni_hostname` extension, cross-origin-redirect refusal (same-origin followed, bounded), and no-ambient-credentials. Every refusal/failure raises `FileExchangeTransferError(NOT_ACCESSIBLE, transport=<caller label>)`. Verification and `Range` recovery are NOT here — they belong to #145/#146.
+
+**Tech Stack:** Python 3.10+, `httpx` (already a dep), stdlib `ipaddress`/`socket`/`asyncio`, `pytest` + `pytest-asyncio` (`asyncio_mode = "auto"`), `httpx.MockTransport` for tests.
+
+**Design reference:** `docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md`.
+
+**No public surface change:** `guarded_stream`/`GuardedResponse` are imported by #145/#146 via `fastmcp_pvl_core._file_exchange._outbound`. They are NOT added to `file_exchange.py` or the subpackage `__init__.py` `__all__`. The only operator-facing additions are two `ServerConfig` fields.
+
+---
+
+### Task 1: ServerConfig fields
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_config.py`
+- Test: `tests/test_config.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_config.py`:
+
+```python
+def test_file_exchange_outbound_defaults():
+    from fastmcp_pvl_core import ServerConfig
+
+    cfg = ServerConfig.from_env("MYAPP")
+    assert cfg.file_exchange_allowed_networks == ()
+    assert cfg.file_exchange_http_timeout == 30.0
+
+
+def test_from_env_file_exchange_allowed_networks(monkeypatch):
+    from fastmcp_pvl_core import ServerConfig
+
+    monkeypatch.setenv(
+        "MYAPP_FILE_EXCHANGE_ALLOWED_NETWORKS", "10.0.0.0/8, 192.168.5.0/24"
+    )
+    cfg = ServerConfig.from_env("MYAPP")
+    assert cfg.file_exchange_allowed_networks == ("10.0.0.0/8", "192.168.5.0/24")
+
+
+def test_from_env_file_exchange_http_timeout(monkeypatch):
+    from fastmcp_pvl_core import ServerConfig
+
+    monkeypatch.setenv("MYAPP_FILE_EXCHANGE_HTTP_TIMEOUT", "12.5")
+    cfg = ServerConfig.from_env("MYAPP")
+    assert cfg.file_exchange_http_timeout == 12.5
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config.py::test_file_exchange_outbound_defaults tests/test_config.py::test_from_env_file_exchange_allowed_networks tests/test_config.py::test_from_env_file_exchange_http_timeout -v`
+Expected: FAIL — `AttributeError: 'ServerConfig' object has no attribute 'file_exchange_allowed_networks'`.
+
+- [ ] **Step 3: Add the import**
+
+In `src/fastmcp_pvl_core/_config.py`, extend the `_env` import (line 15):
+
+```python
+from fastmcp_pvl_core._env import env, parse_bool, parse_list, parse_scopes
+```
+
+- [ ] **Step 4: Add the dataclass fields**
+
+In `src/fastmcp_pvl_core/_config.py`, immediately after the `file_exchange_max_artifact_size` field (line 64):
+
+```python
+    # File-exchange outbound-HTTP guard config (#147). allowed_networks are
+    # CIDRs that bypass the deny-all-non-global SSRF refusal (parsed in
+    # _file_exchange._outbound); http_timeout bounds connect/read/write on
+    # every guarded request.
+    file_exchange_allowed_networks: tuple[str, ...] = ()
+    file_exchange_http_timeout: float = 30.0
+```
+
+- [ ] **Step 5: Parse them in `from_env`**
+
+In `src/fastmcp_pvl_core/_config.py`, after the `max_size_raw = ...` line (line 130):
+
+```python
+        allowed_networks_raw = env(env_prefix, "FILE_EXCHANGE_ALLOWED_NETWORKS")
+        http_timeout_str = env(env_prefix, "FILE_EXCHANGE_HTTP_TIMEOUT", "30")
+```
+
+And in the `return cls(...)` block, immediately after the `file_exchange_max_artifact_size=...` entry:
+
+```python
+            file_exchange_allowed_networks=(
+                tuple(parse_list(allowed_networks_raw)) if allowed_networks_raw else ()
+            ),
+            file_exchange_http_timeout=float(http_timeout_str),
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py -v`
+Expected: PASS (all config tests, including the three new ones).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_config.py tests/test_config.py
+git commit -m "feat(file-exchange): add outbound-HTTP guard config fields (#147)"
+```
+
+---
+
+### Task 2: SSRF pure core (`_outbound.py` helpers)
+
+The security heart — pure, synchronous, exhaustively tested before any async/httpx code.
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_outbound.py`
+- Test: `tests/_file_exchange/test_outbound.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/_file_exchange/test_outbound.py`:
+
+```python
+import ipaddress
+
+import pytest
+
+from fastmcp_pvl_core._errors import ConfigurationError
+from fastmcp_pvl_core._file_exchange import _outbound
+
+
+def test_redact_returns_hostname_only():
+    assert (
+        _outbound._redact("https://h.example.com/d/SECRETTOKEN?sig=abc")
+        == "h.example.com"
+    )
+
+
+def test_redact_handles_missing_host():
+    assert _outbound._redact("::not a url::") == "<unknown-host>"
+
+
+@pytest.mark.parametrize(
+    "addr",
+    [
+        "127.0.0.1",
+        "::1",
+        "169.254.1.1",
+        "fe80::1",
+        "10.0.0.5",
+        "172.16.0.1",
+        "192.168.1.1",
+        "100.64.0.1",  # CGNAT
+        "0.0.0.0",
+        "::ffff:127.0.0.1",  # IPv4-mapped loopback
+    ],
+)
+def test_non_global_addresses_refused(addr):
+    assert _outbound._is_permitted(ipaddress.ip_address(addr), []) is False
+
+
+@pytest.mark.parametrize(
+    "addr",
+    ["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"],
+)
+def test_global_addresses_permitted(addr):
+    assert _outbound._is_permitted(ipaddress.ip_address(addr), []) is True
+
+
+def test_allowlist_permits_private_cidr():
+    allowed = _outbound._parse_allowed_networks(("10.0.0.0/8",))
+    assert _outbound._is_permitted(ipaddress.ip_address("10.1.2.3"), allowed) is True
+
+
+def test_malformed_cidr_raises_configuration_error():
+    with pytest.raises(ConfigurationError):
+        _outbound._parse_allowed_networks(("not-a-cidr",))
+
+
+def test_select_pinned_skips_blocked_picks_global():
+    assert (
+        _outbound._select_pinned(["127.0.0.1", "93.184.216.34"], [])
+        == "93.184.216.34"
+    )
+
+
+def test_select_pinned_none_when_all_blocked():
+    assert _outbound._select_pinned(["127.0.0.1", "10.0.0.1"], []) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/_file_exchange/test_outbound.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'fastmcp_pvl_core._file_exchange._outbound'`.
+
+- [ ] **Step 3: Create the module with docstring, imports, and pure helpers**
+
+Create `src/fastmcp_pvl_core/_file_exchange/_outbound.py`:
+
+```python
+"""Outbound-HTTP guard for the file-exchange data plane (#147).
+
+The single primitive the download fetcher (#145) and upload sender (#146)
+issue their requests through. Enforces the §15 SSRF mitigations (https-only,
+deny-all-non-global address refusal with a CIDR allowlist, no cross-origin
+redirect, no ambient credentials) and the §15 DNS-rebinding mitigation
+(resolve-once-pin-IP via httpx's ``sni_hostname`` extension). Carries the
+URL-redaction discipline: only the hostname ever reaches a log line, and no
+URL parts reach the wire ``detail``.
+
+It does NOT verify size/digest, recover with ``Range``, or touch artifacts —
+those are the consuming data planes' deliverables (#145/#146). See
+``docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import socket
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+import httpx
+
+from fastmcp_pvl_core._errors import ConfigurationError
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterable, AsyncIterator, Mapping
+
+    from fastmcp_pvl_core._config import ServerConfig
+
+logger = logging.getLogger(__name__)
+
+# Max same-origin redirect hops followed before refusing (§15: cross-origin
+# is always refused; this caps a same-origin redirect chain).
+_MAX_REDIRECTS = 5
+
+_IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+_IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
+def _redact(url: str) -> str:
+    """Return only the hostname of ``url``.
+
+    The capability token lives in the URL path/query, so those must never
+    reach a log line or a wire ``detail`` (§15). Falls back to a placeholder
+    for an unparseable value.
+    """
+    host = urlsplit(url).hostname
+    return host or "<unknown-host>"
+
+
+def _parse_allowed_networks(cidrs: tuple[str, ...]) -> list[_IPNetwork]:
+    """Parse operator CIDR strings into networks.
+
+    A malformed entry is operator misconfiguration → :class:`ConfigurationError`
+    (loud), consistent with the rest of the package.
+    """
+    networks: list[_IPNetwork] = []
+    for cidr in cidrs:
+        try:
+            networks.append(ipaddress.ip_network(cidr, strict=False))
+        except ValueError as exc:
+            raise ConfigurationError(
+                f"file-exchange: malformed CIDR in allowed-networks: {cidr!r}"
+            ) from exc
+    return networks
+
+
+def _is_permitted(ip: _IPAddress, allowed: list[_IPNetwork]) -> bool:
+    """A resolved address is permitted iff globally routable or allowlisted.
+
+    An IPv4-mapped IPv6 address is unwrapped first, so a mapped loopback/
+    private address (``::ffff:127.0.0.1``) cannot slip past ``is_global``.
+    Allowlist membership is checked against the unwrapped form; an address/
+    network version mismatch yields ``False`` (never raises).
+    """
+    mapped = ip.ipv4_mapped if isinstance(ip, ipaddress.IPv6Address) else None
+    candidate: _IPAddress = mapped if mapped is not None else ip
+    if candidate.is_global:
+        return True
+    return any(candidate in net for net in allowed)
+
+
+def _select_pinned(resolved: list[str], allowed: list[_IPNetwork]) -> str | None:
+    """Pick the first permitted address to pin, or ``None`` if all are refused.
+
+    Picking a permitted address out of a mixed result set is safe because the
+    connection is then pinned to exactly that address — a DNS result that
+    mixes a private and a public record cannot induce a connection to the
+    private one.
+    """
+    for addr in resolved:
+        if _is_permitted(ipaddress.ip_address(addr), allowed):
+            return addr
+    return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/_file_exchange/test_outbound.py -v`
+Expected: PASS (all pure-core tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_outbound.py tests/_file_exchange/test_outbound.py
+git commit -m "feat(file-exchange): SSRF address-validation core for outbound guard (#147)"
+```
+
+---
+
+### Task 3: `guarded_stream` core (single request, pin, refusals, cleanup)
+
+Implements the full single-request path: scheme check, resolve-once, pin, no-ambient-creds, timeout, streaming, and refusal mapping. Redirect following is added in Task 4.
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_outbound.py`
+- Test: `tests/_file_exchange/test_outbound.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/_file_exchange/test_outbound.py` (add `import socket` and `import httpx` to the existing imports at the top, plus `from fastmcp_pvl_core._config import ServerConfig`, `from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode`, and `from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError`):
+
+```python
+def _cfg(*, allowed=(), timeout=30.0):
+    return ServerConfig(
+        file_exchange_allowed_networks=allowed,
+        file_exchange_http_timeout=timeout,
+    )
+
+
+def _install_mock(monkeypatch, handler, *, resolve_to):
+    """Pin _resolve to a fixed address list and route the client through a
+    MockTransport. Returns a dict tracking the _resolve call count."""
+    calls = {"resolve": 0}
+
+    async def fake_resolve(host, port):
+        calls["resolve"] += 1
+        return list(resolve_to)
+
+    def fake_make_client(timeout):
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            follow_redirects=False,
+        )
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    monkeypatch.setattr(_outbound, "_make_client", fake_make_client)
+    return calls
+
+
+async def test_guarded_stream_streams_body_and_pins(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        return httpx.Response(200, content=b"hello-bytes")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    data = b""
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/d/tok", config=_cfg(), transport="download"
+    ) as resp:
+        assert resp.status == 200
+        async for chunk in resp.aiter_bytes():
+            data += chunk
+    assert data == b"hello-bytes"
+    req = seen[0]
+    assert req.url.host == "93.184.216.34"
+    assert req.headers["host"] == "example.com"
+    assert req.extensions.get("sni_hostname") == "example.com"
+
+
+async def test_resolve_called_once_per_request(monkeypatch):
+    def handler(request):
+        return httpx.Response(200, content=b"x")
+
+    calls = _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/x", config=_cfg(), transport="download"
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    assert calls["resolve"] == 1
+
+
+async def test_refuses_non_https():
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "http://example.com/x", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+    assert ei.value.transport == "download"
+    assert "http://" not in (ei.value.detail or "")
+
+
+async def test_refuses_non_global_address(monkeypatch):
+    def handler(request):
+        raise AssertionError("must not connect to a refused address")
+
+    _install_mock(monkeypatch, handler, resolve_to=["127.0.0.1"])
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://evil.example/x", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_allowlist_permits_private_target(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        return httpx.Response(200, content=b"ok")
+
+    _install_mock(monkeypatch, handler, resolve_to=["10.1.2.3"])
+    async with _outbound.guarded_stream(
+        "GET",
+        "https://internal.example/x",
+        config=_cfg(allowed=("10.0.0.0/8",)),
+        transport="download",
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    assert seen[0].url.host == "10.1.2.3"
+
+
+async def test_refuses_unresolvable_host(monkeypatch):
+    async def fake_resolve(host, port):
+        raise socket.gaierror("name resolution failed")
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://nope.example/x", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_maps_connect_error(monkeypatch):
+    def handler(request):
+        raise httpx.ConnectError("connection refused")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/x", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_passes_caller_headers_adds_no_credentials(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        return httpx.Response(200, content=b"x")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET",
+        "https://example.com/x",
+        config=_cfg(),
+        transport="download",
+        headers={"Range": "bytes=10-"},
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    req = seen[0]
+    assert req.headers["range"] == "bytes=10-"
+    assert "authorization" not in req.headers
+    assert "cookie" not in req.headers
+
+
+async def test_make_client_security_defaults():
+    client = _outbound._make_client(30.0)
+    try:
+        assert client.trust_env is False
+        assert client.follow_redirects is False
+        assert client.timeout.read == 30.0
+        assert client.timeout.connect == 30.0
+    finally:
+        await client.aclose()
+
+
+async def test_client_closed_on_caller_exception(monkeypatch):
+    holder = {}
+
+    def handler(request):
+        return httpx.Response(200, content=b"data")
+
+    async def fake_resolve(host, port):
+        return ["93.184.216.34"]
+
+    def fake_make_client(timeout):
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            follow_redirects=False,
+        )
+        holder["client"] = client
+        return client
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    monkeypatch.setattr(_outbound, "_make_client", fake_make_client)
+    with pytest.raises(RuntimeError):
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/x", config=_cfg(), transport="download"
+        ):
+            raise RuntimeError("boom")
+    assert holder["client"].is_closed is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/_file_exchange/test_outbound.py -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'guarded_stream'` (and `_resolve`/`_make_client` for the monkeypatch).
+
+- [ ] **Step 3: Add `_resolve`, `_make_client`, `GuardedResponse`, `_send_pinned`, and `guarded_stream`**
+
+Append to `src/fastmcp_pvl_core/_file_exchange/_outbound.py`:
+
+```python
+async def _resolve(host: str, port: int) -> list[str]:
+    """Resolve ``host`` once to a list of IP strings (single getaddrinfo call).
+
+    Kept as a module-level function so tests can pin it; this single call is
+    the resolution the §15 DNS-rebind mitigation anchors on — the connection
+    uses only addresses from this result.
+    """
+    loop = asyncio.get_running_loop()
+    infos = await loop.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    return [info[4][0] for info in infos]
+
+
+def _make_client(timeout: float) -> httpx.AsyncClient:
+    """Build the outbound client.
+
+    No ambient credentials and ``trust_env=False`` (so ``HTTP(S)_PROXY`` /
+    ``netrc`` cannot inject credentials or divert past the pinned IP — an SSRF
+    bypass). Redirects are handled by :func:`guarded_stream`, not httpx.
+    """
+    return httpx.AsyncClient(
+        timeout=httpx.Timeout(timeout),
+        follow_redirects=False,
+        trust_env=False,
+    )
+
+
+@dataclass(frozen=True)
+class GuardedResponse:
+    """A streaming response yielded by :func:`guarded_stream`.
+
+    Wraps the underlying ``httpx.Response`` so the raw URL (carrying the
+    capability token) cannot leak through httpx's ``repr``/traceback. The
+    caller reads the body via :meth:`aiter_bytes` inside the ``async with``.
+    """
+
+    status: int
+    headers: Mapping[str, str]
+    _response: httpx.Response = field(repr=False)
+
+    def aiter_bytes(self) -> AsyncIterator[bytes]:
+        return self._response.aiter_bytes()
+
+
+async def _send_pinned(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    transport: str,
+    allowed: list[_IPNetwork],
+    headers: Mapping[str, str] | None,
+    content: AsyncIterable[bytes] | bytes | None,
+) -> httpx.Response:
+    """Resolve-once, validate, pin, and send a single streamed request.
+
+    Raises :class:`FileExchangeTransferError` (``not-accessible``) for a
+    non-https URL, a missing host, an unresolvable host, a non-permitted
+    address, or a connection failure. The returned response is streamed
+    (body not yet read).
+    """
+    parts = urlsplit(url)
+    if parts.scheme != "https":
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="refused non-https URL",
+        )
+    host = parts.hostname
+    if host is None:
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="URL has no host",
+        )
+    port = parts.port or 443
+    try:
+        resolved = await _resolve(host, port)
+    except OSError as exc:
+        logger.debug("file-exchange: DNS resolution failed for %s", _redact(url))
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="host could not be resolved",
+        ) from exc
+    pinned = _select_pinned(resolved, allowed)
+    if pinned is None:
+        logger.debug("file-exchange: refused non-global address for %s", _redact(url))
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="address not permitted",
+        )
+    request = client.build_request(
+        method,
+        httpx.URL(url).copy_with(host=pinned),
+        headers={"Host": host, **(headers or {})},
+        content=content,
+        extensions={"sni_hostname": host},
+    )
+    try:
+        return await client.send(request, stream=True)
+    except httpx.HTTPError as exc:
+        logger.debug("file-exchange: outbound request failed for %s", _redact(url))
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="endpoint unreachable",
+        ) from exc
+
+
+@asynccontextmanager
+async def guarded_stream(
+    method: str,
+    url: str,
+    *,
+    config: ServerConfig,
+    transport: str,
+    headers: Mapping[str, str] | None = None,
+    content: AsyncIterable[bytes] | bytes | None = None,
+) -> AsyncIterator[GuardedResponse]:
+    """Issue a guarded, streamed outbound request and yield the response.
+
+    Enforces the §15 SSRF + DNS-rebind mitigations (see module docstring).
+    ``transport`` is the §13 envelope label (``"download"``/``"upload"``)
+    carried on any raised :class:`FileExchangeTransferError`. The caller reads
+    the body via the yielded :class:`GuardedResponse` inside the ``async
+    with``; the response and client are closed on exit, including on error.
+    """
+    allowed = _parse_allowed_networks(config.file_exchange_allowed_networks)
+    client = _make_client(config.file_exchange_http_timeout)
+    response: httpx.Response | None = None
+    try:
+        response = await _send_pinned(
+            client, method, url, transport, allowed, headers, content
+        )
+        yield GuardedResponse(
+            status=response.status_code,
+            headers=response.headers,
+            _response=response,
+        )
+    finally:
+        if response is not None:
+            await response.aclose()
+        await client.aclose()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/_file_exchange/test_outbound.py -v`
+Expected: PASS (all Task 2 + Task 3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_outbound.py tests/_file_exchange/test_outbound.py
+git commit -m "feat(file-exchange): guarded_stream core with resolve-once-pin (#147)"
+```
+
+---
+
+### Task 4: Redirect handling (refuse cross-origin, follow same-origin)
+
+Replaces the single-request body with a bounded redirect loop that re-guards each hop.
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_outbound.py`
+- Test: `tests/_file_exchange/test_outbound.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/_file_exchange/test_outbound.py`:
+
+```python
+async def test_follows_same_origin_redirect_and_reresolves(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(str(request.url))
+        if len(seen) == 1:
+            return httpx.Response(
+                302, headers={"location": "https://example.com/final"}
+            )
+        return httpx.Response(200, content=b"final-bytes")
+
+    calls = _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    data = b""
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/start", config=_cfg(), transport="download"
+    ) as resp:
+        async for chunk in resp.aiter_bytes():
+            data += chunk
+    assert data == b"final-bytes"
+    assert calls["resolve"] == 2  # re-resolved + re-validated per hop
+
+
+async def test_follows_relative_redirect(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request.url.path)
+        if len(seen) == 1:
+            return httpx.Response(302, headers={"location": "/elsewhere"})
+        return httpx.Response(200, content=b"ok")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/start", config=_cfg(), transport="download"
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    assert seen[1] == "/elsewhere"
+
+
+async def test_refuses_cross_origin_redirect(monkeypatch):
+    def handler(request):
+        return httpx.Response(302, headers={"location": "https://evil.example/x"})
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/start", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+    assert "evil.example" not in (ei.value.detail or "")
+
+
+async def test_refuses_too_many_redirects(monkeypatch):
+    counter = {"n": 0}
+
+    def handler(request):
+        counter["n"] += 1
+        return httpx.Response(
+            302, headers={"location": f"https://example.com/hop{counter['n']}"}
+        )
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/start", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+    assert counter["n"] == _outbound._MAX_REDIRECTS + 1  # initial + 5 follows
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/_file_exchange/test_outbound.py -k redirect -v`
+Expected: FAIL — the current single-request `guarded_stream` yields the 302 instead of following/refusing (e.g. `test_follows_same_origin_redirect_and_reresolves` sees `status == 302`, body empty).
+
+- [ ] **Step 3: Add `_same_origin` and replace the `guarded_stream` body with the redirect loop**
+
+Add this helper above `guarded_stream` in `src/fastmcp_pvl_core/_file_exchange/_outbound.py`:
+
+```python
+def _same_origin(a: str, b: str) -> bool:
+    """Whether two URLs share scheme + host + port (case-insensitive host).
+
+    https default port 443 is normalised so ``https://h/x`` and
+    ``https://h:443/x`` compare equal.
+    """
+    pa, pb = urlsplit(a), urlsplit(b)
+    return (
+        pa.scheme.lower() == pb.scheme.lower()
+        and (pa.hostname or "").lower() == (pb.hostname or "").lower()
+        and (pa.port or 443) == (pb.port or 443)
+    )
+```
+
+Replace the `try:` block inside `guarded_stream` (the `response = await _send_pinned(...)` + `yield ...` portion) with the bounded loop:
+
+```python
+    try:
+        current = url
+        for _hop in range(_MAX_REDIRECTS + 1):
+            response = await _send_pinned(
+                client, method, current, transport, allowed, headers, content
+            )
+            if response.is_redirect:
+                target = str(httpx.URL(current).join(response.headers.get("location", "")))
+                await response.aclose()
+                response = None
+                if not _same_origin(current, target):
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.NOT_ACCESSIBLE,
+                        transport=transport,
+                        detail="refused cross-origin redirect",
+                    )
+                current = target
+                continue
+            yield GuardedResponse(
+                status=response.status_code,
+                headers=response.headers,
+                _response=response,
+            )
+            return
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="too many redirects",
+        )
+    finally:
+        if response is not None:
+            await response.aclose()
+        await client.aclose()
+```
+
+Note: the loop runs at most `_MAX_REDIRECTS + 1` times (1 initial request + up to 5 followed redirects). A redirect on the final iteration falls through to the "too many redirects" refusal. Each hop re-runs `_send_pinned`, so every redirect target is independently resolved + validated + pinned (no redirect-driven rebind).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/_file_exchange/test_outbound.py -v`
+Expected: PASS (all Task 2/3/4 tests — the earlier non-redirect tests still pass against the loop, since a single terminal response yields on the first iteration).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_outbound.py tests/_file_exchange/test_outbound.py
+git commit -m "feat(file-exchange): same-origin redirect following for outbound guard (#147)"
+```
+
+---
+
+### Task 5: Full local quality gates + draft PR
+
+**Files:** none (verification + PR).
+
+- [ ] **Step 1: Run the full repo check suite**
+
+Run (matches CI and `CLAUDE.md`'s "Local checks before pushing"):
+
+```bash
+uv sync --all-extras
+uv run pytest
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
+```
+
+Expected: all green. Fix any failure and re-run before proceeding. If `ruff format --check` reports diffs, run `uv run ruff format .`, re-review, and amend the relevant commit or add a formatting commit.
+
+- [ ] **Step 2: Confirm no public surface drift**
+
+Run: `uv run python -c "import fastmcp_pvl_core.file_exchange as fx; assert not hasattr(fx, 'guarded_stream'); print('internal-only OK')"`
+Expected: prints `internal-only OK` — the guard stays package-internal (not re-exported).
+
+- [ ] **Step 3: Pre-push review (mandatory) and open the draft PR**
+
+Per `CLAUDE.md`: invoke the `preflight-circus` skill on the cumulative `BASE..HEAD` diff and iterate until it returns `clean` (nothing flagged ≥80). Only then push the branch and open the PR **as draft** with `Closes #147` in the body. Bot iteration after open is capped at one round; re-run `preflight-circus` before any fix-push. Flip to ready only when local review was clean, bot bodies say LGTM, and CI is fully green. Do not merge autonomously.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (design doc → task):
+- https-only enforcement → Task 3 (`_send_pinned` scheme check; `test_refuses_non_https`).
+- Deny-all-non-global + IPv4-mapped unwrap → Task 2 (`_is_permitted`; parametrized refusal test incl. `::ffff:127.0.0.1`, CGNAT, `0.0.0.0`).
+- CIDR allowlist + malformed→ConfigurationError → Task 2 (`_parse_allowed_networks`) + Task 3 (`test_allowlist_permits_private_target`).
+- Resolve-once-pin via `sni_hostname` → Task 3 (`_resolve`, `_send_pinned`; `test_..._pins`, `test_resolve_called_once_per_request`).
+- No cross-origin redirect / follow same-origin bounded + re-guard → Task 4 (`_same_origin`, loop; four redirect tests incl. re-resolve count + hop cap).
+- No ambient credentials + `trust_env=False` → Task 3 (`_make_client`; `test_make_client_security_defaults`, `test_passes_caller_headers_adds_no_credentials`).
+- Timeout config → Task 1 (field) + Task 3 (`_make_client`; `test_make_client_security_defaults`).
+- Error surface (`FileExchangeTransferError(NOT_ACCESSIBLE, transport=...)`) → Tasks 3/4 (every refusal asserts code + label).
+- Redaction (hostname-only, generic wire detail) → Task 2 (`_redact` + tests) + Tasks 3/4 (`detail` asserts no URL parts).
+- Streaming, no whole-buffer → Task 3 (`stream=True`, `aiter_bytes`).
+- Cleanup on exit/exception → Task 3 (`finally`; `test_client_closed_on_caller_exception`).
+- Two config fields + env parsing → Task 1.
+- Package-internal (no public re-export) → Task 5 Step 2 guard.
+
+No gaps found.
+
+**2. Placeholder scan:** No TBD/TODO/"add error handling"/"similar to". Every code step shows complete code; every command shows expected output.
+
+**3. Type consistency:** `_IPNetwork`/`_IPAddress` aliases used consistently; `_parse_allowed_networks → list[_IPNetwork]` consumed by `_is_permitted`/`_select_pinned`; `_resolve → list[str]` consumed by `_select_pinned`; `guarded_stream`/`_send_pinned`/`_make_client`/`GuardedResponse` signatures match their call sites and the test monkeypatch targets (`_outbound._resolve`, `_outbound._make_client`). `_MAX_REDIRECTS` referenced in impl and in `test_refuses_too_many_redirects`. Config field names (`file_exchange_allowed_networks`, `file_exchange_http_timeout`) match Task 1 and the `_cfg` test helper.

--- a/docs/superpowers/plans/2026-05-24-file-exchange-147-ssrf-guard.md
+++ b/docs/superpowers/plans/2026-05-24-file-exchange-147-ssrf-guard.md
@@ -12,6 +12,8 @@
 
 **No public surface change:** `guarded_stream`/`GuardedResponse` are imported by #145/#146 via `fastmcp_pvl_core._file_exchange._outbound`. They are NOT added to `file_exchange.py` or the subpackage `__init__.py` `__all__`. The only operator-facing additions are two `ServerConfig` fields.
 
+> **The shipped module is the source of truth, not the code blocks below.** This is a forward-looking TDD plan: the code in each task is the *planned starting point*. During implementation, review surfaced additional security mechanisms that the shipped `_outbound.py` carries and these snippets do not — the userinfo strip and caller-`Host` strip in `_send_pinned`, `has_redirect_location` (not `is_redirect`) gating with a body-on-redirect refusal in `guarded_stream`, the non-positive-timeout `ConfigurationError` guard in `_make_client`, and the empty-resolution guard. Read `_outbound.py` at HEAD for the actual behaviour.
+
 ---
 
 ### Task 1: ServerConfig fields

--- a/docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md
+++ b/docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md
@@ -149,6 +149,7 @@ module (relative-`Location` resolution, origin comparison, per-hop re-guard, hop
 cap); it is accepted over the simpler "refuse all redirects" to stay faithful to
 the spec wording and the issue's intent. Following without re-guarding each hop
 would be a redirect-driven rebind hole — hence the re-run.
+A redirect on a request that carries a body is refused outright — the guard cannot safely replay a streaming request body across hops, so the upload sender (#146) re-issues rather than risk a silently-truncated upload.
 
 ### No ambient credentials and `trust_env=False`
 

--- a/docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md
+++ b/docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md
@@ -96,7 +96,8 @@ redirect-following rebind-safe).
    around the IP pin — an SSRF bypass). Caller headers pass through; the guard
    adds no credential headers.
 5. **Redirects.** On a 3xx with `Location`: resolve `Location` relative to the
-   current request URL. If it is **same-origin** (case-normalized
+   current request URL. If the request carries a body (`content is not None`), refuse — a streaming request body cannot be safely replayed across a redirect hop.
+   If it is **same-origin** (case-normalized
    scheme+host+port match) and the hop count is below the cap (5), recurse from
    step 1 against the new URL (full re-resolve + re-validate + re-pin). If it is
    **cross-origin**, refuse. If the hop cap is exceeded, refuse.

--- a/docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md
+++ b/docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md
@@ -86,21 +86,28 @@ redirect-following rebind-safe).
    permitted → refuse (blocked). If resolution fails or returns nothing → refuse
    (unresolvable).
 4. **Pin + connect.** Issue the request to `https://<pinned-ip>:<port><path+query>`
-   with `headers={"Host": host, **caller_headers}` and
-   `extensions={"sni_hostname": host}` — so TLS SNI and certificate verification
-   still target the hostname while the socket connects to the validated IP.
-   `follow_redirects=False`. `timeout=` from `config.file_exchange_http_timeout`.
-   Streamed (the body is not read here). The `httpx.AsyncClient` is built with
-   **`trust_env=False`** and no auth/cookies: no ambient credentials, and no
-   `HTTP(S)_PROXY`/`NETRC` interference (a proxy env var would otherwise route
-   around the IP pin — an SSRF bypass). Caller headers pass through; the guard
-   adds no credential headers.
-5. **Redirects.** On a 3xx with `Location`: resolve `Location` relative to the
-   current request URL. If the request carries a body (`content is not None`), refuse — a streaming request body cannot be safely replayed across a redirect hop.
-   If it is **same-origin** (case-normalized
-   scheme+host+port match) and the hop count is below the cap (5), recurse from
-   step 1 against the new URL (full re-resolve + re-validate + re-pin). If it is
-   **cross-origin**, refuse. If the hop cap is exceeded, refuse.
+   with `extensions={"sni_hostname": host}` — so TLS SNI and certificate
+   verification still target the hostname while the socket connects to the
+   validated IP. The guard **owns** the `Host` header: it strips any
+   caller-supplied `host` key (case-insensitive) and forces the validated
+   hostname (a non-default port is preserved and an IPv6 literal bracketed), so a
+   caller cannot smuggle a different vhost onto the pinned IP. It also strips any
+   userinfo (`user:pass@`) from the URL, since httpx would otherwise synthesise an
+   `Authorization: Basic` header from it. `follow_redirects=False`. `timeout=`
+   from `config.file_exchange_http_timeout`. Streamed (the body is not read here).
+   The `httpx.AsyncClient` is built with **`trust_env=False`** and no auth/cookies:
+   no ambient credentials, and no `HTTP(S)_PROXY`/`NETRC` interference (a proxy
+   env var would otherwise route around the IP pin — an SSRF bypass). Caller
+   headers other than `Host` pass through; the guard adds no credential headers.
+5. **Redirects.** On a redirect status carrying a valid `Location` (httpx
+   `has_redirect_location` — a `304` or a `Location`-less 3xx is *not* a redirect
+   and is yielded as a terminal response): resolve `Location` relative to the
+   current request URL. If the request carries a body (`content is not None`),
+   refuse — a streaming request body cannot be safely replayed across a redirect
+   hop. If it is **same-origin** (case-normalized scheme+host+port match) and the
+   hop count is below the cap (5), recurse from step 1 against the new URL (full
+   re-resolve + re-validate + re-pin). If it is **cross-origin**, refuse. If the
+   hop cap is exceeded, refuse.
 6. **Yield.** Otherwise wrap the streaming response in `GuardedResponse` and
    yield it.
 
@@ -158,7 +165,12 @@ A redirect on a request that carries a body is refused outright — the guard ca
 client certificates — the capability URL is the only credential. The guard
 builds a fresh client per call with no auth and no cookie jar, and crucially sets
 `trust_env=False` so environment proxies and `netrc` cannot inject credentials or
-divert the connection past the pinned IP.
+divert the connection past the pinned IP. Two further leaks are closed at request
+build: any userinfo in the URL (`user:pass@`) is stripped, because httpx would
+otherwise synthesise an `Authorization: Basic` header from it; and any
+caller-supplied `Host` header is stripped in favour of the validated hostname, so
+a caller cannot smuggle the request onto a different vhost on the pinned IP. Both
+apply to the initial URL and to every same-origin redirect hop.
 
 ### Timeouts
 

--- a/docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md
+++ b/docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md
@@ -99,15 +99,19 @@ redirect-following rebind-safe).
    no ambient credentials, and no `HTTP(S)_PROXY`/`NETRC` interference (a proxy
    env var would otherwise route around the IP pin — an SSRF bypass). Caller
    headers other than `Host` pass through; the guard adds no credential headers.
-5. **Redirects.** On a redirect status carrying a valid `Location` (httpx
+5. **Redirects.** On a redirect status carrying a `Location` header (httpx
    `has_redirect_location` — a `304` or a `Location`-less 3xx is *not* a redirect
-   and is yielded as a terminal response): resolve `Location` relative to the
-   current request URL. If the request carries a body (`content is not None`),
-   refuse — a streaming request body cannot be safely replayed across a redirect
-   hop. If it is **same-origin** (case-normalized scheme+host+port match) and the
-   hop count is below the cap (5), recurse from step 1 against the new URL (full
-   re-resolve + re-validate + re-pin). If it is **cross-origin**, refuse. If the
-   hop cap is exceeded, refuse.
+   and is yielded as a terminal response). `has_redirect_location` is true on
+   header *presence* alone, so a present-but-**empty** `Location` is likewise
+   treated as terminal and yielded (not a usable redirect target). Otherwise
+   resolve `Location` relative to the current request URL; a value `httpx.URL.join`
+   cannot parse is refused as a **malformed redirect location** (a raw
+   `httpx.InvalidURL` must not escape the guard). If the request carries a body
+   (`content is not None`), refuse — a streaming request body cannot be safely
+   replayed across a redirect hop. If it is **same-origin** (case-normalized
+   scheme+host+port match) and the hop count is below the cap (5), recurse from
+   step 1 against the new URL (full re-resolve + re-validate + re-pin). If it is
+   **cross-origin**, refuse. If the hop cap is exceeded, refuse.
 6. **Yield.** Otherwise wrap the streaming response in `GuardedResponse` and
    yield it.
 

--- a/docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md
+++ b/docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md
@@ -1,0 +1,281 @@
+# File-Exchange #147 — SSRF + DNS-rebind guard for outbound HTTP
+
+> **Status:** Contemporaneous design record for issue #147 (9/10 of EPIC
+> #138). The implementation in the same PR is the source of truth; this
+> captures the shape agreed before implementation. This is **not** a wire
+> spec — #147 is pvl-core's own internal outbound-HTTP mechanism layer,
+> governed by `CLAUDE.md` and the project's framing principle, not by
+> `mcp-file-exchange-ext`. No `docs/specs/` wire-format file is touched.
+
+**Goal:** Provide the single, centralized outbound-HTTP primitive that the
+`download` fetcher (#145) and the `upload` sender (#146) issue their requests
+through. It enforces the §15 SSRF mitigations (https-only, private/non-global
+address refusal, no cross-origin redirect, no ambient credentials) and the §15
+DNS-rebinding mitigation (resolve-once-pin-IP), and carries the URL-redaction
+discipline. It does **not** do Range recovery, size/digest verification, or any
+artifact handling — those are the consuming data planes' own deliverables
+(#145/#146).
+
+## Scope (from #138's decomposition + #147's scope statement)
+
+#147 owns exactly the outbound connection: scheme enforcement, single DNS
+resolution + address validation, IP pinning, redirect policy, no-ambient-creds,
+bounded timeouts, and redaction. It yields a streaming response; the **caller**
+reads the body. This boundary is deliberate — the EPIC gives "verify `size` and
+`digest`, recover a dropped connection with `Range`" to #145 and the upload body
+to #146. Folding either into the guard would collapse that split, so the guard
+stays a thin §15 primitive.
+
+The guard is **package-internal** plumbing: #145/#146 import it from
+`_file_exchange._outbound`. It is *not* re-exported through the public
+`file_exchange.py` namespace — downstream servers never call it directly (they
+wire the data plane via #148's register helpers). Only the two new `ServerConfig`
+fields are operator-facing.
+
+## Module shape
+
+New module `src/fastmcp_pvl_core/_file_exchange/_outbound.py`, the outbound-HTTP
+sibling of `_filesystem.py`. **Free functions / an async context manager**,
+mirroring the rest of the package — no service-object pattern. pvl-core already
+depends on `httpx` (used by `_auth.py`); the guard builds on it.
+
+The name is `_outbound` rather than `_ssrf`/`_http_guard`: SSRF refusal is what
+it *enforces*, not the whole of what it does (it is the one place all
+file-exchange outbound HTTP goes through).
+
+## Public function
+
+```python
+@asynccontextmanager
+async def guarded_stream(
+    method: str,
+    url: str,
+    *,
+    config: ServerConfig,
+    transport: str,                       # "download" | "upload" — §13 envelope label
+    headers: Mapping[str, str] | None = None,
+    content: AsyncIterable[bytes] | bytes | None = None,   # request body (#146 upload)
+) -> AsyncIterator[GuardedResponse]: ...
+```
+
+`GuardedResponse` is a thin frozen dataclass exposing `status: int`,
+`headers: Mapping[str, str]`, and `aiter_bytes() -> AsyncIterator[bytes]`. It
+wraps the streaming `httpx.Response` so the raw URL (with its capability token in
+the path/query) cannot leak through httpx's `repr`/traceback. The caller drives
+the body read inside the `async with`; the context manager closes the response
+and the client on exit (including on caller exceptions).
+
+`content` is present from the start so #146's sender streams a request body
+without changing this signature later; #145's fetcher leaves it `None` and passes
+a `Range` header via `headers`.
+
+## Per-call / per-redirect-hop algorithm
+
+Steps 1–6 run once per request, and re-run in full for each followed redirect hop
+(a hop is a new URL → a new resolve+validate+pin; this is what makes
+redirect-following rebind-safe).
+
+1. **Scheme.** Parse `url`; require `https://`. Otherwise refuse.
+2. **Resolve once.** `await loop.getaddrinfo(host, port, type=SOCK_STREAM)` —
+   a single resolution whose result is the only address set used for both the
+   check and the connection. The hostname is never re-resolved between them.
+3. **Validate.** For each returned address: parse with `ipaddress`, unwrap an
+   IPv4-mapped IPv6 address (`ip.ipv4_mapped`) first, then permit it iff
+   `ip.is_global` **or** it is contained in one of the operator's allowlisted
+   networks. Pick the first permitted address as the pinned IP. If no address is
+   permitted → refuse (blocked). If resolution fails or returns nothing → refuse
+   (unresolvable).
+4. **Pin + connect.** Issue the request to `https://<pinned-ip>:<port><path+query>`
+   with `headers={"Host": host, **caller_headers}` and
+   `extensions={"sni_hostname": host}` — so TLS SNI and certificate verification
+   still target the hostname while the socket connects to the validated IP.
+   `follow_redirects=False`. `timeout=` from `config.file_exchange_http_timeout`.
+   Streamed (the body is not read here). The `httpx.AsyncClient` is built with
+   **`trust_env=False`** and no auth/cookies: no ambient credentials, and no
+   `HTTP(S)_PROXY`/`NETRC` interference (a proxy env var would otherwise route
+   around the IP pin — an SSRF bypass). Caller headers pass through; the guard
+   adds no credential headers.
+5. **Redirects.** On a 3xx with `Location`: resolve `Location` relative to the
+   current request URL. If it is **same-origin** (case-normalized
+   scheme+host+port match) and the hop count is below the cap (5), recurse from
+   step 1 against the new URL (full re-resolve + re-validate + re-pin). If it is
+   **cross-origin**, refuse. If the hop cap is exceeded, refuse.
+6. **Yield.** Otherwise wrap the streaming response in `GuardedResponse` and
+   yield it.
+
+## Decisions
+
+### Address posture: deny all non-global
+
+Refuse any resolved address that is not globally routable
+(`not ipaddress.ip_address(...).is_global`), rather than enumerating only the
+three ranges in the issue text. `is_global` already covers loopback, link-local,
+and RFC 1918, and additionally closes CGNAT (`100.64.0.0/10`), reserved,
+multicast, the unspecified address (`0.0.0.0`/`::`), and — after unwrapping —
+IPv4-mapped IPv6 (`::ffff:127.0.0.1`) and similar. Enumerating a fixed blocklist
+leaves exactly those as bypasses; deny-all-non-global is defense in depth, with
+the allowlist as the single escape hatch. This is a pvl-core **shape** decision:
+downstream conforms.
+
+### Allowlist: CIDR networks, not hostnames or a blanket toggle
+
+`config.file_exchange_allowed_networks` is a list of CIDR strings; a resolved IP
+contained in any listed network bypasses the non-global refusal. The check stays
+an **IP** membership test *after* pinning, so it cannot reintroduce DNS rebinding
+(a hostname allowlist would, since a hostname can resolve to anything). It is
+granular per the spec's "explicitly allowed a *specific* target," unlike a single
+"allow private" boolean that would disable the protection wholesale.
+
+### Resolve-once-pin via httpx `sni_hostname`
+
+The DNS-rebind mitigation is "resolve the target hostname once and connect to
+that pinned IP, rather than re-resolving between the check and the connection"
+(§15). httpx's documented `sni_hostname` request extension makes this exact: the
+request URL carries the validated IP, the `Host` header and `sni_hostname` carry
+the hostname, so the certificate is verified against the hostname while the socket
+connects only to the address that passed validation. The window between check and
+connect contains no second resolution. Across *separate* requests (e.g. #145's
+`Range` reconnect after a dropped connection), re-resolving is correct and
+expected — the mitigation is per-request, and each reconnect is a new guarded
+call.
+
+### Redirects: refuse cross-origin, follow same-origin (bounded, re-guarded)
+
+The spec's hard rule is "MUST NOT follow redirects to a different origin"; the
+issue phrases it "no-cross-origin-redirect behaviour." Same-origin redirects are
+therefore permitted and are followed, but only after re-running the full guard on
+each hop and only up to 5 hops. This is the only genuinely fiddly part of the
+module (relative-`Location` resolution, origin comparison, per-hop re-guard, hop
+cap); it is accepted over the simpler "refuse all redirects" to stay faithful to
+the spec wording and the issue's intent. Following without re-guarding each hop
+would be a redirect-driven rebind hole — hence the re-run.
+
+### No ambient credentials and `trust_env=False`
+
+§10.2/§10.3 require the request to carry no cookies, no `Authorization`, no
+client certificates — the capability URL is the only credential. The guard
+builds a fresh client per call with no auth and no cookie jar, and crucially sets
+`trust_env=False` so environment proxies and `netrc` cannot inject credentials or
+divert the connection past the pinned IP.
+
+### Timeouts
+
+A single operator field `config.file_exchange_http_timeout` (default `30.0`
+seconds) is applied to httpx's connect/read/write phases. A stalled connect or a
+body that dribbles bytes below the per-read timeout is a resource-exhaustion
+vector (§15) the guard bounds. A **total**-transfer budget is deliberately *not*
+imposed here — it would wrongly kill legitimate large transfers; bounding overall
+duration is the Tasks / #145 concern.
+
+### Error surface: `FileExchangeTransferError`, code `not-accessible`
+
+Every refusal and connection failure raises
+`FileExchangeTransferError(TransferErrorCode.NOT_ACCESSIBLE, transport=transport,
+detail="<generic>")` — the same typed exception `_filesystem.py` raises, matching
+the established package pattern (no parallel exception hierarchy is introduced).
+All guard failures are pre-body (scheme, resolution, address, redirect, connect,
+timeout) and §13's `not-accessible` is documented as "an endpoint was
+unreachable," so they map to one code; no per-caller judgment is needed. The
+guard takes the `transport` label as a parameter because it is shared by the
+`download` and `upload` data planes and cannot know its own caller's role. The
+original cause is chained for local logs; #148's middleware renders the wire
+envelope via `build_file_exchange_error`, exactly as for the filesystem transport.
+
+### URL redaction
+
+A module-private `_redact(url) -> str` returns the **hostname only**. The
+capability token lives in the URL path/query, so those are never logged and never
+placed in a wire `detail`. Wire `detail` strings stay generic (no URL parts at
+all — they cross to the peer); local debug logs may include the hostname,
+consistent with `_kv_store.py` logging `parsed.hostname`. This carries forward
+the redaction discipline a prior reviewer caught missing on PR #122.
+
+## Config (ServerConfig, file-exchange group)
+
+Two new fields, parsed by `from_env`, sitting beside the existing
+`file_exchange_token_ttl` / `file_exchange_max_artifact_size`:
+
+| Field | Env var | Default | Meaning |
+|---|---|---|---|
+| `file_exchange_allowed_networks: tuple[str, ...]` | `<PREFIX>_FILE_EXCHANGE_ALLOWED_NETWORKS` | `()` | comma-separated CIDRs that bypass the non-global refusal |
+| `file_exchange_http_timeout: float` | `<PREFIX>_FILE_EXCHANGE_HTTP_TIMEOUT` | `30.0` | connect/read/write timeout (seconds) for guarded requests |
+
+CIDR strings are parsed to `ipaddress.ip_network` in the guard at first use; a
+malformed entry raises `ConfigurationError` (loud operator-misconfiguration
+failure, consistent with the rest of the package). These are operator-side
+**configuration**, not domain hooks and not shape — the env-var axis, per
+`CLAUDE.md`.
+
+## Error handling
+
+The single failure type is `FileExchangeTransferError` with code
+`not-accessible` (see the decision above). The async context manager is
+fail-safe: the streaming response and client are closed on `__aexit__`, including
+when the caller's body-reading block raises, so no connection leaks. The guard
+buffers no bytes — it hands back a stream the caller consumes.
+
+## Testing (`tests/_file_exchange/test_outbound.py`)
+
+Driven by TDD, mirroring `test_filesystem`'s structure. Network is never touched
+for real: `getaddrinfo` is monkeypatched to return chosen addresses, and an
+`httpx.MockTransport` captures the actual outgoing request so the pin can be
+asserted.
+
+Refusals (each → `not-accessible`):
+
+1. Non-`https` scheme.
+2. Resolution to loopback / link-local / RFC 1918 / CGNAT / IPv4-mapped-loopback
+   / `0.0.0.0`.
+3. Unresolvable host (empty / failing `getaddrinfo`).
+4. Cross-origin redirect.
+5. Redirect hop cap exceeded (>5).
+6. Connect failure / timeout (MockTransport raising `httpx.ConnectError` /
+   `httpx.ConnectTimeout`).
+
+Behaviour:
+
+7. **Allowlist override** — an address in a blocked range becomes permitted when
+   its network is in `file_exchange_allowed_networks`; a malformed CIDR raises
+   `ConfigurationError`.
+8. **Pin behaviour** — `getaddrinfo` returns IP `X`; assert the captured request
+   targets `X`, with `Host` and `sni_hostname` equal to the hostname, and assert
+   `getaddrinfo` is called **once per hop** (DNS-rebind proof — no re-resolution
+   between check and connect).
+9. **Same-origin redirect** — followed (re-resolved + re-validated each hop),
+   terminal response reaches the caller; relative `Location` is resolved against
+   the current URL.
+10. **No ambient creds** — the captured request carries no `Authorization`/cookie
+    header the caller did not pass; the client is `trust_env=False`.
+11. **Streaming + cleanup** — the body is yielded chunked (never buffered whole);
+    the response/client are closed even when the caller's block raises.
+12. **Redaction** — no token / path / query appears in any captured log record or
+    in the exception `detail`; `detail` is generic.
+
+## Public surface
+
+The guard is **package-internal**. `guarded_stream` and `GuardedResponse` are
+importable from `fastmcp_pvl_core._file_exchange._outbound` by #145/#146; they are
+**not** added to `file_exchange.py`'s or the subpackage `__init__.py`'s public
+`__all__` (downstream does not call them). The two `ServerConfig` fields are the
+only operator-facing additions. `FileExchangeTransferError` / `TransferErrorCode`
+are already exported (reused, not re-declared).
+
+## References
+
+- EPIC #138 (adopt mcp-file-exchange-ext v0.1); this is 9/10. Depends on #139
+  (wire format — provides `FileExchangeTransferError` / `TransferErrorCode`).
+- #145 (download data plane) and #146 (upload data plane) — the two consumers;
+  they own Range recovery, size/digest verification, and artifact handling, which
+  this guard deliberately excludes.
+- #148 (register helpers + Tasks integration) — renders the §13 wire envelope
+  from the `FileExchangeTransferError` this guard raises.
+- Wire spec (`mcp-file-exchange-ext`, pinned commit `5f50a4e…`): §7.2.2/§7.2.4
+  (download/upload descriptors), §10.2/§10.3 (download/upload transport
+  obligations — no ambient creds, https-only, no cross-origin redirect), §12
+  (capability URLs), §15 (security considerations — SSRF, DNS rebinding,
+  redaction, resource exhaustion). This document is **not** a wire spec.
+- `CLAUDE.md` — the framing principle (operator config is the env-var axis, not a
+  kwarg; pvl-core owns shape decisions like the deny-all-non-global posture); the
+  redaction discipline carried forward from PR #122.
+- httpx `sni_hostname` request extension — the documented mechanism for
+  connect-to-IP-with-hostname-cert-verification.

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from fastmcp_pvl_core._env import env, parse_bool, parse_scopes
+from fastmcp_pvl_core._env import env, parse_bool, parse_list, parse_scopes
 
 Transport = Literal["stdio", "http", "sse"]
 
@@ -62,6 +62,12 @@ class ServerConfig:
     # is consumed by the #146 upload route, surfaced here per #144's scope.
     file_exchange_token_ttl: float = 3600.0
     file_exchange_max_artifact_size: int | None = None
+    # File-exchange outbound-HTTP guard config (#147). allowed_networks are
+    # CIDRs that bypass the deny-all-non-global SSRF refusal (parsed in
+    # _file_exchange._outbound); http_timeout bounds connect/read/write on
+    # every guarded request.
+    file_exchange_allowed_networks: tuple[str, ...] = ()
+    file_exchange_http_timeout: float = 30.0
 
     bearer_tokens_file: Path | None = None
     # Subject for the single-token bearer mode; ignored when
@@ -128,6 +134,8 @@ class ServerConfig:
 
         token_ttl_str = env(env_prefix, "FILE_EXCHANGE_TOKEN_TTL", "3600")
         max_size_raw = env(env_prefix, "FILE_EXCHANGE_MAX_ARTIFACT_SIZE")
+        allowed_networks_raw = env(env_prefix, "FILE_EXCHANGE_ALLOWED_NETWORKS")
+        http_timeout_str = env(env_prefix, "FILE_EXCHANGE_HTTP_TIMEOUT", "30")
 
         tokens_file_raw = env(env_prefix, "BEARER_TOKENS_FILE")
         # ``Path(...)`` keeps a leading ``~`` literal here.  Expansion is
@@ -161,6 +169,10 @@ class ServerConfig:
             file_exchange_max_artifact_size=(
                 int(max_size_raw) if max_size_raw else None
             ),
+            file_exchange_allowed_networks=(
+                tuple(parse_list(allowed_networks_raw)) if allowed_networks_raw else ()
+            ),
+            file_exchange_http_timeout=float(http_timeout_str),
             bearer_tokens_file=bearer_tokens_file,
             bearer_default_subject=bearer_default_subject,
         )

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -198,10 +198,14 @@ async def _send_pinned(
             transport=transport,
             detail="address not permitted",
         )
+    # The guard owns the Host header (it must match the validated hostname so a
+    # caller cannot redirect the request to a different vhost on the pinned IP);
+    # strip any caller-supplied host key (case-insensitive) before forcing ours.
+    safe_headers = {k: v for k, v in (headers or {}).items() if k.lower() != "host"}
     request = client.build_request(
         method,
         httpx.URL(url).copy_with(host=pinned),
-        headers={"Host": host, **(headers or {})},
+        headers={"Host": host, **safe_headers},
         content=content,
         extensions={"sni_hostname": host},
     )

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -125,7 +125,15 @@ def _make_client(timeout: float) -> httpx.AsyncClient:
     No ambient credentials and ``trust_env=False`` (so ``HTTP(S)_PROXY`` /
     ``netrc`` cannot inject credentials or divert past the pinned IP — an SSRF
     bypass). Redirects are handled by :func:`guarded_stream`, not httpx.
+
+    A non-positive ``timeout`` is operator misconfiguration that would silently
+    disable the request timeout (the resource-exhaustion bound), so it raises
+    :class:`ConfigurationError` — consistent with the token-store TTL guard.
     """
+    if timeout <= 0:
+        raise ConfigurationError(
+            "file-exchange: file_exchange_http_timeout must be positive"
+        )
     return httpx.AsyncClient(
         timeout=httpx.Timeout(timeout),
         follow_redirects=False,
@@ -137,9 +145,13 @@ def _make_client(timeout: float) -> httpx.AsyncClient:
 class GuardedResponse:
     """A streaming response yielded by :func:`guarded_stream`.
 
-    Wraps the underlying ``httpx.Response`` so the raw URL (carrying the
-    capability token) cannot leak through httpx's ``repr``/traceback. The
-    caller reads the body via :meth:`aiter_bytes` inside the ``async with``.
+    The underlying ``httpx.Response`` is held in a ``repr=False`` field so that
+    logging or ``repr``-ing a :class:`GuardedResponse` never exposes the
+    capability-token-bearing URL (the response stays reachable as a private
+    field for the body read). The caller reads the body via :meth:`aiter_bytes`
+    inside the ``async with``; a failure *during* body iteration propagates as a
+    raw ``httpx`` error for the consuming data plane (#145/#146) to map, whereas
+    pre-body failures are raised as :class:`FileExchangeTransferError`.
     """
 
     status: int
@@ -190,6 +202,15 @@ async def _send_pinned(
             transport=transport,
             detail="host could not be resolved",
         ) from exc
+    if not resolved:
+        logger.debug(
+            "file-exchange: host resolved to no addresses for %s", _redact(url)
+        )
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="host could not be resolved",
+        )
     pinned = _select_pinned(resolved, allowed)
     if pinned is None:
         logger.debug("file-exchange: refused non-global address for %s", _redact(url))
@@ -272,6 +293,16 @@ async def guarded_stream(
                 )
                 await response.aclose()
                 response = None
+                if content is not None:
+                    # A streaming request body cannot be safely replayed across
+                    # a redirect hop (the iterator is already consumed), so a
+                    # redirect on a bodied request is refused rather than
+                    # silently re-sent empty. The upload sender re-issues.
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.NOT_ACCESSIBLE,
+                        transport=transport,
+                        detail="refused redirect on a request with a body",
+                    )
                 if not _same_origin(current, target):
                     raise FileExchangeTransferError(
                         TransferErrorCode.NOT_ACCESSIBLE,

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -2,9 +2,10 @@
 
 The single primitive the download fetcher (#145) and upload sender (#146)
 issue their requests through. Enforces the §15 SSRF mitigations (https-only,
-deny-all-non-global address refusal with a CIDR allowlist, no cross-origin
-redirect, no ambient credentials) and the §15 DNS-rebinding mitigation
-(resolve-once-pin-IP via httpx's ``sni_hostname`` extension). Carries the
+deny-all-non-global address refusal with a CIDR allowlist, cross-origin redirect
+refusal (same-origin followed, bounded), no ambient credentials) and the §15
+DNS-rebinding mitigation (resolve-once-pin-IP via httpx's ``sni_hostname``
+extension). Carries the
 URL-redaction discipline: only the hostname ever reaches a log line, and no
 URL parts reach the wire ``detail``.
 
@@ -128,7 +129,8 @@ def _make_client(timeout: float) -> httpx.AsyncClient:
 
     A non-positive ``timeout`` is operator misconfiguration that would silently
     disable the request timeout (the resource-exhaustion bound), so it raises
-    :class:`ConfigurationError` — consistent with the token-store TTL guard.
+    :class:`ConfigurationError` — the same loud-failure type this module uses for
+    the CIDR-allowlist parse above.
     """
     if timeout <= 0:
         raise ConfigurationError(
@@ -228,10 +230,14 @@ async def _send_pinned(
     # credentials guarantee (§10.2/§10.3). Applies to the initial URL and to
     # every same-origin redirect target (all go through _send_pinned).
     pinned_url = httpx.URL(url).copy_with(host=pinned, username="", password="")
+    # Carry a non-default port in the Host header (RFC 7230 §5.4) and bracket an
+    # IPv6-literal host; SNI stays the bare hostname (no port/brackets).
+    bracketed = f"[{host}]" if ":" in host else host
+    host_header = bracketed if port == 443 else f"{bracketed}:{port}"
     request = client.build_request(
         method,
         pinned_url,
-        headers={"Host": host, **safe_headers},
+        headers={"Host": host_header, **safe_headers},
         content=content,
         extensions={"sni_hostname": host},
     )
@@ -287,7 +293,7 @@ async def guarded_stream(
             response = await _send_pinned(
                 client, method, current, transport, allowed, headers, content
             )
-            if response.is_redirect:
+            if response.has_redirect_location:
                 target = str(
                     httpx.URL(current).join(response.headers.get("location", ""))
                 )

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -21,7 +21,7 @@ import asyncio
 import ipaddress
 import logging
 import socket
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
@@ -112,15 +112,20 @@ def _is_permitted(ip: _IPAddress, allowed: list[_IPNetwork]) -> bool:
 def _select_pinned(resolved: list[str], allowed: list[_IPNetwork]) -> str | None:
     """Pick the first permitted address to pin, or ``None`` if all are refused.
 
-    ``resolved`` entries must be valid IP-address strings as returned by
-    ``socket.getaddrinfo`` (``ipaddress.ip_address`` would raise on a malformed
-    one). Picking a permitted address out of a mixed result set is safe because
-    the connection is then pinned to exactly that address — a DNS result that
-    mixes a private and a public record cannot induce a connection to the
-    private one.
+    ``resolved`` entries are normally valid IP-address strings from
+    ``socket.getaddrinfo``; an entry ``ipaddress.ip_address`` cannot parse is
+    skipped (treated as not-permitted) rather than raising — keeping the
+    pre-yield "all guard failures are coded" contract total. Picking a permitted
+    address out of a mixed result set is safe because the connection is then
+    pinned to exactly that address — a DNS result that mixes a private and a
+    public record cannot induce a connection to the private one.
     """
     for addr in resolved:
-        if _is_permitted(ipaddress.ip_address(addr), allowed):
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        if _is_permitted(ip, allowed):
             return addr
     return None
 
@@ -333,7 +338,12 @@ async def guarded_stream(
                         transport=transport,
                         detail="malformed redirect location",
                     ) from exc
-                await response.aclose()
+                # Discarding a redirect response body: a close error (e.g. the
+                # server dropping the connection mid-discard) is irrelevant and
+                # must not escape the guard as a non-coded exception — matches
+                # the fail-safe cleanup-close pattern in _filesystem.py.
+                with suppress(Exception):
+                    await response.aclose()
                 response = None
                 if content is not None:
                     # A streaming request body cannot be safely replayed across

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -220,6 +220,20 @@ async def _send_pinned(
         ) from exc
 
 
+def _same_origin(a: str, b: str) -> bool:
+    """Whether two URLs share scheme + host + port (case-insensitive host).
+
+    https default port 443 is normalised so ``https://h/x`` and
+    ``https://h:443/x`` compare equal.
+    """
+    pa, pb = urlsplit(a), urlsplit(b)
+    return (
+        pa.scheme.lower() == pb.scheme.lower()
+        and (pa.hostname or "").lower() == (pb.hostname or "").lower()
+        and (pa.port or 443) == (pb.port or 443)
+    )
+
+
 @asynccontextmanager
 async def guarded_stream(
     method: str,
@@ -242,13 +256,35 @@ async def guarded_stream(
     client = _make_client(config.file_exchange_http_timeout)
     response: httpx.Response | None = None
     try:
-        response = await _send_pinned(
-            client, method, url, transport, allowed, headers, content
-        )
-        yield GuardedResponse(
-            status=response.status_code,
-            headers=response.headers,
-            _response=response,
+        current = url
+        for _hop in range(_MAX_REDIRECTS + 1):
+            response = await _send_pinned(
+                client, method, current, transport, allowed, headers, content
+            )
+            if response.is_redirect:
+                target = str(
+                    httpx.URL(current).join(response.headers.get("location", ""))
+                )
+                await response.aclose()
+                response = None
+                if not _same_origin(current, target):
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.NOT_ACCESSIBLE,
+                        transport=transport,
+                        detail="refused cross-origin redirect",
+                    )
+                current = target
+                continue
+            yield GuardedResponse(
+                status=response.status_code,
+                headers=response.headers,
+                _response=response,
+            )
+            return
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="too many redirects",
         )
     finally:
         if response is not None:

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -57,23 +57,39 @@ def _redact(url: str) -> str:
     return host or "<unknown-host>"
 
 
+# The IPv4-mapped IPv6 range. An allowlist CIDR that is a subnet of this is
+# rejected loudly: _is_permitted tests membership against the unwrapped IPv4
+# candidate, so a mapped CIDR would silently never match (the operator means the
+# canonical IPv4 form).
+_IPV4_MAPPED_NETWORK = ipaddress.IPv6Network("::ffff:0:0/96")
+
+
 def _parse_allowed_networks(cidrs: tuple[str, ...]) -> list[_IPNetwork]:
     """Parse operator CIDR strings into networks.
 
     A malformed entry is operator misconfiguration → :class:`ConfigurationError`
-    (loud), consistent with the rest of the package. Allowlist entries must use
-    the canonical address form (e.g. ``10.0.0.0/8``); an IPv4-mapped-IPv6 CIDR
-    (``::ffff:10.0.0.0/104``) parses but will never match, because membership is
-    tested against the unwrapped IPv4 candidate (see :func:`_is_permitted`).
+    (loud), consistent with the rest of the package. An IPv4-mapped-IPv6 CIDR
+    (e.g. ``::ffff:10.0.0.0/104``) is rejected the same way: membership is tested
+    against the unwrapped IPv4 candidate (see :func:`_is_permitted`), so such an
+    entry would silently never match — the operator means the canonical IPv4 form
+    (``10.0.0.0/8``).
     """
     networks: list[_IPNetwork] = []
     for cidr in cidrs:
         try:
-            networks.append(ipaddress.ip_network(cidr, strict=False))
+            net = ipaddress.ip_network(cidr, strict=False)
         except ValueError as exc:
             raise ConfigurationError(
                 f"file-exchange: malformed CIDR in allowed-networks: {cidr!r}"
             ) from exc
+        if isinstance(net, ipaddress.IPv6Network) and net.subnet_of(
+            _IPV4_MAPPED_NETWORK
+        ):
+            raise ConfigurationError(
+                "file-exchange: use the canonical IPv4 CIDR, not an IPv4-mapped "
+                f"IPv6 range, in allowed-networks: {cidr!r}"
+            )
+        networks.append(net)
     return networks
 
 

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -1,0 +1,102 @@
+"""Outbound-HTTP guard for the file-exchange data plane (#147).
+
+The single primitive the download fetcher (#145) and upload sender (#146)
+issue their requests through. Enforces the §15 SSRF mitigations (https-only,
+deny-all-non-global address refusal with a CIDR allowlist, no cross-origin
+redirect, no ambient credentials) and the §15 DNS-rebinding mitigation
+(resolve-once-pin-IP via httpx's ``sni_hostname`` extension). Carries the
+URL-redaction discipline: only the hostname ever reaches a log line, and no
+URL parts reach the wire ``detail``.
+
+It does NOT verify size/digest, recover with ``Range``, or touch artifacts —
+those are the consuming data planes' deliverables (#145/#146). See
+``docs/superpowers/specs/2026-05-24-file-exchange-147-ssrf-guard-design.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import socket
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+import httpx
+
+from fastmcp_pvl_core._errors import ConfigurationError
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterable, AsyncIterator, Mapping
+
+    from fastmcp_pvl_core._config import ServerConfig
+
+logger = logging.getLogger(__name__)
+
+# Max same-origin redirect hops followed before refusing (§15: cross-origin
+# is always refused; this caps a same-origin redirect chain).
+_MAX_REDIRECTS = 5
+
+_IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+_IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
+def _redact(url: str) -> str:
+    """Return only the hostname of ``url``.
+
+    The capability token lives in the URL path/query, so those must never
+    reach a log line or a wire ``detail`` (§15). Falls back to a placeholder
+    for an unparseable value.
+    """
+    host = urlsplit(url).hostname
+    return host or "<unknown-host>"
+
+
+def _parse_allowed_networks(cidrs: tuple[str, ...]) -> list[_IPNetwork]:
+    """Parse operator CIDR strings into networks.
+
+    A malformed entry is operator misconfiguration → :class:`ConfigurationError`
+    (loud), consistent with the rest of the package.
+    """
+    networks: list[_IPNetwork] = []
+    for cidr in cidrs:
+        try:
+            networks.append(ipaddress.ip_network(cidr, strict=False))
+        except ValueError as exc:
+            raise ConfigurationError(
+                f"file-exchange: malformed CIDR in allowed-networks: {cidr!r}"
+            ) from exc
+    return networks
+
+
+def _is_permitted(ip: _IPAddress, allowed: list[_IPNetwork]) -> bool:
+    """A resolved address is permitted iff globally routable or allowlisted.
+
+    An IPv4-mapped IPv6 address is unwrapped first, so a mapped loopback/
+    private address (``::ffff:127.0.0.1``) cannot slip past ``is_global``.
+    Allowlist membership is checked against the unwrapped form; an address/
+    network version mismatch yields ``False`` (never raises).
+    """
+    mapped = ip.ipv4_mapped if isinstance(ip, ipaddress.IPv6Address) else None
+    candidate: _IPAddress = mapped if mapped is not None else ip
+    if candidate.is_global:
+        return True
+    return any(candidate in net for net in allowed)
+
+
+def _select_pinned(resolved: list[str], allowed: list[_IPNetwork]) -> str | None:
+    """Pick the first permitted address to pin, or ``None`` if all are refused.
+
+    Picking a permitted address out of a mixed result set is safe because the
+    connection is then pinned to exactly that address — a DNS result that
+    mixes a private and a public record cannot induce a connection to the
+    private one.
+    """
+    for addr in resolved:
+        if _is_permitted(ipaddress.ip_address(addr), allowed):
+            return addr
+    return None

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -105,3 +105,148 @@ def _select_pinned(resolved: list[str], allowed: list[_IPNetwork]) -> str | None
         if _is_permitted(ipaddress.ip_address(addr), allowed):
             return addr
     return None
+
+
+async def _resolve(host: str, port: int) -> list[str]:
+    """Resolve ``host`` once to a list of IP strings (single getaddrinfo call).
+
+    Kept as a module-level function so tests can pin it; this single call is
+    the resolution the §15 DNS-rebind mitigation anchors on — the connection
+    uses only addresses from this result.
+    """
+    loop = asyncio.get_running_loop()
+    infos = await loop.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    return [info[4][0] for info in infos]
+
+
+def _make_client(timeout: float) -> httpx.AsyncClient:
+    """Build the outbound client.
+
+    No ambient credentials and ``trust_env=False`` (so ``HTTP(S)_PROXY`` /
+    ``netrc`` cannot inject credentials or divert past the pinned IP — an SSRF
+    bypass). Redirects are handled by :func:`guarded_stream`, not httpx.
+    """
+    return httpx.AsyncClient(
+        timeout=httpx.Timeout(timeout),
+        follow_redirects=False,
+        trust_env=False,
+    )
+
+
+@dataclass(frozen=True)
+class GuardedResponse:
+    """A streaming response yielded by :func:`guarded_stream`.
+
+    Wraps the underlying ``httpx.Response`` so the raw URL (carrying the
+    capability token) cannot leak through httpx's ``repr``/traceback. The
+    caller reads the body via :meth:`aiter_bytes` inside the ``async with``.
+    """
+
+    status: int
+    headers: Mapping[str, str]
+    _response: httpx.Response = field(repr=False)
+
+    def aiter_bytes(self) -> AsyncIterator[bytes]:
+        return self._response.aiter_bytes()
+
+
+async def _send_pinned(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    transport: str,
+    allowed: list[_IPNetwork],
+    headers: Mapping[str, str] | None,
+    content: AsyncIterable[bytes] | bytes | None,
+) -> httpx.Response:
+    """Resolve-once, validate, pin, and send a single streamed request.
+
+    Raises :class:`FileExchangeTransferError` (``not-accessible``) for a
+    non-https URL, a missing host, an unresolvable host, a non-permitted
+    address, or a connection failure. The returned response is streamed
+    (body not yet read).
+    """
+    parts = urlsplit(url)
+    if parts.scheme != "https":
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="refused non-https URL",
+        )
+    host = parts.hostname
+    if host is None:
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="URL has no host",
+        )
+    port = parts.port or 443
+    try:
+        resolved = await _resolve(host, port)
+    except OSError as exc:
+        logger.debug("file-exchange: DNS resolution failed for %s", _redact(url))
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="host could not be resolved",
+        ) from exc
+    pinned = _select_pinned(resolved, allowed)
+    if pinned is None:
+        logger.debug("file-exchange: refused non-global address for %s", _redact(url))
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="address not permitted",
+        )
+    request = client.build_request(
+        method,
+        httpx.URL(url).copy_with(host=pinned),
+        headers={"Host": host, **(headers or {})},
+        content=content,
+        extensions={"sni_hostname": host},
+    )
+    try:
+        return await client.send(request, stream=True)
+    except httpx.HTTPError as exc:
+        logger.debug("file-exchange: outbound request failed for %s", _redact(url))
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE,
+            transport=transport,
+            detail="endpoint unreachable",
+        ) from exc
+
+
+@asynccontextmanager
+async def guarded_stream(
+    method: str,
+    url: str,
+    *,
+    config: ServerConfig,
+    transport: str,
+    headers: Mapping[str, str] | None = None,
+    content: AsyncIterable[bytes] | bytes | None = None,
+) -> AsyncIterator[GuardedResponse]:
+    """Issue a guarded, streamed outbound request and yield the response.
+
+    Enforces the §15 SSRF + DNS-rebind mitigations (see module docstring).
+    ``transport`` is the §13 envelope label (``"download"``/``"upload"``)
+    carried on any raised :class:`FileExchangeTransferError`. The caller reads
+    the body via the yielded :class:`GuardedResponse` inside the ``async
+    with``; the response and client are closed on exit, including on error.
+    """
+    allowed = _parse_allowed_networks(config.file_exchange_allowed_networks)
+    client = _make_client(config.file_exchange_http_timeout)
+    response: httpx.Response | None = None
+    try:
+        response = await _send_pinned(
+            client, method, url, transport, allowed, headers, content
+        )
+        yield GuardedResponse(
+            status=response.status_code,
+            headers=response.headers,
+            _response=response,
+        )
+    finally:
+        if response is not None:
+            await response.aclose()
+        await client.aclose()

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -147,17 +147,16 @@ def _make_client(timeout: float) -> httpx.AsyncClient:
 class GuardedResponse:
     """A streaming response yielded by :func:`guarded_stream`.
 
-    The underlying ``httpx.Response`` is held in a ``repr=False`` field so that
-    ``repr``-ing or logging a :class:`GuardedResponse` does not surface the
-    response's request URL — which httpx's own ``Response``/``Request`` repr
-    embeds verbatim, capability token and all. The guarantee is scoped to that
-    httpx-repr channel: ``status`` and ``headers`` are still shown, so a server
-    that echoed the URL into a response header would still expose it (not the
-    normal case). The response stays reachable as a private field for the body
-    read. The caller reads the body via :meth:`aiter_bytes` inside the ``async
-    with``; a failure *during* body iteration propagates as a raw ``httpx`` error
-    for the consuming data plane (#145/#146) to map, whereas pre-body failures are
-    raised as :class:`FileExchangeTransferError`.
+    Surfaces only ``status``, ``headers``, and :meth:`aiter_bytes`. The underlying
+    ``httpx.Response`` is kept in a ``repr=False`` field so it is not rendered into
+    a :class:`GuardedResponse` ``repr`` or log line — defence in depth, since the
+    response's request carries the capability-token URL. (``status`` and
+    ``headers`` are still shown, so a server that echoed the URL into a response
+    header would surface it there.) The caller reads the body via
+    :meth:`aiter_bytes` inside the ``async with``; a failure *during* body
+    iteration propagates as a raw ``httpx`` error for the consuming data plane
+    (#145/#146) to map, whereas pre-body failures raise
+    :class:`FileExchangeTransferError`.
     """
 
     status: int

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -3,7 +3,8 @@
 The single primitive the download fetcher (#145) and upload sender (#146)
 issue their requests through. Enforces the §15 SSRF mitigations (https-only,
 deny-all-non-global address refusal with a CIDR allowlist, cross-origin redirect
-refusal (same-origin followed, bounded), no ambient credentials) and the §15
+refusal — same-origin followed and bounded, but any redirect on a request with a
+body is refused — and no ambient credentials) and the §15
 DNS-rebinding mitigation (resolve-once-pin-IP via httpx's ``sni_hostname``
 extension). Carries the
 URL-redaction discipline: only the hostname ever reaches a log line, and no

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -148,12 +148,16 @@ class GuardedResponse:
     """A streaming response yielded by :func:`guarded_stream`.
 
     The underlying ``httpx.Response`` is held in a ``repr=False`` field so that
-    logging or ``repr``-ing a :class:`GuardedResponse` never exposes the
-    capability-token-bearing URL (the response stays reachable as a private
-    field for the body read). The caller reads the body via :meth:`aiter_bytes`
-    inside the ``async with``; a failure *during* body iteration propagates as a
-    raw ``httpx`` error for the consuming data plane (#145/#146) to map, whereas
-    pre-body failures are raised as :class:`FileExchangeTransferError`.
+    ``repr``-ing or logging a :class:`GuardedResponse` does not surface the
+    response's request URL — which httpx's own ``Response``/``Request`` repr
+    embeds verbatim, capability token and all. The guarantee is scoped to that
+    httpx-repr channel: ``status`` and ``headers`` are still shown, so a server
+    that echoed the URL into a response header would still expose it (not the
+    normal case). The response stays reachable as a private field for the body
+    read. The caller reads the body via :meth:`aiter_bytes` inside the ``async
+    with``; a failure *during* body iteration propagates as a raw ``httpx`` error
+    for the consuming data plane (#145/#146) to map, whereas pre-body failures are
+    raised as :class:`FileExchangeTransferError`.
     """
 
     status: int

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -313,10 +313,26 @@ async def guarded_stream(
             response = await _send_pinned(
                 client, method, current, transport, allowed, headers, content
             )
-            if response.has_redirect_location:
-                target = str(
-                    httpx.URL(current).join(response.headers.get("location", ""))
-                )
+            # ``has_redirect_location`` is True whenever a ``Location`` header is
+            # *present*, even if its value is empty — an empty value is not a
+            # usable redirect target, so treat it (like a 3xx with no Location)
+            # as terminal and yield below.
+            location = (
+                response.headers.get("location", "")
+                if response.has_redirect_location
+                else ""
+            )
+            if location:
+                try:
+                    target = str(httpx.URL(current).join(location))
+                except httpx.InvalidURL as exc:
+                    # A malformed Location must surface as a coded refusal, not a
+                    # raw httpx error escaping the guard.
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.NOT_ACCESSIBLE,
+                        transport=transport,
+                        detail="malformed redirect location",
+                    ) from exc
                 await response.aclose()
                 response = None
                 if content is not None:

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -60,7 +60,10 @@ def _parse_allowed_networks(cidrs: tuple[str, ...]) -> list[_IPNetwork]:
     """Parse operator CIDR strings into networks.
 
     A malformed entry is operator misconfiguration → :class:`ConfigurationError`
-    (loud), consistent with the rest of the package.
+    (loud), consistent with the rest of the package. Allowlist entries must use
+    the canonical address form (e.g. ``10.0.0.0/8``); an IPv4-mapped-IPv6 CIDR
+    (``::ffff:10.0.0.0/104``) parses but will never match, because membership is
+    tested against the unwrapped IPv4 candidate (see :func:`_is_permitted`).
     """
     networks: list[_IPNetwork] = []
     for cidr in cidrs:
@@ -91,8 +94,10 @@ def _is_permitted(ip: _IPAddress, allowed: list[_IPNetwork]) -> bool:
 def _select_pinned(resolved: list[str], allowed: list[_IPNetwork]) -> str | None:
     """Pick the first permitted address to pin, or ``None`` if all are refused.
 
-    Picking a permitted address out of a mixed result set is safe because the
-    connection is then pinned to exactly that address — a DNS result that
+    ``resolved`` entries must be valid IP-address strings as returned by
+    ``socket.getaddrinfo`` (``ipaddress.ip_address`` would raise on a malformed
+    one). Picking a permitted address out of a mixed result set is safe because
+    the connection is then pinned to exactly that address — a DNS result that
     mixes a private and a public record cannot induce a connection to the
     private one.
     """

--- a/src/fastmcp_pvl_core/_file_exchange/_outbound.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_outbound.py
@@ -202,9 +202,14 @@ async def _send_pinned(
     # caller cannot redirect the request to a different vhost on the pinned IP);
     # strip any caller-supplied host key (case-insensitive) before forcing ours.
     safe_headers = {k: v for k, v in (headers or {}).items() if k.lower() != "host"}
+    # Strip any userinfo (user:pass@) from the URL: httpx.send would otherwise
+    # turn it into an Authorization: Basic header, breaking the no-ambient-
+    # credentials guarantee (§10.2/§10.3). Applies to the initial URL and to
+    # every same-origin redirect target (all go through _send_pinned).
+    pinned_url = httpx.URL(url).copy_with(host=pinned, username="", password="")
     request = client.build_request(
         method,
-        httpx.URL(url).copy_with(host=pinned),
+        pinned_url,
         headers={"Host": host, **safe_headers},
         content=content,
         extensions={"sni_hostname": host},

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -399,3 +399,88 @@ async def test_refuses_too_many_redirects(monkeypatch):
             pass
     assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
     assert counter["n"] == _outbound._MAX_REDIRECTS + 1  # initial + 5 follows
+
+
+# ---------------------------------------------------------------------------
+# Task 5: Userinfo / no-ambient-credentials tests
+# ---------------------------------------------------------------------------
+
+
+async def test_initial_url_userinfo_not_sent_as_credentials(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        return httpx.Response(200, content=b"x")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET",
+        "https://user:pass@example.com/d/tok",
+        config=_cfg(),
+        transport="download",
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    assert "authorization" not in seen[0].headers
+
+
+async def test_redirect_userinfo_not_sent_as_credentials(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        if len(seen) == 1:
+            return httpx.Response(
+                302, headers={"location": "https://user:pass@example.com/final"}
+            )
+        return httpx.Response(200, content=b"ok")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/start", config=_cfg(), transport="download"
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    assert "authorization" not in seen[1].headers
+
+
+async def test_refuses_scheme_downgrade_redirect(monkeypatch):
+    def handler(request):
+        return httpx.Response(302, headers={"location": "http://example.com/x"})
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/start", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_refuses_redirect_that_rebinds_to_blocked_ip(monkeypatch):
+    seen = []
+    resolves = [["93.184.216.34"], ["127.0.0.1"]]  # hop 1 global, hop 2 loopback
+
+    async def fake_resolve(host, port):
+        return resolves[len(seen)]
+
+    def handler(request):
+        seen.append(request)
+        return httpx.Response(302, headers={"location": "https://example.com/next"})
+
+    def fake_make_client(timeout):
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            follow_redirects=False,
+        )
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    monkeypatch.setattr(_outbound, "_make_client", fake_make_client)
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/start", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -49,6 +49,14 @@ def test_allowlist_permits_private_cidr():
     assert _outbound._is_permitted(ipaddress.ip_address("10.1.2.3"), allowed) is True
 
 
+def test_allowlist_permits_ipv4_mapped_private():
+    allowed = _outbound._parse_allowed_networks(("192.168.0.0/16",))
+    assert (
+        _outbound._is_permitted(ipaddress.ip_address("::ffff:192.168.1.1"), allowed)
+        is True
+    )
+
+
 def test_malformed_cidr_raises_configuration_error():
     with pytest.raises(ConfigurationError):
         _outbound._parse_allowed_networks(("not-a-cidr",))
@@ -63,3 +71,11 @@ def test_select_pinned_skips_blocked_picks_global():
 
 def test_select_pinned_none_when_all_blocked():
     assert _outbound._select_pinned(["127.0.0.1", "10.0.0.1"], []) is None
+
+
+def test_select_pinned_picks_global_ipv6_over_blocked_ipv4():
+    resolved = ["10.0.0.1", "2606:2800:220:1:248:1893:25c8:1946"]
+    assert (
+        _outbound._select_pinned(resolved, [])
+        == "2606:2800:220:1:248:1893:25c8:1946"
+    )

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -112,6 +112,15 @@ def test_select_pinned_picks_global_ipv6_over_blocked_ipv4():
     )
 
 
+def test_select_pinned_skips_unparseable_address():
+    # A getaddrinfo result ipaddress cannot parse is skipped (not-permitted),
+    # never raising a bare ValueError out of the guard.
+    assert (
+        _outbound._select_pinned(["not-an-ip", "93.184.216.34"], []) == "93.184.216.34"
+    )
+    assert _outbound._select_pinned(["not-an-ip"], []) is None
+
+
 # ---------------------------------------------------------------------------
 # Task 3: guarded_stream core tests
 # ---------------------------------------------------------------------------
@@ -502,6 +511,41 @@ async def test_refuses_malformed_redirect_location(monkeypatch):
         ):
             pass
     assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_redirect_discard_aclose_error_is_suppressed(monkeypatch):
+    # Closing a discarded redirect response can fail (server drops the
+    # connection mid-discard); that error must be suppressed, not escape the
+    # guard as a raw non-coded exception. The redirect is still followed.
+    seen = []
+
+    class _RaisingCloseStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            return
+            yield  # pragma: no cover  (empty body; never iterated for a 302)
+
+        async def aclose(self):
+            raise httpx.RemoteProtocolError("connection dropped mid-discard")
+
+    def handler(request):
+        seen.append(str(request.url))
+        if len(seen) == 1:
+            return httpx.Response(
+                302,
+                headers={"location": "https://example.com/final"},
+                stream=_RaisingCloseStream(),
+            )
+        return httpx.Response(200, content=b"final-bytes")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    data = b""
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/start", config=_cfg(), transport="download"
+    ) as resp:
+        async for chunk in resp.aiter_bytes():
+            data += chunk
+    assert data == b"final-bytes"
+    assert len(seen) == 2
 
 
 async def test_refuses_same_host_different_port_redirect(monkeypatch):

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -1,4 +1,5 @@
 import ipaddress
+import logging
 import socket
 
 import httpx
@@ -484,6 +485,7 @@ async def test_refuses_redirect_that_rebinds_to_blocked_ip(monkeypatch):
         ):
             pass
     assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+    assert ei.value.detail == "address not permitted"
 
 
 async def test_refuses_redirect_on_request_with_body(monkeypatch):
@@ -633,3 +635,113 @@ async def test_client_closed_on_cross_origin_refusal(monkeypatch):
         ):
             pass
     assert holder["client"].is_closed is True
+
+
+async def test_non_redirect_3xx_is_yielded(monkeypatch):
+    def handler(request):
+        return httpx.Response(304)
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/x", config=_cfg(), transport="download"
+    ) as resp:
+        assert resp.status == 304
+        async for _ in resp.aiter_bytes():
+            pass
+
+
+async def test_3xx_without_location_is_yielded(monkeypatch):
+    def handler(request):
+        return httpx.Response(302)  # 3xx but no Location header
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/x", config=_cfg(), transport="download"
+    ) as resp:
+        assert resp.status == 302
+        async for _ in resp.aiter_bytes():
+            pass
+
+
+async def test_host_header_includes_non_default_port(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        return httpx.Response(200, content=b"x")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com:8443/x", config=_cfg(), transport="download"
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    req = seen[0]
+    assert req.headers["host"] == "example.com:8443"
+    assert req.url.host == "93.184.216.34"
+    assert req.url.port == 8443
+    assert req.extensions.get("sni_hostname") == "example.com"
+
+
+async def test_refuses_url_without_host():
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https:///path", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_body_iteration_error_propagates_raw_and_closes_client(monkeypatch):
+    holder = {}
+
+    async def raising_stream():
+        yield b"partial"
+        raise httpx.ReadError("mid-stream failure")
+
+    def handler(request):
+        return httpx.Response(200, content=raising_stream())
+
+    async def fake_resolve(host, port):
+        return ["93.184.216.34"]
+
+    def fake_make_client(timeout):
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            follow_redirects=False,
+        )
+        holder["client"] = client
+        return client
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    monkeypatch.setattr(_outbound, "_make_client", fake_make_client)
+    # A failure during body iteration must surface as a raw httpx error (so the
+    # data plane can map/recover), NOT remapped to FileExchangeTransferError.
+    with pytest.raises(httpx.HTTPError):
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/x", config=_cfg(), transport="download"
+        ) as resp:
+            async for _ in resp.aiter_bytes():
+                pass
+    assert holder["client"].is_closed is True
+
+
+async def test_failure_logs_do_not_leak_credentials_or_token(monkeypatch, caplog):
+    async def fake_resolve(host, port):
+        return ["127.0.0.1"]  # non-global -> refusal + debug log on the failure path
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(FileExchangeTransferError):
+            async with _outbound.guarded_stream(
+                "GET",
+                "https://carol:hunter2@example.com/d/SECRETTOKEN",
+                config=_cfg(),
+                transport="download",
+            ):
+                pass
+    blob = " ".join(record.getMessage() for record in caplog.records)
+    assert "hunter2" not in blob
+    assert "carol" not in blob
+    assert "SECRETTOKEN" not in blob

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -577,6 +577,9 @@ async def test_guarded_response_repr_hides_token(monkeypatch):
         rendered = repr(resp)
         assert "SECRETTOKEN" not in rendered
         assert "/d/" not in rendered
+        # Pin repr=False on _response: with repr=True the field (and the
+        # underlying response/request that carries the URL) would be rendered.
+        assert "_response" not in rendered
         async for _ in resp.aiter_bytes():
             pass
 
@@ -727,11 +730,37 @@ async def test_body_iteration_error_propagates_raw_and_closes_client(monkeypatch
     assert holder["client"].is_closed is True
 
 
-async def test_failure_logs_do_not_leak_credentials_or_token(monkeypatch, caplog):
+@pytest.mark.parametrize(
+    "scenario",
+    ["dns-failure", "empty-resolution", "non-global", "connect-error"],
+)
+async def test_failure_logs_do_not_leak_credentials_or_token(
+    monkeypatch, caplog, scenario
+):
+    # Sweep every logger.debug emit-path in _send_pinned, not just one — the
+    # URL-credential-redaction discipline (PR #122) requires all of them be
+    # proven to log only the redacted hostname.
     async def fake_resolve(host, port):
-        return ["127.0.0.1"]  # non-global -> refusal + debug log on the failure path
+        if scenario == "dns-failure":
+            raise socket.gaierror("resolution failed")
+        if scenario == "empty-resolution":
+            return []
+        if scenario == "non-global":
+            return ["127.0.0.1"]
+        return ["93.184.216.34"]  # connect-error: reach the send path
+
+    def handler(request):
+        raise httpx.ConnectError("connection refused")
+
+    def fake_make_client(timeout):
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            follow_redirects=False,
+        )
 
     monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    monkeypatch.setattr(_outbound, "_make_client", fake_make_client)
     with caplog.at_level(logging.DEBUG):
         with pytest.raises(FileExchangeTransferError):
             async with _outbound.guarded_stream(
@@ -745,3 +774,23 @@ async def test_failure_logs_do_not_leak_credentials_or_token(monkeypatch, caplog
     assert "hunter2" not in blob
     assert "carol" not in blob
     assert "SECRETTOKEN" not in blob
+
+
+async def test_host_header_brackets_ipv6_literal(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        return httpx.Response(200, content=b"x")
+
+    ipv6 = "2606:2800:220:1:248:1893:25c8:1946"
+    _install_mock(monkeypatch, handler, resolve_to=[ipv6])
+    async with _outbound.guarded_stream(
+        "GET", f"https://[{ipv6}]:8443/x", config=_cfg(), transport="download"
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    req = seen[0]
+    assert req.headers["host"] == f"[{ipv6}]:8443"
+    assert req.extensions.get("sni_hostname") == ipv6  # bare, no brackets
+    assert req.url.host == ipv6

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -249,8 +249,7 @@ async def test_make_client_security_defaults():
     try:
         assert client.trust_env is False
         assert client.follow_redirects is False
-        assert client.timeout.read == 30.0
-        assert client.timeout.connect == 30.0
+        assert client.timeout == httpx.Timeout(30.0)
     finally:
         await client.aclose()
 
@@ -280,4 +279,45 @@ async def test_client_closed_on_caller_exception(monkeypatch):
             "GET", "https://example.com/x", config=_cfg(), transport="download"
         ):
             raise RuntimeError("boom")
+    assert holder["client"].is_closed is True
+
+
+async def test_caller_cannot_inject_host_header(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        return httpx.Response(200, content=b"x")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET",
+        "https://example.com/x",
+        config=_cfg(),
+        transport="download",
+        headers={"Host": "evil.com", "host": "evil2.com"},
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    assert seen[0].headers["host"] == "example.com"
+
+
+async def test_client_closed_after_send_pinned_raises(monkeypatch):
+    holder = {}
+
+    async def fake_resolve(host, port):
+        return ["127.0.0.1"]  # non-global -> refusal before yield
+
+    def fake_make_client(timeout):
+        client = httpx.AsyncClient(trust_env=False, follow_redirects=False)
+        holder["client"] = client
+        return client
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    monkeypatch.setattr(_outbound, "_make_client", fake_make_client)
+    with pytest.raises(FileExchangeTransferError):
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/x", config=_cfg(), transport="download"
+        ):
+            pass
     assert holder["client"].is_closed is True

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -321,3 +321,81 @@ async def test_client_closed_after_send_pinned_raises(monkeypatch):
         ):
             pass
     assert holder["client"].is_closed is True
+
+
+# ---------------------------------------------------------------------------
+# Task 4: Redirect handling tests
+# ---------------------------------------------------------------------------
+
+
+async def test_follows_same_origin_redirect_and_reresolves(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(str(request.url))
+        if len(seen) == 1:
+            return httpx.Response(
+                302, headers={"location": "https://example.com/final"}
+            )
+        return httpx.Response(200, content=b"final-bytes")
+
+    calls = _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    data = b""
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/start", config=_cfg(), transport="download"
+    ) as resp:
+        async for chunk in resp.aiter_bytes():
+            data += chunk
+    assert data == b"final-bytes"
+    assert calls["resolve"] == 2  # re-resolved + re-validated per hop
+
+
+async def test_follows_relative_redirect(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request.url.path)
+        if len(seen) == 1:
+            return httpx.Response(302, headers={"location": "/elsewhere"})
+        return httpx.Response(200, content=b"ok")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/start", config=_cfg(), transport="download"
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    assert seen[1] == "/elsewhere"
+
+
+async def test_refuses_cross_origin_redirect(monkeypatch):
+    def handler(request):
+        return httpx.Response(302, headers={"location": "https://evil.example/x"})
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/start", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+    assert "evil.example" not in (ei.value.detail or "")
+
+
+async def test_refuses_too_many_redirects(monkeypatch):
+    counter = {"n": 0}
+
+    def handler(request):
+        counter["n"] += 1
+        return httpx.Response(
+            302, headers={"location": f"https://example.com/hop{counter['n']}"}
+        )
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/start", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+    assert counter["n"] == _outbound._MAX_REDIRECTS + 1  # initial + 5 follows

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -504,6 +504,45 @@ async def test_refuses_malformed_redirect_location(monkeypatch):
     assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
 
 
+async def test_refuses_same_host_different_port_redirect(monkeypatch):
+    # Same host/scheme but a different port is a different origin (a pivot to
+    # another service on the host) — must be refused.
+    def handler(request):
+        return httpx.Response(302, headers={"location": "https://example.com:8443/x"})
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/start", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_follows_same_non_default_port_redirect(monkeypatch):
+    # A redirect that keeps the same non-default port is same-origin and followed
+    # (port normalization must not treat :8443 -> :8443 as cross-origin).
+    seen = []
+
+    def handler(request):
+        seen.append(str(request.url))
+        if len(seen) == 1:
+            return httpx.Response(
+                302, headers={"location": "https://example.com:8443/final"}
+            )
+        return httpx.Response(200, content=b"final-bytes")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    data = b""
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com:8443/start", config=_cfg(), transport="download"
+    ) as resp:
+        async for chunk in resp.aiter_bytes():
+            data += chunk
+    assert data == b"final-bytes"
+    assert len(seen) == 2
+
+
 async def test_refuses_scheme_downgrade_redirect(monkeypatch):
     def handler(request):
         return httpx.Response(302, headers={"location": "http://example.com/x"})

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -1,0 +1,65 @@
+import ipaddress
+
+import pytest
+
+from fastmcp_pvl_core._errors import ConfigurationError
+from fastmcp_pvl_core._file_exchange import _outbound
+
+
+def test_redact_returns_hostname_only():
+    assert (
+        _outbound._redact("https://h.example.com/d/SECRETTOKEN?sig=abc")
+        == "h.example.com"
+    )
+
+
+def test_redact_handles_missing_host():
+    assert _outbound._redact("::not a url::") == "<unknown-host>"
+
+
+@pytest.mark.parametrize(
+    "addr",
+    [
+        "127.0.0.1",
+        "::1",
+        "169.254.1.1",
+        "fe80::1",
+        "10.0.0.5",
+        "172.16.0.1",
+        "192.168.1.1",
+        "100.64.0.1",  # CGNAT
+        "0.0.0.0",
+        "::ffff:127.0.0.1",  # IPv4-mapped loopback
+    ],
+)
+def test_non_global_addresses_refused(addr):
+    assert _outbound._is_permitted(ipaddress.ip_address(addr), []) is False
+
+
+@pytest.mark.parametrize(
+    "addr",
+    ["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"],
+)
+def test_global_addresses_permitted(addr):
+    assert _outbound._is_permitted(ipaddress.ip_address(addr), []) is True
+
+
+def test_allowlist_permits_private_cidr():
+    allowed = _outbound._parse_allowed_networks(("10.0.0.0/8",))
+    assert _outbound._is_permitted(ipaddress.ip_address("10.1.2.3"), allowed) is True
+
+
+def test_malformed_cidr_raises_configuration_error():
+    with pytest.raises(ConfigurationError):
+        _outbound._parse_allowed_networks(("not-a-cidr",))
+
+
+def test_select_pinned_skips_blocked_picks_global():
+    assert (
+        _outbound._select_pinned(["127.0.0.1", "93.184.216.34"], [])
+        == "93.184.216.34"
+    )
+
+
+def test_select_pinned_none_when_all_blocked():
+    assert _outbound._select_pinned(["127.0.0.1", "10.0.0.1"], []) is None

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -68,6 +68,21 @@ def test_malformed_cidr_raises_configuration_error():
         _outbound._parse_allowed_networks(("not-a-cidr",))
 
 
+def test_ipv4_mapped_cidr_in_allowlist_raises_configuration_error():
+    # An IPv4-mapped IPv6 CIDR would silently never match (membership tests the
+    # unwrapped IPv4 form), so it is rejected loudly — the operator means the
+    # canonical IPv4 CIDR.
+    with pytest.raises(ConfigurationError):
+        _outbound._parse_allowed_networks(("::ffff:10.0.0.0/104",))
+
+
+def test_non_mapped_ipv6_cidr_in_allowlist_accepted():
+    # A normal (non-mapped) IPv6 range must still parse — the mapped-CIDR guard
+    # uses subnet_of, so a broad/ULA range is not over-rejected.
+    nets = _outbound._parse_allowed_networks(("fc00::/7",))
+    assert len(nets) == 1
+
+
 def test_select_pinned_skips_blocked_picks_global():
     assert (
         _outbound._select_pinned(["127.0.0.1", "93.184.216.34"], []) == "93.184.216.34"

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -83,6 +83,18 @@ def test_non_mapped_ipv6_cidr_in_allowlist_accepted():
     assert len(nets) == 1
 
 
+@pytest.mark.parametrize(
+    ("addr", "cidr"),
+    [("10.0.0.1", "fc00::/7"), ("fc00::1", "10.0.0.0/8")],
+)
+def test_is_permitted_mixed_version_returns_false_not_raises(addr, cidr):
+    # An address tested against a different-version allowlist network must yield
+    # False (ipaddress __contains__ version-checks), never raise — the guard
+    # docstring's "never raises" contract.
+    allowed = _outbound._parse_allowed_networks((cidr,))
+    assert _outbound._is_permitted(ipaddress.ip_address(addr), allowed) is False
+
+
 def test_select_pinned_skips_blocked_picks_global():
     assert (
         _outbound._select_pinned(["127.0.0.1", "93.184.216.34"], []) == "93.184.216.34"
@@ -459,6 +471,37 @@ async def test_redirect_userinfo_not_sent_as_credentials(monkeypatch):
         async for _ in resp.aiter_bytes():
             pass
     assert "authorization" not in seen[1].headers
+
+
+async def test_empty_location_redirect_is_yielded(monkeypatch):
+    # has_redirect_location is True for a present-but-empty Location; an empty
+    # value is not a usable redirect target, so it must be yielded as terminal
+    # rather than looping (join("") -> current) until "too many redirects".
+    def handler(request):
+        return httpx.Response(302, headers={"location": ""})
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/x", config=_cfg(), transport="download"
+    ) as resp:
+        assert resp.status == 302
+        async for _ in resp.aiter_bytes():
+            pass
+
+
+async def test_refuses_malformed_redirect_location(monkeypatch):
+    # A Location that httpx.URL.join cannot parse must surface as a coded
+    # FileExchangeTransferError, not a raw httpx.InvalidURL escaping the guard.
+    def handler(request):
+        return httpx.Response(302, headers={"location": "ht\x00tp://x"})
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/start", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
 
 
 async def test_refuses_scheme_downgrade_redirect(monkeypatch):

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -1,9 +1,14 @@
 import ipaddress
+import socket
 
+import httpx
 import pytest
 
+from fastmcp_pvl_core._config import ServerConfig
 from fastmcp_pvl_core._errors import ConfigurationError
 from fastmcp_pvl_core._file_exchange import _outbound
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
 
 
 def test_redact_returns_hostname_only():
@@ -79,3 +84,202 @@ def test_select_pinned_picks_global_ipv6_over_blocked_ipv4():
         _outbound._select_pinned(resolved, [])
         == "2606:2800:220:1:248:1893:25c8:1946"
     )
+
+
+# ---------------------------------------------------------------------------
+# Task 3: guarded_stream core tests
+# ---------------------------------------------------------------------------
+
+
+def _cfg(*, allowed=(), timeout=30.0):
+    return ServerConfig(
+        file_exchange_allowed_networks=allowed,
+        file_exchange_http_timeout=timeout,
+    )
+
+
+def _install_mock(monkeypatch, handler, *, resolve_to):
+    """Pin _resolve to a fixed address list and route the client through a
+    MockTransport. Returns a dict tracking the _resolve call count."""
+    calls = {"resolve": 0}
+
+    async def fake_resolve(host, port):
+        calls["resolve"] += 1
+        return list(resolve_to)
+
+    def fake_make_client(timeout):
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            follow_redirects=False,
+        )
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    monkeypatch.setattr(_outbound, "_make_client", fake_make_client)
+    return calls
+
+
+async def test_guarded_stream_streams_body_and_pins(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        return httpx.Response(200, content=b"hello-bytes")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    data = b""
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/d/tok", config=_cfg(), transport="download"
+    ) as resp:
+        assert resp.status == 200
+        async for chunk in resp.aiter_bytes():
+            data += chunk
+    assert data == b"hello-bytes"
+    req = seen[0]
+    assert req.url.host == "93.184.216.34"
+    assert req.headers["host"] == "example.com"
+    assert req.extensions.get("sni_hostname") == "example.com"
+
+
+async def test_resolve_called_once_per_request(monkeypatch):
+    def handler(request):
+        return httpx.Response(200, content=b"x")
+
+    calls = _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/x", config=_cfg(), transport="download"
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    assert calls["resolve"] == 1
+
+
+async def test_refuses_non_https():
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "http://example.com/x", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+    assert ei.value.transport == "download"
+    assert "http://" not in (ei.value.detail or "")
+
+
+async def test_refuses_non_global_address(monkeypatch):
+    def handler(request):
+        raise AssertionError("must not connect to a refused address")
+
+    _install_mock(monkeypatch, handler, resolve_to=["127.0.0.1"])
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://evil.example/x", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_allowlist_permits_private_target(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        return httpx.Response(200, content=b"ok")
+
+    _install_mock(monkeypatch, handler, resolve_to=["10.1.2.3"])
+    async with _outbound.guarded_stream(
+        "GET",
+        "https://internal.example/x",
+        config=_cfg(allowed=("10.0.0.0/8",)),
+        transport="download",
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    assert seen[0].url.host == "10.1.2.3"
+
+
+async def test_refuses_unresolvable_host(monkeypatch):
+    async def fake_resolve(host, port):
+        raise socket.gaierror("name resolution failed")
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://nope.example/x", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_maps_connect_error(monkeypatch):
+    def handler(request):
+        raise httpx.ConnectError("connection refused")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/x", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_passes_caller_headers_adds_no_credentials(monkeypatch):
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        return httpx.Response(200, content=b"x")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET",
+        "https://example.com/x",
+        config=_cfg(),
+        transport="download",
+        headers={"Range": "bytes=10-"},
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    req = seen[0]
+    assert req.headers["range"] == "bytes=10-"
+    assert "authorization" not in req.headers
+    assert "cookie" not in req.headers
+
+
+async def test_make_client_security_defaults():
+    client = _outbound._make_client(30.0)
+    try:
+        assert client.trust_env is False
+        assert client.follow_redirects is False
+        assert client.timeout.read == 30.0
+        assert client.timeout.connect == 30.0
+    finally:
+        await client.aclose()
+
+
+async def test_client_closed_on_caller_exception(monkeypatch):
+    holder = {}
+
+    def handler(request):
+        return httpx.Response(200, content=b"data")
+
+    async def fake_resolve(host, port):
+        return ["93.184.216.34"]
+
+    def fake_make_client(timeout):
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            follow_redirects=False,
+        )
+        holder["client"] = client
+        return client
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    monkeypatch.setattr(_outbound, "_make_client", fake_make_client)
+    with pytest.raises(RuntimeError):
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/x", config=_cfg(), transport="download"
+        ):
+            raise RuntimeError("boom")
+    assert holder["client"].is_closed is True

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -484,3 +484,152 @@ async def test_refuses_redirect_that_rebinds_to_blocked_ip(monkeypatch):
         ):
             pass
     assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_refuses_redirect_on_request_with_body(monkeypatch):
+    async def body():
+        yield b"upload-bytes"
+
+    def handler(request):
+        return httpx.Response(302, headers={"location": "https://example.com/final"})
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "PUT",
+            "https://example.com/start",
+            config=_cfg(),
+            transport="upload",
+            content=body(),
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_refuses_empty_resolution(monkeypatch):
+    async def fake_resolve(host, port):
+        return []
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    with pytest.raises(FileExchangeTransferError) as ei:
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/x", config=_cfg(), transport="download"
+        ):
+            pass
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+    assert ei.value.detail == "host could not be resolved"
+
+
+async def test_nonpositive_timeout_raises_configuration_error():
+    with pytest.raises(ConfigurationError):
+        async with _outbound.guarded_stream(
+            "GET",
+            "https://example.com/x",
+            config=_cfg(timeout=0.0),
+            transport="download",
+        ):
+            pass
+
+
+async def test_http_timeout_threads_to_client(monkeypatch):
+    seen = {}
+
+    def handler(request):
+        return httpx.Response(200, content=b"x")
+
+    async def fake_resolve(host, port):
+        return ["93.184.216.34"]
+
+    def fake_make_client(timeout):
+        seen["timeout"] = timeout
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            follow_redirects=False,
+        )
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    monkeypatch.setattr(_outbound, "_make_client", fake_make_client)
+    async with _outbound.guarded_stream(
+        "GET",
+        "https://example.com/x",
+        config=_cfg(timeout=12.5),
+        transport="download",
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    assert seen["timeout"] == 12.5
+
+
+async def test_guarded_response_repr_hides_token(monkeypatch):
+    def handler(request):
+        return httpx.Response(200, content=b"x")
+
+    _install_mock(monkeypatch, handler, resolve_to=["93.184.216.34"])
+    async with _outbound.guarded_stream(
+        "GET",
+        "https://example.com/d/SECRETTOKEN?sig=abc",
+        config=_cfg(),
+        transport="download",
+    ) as resp:
+        rendered = repr(resp)
+        assert "SECRETTOKEN" not in rendered
+        assert "/d/" not in rendered
+        async for _ in resp.aiter_bytes():
+            pass
+
+
+async def test_client_closed_on_success(monkeypatch):
+    holder = {}
+
+    def handler(request):
+        return httpx.Response(200, content=b"data")
+
+    async def fake_resolve(host, port):
+        return ["93.184.216.34"]
+
+    def fake_make_client(timeout):
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            follow_redirects=False,
+        )
+        holder["client"] = client
+        return client
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    monkeypatch.setattr(_outbound, "_make_client", fake_make_client)
+    async with _outbound.guarded_stream(
+        "GET", "https://example.com/x", config=_cfg(), transport="download"
+    ) as resp:
+        async for _ in resp.aiter_bytes():
+            pass
+    assert holder["client"].is_closed is True
+
+
+async def test_client_closed_on_cross_origin_refusal(monkeypatch):
+    holder = {}
+
+    def handler(request):
+        return httpx.Response(302, headers={"location": "https://evil.example/x"})
+
+    async def fake_resolve(host, port):
+        return ["93.184.216.34"]
+
+    def fake_make_client(timeout):
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            trust_env=False,
+            follow_redirects=False,
+        )
+        holder["client"] = client
+        return client
+
+    monkeypatch.setattr(_outbound, "_resolve", fake_resolve)
+    monkeypatch.setattr(_outbound, "_make_client", fake_make_client)
+    with pytest.raises(FileExchangeTransferError):
+        async with _outbound.guarded_stream(
+            "GET", "https://example.com/start", config=_cfg(), transport="download"
+        ):
+            pass
+    assert holder["client"].is_closed is True

--- a/tests/_file_exchange/test_outbound.py
+++ b/tests/_file_exchange/test_outbound.py
@@ -69,8 +69,7 @@ def test_malformed_cidr_raises_configuration_error():
 
 def test_select_pinned_skips_blocked_picks_global():
     assert (
-        _outbound._select_pinned(["127.0.0.1", "93.184.216.34"], [])
-        == "93.184.216.34"
+        _outbound._select_pinned(["127.0.0.1", "93.184.216.34"], []) == "93.184.216.34"
     )
 
 
@@ -81,8 +80,7 @@ def test_select_pinned_none_when_all_blocked():
 def test_select_pinned_picks_global_ipv6_over_blocked_ipv4():
     resolved = ["10.0.0.1", "2606:2800:220:1:248:1893:25c8:1946"]
     assert (
-        _outbound._select_pinned(resolved, [])
-        == "2606:2800:220:1:248:1893:25c8:1946"
+        _outbound._select_pinned(resolved, []) == "2606:2800:220:1:248:1893:25c8:1946"
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -195,3 +195,29 @@ def test_from_env_file_exchange_max_artifact_size(monkeypatch):
     monkeypatch.setenv("MYAPP_FILE_EXCHANGE_MAX_ARTIFACT_SIZE", "1048576")
     cfg2 = ServerConfig.from_env("MYAPP")
     assert cfg2.file_exchange_max_artifact_size == 1048576
+
+
+def test_file_exchange_outbound_defaults():
+    from fastmcp_pvl_core import ServerConfig
+
+    cfg = ServerConfig.from_env("MYAPP")
+    assert cfg.file_exchange_allowed_networks == ()
+    assert cfg.file_exchange_http_timeout == 30.0
+
+
+def test_from_env_file_exchange_allowed_networks(monkeypatch):
+    from fastmcp_pvl_core import ServerConfig
+
+    monkeypatch.setenv(
+        "MYAPP_FILE_EXCHANGE_ALLOWED_NETWORKS", "10.0.0.0/8, 192.168.5.0/24"
+    )
+    cfg = ServerConfig.from_env("MYAPP")
+    assert cfg.file_exchange_allowed_networks == ("10.0.0.0/8", "192.168.5.0/24")
+
+
+def test_from_env_file_exchange_http_timeout(monkeypatch):
+    from fastmcp_pvl_core import ServerConfig
+
+    monkeypatch.setenv("MYAPP_FILE_EXCHANGE_HTTP_TIMEOUT", "12.5")
+    cfg = ServerConfig.from_env("MYAPP")
+    assert cfg.file_exchange_http_timeout == 12.5


### PR DESCRIPTION
## Summary

Adds the package-internal outbound-HTTP guard (`guarded_stream`) that the `download` fetcher (#145) and `upload` sender (#146) will issue every request through, enforcing the §15 SSRF + DNS-rebind mitigations. It is a thin §15 primitive — verification, `Range` recovery, and artifact handling stay with #145/#146.

- **Deny-all-non-global** address refusal (`ipaddress.is_global`, IPv4-mapped unwrapped) with an operator **CIDR allowlist** escape hatch.
- **Resolve-once-pin-IP** via httpx's `sni_hostname` extension: one `getaddrinfo`, connect to the validated IP, verify the cert against the hostname — no re-resolution between check and connect.
- **Redirects:** refuse cross-origin (and scheme-downgrade); follow same-origin bounded to 5 hops, **re-guarding each hop** (rebind-safe); refuse a redirect on a bodied request; non-redirect 3xx (`304`/no-`Location`) yielded as terminal.
- **No ambient credentials:** `trust_env=False`, fresh client per call, URL userinfo stripped, caller `Host` header stripped in favour of the validated hostname (non-default port preserved, IPv6 bracketed).
- **Redaction:** only the hostname reaches a log line; wire `detail` carries no URL parts; `GuardedResponse` keeps the response out of its `repr`.
- Two operator `ServerConfig` fields: `file_exchange_allowed_networks` (CIDRs) and `file_exchange_http_timeout` (default 30s). The guard stays **package-internal** — not re-exported through the public `file_exchange` surface.

Closes #147. Part of EPIC #138.

## Test plan

- [x] `uv run pytest` green on Python **3.10** and **3.13** (889 passed locally)
- [x] `uv run ruff format --check . && uv run ruff check . && uv run mypy src` clean
- [x] 57 guard tests cover: the deny-all-non-global matrix (loopback / link-local / RFC1918 / CGNAT / `0.0.0.0` / IPv4-mapped, verified on 3.10 + 3.13), CIDR allowlist, resolve-once-pin (Host + `sni_hostname`, IPv6 bracketing, non-default port), redirect policy (cross-origin / scheme-downgrade / rebind-to-blocked-IP / too-many / non-redirect-3xx / bodied-request), no-ambient-credentials (`trust_env`, caller-`Host` injection, URL-userinfo→`Authorization`), credential/token redaction across all four log emit-paths, and client cleanup on success / caller-exception / refusal / mid-body-error

🤖 Generated with [Claude Code](https://claude.com/claude-code)