### PR TITLE
feat(file-exchange): upload transport data plane (#146)

### DIFF
--- a/docs/superpowers/plans/2026-05-24-file-exchange-146-upload-data-plane.md
+++ b/docs/superpowers/plans/2026-05-24-file-exchange-146-upload-data-plane.md
@@ -1,0 +1,1606 @@
+# File-Exchange #146 — Upload Data Plane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the `upload` transport's push data plane — a receiver that mints a capability URL + the `PUT`/`POST` route that deposits the pushed bytes through the `ArtifactSink`, and a sender that pushes an artifact through the SSRF guard with an RFC 9530 `Content-Digest`.
+
+**Architecture:** Mirror of the merged #145 download plane. First refactor merged #145 code: extract shared digest/chunk primitives into `_staging.py`, and move the cross-transport route registrar `register_file_exchange_routes` into a new `_routes.py` (extracting `register_download_route` from `_download.py`). Then add `_upload.py` with `upload_receiver_mint`, the upload route, `upload_sender_consume`, and the RFC 9530 (`Content-Digest`) / RFC 7231 (media-range) helpers. The route streams the request body to a transient temp file (hashing + size-bounded), verifies digest/constraints **before** the sink sees the bytes, then consumes the single-use token only on a successful store.
+
+**Tech Stack:** Python 3.10–3.13, FastMCP (`@mcp.custom_route`), Starlette `Request`/`Response`, httpx (via `guarded_stream`), Pydantic v2 wire models, `pytest` + `pytest-asyncio`, `httpx.ASGITransport` for route/e2e tests.
+
+**Design doc:** `docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md`
+
+---
+
+## File Structure
+
+- **Create `src/fastmcp_pvl_core/_file_exchange/_staging.py`** — shared primitives moved out of `_download.py`: `_CHUNK`, `_HASHLIB_BY_LABEL`, `_digest_verifier`, `_write_chunk`. Imported by both `_download.py` and `_upload.py` (independent leaf modules; no circular import).
+- **Modify `src/fastmcp_pvl_core/_file_exchange/_download.py`** — import the four primitives from `_staging`; remove their local definitions and the now-unused `import hashlib`. Rename `register_file_exchange_routes` → `register_download_route` (signature `register_download_route(mcp, *, token_store, source)`; body unchanged).
+- **Create `src/fastmcp_pvl_core/_file_exchange/_routes.py`** — `register_file_exchange_routes(mcp, *, token_store, source=None, sink=None, config=None)`; mounts the download route iff `source`, the upload route iff `sink` (which requires `config`).
+- **Create `src/fastmcp_pvl_core/_file_exchange/_upload.py`** — `UPLOAD_PREFIX`, `upload_receiver_mint`, `register_upload_route`, `upload_sender_consume`, and the helpers `_format_content_digest`, `_parse_content_digest`, `_media_type_accepted`.
+- **Modify `src/fastmcp_pvl_core/_file_exchange/__init__.py`** and **`src/fastmcp_pvl_core/file_exchange.py`** — re-export `register_file_exchange_routes` from `._routes` (was `._download`); add `upload_receiver_mint`, `upload_sender_consume`.
+- **Create `tests/_file_exchange/test_upload.py`** — unit tests (receiver mint, helpers, route, sender).
+- **Create `tests/_file_exchange/test_upload_e2e.py`** — two-server push end-to-end.
+- **Modify `tests/test_file_exchange_namespace.py`** — assert the upload names are re-exported.
+
+---
+
+### Task 1: Extract `_staging.py` (refactor merged #145)
+
+This is a pure move refactor — no behaviour change. The existing download test suite is the regression gate.
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_staging.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_download.py`
+- Test (regression): `tests/_file_exchange/test_download.py`
+
+- [ ] **Step 1: Create `_staging.py` with the moved primitives**
+
+```python
+"""Shared temp-file staging + digest primitives for the HTTP transports.
+
+The download fetcher (#145) and the upload route/sender (#146) both buffer a
+byte stream to a transient temp file with hashing and a size bound, and verify a
+declared digest. These primitives factor out the common parts. Each transport
+keeps its own read loop (download resumes via ``Range``; upload reads
+``request.stream()`` or a hook stream) and applies the
+``OSError -> transfer-failed`` mapping / cleanup-suppression contract around
+them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import IO
+
+# Streaming chunk size for temp-file staging (1 MiB).
+_CHUNK = 1024 * 1024
+
+# Declared-digest label -> hashlib name; an unsupported label fails verification
+# (cannot verify -> digest-mismatch), never silently skips (§15).
+_HASHLIB_BY_LABEL = {"sha-256": "sha256", "sha-384": "sha384", "sha-512": "sha512"}
+
+
+def _digest_verifier(
+    declared: str | None,
+) -> tuple[hashlib._Hash | None, str | None, bool]:
+    """Return (hasher | None, expected_hex | None, unverifiable).
+
+    ``unverifiable`` is True when a digest is declared with an unsupported label
+    — verification must then fail (cannot verify), never silently skip (§15).
+    """
+    if declared is None:
+        return None, None, False
+    label, _, expected_hex = declared.partition(":")
+    name = _HASHLIB_BY_LABEL.get(label.lower())
+    if name is None:
+        return None, expected_hex, True
+    return hashlib.new(name), expected_hex.lower(), False
+
+
+def _write_chunk(tmp: IO[bytes], hasher: hashlib._Hash | None, chunk: bytes) -> None:
+    """Write a body chunk to the temp file and fold it into the running hash.
+
+    Both ops run off the event loop in a single ``asyncio.to_thread`` dispatch.
+    """
+    tmp.write(chunk)
+    if hasher is not None:
+        hasher.update(chunk)
+```
+
+- [ ] **Step 2: Point `_download.py` at `_staging`**
+
+In `src/fastmcp_pvl_core/_file_exchange/_download.py`:
+
+1. Delete the local definitions of `_CHUNK` (line ~54), `_HASHLIB_BY_LABEL` (line ~57), `_digest_verifier` (lines ~96–110), and `_write_chunk` (lines ~113–120). Leave `DOWNLOAD_PREFIX` and `_MAX_RECONNECTS` in place.
+2. Remove `import hashlib` (now unused in `_download.py`).
+3. Add this import alongside the other `_file_exchange` imports:
+
+```python
+from fastmcp_pvl_core._file_exchange._staging import (
+    _CHUNK,
+    _HASHLIB_BY_LABEL,
+    _digest_verifier,
+    _write_chunk,
+)
+```
+
+`_HASHLIB_BY_LABEL` is still referenced by `_download.py`'s fetcher status-check path, so keep it in the import even though `_digest_verifier` also uses it.
+
+- [ ] **Step 3: Run the download suite + gates to verify no behaviour change**
+
+Run: `uv run pytest tests/_file_exchange/test_download.py tests/_file_exchange/test_download_e2e.py -q`
+Expected: PASS (same counts as before the refactor).
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean (in particular, no "imported but unused" for `hashlib`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_staging.py src/fastmcp_pvl_core/_file_exchange/_download.py
+git commit -m "refactor(file-exchange): extract shared staging primitives (#146)"
+```
+
+---
+
+### Task 2: Move `register_file_exchange_routes` to `_routes.py`
+
+Extract the download route registrar into `_download.py` as `register_download_route`, and create `_routes.py` to own the public cross-transport `register_file_exchange_routes` (download-only for now; the upload branch is added in Task 5). Pure move — existing tests are the gate.
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_download.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_routes.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/__init__.py`
+- Modify: `src/fastmcp_pvl_core/file_exchange.py`
+- Modify: `tests/_file_exchange/test_download_e2e.py`
+
+- [ ] **Step 1: Rename the registrar in `_download.py`**
+
+In `src/fastmcp_pvl_core/_file_exchange/_download.py`, rename the function `register_file_exchange_routes` (line ~349) to `register_download_route`. Its body (the `@mcp.custom_route` GET handler `_serve_download`) is unchanged. The signature stays `(mcp: FastMCP, *, token_store: CapabilityTokenStore, source: ArtifactSource)` — `source` stays required here; optionality lives in `_routes.py`. Update the first docstring line to read:
+
+```python
+    """Mount the ``download`` GET route on ``mcp`` (serves §12 capability URLs).
+```
+
+(unchanged — only the function name changes).
+
+- [ ] **Step 2: Create `_routes.py`**
+
+```python
+"""Cross-transport FastMCP route registration for the file-exchange HTTP transports.
+
+``register_file_exchange_routes`` mounts the ``download`` GET route (when a
+``source`` hook is given) and the ``upload`` PUT/POST route (when a ``sink`` hook
+is given). Each transport's registrar lives in its own leaf module
+(``_download``/``_upload``); this module is the single public entry point #148
+threads ``token_store``/``source``/``sink``/``config`` into.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastmcp_pvl_core._file_exchange._download import register_download_route
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+
+
+def register_file_exchange_routes(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    source: ArtifactSource | None = None,
+    sink: ArtifactSink | None = None,
+    config: ServerConfig | None = None,
+) -> None:
+    """Mount the file-exchange HTTP routes on ``mcp``.
+
+    Mounts the ``download`` GET route iff ``source`` is given. (The ``upload``
+    PUT/POST route — mounted iff ``sink`` is given — is added in #146 Task 5.)
+    ``token_store``/``source``/``sink``/``config`` are threaded by #148.
+    """
+    if source is not None:
+        register_download_route(mcp, token_store=token_store, source=source)
+```
+
+Note: `sink`/`config` are accepted now so the public signature is stable across Task 5 (which adds the upload branch). They are intentionally unused until then.
+
+- [ ] **Step 3: Re-export `register_file_exchange_routes` from `_routes`**
+
+In `src/fastmcp_pvl_core/_file_exchange/__init__.py`, change the `_download` import block (lines ~19–23) to drop `register_file_exchange_routes`:
+
+```python
+from fastmcp_pvl_core._file_exchange._download import (
+    download_fetcher_consume,
+    download_provider_mint,
+)
+```
+
+and add a new import block (keep import blocks grouped by module, alphabetical by module name — `_routes` sorts after `_paths`/`_selection`? place it after the `_paths` block and before `_selection`):
+
+```python
+from fastmcp_pvl_core._file_exchange._routes import register_file_exchange_routes
+```
+
+`__all__` already lists `register_file_exchange_routes` — leave it.
+
+In `src/fastmcp_pvl_core/file_exchange.py`, the names are imported in one combined block from `fastmcp_pvl_core._file_exchange` (the subpackage), so no per-module change is needed there — `register_file_exchange_routes` still resolves. Leave `file_exchange.py` unchanged in this task.
+
+- [ ] **Step 4: Update the download e2e import**
+
+`tests/_file_exchange/test_download_e2e.py` calls `_download.register_file_exchange_routes(...)` (line ~67). It must now use the public registrar. Change the import (line ~18) and the call:
+
+```python
+from fastmcp_pvl_core._file_exchange import _download, _routes
+```
+
+```python
+    _routes.register_file_exchange_routes(
+        mcp, token_store=store, source=_BytesSource("doc", body)
+    )
+```
+
+(`_download` is still imported — the test monkeypatches `_download.guarded_stream` and calls `_download.download_provider_mint`/`download_fetcher_consume`.)
+
+- [ ] **Step 5: Run download tests + namespace test + gates**
+
+Run: `uv run pytest tests/_file_exchange/test_download.py tests/_file_exchange/test_download_e2e.py tests/test_file_exchange_namespace.py -q`
+Expected: PASS. `test_download_data_plane_names_reexported` still passes (the public name is unchanged).
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_download.py src/fastmcp_pvl_core/_file_exchange/_routes.py src/fastmcp_pvl_core/_file_exchange/__init__.py tests/_file_exchange/test_download_e2e.py
+git commit -m "refactor(file-exchange): move route registrar to _routes, source optional (#146)"
+```
+
+---
+
+### Task 3: `upload_receiver_mint` + `UPLOAD_PREFIX`
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/__init__.py`
+- Modify: `src/fastmcp_pvl_core/file_exchange.py`
+- Test: `tests/_file_exchange/test_upload.py`
+- Modify: `tests/test_file_exchange_namespace.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/_file_exchange/test_upload.py`:
+
+```python
+"""Tests for the ``upload`` transport data plane (#146)."""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _routes, _upload
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import (
+    ArtifactConstraints,
+    ArtifactMetadata,
+    IntakeTicket,
+    UploadSink,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+async def test_receiver_mint_returns_ticket_with_upload_sink():
+    store = _store()
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://recv.test", ttl=300.0
+    )
+    assert isinstance(ticket, IntakeTicket)
+    assert ticket.artifactId == "art-1"
+    assert len(ticket.sinks) == 1
+    sink = ticket.sinks[0]
+    assert isinstance(sink, UploadSink)
+    assert sink.transport == "upload"
+    assert sink.method == "PUT"
+    assert sink.url.startswith("https://recv.test/fx/u/")
+    token = sink.url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata["artifact_id"] == "art-1"
+    assert rec.metadata["expected"] is None
+
+
+async def test_receiver_mint_threads_method_and_expected():
+    store = _store()
+    expected = ArtifactConstraints(maxSize=1024, acceptMimeTypes=["text/*"])
+    ticket = await _upload.upload_receiver_mint(
+        "art-2",
+        token_store=store,
+        base_url="https://recv.test",
+        ttl=300.0,
+        expected=expected,
+        method="POST",
+    )
+    assert ticket.expected == expected
+    assert ticket.sinks[0].method == "POST"
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata["expected"] == {
+        "maxSize": 1024,
+        "acceptMimeTypes": ["text/*"],
+        "requireDigest": None,
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -q`
+Expected: FAIL with `ModuleNotFoundError`/`AttributeError` (`_upload` has no `upload_receiver_mint`).
+
+- [ ] **Step 3: Create `_upload.py` with the constant + receiver mint**
+
+```python
+"""The ``upload`` transport data plane (#146).
+
+Three role helpers (receiver mint, the PUT/POST serving route, sender) plus the
+RFC 9530 / RFC 7231 HTTP helpers the route and sender need, free functions
+mirroring ``_filesystem.py`` / ``_download.py``. The receiver mints a capability
+URL backed by the #144 token store; the route streams the pushed body to a
+transient temp file, verifies the declared ``Content-Digest`` and the ticket's
+``expected`` constraints **before** handing the #142 ``ArtifactSink`` a real sync
+fd, then consumes the single-use token only on a successful store; the sender
+stages the artifact, computes a ``Content-Digest``, and pushes it through the
+#147 ``guarded_stream``. See
+``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal
+
+from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._tokens import capability_url
+from fastmcp_pvl_core._file_exchange._wire import IntakeTicket, UploadSink
+
+if TYPE_CHECKING:
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+    from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
+
+logger = logging.getLogger(__name__)
+
+# pvl-core's upload route shape (§12 capability URL path). A constant, not a
+# kwarg — route structure is a pvl-core shape decision (mirrors DOWNLOAD_PREFIX).
+UPLOAD_PREFIX = "/fx/u"
+
+
+async def upload_receiver_mint(
+    artifact_id: str,
+    *,
+    token_store: CapabilityTokenStore,
+    base_url: str,
+    ttl: float,
+    expected: ArtifactConstraints | None = None,
+    method: Literal["PUT", "POST"] = "PUT",
+) -> IntakeTicket:
+    """Receiver role (push): mint an upload token and emit an IntakeTicket.
+
+    ``artifact_id`` is the server's opaque identifier for the artifact slot,
+    stored in the token for the route to correlate the pushed bytes; ``expected``
+    is the §7.4 constraint set the route enforces at ingest (stored opaquely too).
+    ``base_url`` is the server's public https origin; ``ttl`` is clamped by the
+    token store's ceiling. Minting only — no hook runs and no bytes move (the
+    sink is threaded into the route, where the bytes actually arrive).
+    """
+    minted = await token_store.mint(
+        {
+            "artifact_id": artifact_id,
+            "expected": expected.model_dump(mode="json") if expected else None,
+        },
+        ttl=ttl,
+        single_use=True,
+    )
+    url = capability_url(base_url, UPLOAD_PREFIX, minted.token)
+    return IntakeTicket(
+        type=TICKET_TYPE,
+        version=SPEC_VERSION,
+        artifactId=artifact_id,
+        expected=expected,
+        sinks=[
+            UploadSink(
+                transport="upload",
+                url=url,
+                method=method,
+                expiresAt=minted.expires_at,
+            )
+        ],
+    )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -q`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Re-export `upload_receiver_mint` + update namespace test**
+
+In `src/fastmcp_pvl_core/_file_exchange/__init__.py`, add an import block for `_upload` (place after the `_tokens` block, before `_validation`):
+
+```python
+from fastmcp_pvl_core._file_exchange._upload import (
+    upload_receiver_mint,
+)
+```
+
+and add `"upload_receiver_mint"` to `__all__` (alphabetical — after `select_source`, before `validate_wire`).
+
+In `src/fastmcp_pvl_core/file_exchange.py`, add `upload_receiver_mint` to the combined import (alphabetical, after `select_source`) and to `__all__` (after `select_source`).
+
+In `tests/test_file_exchange_namespace.py`, add a new test:
+
+```python
+def test_upload_data_plane_names_reexported():
+    from fastmcp_pvl_core import file_exchange
+
+    for name in (
+        "upload_receiver_mint",
+        "upload_sender_consume",
+        "register_file_exchange_routes",
+    ):
+        assert hasattr(file_exchange, name), name
+        assert name in file_exchange.__all__, name
+    # UPLOAD_PREFIX is internal route shape, not part of the public surface.
+    assert not hasattr(file_exchange, "UPLOAD_PREFIX")
+```
+
+(`upload_sender_consume` is added in Task 6 — this test will fail until then; that is expected and acceptable for the incremental sequence, but to keep every task green, add `upload_sender_consume` to both `__all__`s and the imports as a forward reference now is NOT possible since the symbol doesn't exist. Instead: in THIS task, write the test referencing only `upload_receiver_mint` and `register_file_exchange_routes`; Task 6 extends it to include `upload_sender_consume`.)
+
+Replace the test body above with the Task-3 version:
+
+```python
+def test_upload_data_plane_names_reexported():
+    from fastmcp_pvl_core import file_exchange
+
+    for name in ("upload_receiver_mint", "register_file_exchange_routes"):
+        assert hasattr(file_exchange, name), name
+        assert name in file_exchange.__all__, name
+    # UPLOAD_PREFIX is internal route shape, not part of the public surface.
+    assert not hasattr(file_exchange, "UPLOAD_PREFIX")
+```
+
+- [ ] **Step 6: Run namespace test + gates**
+
+Run: `uv run pytest tests/test_file_exchange_namespace.py tests/_file_exchange/test_upload.py -q`
+Expected: PASS.
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_upload.py src/fastmcp_pvl_core/_file_exchange/__init__.py src/fastmcp_pvl_core/file_exchange.py tests/_file_exchange/test_upload.py tests/test_file_exchange_namespace.py
+git commit -m "feat(file-exchange): add upload_receiver_mint + IntakeTicket (#146)"
+```
+
+---
+
+### Task 4: `Content-Digest` (RFC 9530) + media-range (RFC 7231) helpers
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+- Test: `tests/_file_exchange/test_upload.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/_file_exchange/test_upload.py`:
+
+```python
+def test_format_content_digest_rfc9530():
+    raw = hashlib.sha256(b"abc").digest()
+    out = _upload._format_content_digest("sha-256", raw)
+    assert out == "sha-256=:" + base64.b64encode(raw).decode("ascii") + ":"
+
+
+def test_parse_content_digest_roundtrip():
+    raw = hashlib.sha256(b"abc").digest()
+    header = _upload._format_content_digest("sha-256", raw)
+    assert _upload._parse_content_digest(header) == ("sha-256", raw)
+
+
+def test_parse_content_digest_picks_first_supported():
+    raw = hashlib.sha512(b"abc").digest()
+    header = "md5=:" + base64.b64encode(b"x").decode() + ":, sha-512=:" + (
+        base64.b64encode(raw).decode() + ":"
+    )
+    assert _upload._parse_content_digest(header) == ("sha-512", raw)
+
+
+def test_parse_content_digest_rejects_unparseable():
+    assert _upload._parse_content_digest("sha-256=not-a-byte-sequence") is None
+    assert _upload._parse_content_digest("sha-256=:!!!notbase64!!!:") is None
+    assert _upload._parse_content_digest("md5=:" + base64.b64encode(b"x").decode() + ":") is None
+
+
+@pytest.mark.parametrize(
+    ("content_type", "accept", "ok"),
+    [
+        ("text/plain", ["text/plain"], True),
+        ("text/plain; charset=utf-8", ["text/plain"], True),
+        ("text/plain", ["text/*"], True),
+        ("text/plain", ["*/*"], True),
+        ("application/json", ["text/*"], False),
+        ("application/json", ["text/*", "application/json"], True),
+        (None, ["text/*"], False),
+        ("not-a-media-type", ["*/*"], False),
+    ],
+)
+def test_media_type_accepted(content_type, accept, ok):
+    assert _upload._media_type_accepted(content_type, accept) is ok
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -k "content_digest or media_type" -q`
+Expected: FAIL (`AttributeError`: helpers not defined).
+
+- [ ] **Step 3: Implement the helpers**
+
+Add to the imports at the top of `_upload.py`:
+
+```python
+import base64
+import binascii
+```
+
+Add to the constants section of `_upload.py` (after `UPLOAD_PREFIX`):
+
+```python
+# Default digest algorithm for the receiver's recorded ArtifactMetadata.digest
+# and the sender's Content-Digest (pvl-core's shape). Members of _HASHLIB_BY_LABEL
+# are also accepted on an inbound Content-Digest.
+_DEFAULT_DIGEST_LABEL = "sha-256"
+```
+
+Add `_HASHLIB_BY_LABEL` to the `_staging` import (the helpers need it):
+
+```python
+from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL
+```
+
+Add the helpers:
+
+```python
+def _format_content_digest(label: str, raw: bytes) -> str:
+    """Format a raw digest as an RFC 9530 ``Content-Digest`` member: ``label=:b64:``.
+
+    The Structured-Field byte-sequence form (base64 wrapped in colons) — distinct
+    from the wire ``ArtifactMetadata.digest`` field's ``label:hex`` form.
+    """
+    return f"{label}=:{base64.b64encode(raw).decode('ascii')}:"
+
+
+def _parse_content_digest(header: str) -> tuple[str, bytes] | None:
+    """Parse the first supported RFC 9530 ``Content-Digest`` member.
+
+    Returns ``(label, raw_digest_bytes)`` for the first member whose algorithm is
+    in :data:`_HASHLIB_BY_LABEL` and whose value is a well-formed byte sequence,
+    or ``None`` when the header has no supported, well-formed member. A present
+    header that parses to ``None`` is unverifiable -> the route rejects it
+    (digest-mismatch), never silently skips (§15).
+    """
+    for member in header.split(","):
+        label, sep, value = member.strip().partition("=")
+        if sep != "=":
+            continue
+        label = label.strip().lower()
+        value = value.strip()
+        if label not in _HASHLIB_BY_LABEL:
+            continue
+        if len(value) < 2 or value[0] != ":" or value[-1] != ":":
+            continue
+        try:
+            raw = base64.b64decode(value[1:-1], validate=True)
+        except (binascii.Error, ValueError):
+            continue
+        return label, raw
+    return None
+
+
+def _media_type_accepted(content_type: str | None, accept: list[str]) -> bool:
+    """Match a request media type against RFC 7231 §3.1.1.1 media-ranges.
+
+    ``type/subtype`` matches exactly; ``type/*`` matches any subtype of ``type``;
+    ``*/*`` matches anything. Parameters (``; charset=...``) are ignored. A
+    missing or malformed ``Content-Type`` matches nothing (the route rejects).
+    """
+    media = (content_type or "").split(";", 1)[0].strip().lower()
+    if "/" not in media:
+        return False
+    main, sub = media.split("/", 1)
+    for entry in accept:
+        candidate = entry.split(";", 1)[0].strip().lower()
+        if candidate == "*/*":
+            return True
+        if "/" not in candidate:
+            continue
+        cand_main, cand_sub = candidate.split("/", 1)
+        if cand_main == main and cand_sub in ("*", sub):
+            return True
+    return False
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -k "content_digest or media_type" -q`
+Expected: PASS.
+
+- [ ] **Step 5: Gates**
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_upload.py tests/_file_exchange/test_upload.py
+git commit -m "feat(file-exchange): add Content-Digest (RFC 9530) + media-range helpers (#146)"
+```
+
+---
+
+### Task 5: The upload route + wire `sink`/`config` into `register_file_exchange_routes`
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_routes.py`
+- Test: `tests/_file_exchange/test_upload.py`
+
+- [ ] **Step 1: Write the failing route tests**
+
+Append to `tests/_file_exchange/test_upload.py`:
+
+```python
+class _CapturingSink:
+    def __init__(self):
+        self.calls = []
+
+    async def store_artifact(self, artifact_id, metadata, stream):
+        self.calls.append((artifact_id, metadata, stream.read()))
+
+
+class _BoomSink:
+    async def store_artifact(self, artifact_id, metadata, stream):
+        raise RuntimeError("sink failure with /secret/path detail")
+
+
+def _mount(sink, *, config=None):
+    store = _store()
+    mcp = FastMCP("receiver")
+    _routes.register_file_exchange_routes(
+        mcp, token_store=store, sink=sink, config=config or ServerConfig()
+    )
+    return store, mcp
+
+
+def _client(mcp):
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=mcp.http_app()), base_url="http://up.test"
+    )
+
+
+async def _mint_token(store, *, artifact_id="art-1", expected=None):
+    minted = await store.mint(
+        {
+            "artifact_id": artifact_id,
+            "expected": expected.model_dump(mode="json") if expected else None,
+        },
+        ttl=300.0,
+        single_use=True,
+    )
+    return minted.token
+
+
+async def test_upload_route_unknown_token_404():
+    _store_, mcp = _mount(_CapturingSink())
+    async with _client(mcp) as client:
+        resp = await client.put("/fx/u/nonexistent", content=b"x")
+    assert resp.status_code == 404
+
+
+async def test_upload_route_happy_deposits_and_consumes():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    body = b"upload-payload" * 100
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=body)
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+    artifact_id, meta, deposited = sink.calls[0]
+    assert artifact_id == "art-1"
+    assert deposited == body
+    assert meta.size == len(body)
+    assert meta.digest == "sha-256:" + hashlib.sha256(body).hexdigest()
+    # Single-use token consumed -> a replay is 404.
+    assert await store.lookup(token) is None
+    async with _client(mcp) as client:
+        resp2 = await client.put(f"/fx/u/{token}", content=body)
+    assert resp2.status_code == 404
+
+
+async def test_upload_route_oversize_413_no_consume():
+    store, mcp = _mount(
+        sink := _CapturingSink(),
+        config=ServerConfig(file_exchange_max_artifact_size=16),
+    )
+    token = await _mint_token(store)
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"x" * 64)
+    assert resp.status_code == 413
+    assert sink.calls == []
+    assert await store.lookup(token) is not None  # not consumed
+
+
+async def test_upload_route_maxsize_constraint_413():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store, expected=ArtifactConstraints(maxSize=8))
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"x" * 64)
+    assert resp.status_code == 413
+    assert sink.calls == []
+
+
+async def test_upload_route_mime_reject_415_no_consume():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(
+        store, expected=ArtifactConstraints(acceptMimeTypes=["text/*"])
+    )
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}", content=b"{}", headers={"content-type": "application/json"}
+        )
+    assert resp.status_code == 415
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+
+async def test_upload_route_valid_content_digest_verifies():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    body = b"digest-checked-body"
+    cd = _upload._format_content_digest("sha-256", hashlib.sha256(body).digest())
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}", content=body, headers={"content-digest": cd}
+        )
+    assert resp.status_code == 204
+    assert sink.calls[0][2] == body
+
+
+async def test_upload_route_digest_mismatch_400_no_sink_call():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    body = b"the-real-body"
+    wrong = _upload._format_content_digest("sha-256", hashlib.sha256(b"other").digest())
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}", content=body, headers={"content-digest": wrong}
+        )
+    assert resp.status_code == 400
+    assert sink.calls == []  # verify-before-use: sink never saw the bytes
+    assert await store.lookup(token) is not None  # not consumed
+
+
+async def test_upload_route_require_digest_missing_header_400():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(
+        store, expected=ArtifactConstraints(requireDigest=["sha-256"])
+    )
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"no-digest-header")
+    assert resp.status_code == 400
+    assert sink.calls == []
+
+
+async def test_upload_route_ambient_credentials_ignored():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}",
+            content=b"ok",
+            headers={"authorization": "Bearer bogus", "cookie": "x=y"},
+        )
+    assert resp.status_code == 204
+    assert sink.calls[0][2] == b"ok"
+
+
+async def test_upload_route_sink_failure_500_no_consume():
+    store, mcp = _mount(_BoomSink())
+    token = await _mint_token(store)
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"data")
+    assert resp.status_code == 500
+    assert resp.content == b""  # body-free: no hook detail echoed
+    assert await store.lookup(token) is not None  # not consumed -> retryable
+
+
+async def test_register_routes_upload_requires_config():
+    store = _store()
+    mcp = FastMCP("receiver")
+    with pytest.raises(ValueError, match="config"):
+        _routes.register_file_exchange_routes(
+            mcp, token_store=store, sink=_CapturingSink(), config=None
+        )
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -k "route or requires_config" -q`
+Expected: FAIL (route + `register_upload_route` not implemented; `register_file_exchange_routes` does not mount upload).
+
+- [ ] **Step 3: Implement the upload route in `_upload.py`**
+
+Add to the imports at the top of `_upload.py`:
+
+```python
+import asyncio
+import contextlib
+import hashlib
+import os
+import tempfile
+```
+
+(extend the existing TYPE_CHECKING block):
+
+```python
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from starlette.requests import Request
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+    from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
+```
+
+Add the runtime imports (these are used at runtime, not just typing):
+
+```python
+from starlette.responses import Response
+
+from fastmcp_pvl_core._file_exchange._staging import _CHUNK, _HASHLIB_BY_LABEL, _write_chunk
+from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints, ArtifactMetadata
+```
+
+(Consolidate the `_wire` / `_staging` imports — do not import a name twice. `ArtifactConstraints` moves from the TYPE_CHECKING block to the runtime block because the route calls `ArtifactConstraints.model_validate`.)
+
+Add the registrar:
+
+```python
+def register_upload_route(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    sink: ArtifactSink,
+    config: ServerConfig,
+) -> None:
+    """Mount the ``upload`` PUT/POST route on ``mcp`` (serves §12 capability URLs).
+
+    ``PUT``/``POST <UPLOAD_PREFIX>/{token}`` looks the token up, streams the
+    request body to a transient temp file (hashing, bounded by the operator cap
+    ``config.file_exchange_max_artifact_size`` and the ticket's
+    ``expected.maxSize``), enforces ``acceptMimeTypes`` and verifies a declared
+    ``Content-Digest`` **before** depositing through ``sink.store_artifact``, and
+    consumes the single-use token only on a successful store (§10.3). Ambient
+    credentials are ignored — the in-URL token is the only authorization.
+    ``token_store``/``sink``/``config`` are threaded by #148.
+    """
+    max_artifact = config.file_exchange_max_artifact_size
+
+    @mcp.custom_route(f"{UPLOAD_PREFIX}/{{token}}", methods=["PUT", "POST"])
+    async def _serve_upload(request: Request) -> Response:
+        token = request.path_params["token"]
+        rec = await token_store.lookup(token)
+        if rec is None:
+            return Response(status_code=404)
+        artifact_id = rec.metadata["artifact_id"]
+        expected_raw = rec.metadata.get("expected")
+        expected: ArtifactConstraints | None = (
+            ArtifactConstraints.model_validate(expected_raw)
+            if expected_raw is not None
+            else None
+        )
+
+        content_type = request.headers.get("content-type")
+        if (
+            expected is not None
+            and expected.acceptMimeTypes
+            and not _media_type_accepted(content_type, expected.acceptMimeTypes)
+        ):
+            return Response(status_code=415)
+
+        cd_header = request.headers.get("content-digest")
+        require_digest = bool(expected is not None and expected.requireDigest)
+        cd = _parse_content_digest(cd_header) if cd_header is not None else None
+        if cd_header is not None and cd is None:
+            # A present but unverifiable Content-Digest is a verification
+            # failure, never a silent skip (§15).
+            return Response(status_code=400)
+        if cd is None and require_digest:
+            return Response(status_code=400)
+        algo_label = cd[0] if cd is not None else _DEFAULT_DIGEST_LABEL
+
+        # Smaller of the operator cap and the per-ticket cap, each when set.
+        size_cap = max_artifact
+        if expected is not None and expected.maxSize is not None:
+            size_cap = (
+                expected.maxSize
+                if size_cap is None
+                else min(size_cap, expected.maxSize)
+            )
+
+        try:
+            fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-")
+        except OSError:
+            logger.exception("file-exchange: upload temp create failed")
+            return Response(status_code=500)
+        try:
+            try:
+                tmp = os.fdopen(fd, "wb")
+            except OSError:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                logger.exception("file-exchange: upload temp open failed")
+                return Response(status_code=500)
+            hasher = hashlib.new(_HASHLIB_BY_LABEL[algo_label])
+            received = 0
+            try:
+                try:
+                    async for chunk in request.stream():
+                        if not chunk:
+                            continue
+                        received += len(chunk)
+                        if size_cap is not None and received > size_cap:
+                            return Response(status_code=413)
+                        await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                    await asyncio.to_thread(tmp.flush)
+                except OSError:
+                    logger.exception("file-exchange: upload temp write failed")
+                    return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    tmp.close()
+
+            # Verify-before-use: an uploaded body is untrusted, so the digest is
+            # checked before the sink ever sees the bytes.
+            if cd is not None and hasher.digest() != cd[1]:
+                return Response(status_code=400)
+
+            meta = ArtifactMetadata(
+                mimeType=content_type,
+                size=received,
+                digest=f"{algo_label}:{hasher.hexdigest()}",
+            )
+            try:
+                ingest = await asyncio.to_thread(open, tmp_path, "rb")
+            except OSError:
+                logger.exception("file-exchange: upload staged open failed")
+                return Response(status_code=500)
+            try:
+                await sink.store_artifact(artifact_id, meta, ingest)
+            except Exception:
+                # The hook may carry server paths in its message — never echo it;
+                # log locally, body-free 500. The token is not consumed (nothing
+                # stored), so the sender can re-request a ticket and retry.
+                logger.exception("file-exchange: upload sink store_artifact failed")
+                return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    ingest.close()
+
+            # Single-success-per-URL: consume only after a successful store.
+            try:
+                await token_store.consume(token)
+            except Exception:
+                # The artifact was stored; a consume failure must not fail the
+                # request. Log it (no token — redaction): the single-use token
+                # may remain usable until it expires.
+                logger.warning(
+                    "file-exchange: upload token consume failed after store; "
+                    "token may remain usable to TTL"
+                )
+            return Response(status_code=204)
+        finally:
+            with contextlib.suppress(OSError):
+                await asyncio.to_thread(os.unlink, tmp_path)
+```
+
+- [ ] **Step 4: Wire the upload branch into `register_file_exchange_routes`**
+
+In `src/fastmcp_pvl_core/_file_exchange/_routes.py`, add the `_upload` import and the upload branch:
+
+```python
+from fastmcp_pvl_core._file_exchange._download import register_download_route
+from fastmcp_pvl_core._file_exchange._upload import register_upload_route
+```
+
+Replace the body of `register_file_exchange_routes` and its docstring tail:
+
+```python
+    """Mount the file-exchange HTTP routes on ``mcp``.
+
+    Mounts the ``download`` GET route iff ``source`` is given and the ``upload``
+    PUT/POST route iff ``sink`` is given. Mounting the upload route requires
+    ``config`` (the operator size cap bounds untrusted request bodies). All of
+    ``token_store``/``source``/``sink``/``config`` are threaded by #148.
+    """
+    if source is not None:
+        register_download_route(mcp, token_store=token_store, source=source)
+    if sink is not None:
+        if config is None:
+            raise ValueError(
+                "register_file_exchange_routes: mounting the upload route "
+                "requires `config` for the operator size cap"
+            )
+        register_upload_route(mcp, token_store=token_store, sink=sink, config=config)
+```
+
+- [ ] **Step 5: Run the route tests**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -q`
+Expected: PASS (all unit + route tests).
+
+- [ ] **Step 6: Gates**
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_upload.py src/fastmcp_pvl_core/_file_exchange/_routes.py tests/_file_exchange/test_upload.py
+git commit -m "feat(file-exchange): add upload PUT/POST route with verify-before-use (#146)"
+```
+
+---
+
+### Task 6: `upload_sender_consume`
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/__init__.py`
+- Modify: `src/fastmcp_pvl_core/file_exchange.py`
+- Test: `tests/_file_exchange/test_upload.py`
+- Modify: `tests/test_file_exchange_namespace.py`
+
+- [ ] **Step 1: Write the failing sender tests**
+
+Append to `tests/_file_exchange/test_upload.py`:
+
+```python
+class _BytesSource:
+    def __init__(self, key, body, *, mime="application/octet-stream"):
+        self._key, self._body, self._mime = key, body, mime
+
+    async def open_artifact(self, key):
+        import io
+
+        assert key == self._key
+        return io.BytesIO(self._body), ArtifactMetadata(
+            name="a", mimeType=self._mime, size=len(self._body)
+        )
+
+
+class _FakeGuarded:
+    def __init__(self, status):
+        self.status = status
+
+
+def _upload_sink(method="PUT"):
+    return UploadSink(
+        transport="upload",
+        url="https://up.test/fx/u/tok",
+        method=method,
+        expiresAt=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+
+async def test_sender_stages_and_sends_with_headers(monkeypatch):
+    body = b"sender-payload" * 50
+    captured: dict = {}
+
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        captured["method"] = method
+        captured["url"] = url
+        captured["transport"] = transport
+        captured["headers"] = dict(headers or {})
+        captured["body"] = b"".join([chunk async for chunk in content])
+        yield _FakeGuarded(204)
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    await _upload.upload_sender_consume(
+        _upload_sink(), _BytesSource("k", body, mime="text/plain"), "k",
+        config=ServerConfig(),
+    )
+    assert captured["method"] == "PUT"
+    assert captured["url"] == "https://up.test/fx/u/tok"
+    assert captured["transport"] == "upload"
+    assert captured["body"] == body
+    assert captured["headers"]["Content-Length"] == str(len(body))
+    assert captured["headers"]["Content-Type"] == "text/plain"
+    assert captured["headers"]["Content-Digest"] == (
+        "sha-256=:" + base64.b64encode(hashlib.sha256(body).digest()).decode() + ":"
+    )
+
+
+async def test_sender_omits_content_type_when_unknown(monkeypatch):
+    captured: dict = {}
+
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        async for _ in content:
+            pass
+        captured["headers"] = dict(headers or {})
+        yield _FakeGuarded(201)
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+
+    class _NoMimeSource:
+        async def open_artifact(self, key):
+            import io
+
+            return io.BytesIO(b"x"), ArtifactMetadata(size=1)
+
+    await _upload.upload_sender_consume(
+        _upload_sink(), _NoMimeSource(), "k", config=ServerConfig()
+    )
+    assert "Content-Type" not in captured["headers"]
+
+
+async def test_sender_non_2xx_raises_transfer_failed(monkeypatch):
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        async for _ in content:
+            pass
+        yield _FakeGuarded(500)
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    with pytest.raises(FileExchangeTransferError) as exc:
+        await _upload.upload_sender_consume(
+            _upload_sink(), _BytesSource("k", b"data"), "k", config=ServerConfig()
+        )
+    assert exc.value.code == TransferErrorCode.TRANSFER_FAILED
+    assert exc.value.transport == "upload"
+
+
+async def test_sender_guard_refusal_propagates(monkeypatch):
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE, transport="upload", detail="blocked"
+        )
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    with pytest.raises(FileExchangeTransferError) as exc:
+        await _upload.upload_sender_consume(
+            _upload_sink(), _BytesSource("k", b"data"), "k", config=ServerConfig()
+        )
+    assert exc.value.code == TransferErrorCode.NOT_ACCESSIBLE
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -k sender -q`
+Expected: FAIL (`AttributeError`: `upload_sender_consume` not defined).
+
+- [ ] **Step 3: Implement `upload_sender_consume`**
+
+Add the runtime imports to `_upload.py` (consolidate with the existing import lines — add the new names, do not duplicate):
+
+```python
+from collections.abc import AsyncIterator
+
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+from fastmcp_pvl_core._file_exchange._outbound import guarded_stream
+```
+
+Extend the runtime TYPE_CHECKING / `_wire` imports so `UploadSink` and `ArtifactSource` are available — `UploadSink` is already imported at runtime; add `ArtifactSource` to the TYPE_CHECKING block:
+
+```python
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
+```
+
+Add the function:
+
+```python
+async def upload_sender_consume(
+    sink: UploadSink,
+    source: ArtifactSource,
+    key: str,
+    *,
+    config: ServerConfig,
+) -> None:
+    """Sender role (push): stage ``source[key]`` and push it to ``sink``.
+
+    Selection (``select_sink``) is the caller's step. Stages the artifact to a
+    transient temp file (single pass, hashing), computes an RFC 9530
+    ``Content-Digest``, and streams the temp through the #147 ``guarded_stream``
+    (which strips ambient credentials and refuses redirects on a bodied request).
+    A non-2xx response maps to ``transfer-failed``; a guard refusal arrives coded
+    and propagates. The temp is deleted on every path.
+
+    Staging is required: the hook stream is non-seekable and the ``Content-Digest``
+    must be hashed before it can be sent in the request header, so a single hook
+    read cannot both hash-first and stream-from-the-hook.
+    """
+    stream, meta = await source.open_artifact(key)
+    try:
+        fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-send-")
+    except OSError as exc:
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(stream.close)
+        raise FileExchangeTransferError(
+            TransferErrorCode.TRANSFER_FAILED,
+            transport="upload",
+            detail="failed to create a temporary file",
+        ) from exc
+    try:
+        try:
+            tmp = os.fdopen(fd, "wb")
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        hasher = hashlib.sha256()
+        size = 0
+        try:
+            try:
+                while True:
+                    chunk = await asyncio.to_thread(stream.read, _CHUNK)
+                    if not chunk:
+                        break
+                    size += len(chunk)
+                    await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                await asyncio.to_thread(tmp.flush)
+            except OSError as exc:
+                raise FileExchangeTransferError(
+                    TransferErrorCode.TRANSFER_FAILED,
+                    transport="upload",
+                    detail="failed to stage the artifact for upload",
+                ) from exc
+            finally:
+                with contextlib.suppress(OSError):
+                    tmp.close()
+        finally:
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(stream.close)
+
+        headers = {
+            "Content-Length": str(size),
+            "Content-Digest": _format_content_digest(
+                _DEFAULT_DIGEST_LABEL, hasher.digest()
+            ),
+        }
+        if meta.mimeType is not None:
+            headers["Content-Type"] = meta.mimeType
+
+        async def _content() -> AsyncIterator[bytes]:
+            handle = await asyncio.to_thread(open, tmp_path, "rb")
+            try:
+                while True:
+                    chunk = await asyncio.to_thread(handle.read, _CHUNK)
+                    if not chunk:
+                        break
+                    yield chunk
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(handle.close)
+
+        try:
+            async with guarded_stream(
+                sink.method,
+                sink.url,
+                config=config,
+                transport="upload",
+                headers=headers,
+                content=_content(),
+            ) as resp:
+                if not 200 <= resp.status < 300:
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.TRANSFER_FAILED,
+                        transport="upload",
+                        detail="upload endpoint returned a non-success status",
+                    )
+        except OSError as exc:
+            # A temp read surfacing from the content generator during send.
+            raise FileExchangeTransferError(
+                TransferErrorCode.TRANSFER_FAILED,
+                transport="upload",
+                detail="failed to read the staged artifact during upload",
+            ) from exc
+    finally:
+        with contextlib.suppress(OSError):
+            await asyncio.to_thread(os.unlink, tmp_path)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -k sender -q`
+Expected: PASS.
+
+- [ ] **Step 5: Re-export `upload_sender_consume` + extend namespace test**
+
+In `src/fastmcp_pvl_core/_file_exchange/__init__.py`, extend the `_upload` import block:
+
+```python
+from fastmcp_pvl_core._file_exchange._upload import (
+    upload_receiver_mint,
+    upload_sender_consume,
+)
+```
+
+and add `"upload_sender_consume"` to `__all__` (alphabetical — after `upload_receiver_mint`).
+
+In `src/fastmcp_pvl_core/file_exchange.py`, add `upload_sender_consume` to the combined import (after `upload_receiver_mint`) and `__all__` (after `upload_receiver_mint`).
+
+In `tests/test_file_exchange_namespace.py`, extend `test_upload_data_plane_names_reexported`:
+
+```python
+def test_upload_data_plane_names_reexported():
+    from fastmcp_pvl_core import file_exchange
+
+    for name in (
+        "upload_receiver_mint",
+        "upload_sender_consume",
+        "register_file_exchange_routes",
+    ):
+        assert hasattr(file_exchange, name), name
+        assert name in file_exchange.__all__, name
+    # UPLOAD_PREFIX is internal route shape, not part of the public surface.
+    assert not hasattr(file_exchange, "UPLOAD_PREFIX")
+```
+
+- [ ] **Step 6: Run namespace + full upload suite + gates**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py tests/test_file_exchange_namespace.py -q`
+Expected: PASS.
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_upload.py src/fastmcp_pvl_core/_file_exchange/__init__.py src/fastmcp_pvl_core/file_exchange.py tests/_file_exchange/test_upload.py tests/test_file_exchange_namespace.py
+git commit -m "feat(file-exchange): add upload_sender_consume (#146)"
+```
+
+---
+
+### Task 7: Two-server push end-to-end
+
+**Files:**
+- Create: `tests/_file_exchange/test_upload_e2e.py`
+
+- [ ] **Step 1: Write the failing e2e test**
+
+```python
+"""End-to-end upload push: server A sends, server B mints + receives.
+
+Exercises the whole ``upload`` data plane together — ``upload_receiver_mint``,
+``register_file_exchange_routes`` (upload route mounted on a real ASGI app),
+``select_sink``, and ``upload_sender_consume`` — over a loopback ASGI transport.
+The SSRF guard is replaced with one that routes to server B's app, because we are
+exercising the push flow, not the guard (which has its own tests).
+"""
+
+import contextlib
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _routes, _upload
+from fastmcp_pvl_core._file_exchange._selection import select_sink
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+pytestmark = pytest.mark.anyio
+
+
+class _BytesSource:
+    def __init__(self, key, body):
+        self._key, self._body = key, body
+
+    async def open_artifact(self, key):
+        import io
+
+        assert key == self._key
+        return io.BytesIO(self._body), ArtifactMetadata(
+            name="a", mimeType="application/octet-stream", size=len(self._body)
+        )
+
+
+class _CapturingSink:
+    def __init__(self):
+        self.calls = []
+
+    async def store_artifact(self, artifact_id, metadata, stream):
+        self.calls.append((artifact_id, metadata, stream.read()))
+
+
+class _FakeGuarded:
+    def __init__(self, status):
+        self.status = status
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+async def test_two_server_push_upload(monkeypatch):
+    body = b"end-to-end-upload-payload" * 64
+
+    # Server B: receiver mint + upload route on a real ASGI app.
+    store = _store()
+    sink = _CapturingSink()
+    recv = FastMCP("receiver")
+    _routes.register_file_exchange_routes(
+        recv, token_store=store, sink=sink, config=ServerConfig()
+    )
+    app_b = recv.http_app()
+
+    # Server A's guard, redirected at B's ASGI app (no real network / SSRF check).
+    @contextlib.asynccontextmanager
+    async def guard_to_app_b(
+        method, url, *, config, transport, headers=None, content=None
+    ):
+        client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app_b), base_url="http://recv.test"
+        )
+        try:
+            path = url.split("recv.test", 1)[1]
+            req = client.build_request(
+                method, path, headers=headers or {}, content=content
+            )
+            resp = await client.send(req)
+            try:
+                yield _FakeGuarded(resp.status_code)
+            finally:
+                await resp.aclose()
+        finally:
+            await client.aclose()
+
+    monkeypatch.setattr(_upload, "guarded_stream", guard_to_app_b)
+
+    # B mints an intake ticket; A selects the upload sink and pushes.
+    ticket = await _upload.upload_receiver_mint(
+        "art-e2e", token_store=store, base_url="https://recv.test", ttl=300.0
+    )
+    descriptor = select_sink(ticket)
+    assert descriptor is not None and descriptor.transport == "upload"
+
+    await _upload.upload_sender_consume(
+        descriptor, _BytesSource("k", body), "k", config=ServerConfig()
+    )
+
+    # The bytes landed in B's sink, correlated to artifactId.
+    assert len(sink.calls) == 1
+    assert sink.calls[0][0] == "art-e2e"
+    assert sink.calls[0][2] == body
+    # The single-use token was consumed by the completed upload.
+    assert await store.lookup(descriptor.url.rsplit("/", 1)[1]) is None
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `uv run pytest tests/_file_exchange/test_upload_e2e.py -q`
+Expected: PASS (the implementation already exists from Tasks 3–6; this is an integration check, so it should pass on the first run — if it fails, the failure is a real integration gap to fix before committing).
+
+- [ ] **Step 3: Gates**
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/_file_exchange/test_upload_e2e.py
+git commit -m "test(file-exchange): two-server push e2e for upload data plane (#146)"
+```
+
+---
+
+### Task 8: Full suite, quality gates, preflight-circus, draft PR
+
+**Files:** none (verification + PR).
+
+- [ ] **Step 1: Full local check matrix (matches CI's dependency state)**
+
+```bash
+uv sync --all-extras
+uv run pytest
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
+```
+Expected: all green; the new `test_upload.py` + `test_upload_e2e.py` tests are included; download tests unchanged.
+
+- [ ] **Step 2: Cross-version check (min + max interpreter)**
+
+```bash
+uv run --python 3.10 pytest tests/_file_exchange/test_upload.py tests/_file_exchange/test_upload_e2e.py -q
+uv run --python 3.13 pytest tests/_file_exchange/test_upload.py tests/_file_exchange/test_upload_e2e.py -q
+```
+Expected: PASS on both (no version-dependent behaviour in the upload path; this guards against the 3.10/3.13 split that bit #152).
+
+- [ ] **Step 3: Preflight-circus on the cumulative diff**
+
+Invoke the `preflight-circus` skill against `BASE..HEAD` (`BASE = $(git merge-base HEAD origin/main)`). It is a normative-content change (the design doc cites RFC 9530 / RFC 7231 / spec §10.3 but is **informative**, not a wire spec — lens 6 fires only if a `docs/specs/` wire-format file changes, which it does not here). Resolve every finding surviving the ≥80 filter before pushing.
+
+- [ ] **Step 4: Open the draft PR**
+
+Confirm an issue exists (#146). Push the branch and open as draft:
+
+```bash
+git push -u origin feat/146-upload-data-plane
+gh pr create --draft --title "feat(file-exchange): upload transport data plane (#146)" --body "$(cat <<'EOF'
+## Summary
+- Adds the `upload` transport data plane (EPIC #138, 8/10): `upload_receiver_mint` (token + IntakeTicket/UploadSink), the PUT/POST route (stream-to-temp, `acceptMimeTypes` RFC 7231, `Content-Digest` RFC 9530 verify, single-success-per-URL, verify-before-use into the `ArtifactSink`), and `upload_sender_consume` (stage + `Content-Digest` + `guarded_stream`).
+- Refactor: extracts shared digest/chunk primitives into `_staging.py`; moves `register_file_exchange_routes` into `_routes.py` (now mounts download iff `source`, upload iff `sink`+`config`).
+- #148 threads `source`/`sink`/`config` + adds Tasks integration; this PR ships the primitives + route.
+
+## Test plan
+- [ ] `uv run pytest` green (new `test_upload.py` + `test_upload_e2e.py`; download suite unchanged)
+- [ ] `uv run ruff format --check . && uv run ruff check . && uv run mypy src` clean
+- [ ] Cross-version: `uv run --python 3.10/3.13 pytest tests/_file_exchange/test_upload*.py`
+- [ ] Receiver mint, route happy+consume / replay-404 / oversize-413 / mime-415 / digest-verify+mismatch-400 / requireDigest-missing-400 / ambient-creds-ignored / sink-failure-500, sender headers+non-2xx+guard-refusal, two-server push e2e
+
+Closes #146.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Bot iteration (capped) → flip ready**
+
+Read the `claude-review` body (not just the check status). Address any finding per the iteration cap (re-run the full `preflight-circus` before each fix push). Once local circus was clean, bot bodies LGTM, and CI is green, flip ready: `gh pr ready <N>`.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (design doc → task):
+- `upload_receiver_mint` (token stores `artifact_id`+`expected`; IntakeTicket+UploadSink) → Task 3. ✓
+- `register_file_exchange_routes` optional `source`/`sink`/`config`; download-only / upload-only / both; upload requires `config` → Task 2 (download + optional source) + Task 5 (sink/config + ValueError guard). ✓
+- Upload route: 404 / acceptMimeTypes-415 / stream-to-temp + size-cap-413 / Content-Digest verify (present→verify, requireDigest→required) / verify-before-use / store + 204 / consume-only-on-success / ambient-creds-ignored / hook-fail-500 → Task 5. ✓
+- `upload_sender_consume`: stage + Content-Digest + `guarded_stream` content body + non-2xx→transfer-failed + guard-refusal propagates + temp cleanup + omit Content-Type when unknown → Task 6. ✓
+- §10.3 Content-Digest RFC 9530 (`label=:b64:`, verify in declared algo, metadata `label:hex`) + acceptMimeTypes RFC 7231 media-range → Task 4 (helpers) + Task 5 (route use). ✓
+- File structure: `_staging.py` (Task 1), `_routes.py` (Task 2), `_upload.py` (Tasks 3–6); temp-IO OSError contract from #145 preserved (route→body-free 500; sender→transfer-failed) → Tasks 5/6. ✓
+- Public surface re-exports + namespace test → Tasks 3/6. ✓
+- Testing (unit + route + sender + e2e) → Tasks 3–7. ✓
+
+**2. Placeholder scan:** No "TBD"/"implement later"/"add error handling"/"write tests for the above". Every code/test step shows complete code. The only deferred items are explicitly out of scope (#148 threading; sender-side mime pre-check deferred per the design's §10.3 rationale).
+
+**3. Type consistency:**
+- `register_download_route(mcp, *, token_store, source)` — defined Task 2, called from `_routes.py` Task 2. ✓
+- `register_upload_route(mcp, *, token_store, sink, config)` — defined Task 5, called from `_routes.py` Task 5. ✓
+- `register_file_exchange_routes(mcp, *, token_store, source=None, sink=None, config=None)` — Task 2 (download branch + sink/config params present) → Task 5 (upload branch added). Signature stable across both. ✓
+- `upload_receiver_mint(artifact_id, *, token_store, base_url, ttl, expected=None, method="PUT")` — Task 3 def; same shape in e2e (Task 7) and unit (Task 3). ✓
+- `upload_sender_consume(sink, source, key, *, config)` — Task 6 def; same call in sender tests (Task 6) + e2e (Task 7). ✓
+- Helpers `_format_content_digest(label, raw)`, `_parse_content_digest(header) -> (label, raw)|None`, `_media_type_accepted(content_type, accept) -> bool` — Task 4 def; used in Task 5 route + Task 6 sender + tests. ✓
+- `_staging` exports `_CHUNK`, `_HASHLIB_BY_LABEL`, `_digest_verifier`, `_write_chunk` — Task 1; imported by `_download` (Task 1) and `_upload` (Tasks 4–6). ✓
+- Token metadata keys `"artifact_id"` / `"expected"` — written by `upload_receiver_mint` (Task 3) and the route's `_mint_token` helper (Task 5), read by the route (Task 5). Consistent. ✓
+- `ArtifactMetadata(mimeType=, size=, digest=)` with all-optional fields (≥1 required) — the route always sets size+digest, so the invariant holds. ✓

--- a/docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md
+++ b/docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md
@@ -1,0 +1,279 @@
+# File-Exchange #146 — upload data plane (route + receiver/sender)
+
+> **Status:** Contemporaneous design record for issue #146 (8/10 of EPIC
+> #138). The implementation in the same PR is the source of truth; this
+> captures the shape agreed before implementation. This is **not** a wire
+> spec — #146 is pvl-core's own implementation of the `upload` transport's
+> data plane, governed by `CLAUDE.md` and the project's framing principle,
+> not by `mcp-file-exchange-ext`. No `docs/specs/` wire-format file is touched.
+
+**Goal:** Implement the `upload` transport's push data plane, the mirror of the
+#145 `download` pull plane: the receiver mints a capability URL backed by the
+#144 token store, an HTTPS `PUT`/`POST` route on the receiver's own server
+accepts the artifact bytes and deposits them through the #142 `ArtifactSink`, and
+the sender pushes them through the #147 SSRF guard with a `Content-Digest`.
+Everything streams — no artifact is buffered whole in memory.
+
+## Scope (from #138's decomposition + #146's scope statement)
+
+#146 owns the three `upload` role primitives and the serving route:
+`upload_receiver_mint`, the upload `PUT`/`POST` route, and
+`upload_sender_consume`. It builds on three merged dependencies:
+`CapabilityTokenStore` (#144), `guarded_stream` (#147 — which already accepts a
+request `content` body), and the `ArtifactSource`/`ArtifactSink` hooks (#142). It
+does **not** build the top-level `register_file_exchange_*` umbrella, the shared
+token-store construction, or Tasks integration — those are #148. The primitives
+take their dependencies (token store / sink / source / config) as parameters;
+#148 constructs and threads them.
+
+## File structure
+
+The EPIC's pattern is one module per transport (`_filesystem.py`, `_download.py`),
+so upload gets its own module, and the cross-transport route registrar moves to a
+neutral home:
+
+- **New `_upload.py`** — `upload_receiver_mint`, `upload_sender_consume`, the
+  upload route registrar (`register_upload_route`, internal), and the
+  upload-specific HTTP helpers (`Content-Digest` RFC 9530 parse/format,
+  `acceptMimeTypes` RFC 7231 media-range matching).
+- **New `_routes.py`** — `register_file_exchange_routes` moves here from
+  `_download.py` (it is cross-transport, not download-specific). It calls
+  `register_download_route` (extracted from `_download.py`) and
+  `register_upload_route` (from `_upload.py`). `_download` and `_upload` stay
+  independent leaf modules — no circular imports.
+- **New `_staging.py`** — the digest/chunk primitives shared by both transports:
+  `_HASHLIB_BY_LABEL`, `_digest_verifier`, `_write_chunk`, `_CHUNK`, and a
+  temp-file staging helper that writes an async byte stream to a `mkstemp` temp
+  with hashing + a size bound, **preserving the `OSError → transfer-failed`
+  mapping / cleanup-suppression contract established in #145** (the download
+  fetcher's hard-won temp-IO error sweep must not be re-derived divergently in
+  upload). The download fetcher's `Range`-resume loop stays in `_download.py`
+  (download-specific); only the per-chunk write/hash/verify primitives are
+  shared. The exact split of "shared helper vs. per-transport loop" is the
+  plan's call; the contract (every temp-file op maps to `transfer-failed` or is
+  suppressed for cleanup) is not.
+
+This refactors merged #145 code (moving `register_file_exchange_routes`,
+extracting `_staging.py`). The re-export surface is updated to import
+`register_file_exchange_routes` from `_routes` (the public name is unchanged).
+
+## register_file_exchange_routes shape
+
+```python
+def register_file_exchange_routes(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    source: ArtifactSource | None = None,
+    sink: ArtifactSink | None = None,
+) -> None: ...
+```
+
+Mounts the download `GET` route iff `source` is given, and the upload
+`PUT`/`POST` route iff `sink` is given — supporting download-only, upload-only,
+or both. This makes #145's `source` parameter optional (it was required); safe
+because no downstream has adopted the hooks yet (#148 threads them). `UPLOAD_PREFIX`
+is a pvl-core route-shape constant (e.g. `/fx/u`), not a kwarg, not exported —
+mirroring `DOWNLOAD_PREFIX`.
+
+## Components (mirroring #145's provider/fetcher)
+
+### `upload_receiver_mint`
+
+```python
+async def upload_receiver_mint(
+    artifact_id: str,
+    *,
+    token_store: CapabilityTokenStore,
+    base_url: str,
+    ttl: float,
+    expected: ArtifactConstraints | None = None,
+    method: Literal["PUT", "POST"] = "PUT",
+) -> IntakeTicket: ...
+```
+
+- `minted = await token_store.mint({"artifact_id": artifact_id, "expected":
+  expected.model_dump() if expected else None}, ttl=ttl, single_use=True)`. The
+  token stores the `artifact_id` and the `expected` constraints so the route can
+  correlate received bytes and enforce limits; the token store treats the
+  metadata as opaque (#144).
+- `url = capability_url(base_url, UPLOAD_PREFIX, minted.token)`.
+- Returns `IntakeTicket(type=TICKET_TYPE, version=SPEC_VERSION,
+  artifactId=artifact_id, expected=expected, sinks=[UploadSink(transport="upload",
+  url=url, method=method, expiresAt=minted.expires_at)])`.
+
+Minting only — no hook is called, no bytes move (mirrors
+`filesystem_receiver_mint`). The receiver's `ArtifactSink` is threaded into the
+route (not into mint), since the bytes arrive at the route, not at mint time.
+
+### The upload route (`register_upload_route` → `PUT`/`POST <UPLOAD_PREFIX>/{token}`)
+
+Mounted via `@mcp.custom_route`. Handler (Starlette `Request` → `Response`):
+
+1. `rec = await token_store.lookup(token)`; if `None` → **`404`** (uniform for
+   unknown / expired / already-consumed — leaks no token state).
+2. Read `artifact_id` and `expected` (re-hydrated to `ArtifactConstraints`) from
+   `rec.metadata`.
+3. **`acceptMimeTypes` (RFC 7231 §3.1.1.1 media-range):** if `expected.acceptMimeTypes`
+   is set, match the request `Content-Type` (media type, parameters ignored)
+   against the list (`type/*` matches a subtype, `*/*` matches anything). No
+   match → **`415`** (no token consumed).
+4. **Stream the request body to a transient temp file** (`request.stream()` →
+   temp, hashing + counting via the shared staging helper). Enforce the byte
+   bound — reject with **`413`** (no consume) when the received count exceeds
+   either `expected.maxSize` or `config.file_exchange_max_artifact_size` (each
+   enforced when set), bounding consumption to the smaller cap + one chunk.
+5. **Verify-before-use:** after the body completes, verify `Content-Digest`
+   (RFC 9530) against the received bytes **if the header is present**; if
+   `expected.requireDigest` is set, a **missing** or **mismatched** digest →
+   **`400`** (`digest-mismatch`, §13). Uploaded bytes are untrusted, so this
+   happens **before** the sink sees them.
+6. Only on a clean verify, construct `meta = ArtifactMetadata(mimeType=<request
+   Content-Type>, size=<received>, digest="sha-256:<hex>")` and
+   `await sink.store_artifact(artifact_id, meta, <temp fd>)` — the same real sync
+   fd / temp-file async→sync bridge as the download fetcher.
+7. **Single-success-per-URL:** `await token_store.consume(token)` **only after a
+   successful store** (§10.3: at most one successful upload). A rejected upload
+   (415/413/400) or a sink failure never consumes, so the slot is not burned.
+8. Success → **`204`** (body-free). The temp file is deleted on every path.
+   Ambient credentials are ignored — the in-URL token is the only authorization.
+
+### `upload_sender_consume`
+
+```python
+async def upload_sender_consume(
+    sink: UploadSink,
+    source: ArtifactSource,
+    key: str,
+    *,
+    config: ServerConfig,
+) -> None: ...
+```
+
+Selection (`select_sink`) is the caller's step (consistent with `_filesystem`).
+The sender:
+
+- Opens `source.open_artifact(key) -> (stream, metadata)` and **stages the bytes
+  to a transient temp file** (single pass, hashing). Staging is required because
+  the hook stream is non-seekable and `Content-Digest` must be computed (hashed)
+  before it can be sent in the request header — a single-pass read can't both
+  hash-first and stream-from-the-hook.
+- Sends via `guarded_stream(sink.method, sink.url, config=config,
+  transport="upload", content=<async iterator over the temp file>,
+  headers={"Content-Type": metadata.mimeType (if known), "Content-Length":
+  <size>, "Content-Digest": "sha-256=:<base64>:"})`. The body streams from the
+  temp (not buffered in memory); the guard re-resolves/pins and strips ambient
+  credentials (#147).
+- Treats a non-2xx response as `FileExchangeTransferError(transfer-failed,
+  transport="upload")`; a guard refusal already arrives coded (`not-accessible`)
+  and propagates. The temp is deleted on every path.
+- **Deferred (per §10.3 SHOULD):** the sender does **not** pre-check
+  `acceptMimeTypes`. The receiver rejects a mismatch *before* consuming the
+  token, so a mismatch never burns the slot — the pre-check is only a round-trip
+  saving, and adding it would require threading `expected` into the sender. The
+  sender always sends `Content-Digest` (it stages+hashes anyway), which satisfies
+  `requireDigest` without needing `expected`.
+
+## §10.3 specifics
+
+- **`Content-Digest` (RFC 9530):** the wire header form is a Structured-Field
+  dictionary `algo=:base64:` (e.g. `sha-256=:<base64 of the raw digest>:`) —
+  **distinct** from the `ArtifactMetadata.digest` field's `sha-256:<hex>` form.
+  A small hand-rolled parse (receiver) and format (sender) for the
+  `sha-256/384/512` labels in `_HASHLIB_BY_LABEL` is sufficient; an unsupported
+  or unparseable `Content-Digest` is a verification failure (`digest-mismatch`),
+  never a silent skip (§15, mirroring `_digest_verifier`). The receiver verifies
+  the header in **its declared algorithm** (hashing the received bytes with that
+  algorithm) and separately records `ArtifactMetadata.digest` in pvl-core's
+  `sha-256:<hex>` form; when the sender used `sha-256` (pvl-core's sender always
+  does) a single hash serves both. The sender always sends a `sha-256`
+  `Content-Digest`, which satisfies any `requireDigest` that lists `sha-256`.
+- **HTTP status mapping** (pvl-core shape, not §13 — the route serves a possibly
+  non-MCP HTTP client): `204` success; `404` unknown/expired/consumed token;
+  `413` over the size bound; `415` `acceptMimeTypes` reject; `400`
+  digest-mismatch / missing-required-digest; hook failure → body-free `500`
+  (the sink's exception message may carry server detail — log locally, never
+  echo). `upload_sender_consume` raises the §13-coded `FileExchangeTransferError`.
+
+## #146 ↔ #148 boundary
+
+#146 ships the three primitives + the route registrars. #148 builds the shared
+token store, threads `source`/`sink`/`config` into `register_file_exchange_routes`,
+registers the routes on the server, exposes the umbrella, and wires the §14 Tasks
+path (large-artifact transfers). Same boundary as #145.
+
+## Error handling
+
+- `upload_sender_consume`: guard refusals arrive as
+  `FileExchangeTransferError(not-accessible, transport="upload")` and propagate;
+  a non-2xx response or any other failure maps to `transfer-failed`; the temp is
+  removed on every path (`finally`), with the temp-IO `OSError` contract from
+  #145 (map to `transfer-failed`, suppress cleanup-close).
+- `upload_receiver_mint` is an offering-side op (§16): a token-store failure
+  during minting propagates unwrapped to the offering tool's handler (matching
+  `filesystem_receiver_mint` / `download_provider_mint`).
+- The route maps failures to HTTP status (above); a hook/store failure mid-deposit
+  does **not** consume the token, so the sender can retry or re-request a ticket.
+
+## Testing (`tests/_file_exchange/test_upload.py`, plus an e2e module)
+
+Unit:
+
+1. `upload_receiver_mint` — returns an `IntakeTicket` with one `UploadSink`
+   whose `url` is `capability_url(base_url, UPLOAD_PREFIX, token)`, `method`
+   threads through, `expiresAt` is the minted (clamped) expiry; the token stores
+   `{"artifact_id", "expected"}`; `expected` round-trips onto the ticket.
+2. Route (via `httpx.ASGITransport` on `mcp.http_app()`): unknown/expired/consumed
+   token → `404`; happy `PUT` deposits the bytes into the sink and consumes the
+   token (second `PUT` → `404`); over `maxSize`/cap → `413` (no consume); a
+   `Content-Type` not in `acceptMimeTypes` → `415` (no consume); a valid
+   `Content-Digest` verifies; a mismatched `Content-Digest` → `400` and the sink
+   is **not** called (verify-before-use); `requireDigest` with a missing header →
+   `400`; ambient `Authorization`/`Cookie` ignored; the temp file is gone after
+   every outcome.
+3. `upload_sender_consume` — happy path stages and `PUT`s with `Content-Type` /
+   `Content-Length` / `Content-Digest` headers asserted (mock `guarded_stream`);
+   a non-2xx response → `transfer-failed`; a guard refusal → `not-accessible`;
+   the temp file is gone after every outcome.
+
+End-to-end (`test_upload_e2e.py`): two pvl-core-built mock servers. Server B
+(receiver) mints via `upload_receiver_mint` and serves via the upload route
+mounted on a real ASGI app; server A (sender) selects the `upload` sink and runs
+`upload_sender_consume` against B's route through `guarded_stream` (pointed at
+B's app) — bytes land in B's `ArtifactSink`, correlated to `artifactId`, with the
+`Content-Digest` verified. Upload transport only.
+
+Namespace re-export: each new public name reachable via
+`fastmcp_pvl_core.file_exchange`.
+
+## Public surface
+
+Re-exported via `file_exchange.py` and the subpackage `__init__.py` (both
+`__all__`s updated, alphabetical), transport-qualified beside the `filesystem_*`
+and `download_*` ops:
+
+- `upload_receiver_mint`, `upload_sender_consume` — the two role ops.
+- `register_file_exchange_routes` — unchanged public name (now from `_routes`),
+  with the added optional `sink` and now-optional `source`.
+
+`UPLOAD_PREFIX` is a module constant (pvl-core route shape) — not re-exported, not
+configurable. `FileExchangeTransferError`, `UploadSink`, `IntakeTicket`,
+`ArtifactConstraints`, `CapabilityTokenStore`, `capability_url`,
+`ArtifactSource`/`ArtifactSink`, `guarded_stream` are reused, not re-declared.
+
+## References
+
+- EPIC #138 (adopt mcp-file-exchange-ext v0.1); this is 8/10. Depends on #144
+  (token store — merged), #147 (SSRF guard — merged), #142 (hooks — merged).
+  Mirror of #145 (download data plane — merged).
+- #148 (top-level `register_file_exchange_*` helpers + Tasks integration +
+  adoption docs) — threads `source`/`sink`/`config` and exposes the umbrella.
+- Wire spec (`mcp-file-exchange-ext`, pinned commit `5f50a4e…`): §7.4
+  (`IntakeTicket`), §8.2 (push flow), §10.3 (`upload` transport obligations —
+  receiver single-success/digest/constraints, sender method/Content-Digest/
+  no-ambient-creds, RFC 7231 media-range, RFC 9530 `Content-Digest`), §12
+  (capability URLs), §13 (error codes), §15 (security — integrity, untrusted
+  bytes, resource exhaustion). This document is **not** a wire spec.
+- `CLAUDE.md` — route structure is a pvl-core shape decision (constant, not
+  kwarg); URL/credential-redaction discipline; the temp-IO error contract and
+  verify-before-use carried over from #145.

--- a/docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md
+++ b/docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md
@@ -66,15 +66,21 @@ def register_file_exchange_routes(
     token_store: CapabilityTokenStore,
     source: ArtifactSource | None = None,
     sink: ArtifactSink | None = None,
+    config: ServerConfig | None = None,
 ) -> None: ...
 ```
 
 Mounts the download `GET` route iff `source` is given, and the upload
 `PUT`/`POST` route iff `sink` is given — supporting download-only, upload-only,
 or both. This makes #145's `source` parameter optional (it was required); safe
-because no downstream has adopted the hooks yet (#148 threads them). `UPLOAD_PREFIX`
-is a pvl-core route-shape constant (e.g. `/fx/u`), not a kwarg, not exported —
-mirroring `DOWNLOAD_PREFIX`.
+because no downstream has adopted the hooks yet (#148 threads them).
+`config` carries the operator size cap (`file_exchange_max_artifact_size`) the
+upload route needs to bound untrusted request bodies (§15); the download route
+ignores it. **Mounting the upload route requires `config`** — `sink` given
+without `config` raises `ValueError` at registration, since an upload route with
+no operator cap could accept an unbounded body. `UPLOAD_PREFIX` is a pvl-core
+route-shape constant (e.g. `/fx/u`), not a kwarg, not exported — mirroring
+`DOWNLOAD_PREFIX`.
 
 ## Components (mirroring #145's provider/fetcher)
 

--- a/src/fastmcp_pvl_core/_file_exchange/__init__.py
+++ b/src/fastmcp_pvl_core/_file_exchange/__init__.py
@@ -69,6 +69,7 @@ from fastmcp_pvl_core._file_exchange._tokens import (
 )
 from fastmcp_pvl_core._file_exchange._upload import (
     upload_receiver_mint,
+    upload_sender_consume,
 )
 from fastmcp_pvl_core._file_exchange._validation import (
     WireFormatError,
@@ -144,5 +145,6 @@ __all__ = [
     "select_sink",
     "select_source",
     "upload_receiver_mint",
+    "upload_sender_consume",
     "validate_wire",
 ]

--- a/src/fastmcp_pvl_core/_file_exchange/__init__.py
+++ b/src/fastmcp_pvl_core/_file_exchange/__init__.py
@@ -19,7 +19,6 @@ from fastmcp_pvl_core._file_exchange._codes import (
 from fastmcp_pvl_core._file_exchange._download import (
     download_fetcher_consume,
     download_provider_mint,
-    register_file_exchange_routes,
 )
 from fastmcp_pvl_core._file_exchange._errors import (
     FileExchangeTransferError,
@@ -44,6 +43,7 @@ from fastmcp_pvl_core._file_exchange._paths import (
     load_volume_map,
     resolve_filesystem_uri,
 )
+from fastmcp_pvl_core._file_exchange._routes import register_file_exchange_routes
 from fastmcp_pvl_core._file_exchange._selection import (
     select_sink,
     select_source,

--- a/src/fastmcp_pvl_core/_file_exchange/__init__.py
+++ b/src/fastmcp_pvl_core/_file_exchange/__init__.py
@@ -67,6 +67,9 @@ from fastmcp_pvl_core._file_exchange._tokens import (
     build_capability_token_store,
     capability_url,
 )
+from fastmcp_pvl_core._file_exchange._upload import (
+    upload_receiver_mint,
+)
 from fastmcp_pvl_core._file_exchange._validation import (
     WireFormatError,
     validate_wire,
@@ -140,5 +143,6 @@ __all__ = [
     "resolve_filesystem_uri",
     "select_sink",
     "select_source",
+    "upload_receiver_mint",
     "validate_wire",
 ]

--- a/src/fastmcp_pvl_core/_file_exchange/_download.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_download.py
@@ -319,7 +319,7 @@ def _parse_range(header: str | None, size: int | None) -> tuple[int, int | None]
     return start, end
 
 
-def register_file_exchange_routes(
+def register_download_route(
     mcp: FastMCP,
     *,
     token_store: CapabilityTokenStore,

--- a/src/fastmcp_pvl_core/_file_exchange/_download.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_download.py
@@ -19,12 +19,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import hashlib
 import logging
 import os
 import tempfile
 from collections.abc import AsyncGenerator
-from typing import IO, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import httpx
 from starlette.responses import Response, StreamingResponse
@@ -33,6 +32,11 @@ from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
 from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
 from fastmcp_pvl_core._file_exchange._outbound import guarded_stream
 from fastmcp_pvl_core._file_exchange._spec import HANDLE_TYPE, SPEC_VERSION
+from fastmcp_pvl_core._file_exchange._staging import (
+    _CHUNK,
+    _digest_verifier,
+    _write_chunk,
+)
 from fastmcp_pvl_core._file_exchange._tokens import capability_url
 from fastmcp_pvl_core._file_exchange._wire import DownloadSource, TransferHandle
 
@@ -51,10 +55,6 @@ logger = logging.getLogger(__name__)
 # kwarg — route structure is a pvl-core shape decision.
 DOWNLOAD_PREFIX = "/fx/d"
 
-_CHUNK = 1024 * 1024
-# Declared-digest label -> hashlib name; an unsupported label fails verification
-# (cannot verify -> digest-mismatch), never silently skips. Mirrors _filesystem.
-_HASHLIB_BY_LABEL = {"sha-256": "sha256", "sha-384": "sha384", "sha-512": "sha512"}
 # Max mid-stream reconnects before giving up on a dropped download.
 _MAX_RECONNECTS = 5
 
@@ -91,33 +91,6 @@ async def download_provider_mint(
             )
         ],
     )
-
-
-def _digest_verifier(
-    declared: str | None,
-) -> tuple[hashlib._Hash | None, str | None, bool]:
-    """Return (hasher | None, expected_hex | None, unverifiable).
-
-    ``unverifiable`` is True when a digest is declared with an unsupported label
-    — verification must then fail (cannot verify), never silently skip (§15).
-    """
-    if declared is None:
-        return None, None, False
-    label, _, expected_hex = declared.partition(":")
-    name = _HASHLIB_BY_LABEL.get(label.lower())
-    if name is None:
-        return None, expected_hex, True
-    return hashlib.new(name), expected_hex.lower(), False
-
-
-def _write_chunk(tmp: IO[bytes], hasher: hashlib._Hash | None, chunk: bytes) -> None:
-    """Write a body chunk to the temp file and fold it into the running hash.
-
-    Both ops run off the event loop in a single ``asyncio.to_thread`` dispatch.
-    """
-    tmp.write(chunk)
-    if hasher is not None:
-        hasher.update(chunk)
 
 
 async def download_fetcher_consume(

--- a/src/fastmcp_pvl_core/_file_exchange/_filesystem.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_filesystem.py
@@ -34,7 +34,7 @@ from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
 from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
 from fastmcp_pvl_core._file_exchange._paths import atomic_write, resolve_filesystem_uri
 from fastmcp_pvl_core._file_exchange._spec import HANDLE_TYPE, SPEC_VERSION, TICKET_TYPE
-from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL
+from fastmcp_pvl_core._file_exchange._staging import _CHUNK, _HASHLIB_BY_LABEL
 from fastmcp_pvl_core._file_exchange._wire import (
     FilesystemSink,
     FilesystemSource,
@@ -88,8 +88,6 @@ _DIGEST_LABEL = "sha-256"
 # Fixed deposit/staged-file mode (#155): owner rw, group rw, other r — so a
 # different-uid party on a shared volume can read what pvl-core writes.
 _DEPOSIT_MODE = 0o664
-
-_CHUNK = 1024 * 1024
 
 logger = logging.getLogger(__name__)
 

--- a/src/fastmcp_pvl_core/_file_exchange/_filesystem.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_filesystem.py
@@ -34,6 +34,7 @@ from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
 from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
 from fastmcp_pvl_core._file_exchange._paths import atomic_write, resolve_filesystem_uri
 from fastmcp_pvl_core._file_exchange._spec import HANDLE_TYPE, SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL
 from fastmcp_pvl_core._file_exchange._wire import (
     FilesystemSink,
     FilesystemSource,
@@ -87,10 +88,6 @@ _DIGEST_LABEL = "sha-256"
 # Fixed deposit/staged-file mode (#155): owner rw, group rw, other r — so a
 # different-uid party on a shared volume can read what pvl-core writes.
 _DEPOSIT_MODE = 0o664
-
-# Verifier maps a declared `<label>:` to a hashlib name; an unsupported label
-# fails verification (cannot verify -> digest-mismatch), never silently skips.
-_HASHLIB_BY_LABEL = {"sha-256": "sha256", "sha-384": "sha384", "sha-512": "sha512"}
 
 _CHUNK = 1024 * 1024
 

--- a/src/fastmcp_pvl_core/_file_exchange/_hooks.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_hooks.py
@@ -56,7 +56,11 @@ class ArtifactSink(Protocol):
         The caller (pvl-core) owns ``stream`` and is responsible for
         verifying the artifact's size + digest by its own means (before or
         as the sink reads); the sink reads but does **not** close it, and
-        MUST NOT assume the stream's concrete type. Return ``None`` on
-        success; raise on failure.
+        MUST NOT assume the stream's concrete type. The caller closes
+        ``stream`` and may delete its backing storage immediately after this
+        method returns, so the sink MUST finish reading before returning (it
+        may read on the loop or off-load to a thread, but MUST NOT retain the
+        handle for deferred reads). Return ``None`` on success; raise on
+        failure.
         """
         ...

--- a/src/fastmcp_pvl_core/_file_exchange/_routes.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_routes.py
@@ -37,6 +37,11 @@ def register_file_exchange_routes(
     ``config`` (the operator size cap bounds untrusted request bodies). All of
     ``token_store``/``source``/``sink``/``config`` are threaded by #148.
     """
+    if source is None and sink is None:
+        raise ValueError(
+            "register_file_exchange_routes: at least one of `source` or `sink` "
+            "must be provided"
+        )
     if source is not None:
         register_download_route(mcp, token_store=token_store, source=source)
     if sink is not None:

--- a/src/fastmcp_pvl_core/_file_exchange/_routes.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_routes.py
@@ -1,0 +1,39 @@
+"""Cross-transport FastMCP route registration for the file-exchange HTTP transports.
+
+``register_file_exchange_routes`` mounts the ``download`` GET route (when a
+``source`` hook is given) and the ``upload`` PUT/POST route (when a ``sink`` hook
+is given). Each transport's registrar lives in its own leaf module
+(``_download``/``_upload``); this module is the single public entry point #148
+threads ``token_store``/``source``/``sink``/``config`` into.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastmcp_pvl_core._file_exchange._download import register_download_route
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+
+
+def register_file_exchange_routes(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    source: ArtifactSource | None = None,
+    sink: ArtifactSink | None = None,
+    config: ServerConfig | None = None,
+) -> None:
+    """Mount the file-exchange HTTP routes on ``mcp``.
+
+    Mounts the ``download`` GET route iff ``source`` is given. (The ``upload``
+    PUT/POST route — mounted iff ``sink`` is given — is added in #146 Task 5.)
+    ``token_store``/``source``/``sink``/``config`` are threaded by #148.
+    """
+    if source is not None:
+        register_download_route(mcp, token_store=token_store, source=source)

--- a/src/fastmcp_pvl_core/_file_exchange/_routes.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_routes.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from fastmcp_pvl_core._file_exchange._download import register_download_route
+from fastmcp_pvl_core._file_exchange._upload import register_upload_route
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -31,9 +32,17 @@ def register_file_exchange_routes(
 ) -> None:
     """Mount the file-exchange HTTP routes on ``mcp``.
 
-    Mounts the ``download`` GET route iff ``source`` is given. (The ``upload``
-    PUT/POST route — mounted iff ``sink`` is given — is added in #146 Task 5.)
+    Mounts the ``download`` GET route iff ``source`` is given and the ``upload``
+    PUT/POST route iff ``sink`` is given. Mounting the upload route requires
+    ``config`` (the operator size cap bounds untrusted request bodies). All of
     ``token_store``/``source``/``sink``/``config`` are threaded by #148.
     """
     if source is not None:
         register_download_route(mcp, token_store=token_store, source=source)
+    if sink is not None:
+        if config is None:
+            raise ValueError(
+                "register_file_exchange_routes: mounting the upload route "
+                "requires `config` for the operator size cap"
+            )
+        register_upload_route(mcp, token_store=token_store, sink=sink, config=config)

--- a/src/fastmcp_pvl_core/_file_exchange/_staging.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_staging.py
@@ -10,12 +10,15 @@ construction for the download fetcher (the filesystem transport's verifier
 inlines equivalent logic against :data:`_HASHLIB_BY_LABEL`; the upload
 transport's RFC 9530 verifier is in ``_upload.py``).
 
-:data:`_CHUNK` and :func:`_write_chunk` are used by the HTTP transports
-(download fetcher / upload route + sender) for buffered staging to a transient
-temp file with hashing — each HTTP transport keeps its own read loop (download
-resumes via ``Range``; upload reads ``request.stream()`` or a hook stream) and
-applies the ``OSError -> transfer-failed`` mapping / cleanup-suppression contract
-around them.
+:data:`_CHUNK` is the canonical chunk size for buffered reads across all
+transports (download fetcher / upload route + sender / filesystem reader).
+
+:func:`_write_chunk` is used by the HTTP transports (download fetcher / upload
+route + sender) for buffered staging to a transient temp file with hashing —
+each HTTP transport keeps its own read loop (download resumes via ``Range``;
+upload reads ``request.stream()`` or a hook stream) and applies the
+``OSError -> transfer-failed`` mapping / cleanup-suppression contract around
+them.
 """
 
 from __future__ import annotations

--- a/src/fastmcp_pvl_core/_file_exchange/_staging.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_staging.py
@@ -42,7 +42,8 @@ def _digest_verifier(
 def _write_chunk(tmp: IO[bytes], hasher: hashlib._Hash | None, chunk: bytes) -> None:
     """Write a body chunk to the temp file and fold it into the running hash.
 
-    Both ops run off the event loop in a single ``asyncio.to_thread`` dispatch.
+    Both ops are synchronous and are designed to be dispatched off the event
+    loop by the caller (e.g. via ``asyncio.to_thread``).
     """
     tmp.write(chunk)
     if hasher is not None:

--- a/src/fastmcp_pvl_core/_file_exchange/_staging.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_staging.py
@@ -1,12 +1,14 @@
-"""Shared temp-file staging + digest primitives for the HTTP transports.
+"""Shared digest + temp-file staging primitives for the file-exchange transports.
 
-The download fetcher (#145) and the upload route/sender (#146) both buffer a
-byte stream to a transient temp file with hashing and a size bound, and verify a
-declared digest. These primitives factor out the common parts. Each transport
-keeps its own read loop (download resumes via ``Range``; upload reads
-``request.stream()`` or a hook stream) and applies the
-``OSError -> transfer-failed`` mapping / cleanup-suppression contract around
-them.
+The supported-algorithm table (:data:`_HASHLIB_BY_LABEL`) and the
+:func:`_digest_verifier` helper are shared across every transport that verifies a
+declared ``label:hex`` digest (download, upload, filesystem). The streaming
+primitives (:data:`_CHUNK`, :func:`_write_chunk`) are used by the HTTP transports
+(download fetcher / upload route + sender) for buffered staging to a transient
+temp file with hashing — each HTTP transport keeps its own read loop (download
+resumes via ``Range``; upload reads ``request.stream()`` or a hook stream) and
+applies the ``OSError -> transfer-failed`` mapping / cleanup-suppression contract
+around them.
 """
 
 from __future__ import annotations

--- a/src/fastmcp_pvl_core/_file_exchange/_staging.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_staging.py
@@ -1,9 +1,16 @@
 """Shared digest + temp-file staging primitives for the file-exchange transports.
 
-The supported-algorithm table (:data:`_HASHLIB_BY_LABEL`) and the
-:func:`_digest_verifier` helper are shared across every transport that verifies a
-declared ``label:hex`` digest (download, upload, filesystem). The streaming
-primitives (:data:`_CHUNK`, :func:`_write_chunk`) are used by the HTTP transports
+:data:`_HASHLIB_BY_LABEL` is the canonical supported-algorithm table, shared by
+every transport — directly for the download fetcher's and filesystem transport's
+``label:hex`` digest verification, and as the validation set for the upload
+transport's inbound/outbound RFC 9530 ``Content-Digest`` algorithms.
+
+:func:`_digest_verifier` bundles ``label:hex`` partition + lookup + hasher
+construction for the download fetcher (the filesystem transport's verifier
+inlines equivalent logic against :data:`_HASHLIB_BY_LABEL`; the upload
+transport's RFC 9530 verifier is in ``_upload.py``).
+
+:data:`_CHUNK` and :func:`_write_chunk` are used by the HTTP transports
 (download fetcher / upload route + sender) for buffered staging to a transient
 temp file with hashing — each HTTP transport keeps its own read loop (download
 resumes via ``Range``; upload reads ``request.stream()`` or a hook stream) and

--- a/src/fastmcp_pvl_core/_file_exchange/_staging.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_staging.py
@@ -1,0 +1,49 @@
+"""Shared temp-file staging + digest primitives for the HTTP transports.
+
+The download fetcher (#145) and the upload route/sender (#146) both buffer a
+byte stream to a transient temp file with hashing and a size bound, and verify a
+declared digest. These primitives factor out the common parts. Each transport
+keeps its own read loop (download resumes via ``Range``; upload reads
+``request.stream()`` or a hook stream) and applies the
+``OSError -> transfer-failed`` mapping / cleanup-suppression contract around
+them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import IO
+
+# Streaming chunk size for temp-file staging (1 MiB).
+_CHUNK = 1024 * 1024
+
+# Declared-digest label -> hashlib name; an unsupported label fails verification
+# (cannot verify -> digest-mismatch), never silently skips (§15).
+_HASHLIB_BY_LABEL = {"sha-256": "sha256", "sha-384": "sha384", "sha-512": "sha512"}
+
+
+def _digest_verifier(
+    declared: str | None,
+) -> tuple[hashlib._Hash | None, str | None, bool]:
+    """Return (hasher | None, expected_hex | None, unverifiable).
+
+    ``unverifiable`` is True when a digest is declared with an unsupported label
+    — verification must then fail (cannot verify), never silently skip (§15).
+    """
+    if declared is None:
+        return None, None, False
+    label, _, expected_hex = declared.partition(":")
+    name = _HASHLIB_BY_LABEL.get(label.lower())
+    if name is None:
+        return None, expected_hex, True
+    return hashlib.new(name), expected_hex.lower(), False
+
+
+def _write_chunk(tmp: IO[bytes], hasher: hashlib._Hash | None, chunk: bytes) -> None:
+    """Write a body chunk to the temp file and fold it into the running hash.
+
+    Both ops run off the event loop in a single ``asyncio.to_thread`` dispatch.
+    """
+    tmp.write(chunk)
+    if hasher is not None:
+        hasher.update(chunk)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -273,17 +273,21 @@ def register_upload_route(
             hasher = hashlib.new(_HASHLIB_BY_LABEL[algo_label])
             received = 0
             try:
-                try:
-                    async for chunk in request.stream():
-                        if not chunk:
-                            continue
-                        received += len(chunk)
-                        if size_cap is not None and received > size_cap:
-                            return Response(status_code=413)
+                async for chunk in request.stream():
+                    if not chunk:
+                        continue
+                    received += len(chunk)
+                    if size_cap is not None and received > size_cap:
+                        return Response(status_code=413)
+                    try:
                         await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                    except OSError:
+                        logger.exception("file-exchange: upload temp write failed")
+                        return Response(status_code=500)
+                try:
                     await asyncio.to_thread(tmp.flush)
                 except OSError:
-                    logger.exception("file-exchange: upload temp write failed")
+                    logger.exception("file-exchange: upload temp flush failed")
                     return Response(status_code=500)
             finally:
                 with contextlib.suppress(OSError):
@@ -334,6 +338,7 @@ async def upload_sender_consume(
     key: str,
     *,
     config: ServerConfig,
+    digest_algo: str = _DEFAULT_DIGEST_LABEL,
 ) -> None:
     """Sender role (push): stage ``source[key]`` and push it to ``sink``.
 
@@ -344,10 +349,21 @@ async def upload_sender_consume(
     A non-2xx response maps to ``transfer-failed``; a guard refusal arrives coded
     and propagates. The temp is deleted on every path.
 
+    ``digest_algo`` (defaults to ``sha-256``) is the algorithm used for the
+    outbound ``Content-Digest`` header — set it to match the receiver's
+    ``requireDigest`` constraint when interoperating with a receiver that requires
+    a non-default algorithm. Must be one of the keys in ``_HASHLIB_BY_LABEL``;
+    invalid values raise ``ValueError``.
+
     Staging is required: the hook stream is non-seekable and the ``Content-Digest``
     must be hashed before it can be sent in the request header, so a single hook
     read cannot both hash-first and stream-from-the-hook.
     """
+    if digest_algo not in _HASHLIB_BY_LABEL:
+        raise ValueError(
+            f"upload_sender_consume: digest_algo {digest_algo!r} not in supported set "
+            f"{sorted(_HASHLIB_BY_LABEL)}"
+        )
     stream, meta = await source.open_artifact(key)
     try:
         fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-send-")
@@ -378,7 +394,7 @@ async def upload_sender_consume(
             with contextlib.suppress(Exception):
                 await asyncio.to_thread(stream.close)
             raise
-        hasher = hashlib.sha256()
+        hasher = hashlib.new(_HASHLIB_BY_LABEL[digest_algo])
         size = 0
         try:
             try:
@@ -404,9 +420,7 @@ async def upload_sender_consume(
 
         headers = {
             "Content-Length": str(size),
-            "Content-Digest": _format_content_digest(
-                _DEFAULT_DIGEST_LABEL, hasher.digest()
-            ),
+            "Content-Digest": _format_content_digest(digest_algo, hasher.digest()),
         }
         if meta.mimeType is not None:
             headers["Content-Type"] = meta.mimeType

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -343,6 +343,8 @@ async def upload_sender_consume(
         except BaseException:
             with contextlib.suppress(OSError):
                 os.close(fd)
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(stream.close)
             raise
         hasher = hashlib.sha256()
         size = 0

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -19,10 +19,11 @@ import base64
 import binascii
 import contextlib
 import hashlib
+import hmac
 import logging
 import os
 import tempfile
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Literal
 
 from starlette.responses import Response
@@ -181,11 +182,12 @@ def register_upload_route(
     ``PUT``/``POST <UPLOAD_PREFIX>/{token}`` looks the token up, streams the
     request body to a transient temp file (hashing, bounded by the operator cap
     ``config.file_exchange_max_artifact_size`` and the ticket's
-    ``expected.maxSize``), enforces ``acceptMimeTypes`` and verifies a declared
-    ``Content-Digest`` **before** depositing through ``sink.store_artifact``, and
-    consumes the single-use token only on a successful store (§10.3). Ambient
-    credentials are ignored — the in-URL token is the only authorization.
-    ``token_store``/``sink``/``config`` are threaded by #148.
+    ``expected.maxSize``), enforces ``acceptMimeTypes`` and ``requireDigest``
+    and verifies a declared ``Content-Digest`` **before** depositing through
+    ``sink.store_artifact``, and consumes the single-use token only on a
+    successful store (§10.3). Ambient credentials are ignored — the in-URL
+    token is the only authorization. ``token_store``/``sink``/``config`` are
+    threaded by #148.
 
     "single-use" means the first successful store burns the token (§10.3), not
     a concurrency lock: two concurrent PUTs begun before either completes can
@@ -193,6 +195,12 @@ def register_upload_route(
     wins. The ``ArtifactSink`` MUST therefore tolerate duplicate
     ``store_artifact`` calls for the same ``artifact_id`` within the token's
     TTL window.
+
+    ``requireDigest`` is enforced against ``_parse_content_digest``'s first
+    supported member. A sender that includes multiple ``Content-Digest`` members
+    in a single header MUST place a required algorithm first (or send only the
+    required algorithm) — a non-required algorithm in the first supported slot
+    yields ``400`` even when a required-algo member follows.
     """
     max_artifact = config.file_exchange_max_artifact_size
 
@@ -279,9 +287,9 @@ def register_upload_route(
                     return Response(status_code=500)
             finally:
                 with contextlib.suppress(OSError):
-                    tmp.close()
+                    await asyncio.to_thread(tmp.close)
 
-            if cd is not None and hasher.digest() != cd[1]:
+            if cd is not None and not hmac.compare_digest(hasher.digest(), cd[1]):
                 return Response(status_code=400)
 
             meta = ArtifactMetadata(
@@ -305,7 +313,7 @@ def register_upload_route(
                 return Response(status_code=500)
             finally:
                 with contextlib.suppress(OSError):
-                    ingest.close()
+                    await asyncio.to_thread(ingest.close)
 
             try:
                 await token_store.consume(token)
@@ -389,7 +397,7 @@ async def upload_sender_consume(
                 ) from exc
             finally:
                 with contextlib.suppress(OSError):
-                    tmp.close()
+                    await asyncio.to_thread(tmp.close)
         finally:
             with contextlib.suppress(Exception):
                 await asyncio.to_thread(stream.close)
@@ -403,7 +411,7 @@ async def upload_sender_consume(
         if meta.mimeType is not None:
             headers["Content-Type"] = meta.mimeType
 
-        async def _content() -> AsyncIterator[bytes]:
+        async def _content() -> AsyncGenerator[bytes, None]:
             handle = await asyncio.to_thread(open, tmp_path, "rb")
             try:
                 while True:

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -1,0 +1,75 @@
+"""The ``upload`` transport data plane (#146).
+
+Three role helpers (receiver mint, the PUT/POST serving route, sender) plus the
+RFC 9530 / RFC 7231 HTTP helpers the route and sender need, free functions
+mirroring ``_filesystem.py`` / ``_download.py``. The receiver mints a capability
+URL backed by the #144 token store; the route streams the pushed body to a
+transient temp file, verifies the declared ``Content-Digest`` and the ticket's
+``expected`` constraints **before** handing the #142 ``ArtifactSink`` a real sync
+fd, then consumes the single-use token only on a successful store; the sender
+stages the artifact, computes a ``Content-Digest``, and pushes it through the
+#147 ``guarded_stream``. See
+``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal
+
+from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._tokens import capability_url
+from fastmcp_pvl_core._file_exchange._wire import IntakeTicket, UploadSink
+
+if TYPE_CHECKING:
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+    from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
+
+logger = logging.getLogger(__name__)
+
+# pvl-core's upload route shape (§12 capability URL path). A constant, not a
+# kwarg — route structure is a pvl-core shape decision (mirrors DOWNLOAD_PREFIX).
+UPLOAD_PREFIX = "/fx/u"
+
+
+async def upload_receiver_mint(
+    artifact_id: str,
+    *,
+    token_store: CapabilityTokenStore,
+    base_url: str,
+    ttl: float,
+    expected: ArtifactConstraints | None = None,
+    method: Literal["PUT", "POST"] = "PUT",
+) -> IntakeTicket:
+    """Receiver role (push): mint an upload token and emit an IntakeTicket.
+
+    ``artifact_id`` is the server's opaque identifier for the artifact slot,
+    stored in the token for the route to correlate the pushed bytes; ``expected``
+    is the §7.4 constraint set the route enforces at ingest (stored opaquely too).
+    ``base_url`` is the server's public https origin; ``ttl`` is clamped by the
+    token store's ceiling. Minting only — no hook runs and no bytes move (the
+    sink is threaded into the route, where the bytes actually arrive).
+    """
+    minted = await token_store.mint(
+        {
+            "artifact_id": artifact_id,
+            "expected": expected.model_dump(mode="json") if expected else None,
+        },
+        ttl=ttl,
+        single_use=True,
+    )
+    url = capability_url(base_url, UPLOAD_PREFIX, minted.token)
+    return IntakeTicket(
+        type=TICKET_TYPE,
+        version=SPEC_VERSION,
+        artifactId=artifact_id,
+        expected=expected,
+        sinks=[
+            UploadSink(
+                transport="upload",
+                url=url,
+                method=method,
+                expiresAt=minted.expires_at,
+            )
+        ],
+    )

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -411,6 +411,12 @@ async def upload_sender_consume(
                     transport="upload",
                     detail="failed to stage the artifact for upload",
                 ) from exc
+            except Exception as exc:
+                raise FileExchangeTransferError(
+                    TransferErrorCode.TRANSFER_FAILED,
+                    transport="upload",
+                    detail="artifact source read failed",
+                ) from exc
             finally:
                 with contextlib.suppress(OSError):
                     await asyncio.to_thread(tmp.close)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -96,26 +96,29 @@ def _parse_content_digest(header: str) -> tuple[str, bytes] | None:
     """Parse the first supported RFC 9530 ``Content-Digest`` member.
 
     Returns ``(label, raw_digest_bytes)`` for the first member whose algorithm is
-    in :data:`_HASHLIB_BY_LABEL` and whose value is a well-formed byte sequence,
-    or ``None`` when the header has no supported, well-formed member. A present
-    header that parses to ``None`` is unverifiable -> the route rejects it
-    (digest-mismatch), never silently skips (§15).
+    in :data:`_HASHLIB_BY_LABEL`, or ``None`` when the header carries no member
+    for a supported algorithm. RFC 8941 member parameters (``;key=value`` after
+    the byte sequence) are ignored. A member for a *supported* algorithm whose
+    byte sequence is malformed (bad colon-wrapping or invalid base64) yields
+    ``None`` rather than falling through to a later member — a supported digest
+    we cannot verify is rejected, never silently skipped (§15). Members for
+    unsupported algorithms are skipped so a supported member elsewhere in the
+    dictionary still wins.
     """
     for member in header.split(","):
         label, sep, value = member.strip().partition("=")
         if sep != "=":
             continue
         label = label.strip().lower()
-        value = value.strip()
         if label not in _HASHLIB_BY_LABEL:
             continue
+        value = value.split(";", 1)[0].strip()
         if len(value) < 2 or value[0] != ":" or value[-1] != ":":
-            continue
+            return None
         try:
-            raw = base64.b64decode(value[1:-1], validate=True)
+            return label, base64.b64decode(value[1:-1], validate=True)
         except (binascii.Error, ValueError):
-            continue
-        return label, raw
+            return None
     return None
 
 

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -14,10 +14,13 @@ stages the artifact, computes a ``Content-Digest``, and pushes it through the
 
 from __future__ import annotations
 
+import base64
+import binascii
 import logging
 from typing import TYPE_CHECKING, Literal
 
 from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL
 from fastmcp_pvl_core._file_exchange._tokens import capability_url
 from fastmcp_pvl_core._file_exchange._wire import IntakeTicket, UploadSink
 
@@ -30,6 +33,11 @@ logger = logging.getLogger(__name__)
 # pvl-core's upload route shape (§12 capability URL path). A constant, not a
 # kwarg — route structure is a pvl-core shape decision (mirrors DOWNLOAD_PREFIX).
 UPLOAD_PREFIX = "/fx/u"
+
+# Default digest algorithm for the receiver's recorded ArtifactMetadata.digest
+# and the sender's Content-Digest (pvl-core's shape). Members of _HASHLIB_BY_LABEL
+# are also accepted on an inbound Content-Digest.
+_DEFAULT_DIGEST_LABEL = "sha-256"
 
 
 async def upload_receiver_mint(
@@ -73,3 +81,62 @@ async def upload_receiver_mint(
             )
         ],
     )
+
+
+def _format_content_digest(label: str, raw: bytes) -> str:
+    """Format a raw digest as an RFC 9530 ``Content-Digest`` member: ``label=:b64:``.
+
+    The Structured-Field byte-sequence form (base64 wrapped in colons) — distinct
+    from the wire ``ArtifactMetadata.digest`` field's ``label:hex`` form.
+    """
+    return f"{label}=:{base64.b64encode(raw).decode('ascii')}:"
+
+
+def _parse_content_digest(header: str) -> tuple[str, bytes] | None:
+    """Parse the first supported RFC 9530 ``Content-Digest`` member.
+
+    Returns ``(label, raw_digest_bytes)`` for the first member whose algorithm is
+    in :data:`_HASHLIB_BY_LABEL` and whose value is a well-formed byte sequence,
+    or ``None`` when the header has no supported, well-formed member. A present
+    header that parses to ``None`` is unverifiable -> the route rejects it
+    (digest-mismatch), never silently skips (§15).
+    """
+    for member in header.split(","):
+        label, sep, value = member.strip().partition("=")
+        if sep != "=":
+            continue
+        label = label.strip().lower()
+        value = value.strip()
+        if label not in _HASHLIB_BY_LABEL:
+            continue
+        if len(value) < 2 or value[0] != ":" or value[-1] != ":":
+            continue
+        try:
+            raw = base64.b64decode(value[1:-1], validate=True)
+        except (binascii.Error, ValueError):
+            continue
+        return label, raw
+    return None
+
+
+def _media_type_accepted(content_type: str | None, accept: list[str]) -> bool:
+    """Match a request media type against RFC 7231 §3.1.1.1 media-ranges.
+
+    ``type/subtype`` matches exactly; ``type/*`` matches any subtype of ``type``;
+    ``*/*`` matches anything. Parameters (``; charset=...``) are ignored. A
+    missing or malformed ``Content-Type`` matches nothing (the route rejects).
+    """
+    media = (content_type or "").split(";", 1)[0].strip().lower()
+    if "/" not in media:
+        return False
+    main, sub = media.split("/", 1)
+    for entry in accept:
+        candidate = entry.split(";", 1)[0].strip().lower()
+        if candidate == "*/*":
+            return True
+        if "/" not in candidate:
+            continue
+        cand_main, cand_sub = candidate.split("/", 1)
+        if cand_main == main and cand_sub in ("*", sub):
+            return True
+    return False

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -14,19 +14,35 @@ stages the artifact, computes a ``Content-Digest``, and pushes it through the
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
+import contextlib
+import hashlib
 import logging
+import os
+import tempfile
 from typing import TYPE_CHECKING, Literal
 
+from starlette.responses import Response
+
 from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
-from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL
+from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL, _write_chunk
 from fastmcp_pvl_core._file_exchange._tokens import capability_url
-from fastmcp_pvl_core._file_exchange._wire import IntakeTicket, UploadSink
+from fastmcp_pvl_core._file_exchange._wire import (
+    ArtifactConstraints,
+    ArtifactMetadata,
+    IntakeTicket,
+    UploadSink,
+)
 
 if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from starlette.requests import Request
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink
     from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
-    from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
 
 logger = logging.getLogger(__name__)
 
@@ -143,3 +159,129 @@ def _media_type_accepted(content_type: str | None, accept: list[str]) -> bool:
         if cand_main == main and cand_sub in ("*", sub):
             return True
     return False
+
+
+def register_upload_route(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    sink: ArtifactSink,
+    config: ServerConfig,
+) -> None:
+    """Mount the ``upload`` PUT/POST route on ``mcp`` (serves §12 capability URLs).
+
+    ``PUT``/``POST <UPLOAD_PREFIX>/{token}`` looks the token up, streams the
+    request body to a transient temp file (hashing, bounded by the operator cap
+    ``config.file_exchange_max_artifact_size`` and the ticket's
+    ``expected.maxSize``), enforces ``acceptMimeTypes`` and verifies a declared
+    ``Content-Digest`` **before** depositing through ``sink.store_artifact``, and
+    consumes the single-use token only on a successful store (§10.3). Ambient
+    credentials are ignored — the in-URL token is the only authorization.
+    ``token_store``/``sink``/``config`` are threaded by #148.
+    """
+    max_artifact = config.file_exchange_max_artifact_size
+
+    @mcp.custom_route(f"{UPLOAD_PREFIX}/{{token}}", methods=["PUT", "POST"])
+    async def _serve_upload(request: Request) -> Response:
+        token = request.path_params["token"]
+        rec = await token_store.lookup(token)
+        if rec is None:
+            return Response(status_code=404)
+        artifact_id = rec.metadata["artifact_id"]
+        expected_raw = rec.metadata.get("expected")
+        expected: ArtifactConstraints | None = (
+            ArtifactConstraints.model_validate(expected_raw)
+            if expected_raw is not None
+            else None
+        )
+
+        content_type = request.headers.get("content-type")
+        if (
+            expected is not None
+            and expected.acceptMimeTypes
+            and not _media_type_accepted(content_type, expected.acceptMimeTypes)
+        ):
+            return Response(status_code=415)
+
+        cd_header = request.headers.get("content-digest")
+        require_digest = bool(expected is not None and expected.requireDigest)
+        cd = _parse_content_digest(cd_header) if cd_header is not None else None
+        if cd_header is not None and cd is None:
+            return Response(status_code=400)
+        if cd is None and require_digest:
+            return Response(status_code=400)
+        algo_label = cd[0] if cd is not None else _DEFAULT_DIGEST_LABEL
+
+        size_cap = max_artifact
+        if expected is not None and expected.maxSize is not None:
+            size_cap = (
+                expected.maxSize
+                if size_cap is None
+                else min(size_cap, expected.maxSize)
+            )
+
+        try:
+            fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-")
+        except OSError:
+            logger.exception("file-exchange: upload temp create failed")
+            return Response(status_code=500)
+        try:
+            try:
+                tmp = os.fdopen(fd, "wb")
+            except OSError:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                logger.exception("file-exchange: upload temp open failed")
+                return Response(status_code=500)
+            hasher = hashlib.new(_HASHLIB_BY_LABEL[algo_label])
+            received = 0
+            try:
+                try:
+                    async for chunk in request.stream():
+                        if not chunk:
+                            continue
+                        received += len(chunk)
+                        if size_cap is not None and received > size_cap:
+                            return Response(status_code=413)
+                        await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                    await asyncio.to_thread(tmp.flush)
+                except OSError:
+                    logger.exception("file-exchange: upload temp write failed")
+                    return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    tmp.close()
+
+            if cd is not None and hasher.digest() != cd[1]:
+                return Response(status_code=400)
+
+            meta = ArtifactMetadata(
+                mimeType=content_type,
+                size=received,
+                digest=f"{algo_label}:{hasher.hexdigest()}",
+            )
+            try:
+                ingest = await asyncio.to_thread(open, tmp_path, "rb")
+            except OSError:
+                logger.exception("file-exchange: upload staged open failed")
+                return Response(status_code=500)
+            try:
+                await sink.store_artifact(artifact_id, meta, ingest)
+            except Exception:
+                logger.exception("file-exchange: upload sink store_artifact failed")
+                return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    ingest.close()
+
+            try:
+                await token_store.consume(token)
+            except Exception:
+                logger.warning(
+                    "file-exchange: upload token consume failed after store; "
+                    "token may remain usable to TTL"
+                )
+            return Response(status_code=204)
+        finally:
+            with contextlib.suppress(OSError):
+                await asyncio.to_thread(os.unlink, tmp_path)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -258,6 +258,10 @@ def register_upload_route(
                     os.close(fd)
                 logger.exception("file-exchange: upload temp open failed")
                 return Response(status_code=500)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                raise
             hasher = hashlib.new(_HASHLIB_BY_LABEL[algo_label])
             received = 0
             try:

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -178,6 +178,13 @@ def register_upload_route(
     consumes the single-use token only on a successful store (§10.3). Ambient
     credentials are ignored — the in-URL token is the only authorization.
     ``token_store``/``sink``/``config`` are threaded by #148.
+
+    "single-use" means the first successful store burns the token (§10.3), not
+    a concurrency lock: two concurrent PUTs begun before either completes can
+    both pass verification and reach ``store_artifact`` before one ``consume``
+    wins. The ``ArtifactSink`` MUST therefore tolerate duplicate
+    ``store_artifact`` calls for the same ``artifact_id`` within the token's
+    TTL window.
     """
     max_artifact = config.file_exchange_max_artifact_size
 
@@ -260,6 +267,10 @@ def register_upload_route(
                 size=received,
                 digest=f"{algo_label}:{hasher.hexdigest()}",
             )
+            # ingest: hand the sink a real sync fd (works whether it reads on the
+            # loop or offloads — the async->sync bridge the temp file provides).
+            # The sink MUST drain before returning: ingest is closed and the temp
+            # unlinked immediately after the await.
             try:
                 ingest = await asyncio.to_thread(open, tmp_path, "rb")
             except OSError:

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -219,11 +219,21 @@ def register_upload_route(
             return Response(status_code=415)
 
         cd_header = request.headers.get("content-digest")
-        require_digest = bool(expected is not None and expected.requireDigest)
+        required_algos = (
+            {a.lower() for a in expected.requireDigest}
+            if expected is not None and expected.requireDigest
+            else None
+        )
         cd = _parse_content_digest(cd_header) if cd_header is not None else None
         if cd_header is not None and cd is None:
             return Response(status_code=400)
-        if cd is None and require_digest:
+        if cd is None and required_algos is not None:
+            return Response(status_code=400)
+        if (
+            cd is not None
+            and required_algos is not None
+            and cd[0] not in required_algos
+        ):
             return Response(status_code=400)
         algo_label = cd[0] if cd is not None else _DEFAULT_DIGEST_LABEL
 
@@ -340,6 +350,16 @@ async def upload_sender_consume(
     try:
         try:
             tmp = os.fdopen(fd, "wb")
+        except OSError as exc:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(stream.close)
+            raise FileExchangeTransferError(
+                TransferErrorCode.TRANSFER_FAILED,
+                transport="upload",
+                detail="failed to open the temporary file for writing",
+            ) from exc
         except BaseException:
             with contextlib.suppress(OSError):
                 os.close(fd)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -22,12 +22,20 @@ import hashlib
 import logging
 import os
 import tempfile
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Literal
 
 from starlette.responses import Response
 
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+from fastmcp_pvl_core._file_exchange._outbound import guarded_stream
 from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
-from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL, _write_chunk
+from fastmcp_pvl_core._file_exchange._staging import (
+    _CHUNK,
+    _HASHLIB_BY_LABEL,
+    _write_chunk,
+)
 from fastmcp_pvl_core._file_exchange._tokens import capability_url
 from fastmcp_pvl_core._file_exchange._wire import (
     ArtifactConstraints,
@@ -41,7 +49,7 @@ if TYPE_CHECKING:
     from starlette.requests import Request
 
     from fastmcp_pvl_core._config import ServerConfig
-    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
     from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
 
 logger = logging.getLogger(__name__)
@@ -296,3 +304,112 @@ def register_upload_route(
         finally:
             with contextlib.suppress(OSError):
                 await asyncio.to_thread(os.unlink, tmp_path)
+
+
+async def upload_sender_consume(
+    sink: UploadSink,
+    source: ArtifactSource,
+    key: str,
+    *,
+    config: ServerConfig,
+) -> None:
+    """Sender role (push): stage ``source[key]`` and push it to ``sink``.
+
+    Selection (``select_sink``) is the caller's step. Stages the artifact to a
+    transient temp file (single pass, hashing), computes an RFC 9530
+    ``Content-Digest``, and streams the temp through the #147 ``guarded_stream``
+    (which strips ambient credentials and refuses redirects on a bodied request).
+    A non-2xx response maps to ``transfer-failed``; a guard refusal arrives coded
+    and propagates. The temp is deleted on every path.
+
+    Staging is required: the hook stream is non-seekable and the ``Content-Digest``
+    must be hashed before it can be sent in the request header, so a single hook
+    read cannot both hash-first and stream-from-the-hook.
+    """
+    stream, meta = await source.open_artifact(key)
+    try:
+        fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-send-")
+    except OSError as exc:
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(stream.close)
+        raise FileExchangeTransferError(
+            TransferErrorCode.TRANSFER_FAILED,
+            transport="upload",
+            detail="failed to create a temporary file",
+        ) from exc
+    try:
+        try:
+            tmp = os.fdopen(fd, "wb")
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        hasher = hashlib.sha256()
+        size = 0
+        try:
+            try:
+                while True:
+                    chunk = await asyncio.to_thread(stream.read, _CHUNK)
+                    if not chunk:
+                        break
+                    size += len(chunk)
+                    await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                await asyncio.to_thread(tmp.flush)
+            except OSError as exc:
+                raise FileExchangeTransferError(
+                    TransferErrorCode.TRANSFER_FAILED,
+                    transport="upload",
+                    detail="failed to stage the artifact for upload",
+                ) from exc
+            finally:
+                with contextlib.suppress(OSError):
+                    tmp.close()
+        finally:
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(stream.close)
+
+        headers = {
+            "Content-Length": str(size),
+            "Content-Digest": _format_content_digest(
+                _DEFAULT_DIGEST_LABEL, hasher.digest()
+            ),
+        }
+        if meta.mimeType is not None:
+            headers["Content-Type"] = meta.mimeType
+
+        async def _content() -> AsyncIterator[bytes]:
+            handle = await asyncio.to_thread(open, tmp_path, "rb")
+            try:
+                while True:
+                    chunk = await asyncio.to_thread(handle.read, _CHUNK)
+                    if not chunk:
+                        break
+                    yield chunk
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(handle.close)
+
+        try:
+            async with guarded_stream(
+                sink.method,
+                sink.url,
+                config=config,
+                transport="upload",
+                headers=headers,
+                content=_content(),
+            ) as resp:
+                if not 200 <= resp.status < 300:
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.TRANSFER_FAILED,
+                        transport="upload",
+                        detail="upload endpoint returned a non-success status",
+                    )
+        except OSError as exc:
+            raise FileExchangeTransferError(
+                TransferErrorCode.TRANSFER_FAILED,
+                transport="upload",
+                detail="failed to read the staged artifact during upload",
+            ) from exc
+    finally:
+        with contextlib.suppress(OSError):
+            await asyncio.to_thread(os.unlink, tmp_path)

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -70,6 +70,7 @@ from fastmcp_pvl_core._file_exchange import (
     select_sink,
     select_source,
     upload_receiver_mint,
+    upload_sender_consume,
     validate_wire,
 )
 
@@ -128,5 +129,6 @@ __all__ = [
     "select_sink",
     "select_source",
     "upload_receiver_mint",
+    "upload_sender_consume",
     "validate_wire",
 ]

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -69,6 +69,7 @@ from fastmcp_pvl_core._file_exchange import (
     resolve_filesystem_uri,
     select_sink,
     select_source,
+    upload_receiver_mint,
     validate_wire,
 )
 
@@ -126,5 +127,6 @@ __all__ = [
     "resolve_filesystem_uri",
     "select_sink",
     "select_source",
+    "upload_receiver_mint",
     "validate_wire",
 ]

--- a/tests/_file_exchange/test_download.py
+++ b/tests/_file_exchange/test_download.py
@@ -9,7 +9,7 @@ import pytest
 from fastmcp import FastMCP
 
 from fastmcp_pvl_core._config import ServerConfig
-from fastmcp_pvl_core._file_exchange import _download
+from fastmcp_pvl_core._file_exchange import _download, _routes
 from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
 from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
 from fastmcp_pvl_core._file_exchange._spec import HANDLE_TYPE, SPEC_VERSION
@@ -430,7 +430,7 @@ class _BytesSource:
 
 def _route_client(store, source):
     mcp = FastMCP("test")
-    _download.register_file_exchange_routes(mcp, token_store=store, source=source)
+    _routes.register_file_exchange_routes(mcp, token_store=store, source=source)
     app = mcp.http_app()
     return httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://route.test"

--- a/tests/_file_exchange/test_download_e2e.py
+++ b/tests/_file_exchange/test_download_e2e.py
@@ -15,7 +15,7 @@ import httpx
 from fastmcp import FastMCP
 
 from fastmcp_pvl_core._config import ServerConfig
-from fastmcp_pvl_core._file_exchange import _download
+from fastmcp_pvl_core._file_exchange import _download, _routes
 from fastmcp_pvl_core._file_exchange._selection import select_source
 from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
 from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
@@ -64,7 +64,7 @@ async def test_two_server_pull_download(monkeypatch):
     # Server A: provider mint + serving route on a real ASGI app.
     store = _store()
     mcp = FastMCP("provider")
-    _download.register_file_exchange_routes(
+    _routes.register_file_exchange_routes(
         mcp, token_store=store, source=_BytesSource("doc", body)
     )
     app_a = mcp.http_app()

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -229,6 +229,49 @@ async def test_upload_route_maxsize_constraint_413():
     assert sink.calls == []
 
 
+async def test_upload_route_takes_min_of_both_size_caps():
+    # Operator cap looser than ticket cap -> ticket cap wins.
+    store, mcp = _mount(
+        sink := _CapturingSink(),
+        config=ServerConfig(file_exchange_max_artifact_size=100),
+    )
+    token = await _mint_token(store, expected=ArtifactConstraints(maxSize=8))
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"x" * 50)
+    assert resp.status_code == 413
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+    # Ticket cap looser than operator cap -> operator cap wins.
+    store2, mcp2 = _mount(
+        sink2 := _CapturingSink(),
+        config=ServerConfig(file_exchange_max_artifact_size=8),
+    )
+    token2 = await _mint_token(store2, expected=ArtifactConstraints(maxSize=100))
+    async with _client(mcp2) as client:
+        resp2 = await client.put(f"/fx/u/{token2}", content=b"x" * 50)
+    assert resp2.status_code == 413
+    assert sink2.calls == []
+
+
+@pytest.mark.parametrize(
+    ("algo", "hasher_factory"),
+    [("sha-384", hashlib.sha384), ("sha-512", hashlib.sha512)],
+)
+async def test_upload_route_verifies_non_sha256_digest(algo, hasher_factory):
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    body = b"non-sha256-payload"
+    cd = _upload._format_content_digest(algo, hasher_factory(body).digest())
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}", content=body, headers={"content-digest": cd}
+        )
+    assert resp.status_code == 204
+    assert sink.calls[0][2] == body
+    assert sink.calls[0][1].digest == f"{algo}:{hasher_factory(body).hexdigest()}"
+
+
 async def test_upload_route_mime_reject_415_no_consume():
     store, mcp = _mount(sink := _CapturingSink())
     token = await _mint_token(

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -283,6 +283,23 @@ async def test_upload_route_require_digest_missing_header_400():
     assert sink.calls == []
 
 
+async def test_upload_route_require_digest_algo_mismatch_400():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(
+        store, expected=ArtifactConstraints(requireDigest=["sha-512"])
+    )
+    body = b"the-body"
+    # Sender supplies a valid sha-256 digest, but the receiver requires sha-512.
+    cd = _upload._format_content_digest("sha-256", hashlib.sha256(body).digest())
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}", content=body, headers={"content-digest": cd}
+        )
+    assert resp.status_code == 400
+    assert sink.calls == []
+    assert await store.lookup(token) is not None  # not consumed
+
+
 async def test_upload_route_ambient_credentials_ignored():
     store, mcp = _mount(sink := _CapturingSink())
     token = await _mint_token(store)

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import base64
 import hashlib
 
+import httpx
 import pytest
+from fastmcp import FastMCP
 
 from fastmcp_pvl_core._config import ServerConfig
-from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange import _routes, _upload
 from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
 from fastmcp_pvl_core._file_exchange._wire import (
     ArtifactConstraints,
@@ -132,3 +134,177 @@ def test_parse_content_digest_supported_malformed_does_not_fall_through():
 )
 def test_media_type_accepted(content_type, accept, ok):
     assert _upload._media_type_accepted(content_type, accept) is ok
+
+
+class _CapturingSink:
+    def __init__(self):
+        self.calls = []
+
+    async def store_artifact(self, artifact_id, metadata, stream):
+        self.calls.append((artifact_id, metadata, stream.read()))
+
+
+class _BoomSink:
+    async def store_artifact(self, artifact_id, metadata, stream):
+        raise RuntimeError("sink failure with /secret/path detail")
+
+
+def _mount(sink, *, config=None):
+    store = _store()
+    mcp = FastMCP("receiver")
+    _routes.register_file_exchange_routes(
+        mcp, token_store=store, sink=sink, config=config or ServerConfig()
+    )
+    return store, mcp
+
+
+def _client(mcp):
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=mcp.http_app()), base_url="http://up.test"
+    )
+
+
+async def _mint_token(store, *, artifact_id="art-1", expected=None):
+    minted = await store.mint(
+        {
+            "artifact_id": artifact_id,
+            "expected": expected.model_dump(mode="json") if expected else None,
+        },
+        ttl=300.0,
+        single_use=True,
+    )
+    return minted.token
+
+
+async def test_upload_route_unknown_token_404():
+    _store_, mcp = _mount(_CapturingSink())
+    async with _client(mcp) as client:
+        resp = await client.put("/fx/u/nonexistent", content=b"x")
+    assert resp.status_code == 404
+
+
+async def test_upload_route_happy_deposits_and_consumes():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    body = b"upload-payload" * 100
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=body)
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+    artifact_id, meta, deposited = sink.calls[0]
+    assert artifact_id == "art-1"
+    assert deposited == body
+    assert meta.size == len(body)
+    assert meta.digest == "sha-256:" + hashlib.sha256(body).hexdigest()
+    assert await store.lookup(token) is None
+    async with _client(mcp) as client:
+        resp2 = await client.put(f"/fx/u/{token}", content=body)
+    assert resp2.status_code == 404
+
+
+async def test_upload_route_oversize_413_no_consume():
+    store, mcp = _mount(
+        sink := _CapturingSink(),
+        config=ServerConfig(file_exchange_max_artifact_size=16),
+    )
+    token = await _mint_token(store)
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"x" * 64)
+    assert resp.status_code == 413
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+
+async def test_upload_route_maxsize_constraint_413():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store, expected=ArtifactConstraints(maxSize=8))
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"x" * 64)
+    assert resp.status_code == 413
+    assert sink.calls == []
+
+
+async def test_upload_route_mime_reject_415_no_consume():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(
+        store, expected=ArtifactConstraints(acceptMimeTypes=["text/*"])
+    )
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}",
+            content=b"{}",
+            headers={"content-type": "application/json"},
+        )
+    assert resp.status_code == 415
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+
+async def test_upload_route_valid_content_digest_verifies():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    body = b"digest-checked-body"
+    cd = _upload._format_content_digest("sha-256", hashlib.sha256(body).digest())
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}", content=body, headers={"content-digest": cd}
+        )
+    assert resp.status_code == 204
+    assert sink.calls[0][2] == body
+
+
+async def test_upload_route_digest_mismatch_400_no_sink_call():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    body = b"the-real-body"
+    wrong = _upload._format_content_digest("sha-256", hashlib.sha256(b"other").digest())
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}", content=body, headers={"content-digest": wrong}
+        )
+    assert resp.status_code == 400
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+
+async def test_upload_route_require_digest_missing_header_400():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(
+        store, expected=ArtifactConstraints(requireDigest=["sha-256"])
+    )
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"no-digest-header")
+    assert resp.status_code == 400
+    assert sink.calls == []
+
+
+async def test_upload_route_ambient_credentials_ignored():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}",
+            content=b"ok",
+            headers={"authorization": "Bearer bogus", "cookie": "x=y"},
+        )
+    assert resp.status_code == 204
+    assert sink.calls[0][2] == b"ok"
+
+
+async def test_upload_route_sink_failure_500_no_consume():
+    store, mcp = _mount(_BoomSink())
+    token = await _mint_token(store)
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"data")
+    assert resp.status_code == 500
+    assert resp.content == b""
+    assert await store.lookup(token) is not None
+
+
+async def test_register_routes_upload_requires_config():
+    store = _store()
+    mcp = FastMCP("receiver")
+    with pytest.raises(ValueError, match="config"):
+        _routes.register_file_exchange_routes(
+            mcp, token_store=store, sink=_CapturingSink(), config=None
+        )

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -737,6 +737,35 @@ async def test_sender_rejects_unsupported_digest_algo():
         )
 
 
+async def test_sender_wraps_hook_stream_non_oserror_as_transfer_failed(monkeypatch):
+    # A buggy/domain-specific ArtifactSource that raises a non-OSError on
+    # stream.read must NOT escape upload_sender_consume raw — the contract is
+    # to always raise FileExchangeTransferError. (claude-review #3, F1.)
+    class _BoomReadStream:
+        def read(self, _n):
+            raise RuntimeError("hook's stream is broken")
+
+        def close(self):
+            return None
+
+    class _BoomReadSource:
+        async def open_artifact(self, _key):
+            return _BoomReadStream(), ArtifactMetadata(size=1)
+
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        yield _FakeGuarded(204)  # pragma: no cover — never reached
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    with pytest.raises(FileExchangeTransferError) as exc:
+        await _upload.upload_sender_consume(
+            _upload_sink(), _BoomReadSource(), "k", config=ServerConfig()
+        )
+    assert exc.value.code == TransferErrorCode.TRANSFER_FAILED
+    assert exc.value.transport == "upload"
+    assert isinstance(exc.value.__cause__, RuntimeError)
+
+
 async def test_register_routes_requires_source_or_sink():
     store = _store()
     mcp = FastMCP("receiver")

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -585,3 +585,117 @@ async def test_upload_sender_temp_file_unlinked_on_non_2xx(monkeypatch):
     assert captured, "expected the sender to have created a temp file"
     leaked = [p for p in captured if os.path.exists(p)]
     assert not leaked, f"sender temp files leaked: {leaked}"
+
+
+async def test_upload_route_flush_failure_returns_500(monkeypatch):
+    # When tmp.flush() raises OSError after the body has been streamed, the route
+    # must return 500, not call the sink, and not consume the token.
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+
+    real_fdopen = os.fdopen
+
+    class _FlushFails:
+        def __init__(self, f):
+            self._f = f
+
+        def write(self, b):
+            return self._f.write(b)
+
+        def flush(self):
+            raise OSError("disk full on flush")
+
+        def close(self):
+            return self._f.close()
+
+    monkeypatch.setattr(
+        _upload.os, "fdopen", lambda fd, mode: _FlushFails(real_fdopen(fd, mode))
+    )
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"some-upload-body")
+    assert resp.status_code == 500
+    assert resp.content == b""
+    assert sink.calls == []  # flush failed before the sink was ever invoked
+    assert await store.lookup(token) is not None  # token not consumed
+
+
+async def test_upload_route_close_failure_after_success_still_204(monkeypatch):
+    # When tmp.close() raises OSError in the inner finally after a successful
+    # write+flush, the contextlib.suppress(OSError) around it must keep the
+    # success path intact: the response is still 204, the sink IS called, and
+    # the token IS consumed.
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+
+    real_fdopen = os.fdopen
+
+    class _CloseFails:
+        def __init__(self, f):
+            self._f = f
+
+        def write(self, b):
+            return self._f.write(b)
+
+        def flush(self):
+            return self._f.flush()
+
+        def close(self):
+            self._f.close()
+            raise OSError("disk full on close")
+
+    monkeypatch.setattr(
+        _upload.os, "fdopen", lambda fd, mode: _CloseFails(real_fdopen(fd, mode))
+    )
+    body = b"close-raises-but-success"
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=body)
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1  # sink was called despite close() raising
+    assert sink.calls[0][2] == body
+    assert await store.lookup(token) is None  # token consumed
+
+
+async def test_sender_close_after_flush_failure_keeps_transfer_error(monkeypatch):
+    # When tmp.flush() raises OSError in the sender (mapped to
+    # FileExchangeTransferError(TRANSFER_FAILED)) AND tmp.close() ALSO raises in
+    # the finally, the in-flight FileExchangeTransferError must NOT be replaced by
+    # the raw OSError from close. This pins the contextlib.suppress(OSError) around
+    # tmp.close in the sender.
+    real_fdopen = os.fdopen
+
+    class _FlushAndCloseFail:
+        def __init__(self, f):
+            self._f = f
+
+        def write(self, b):
+            return self._f.write(b)
+
+        def flush(self):
+            raise OSError("disk full on flush")
+
+        def close(self):
+            self._f.close()
+            raise OSError("disk full on close")
+
+    monkeypatch.setattr(
+        _upload.os,
+        "fdopen",
+        lambda fd, mode: _FlushAndCloseFail(real_fdopen(fd, mode)),
+    )
+
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        async for _ in content:  # pragma: no cover
+            pass
+        yield _FakeGuarded(204)  # pragma: no cover
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    with pytest.raises(FileExchangeTransferError) as ei:
+        await _upload.upload_sender_consume(
+            _upload_sink(),
+            _BytesSource("k", b"sender-payload"),
+            "k",
+            config=ServerConfig(),
+        )
+    # close()'s OSError must not replace the flush's mapped FileExchangeTransferError
+    assert ei.value.code == TransferErrorCode.TRANSFER_FAILED

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import base64
 import contextlib
 import hashlib
+import os
+import tempfile
 from datetime import datetime, timedelta, timezone
 
 import httpx
@@ -487,3 +489,99 @@ async def test_sender_guard_refusal_propagates(monkeypatch):
             _upload_sink(), _BytesSource("k", b"data"), "k", config=ServerConfig()
         )
     assert exc.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_upload_route_consume_failure_still_returns_204():
+    # The route's contract (docstring): consume runs only after a successful
+    # store, and if consume itself raises the route logs a warning and still
+    # returns 204 — the bytes already landed, failing the request would mislead
+    # the client into retrying against a slot that may already be filled.
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+
+    async def boom_consume(_token):
+        raise RuntimeError("kv backend down")
+
+    store.consume = boom_consume  # type: ignore[method-assign]
+    body = b"consume-fails-but-store-ok"
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=body)
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+    assert sink.calls[0][2] == body
+
+
+async def test_upload_route_temp_file_unlinked_on_failure_paths(monkeypatch):
+    # Regression guard: the outer try/finally unlinks tmp_path on every exit
+    # path (413/415/400/500/204). A refactor that moved the unlink inside the
+    # inner try, or returned before reaching the outer finally, would silently
+    # leak temp files. Capture every mkstemp path; assert none survive.
+    captured: list[str] = []
+    real_mkstemp = tempfile.mkstemp
+
+    def capturing_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        captured.append(path)
+        return fd, path
+
+    monkeypatch.setattr(tempfile, "mkstemp", capturing_mkstemp)
+
+    # Drive the 413 oversize path (operator cap).
+    store, mcp = _mount(
+        sink := _CapturingSink(),
+        config=ServerConfig(file_exchange_max_artifact_size=8),
+    )
+    token = await _mint_token(store)
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"x" * 64)
+    assert resp.status_code == 413
+    # Drive the 400 digest-mismatch path on a separate mount.
+    store2, mcp2 = _mount(_CapturingSink())
+    token2 = await _mint_token(store2)
+    body2 = b"the-real-body"
+    wrong = _upload._format_content_digest("sha-256", hashlib.sha256(b"other").digest())
+    async with _client(mcp2) as client:
+        resp2 = await client.put(
+            f"/fx/u/{token2}", content=body2, headers={"content-digest": wrong}
+        )
+    assert resp2.status_code == 400
+    # Drive the 500 sink-failure path on a third mount.
+    store3, mcp3 = _mount(_BoomSink())
+    token3 = await _mint_token(store3)
+    async with _client(mcp3) as client:
+        resp3 = await client.put(f"/fx/u/{token3}", content=b"data")
+    assert resp3.status_code == 500
+
+    assert captured, "expected at least one temp file to have been created"
+    leaked = [p for p in captured if os.path.exists(p)]
+    assert not leaked, f"temp files leaked across failure paths: {leaked}"
+
+
+async def test_upload_sender_temp_file_unlinked_on_non_2xx(monkeypatch):
+    # Regression guard mirroring the route's: the sender's outer finally unlinks
+    # tmp_path on every exit path including non-2xx and guard-refusal. A refactor
+    # that moved the unlink would silently leak temps on every send failure.
+    captured: list[str] = []
+    real_mkstemp = tempfile.mkstemp
+
+    def capturing_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        captured.append(path)
+        return fd, path
+
+    monkeypatch.setattr(tempfile, "mkstemp", capturing_mkstemp)
+
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        async for _ in content:
+            pass
+        yield _FakeGuarded(500)
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    with pytest.raises(FileExchangeTransferError):
+        await _upload.upload_sender_consume(
+            _upload_sink(), _BytesSource("k", b"data"), "k", config=ServerConfig()
+        )
+    assert captured, "expected the sender to have created a temp file"
+    leaked = [p for p in captured if os.path.exists(p)]
+    assert not leaked, f"sender temp files leaked: {leaked}"

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -699,3 +699,46 @@ async def test_sender_close_after_flush_failure_keeps_transfer_error(monkeypatch
         )
     # close()'s OSError must not replace the flush's mapped FileExchangeTransferError
     assert ei.value.code == TransferErrorCode.TRANSFER_FAILED
+
+
+async def test_sender_with_non_sha256_digest_algo_sends_that_algo(monkeypatch):
+    body = b"non-default-algo"
+    captured: dict = {}
+
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        async for _ in content:
+            pass
+        captured["headers"] = dict(headers or {})
+        yield _FakeGuarded(204)
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    await _upload.upload_sender_consume(
+        _upload_sink(),
+        _BytesSource("k", body),
+        "k",
+        config=ServerConfig(),
+        digest_algo="sha-512",
+    )
+    expected_cd = (
+        "sha-512=:" + base64.b64encode(hashlib.sha512(body).digest()).decode() + ":"
+    )
+    assert captured["headers"]["Content-Digest"] == expected_cd
+
+
+async def test_sender_rejects_unsupported_digest_algo():
+    with pytest.raises(ValueError, match="digest_algo"):
+        await _upload.upload_sender_consume(
+            _upload_sink(),
+            _BytesSource("k", b"x"),
+            "k",
+            config=ServerConfig(),
+            digest_algo="md5",
+        )
+
+
+async def test_register_routes_requires_source_or_sink():
+    store = _store()
+    mcp = FastMCP("receiver")
+    with pytest.raises(ValueError, match="source.*sink"):
+        _routes.register_file_exchange_routes(mcp, token_store=store)

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -1,0 +1,65 @@
+"""Tests for the ``upload`` transport data plane (#146)."""
+
+from __future__ import annotations
+
+import pytest
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import (
+    ArtifactConstraints,
+    IntakeTicket,
+    UploadSink,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+async def test_receiver_mint_returns_ticket_with_upload_sink():
+    store = _store()
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://recv.test", ttl=300.0
+    )
+    assert isinstance(ticket, IntakeTicket)
+    assert ticket.artifactId == "art-1"
+    assert len(ticket.sinks) == 1
+    sink = ticket.sinks[0]
+    assert isinstance(sink, UploadSink)
+    assert sink.transport == "upload"
+    assert sink.method == "PUT"
+    assert sink.url.startswith("https://recv.test/fx/u/")
+    token = sink.url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata["artifact_id"] == "art-1"
+    assert rec.metadata["expected"] is None
+
+
+async def test_receiver_mint_threads_method_and_expected():
+    store = _store()
+    expected = ArtifactConstraints(maxSize=1024, acceptMimeTypes=["text/*"])
+    ticket = await _upload.upload_receiver_mint(
+        "art-2",
+        token_store=store,
+        base_url="https://recv.test",
+        ttl=300.0,
+        expected=expected,
+        method="POST",
+    )
+    assert ticket.expected == expected
+    assert ticket.sinks[0].method == "POST"
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata["expected"] == {
+        "maxSize": 1024,
+        "acceptMimeTypes": ["text/*"],
+        "requireDigest": None,
+    }

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
+from datetime import datetime, timedelta, timezone
 
 import httpx
 import pytest
@@ -11,9 +13,12 @@ from fastmcp import FastMCP
 
 from fastmcp_pvl_core._config import ServerConfig
 from fastmcp_pvl_core._file_exchange import _routes, _upload
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
 from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
 from fastmcp_pvl_core._file_exchange._wire import (
     ArtifactConstraints,
+    ArtifactMetadata,
     IntakeTicket,
     UploadSink,
 )
@@ -308,3 +313,117 @@ async def test_register_routes_upload_requires_config():
         _routes.register_file_exchange_routes(
             mcp, token_store=store, sink=_CapturingSink(), config=None
         )
+
+
+class _BytesSource:
+    def __init__(self, key, body, *, mime="application/octet-stream"):
+        self._key, self._body, self._mime = key, body, mime
+
+    async def open_artifact(self, key):
+        import io
+
+        assert key == self._key
+        return io.BytesIO(self._body), ArtifactMetadata(
+            name="a", mimeType=self._mime, size=len(self._body)
+        )
+
+
+class _FakeGuarded:
+    def __init__(self, status):
+        self.status = status
+
+
+def _upload_sink(method="PUT"):
+    return UploadSink(
+        transport="upload",
+        url="https://up.test/fx/u/tok",
+        method=method,
+        expiresAt=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+
+async def test_sender_stages_and_sends_with_headers(monkeypatch):
+    body = b"sender-payload" * 50
+    captured: dict = {}
+
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        captured["method"] = method
+        captured["url"] = url
+        captured["transport"] = transport
+        captured["headers"] = dict(headers or {})
+        captured["body"] = b"".join([chunk async for chunk in content])
+        yield _FakeGuarded(204)
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    await _upload.upload_sender_consume(
+        _upload_sink(),
+        _BytesSource("k", body, mime="text/plain"),
+        "k",
+        config=ServerConfig(),
+    )
+    assert captured["method"] == "PUT"
+    assert captured["url"] == "https://up.test/fx/u/tok"
+    assert captured["transport"] == "upload"
+    assert captured["body"] == body
+    assert captured["headers"]["Content-Length"] == str(len(body))
+    assert captured["headers"]["Content-Type"] == "text/plain"
+    assert captured["headers"]["Content-Digest"] == (
+        "sha-256=:" + base64.b64encode(hashlib.sha256(body).digest()).decode() + ":"
+    )
+
+
+async def test_sender_omits_content_type_when_unknown(monkeypatch):
+    captured: dict = {}
+
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        async for _ in content:
+            pass
+        captured["headers"] = dict(headers or {})
+        yield _FakeGuarded(201)
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+
+    class _NoMimeSource:
+        async def open_artifact(self, key):
+            import io
+
+            return io.BytesIO(b"x"), ArtifactMetadata(size=1)
+
+    await _upload.upload_sender_consume(
+        _upload_sink(), _NoMimeSource(), "k", config=ServerConfig()
+    )
+    assert "Content-Type" not in captured["headers"]
+
+
+async def test_sender_non_2xx_raises_transfer_failed(monkeypatch):
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        async for _ in content:
+            pass
+        yield _FakeGuarded(500)
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    with pytest.raises(FileExchangeTransferError) as exc:
+        await _upload.upload_sender_consume(
+            _upload_sink(), _BytesSource("k", b"data"), "k", config=ServerConfig()
+        )
+    assert exc.value.code == TransferErrorCode.TRANSFER_FAILED
+    assert exc.value.transport == "upload"
+
+
+async def test_sender_guard_refusal_propagates(monkeypatch):
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE, transport="upload", detail="blocked"
+        )
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    with pytest.raises(FileExchangeTransferError) as exc:
+        await _upload.upload_sender_consume(
+            _upload_sink(), _BytesSource("k", b"data"), "k", config=ServerConfig()
+        )
+    assert exc.value.code == TransferErrorCode.NOT_ACCESSIBLE

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
+
 import pytest
 
 from fastmcp_pvl_core._config import ServerConfig
@@ -63,3 +66,52 @@ async def test_receiver_mint_threads_method_and_expected():
         "acceptMimeTypes": ["text/*"],
         "requireDigest": None,
     }
+
+
+def test_format_content_digest_rfc9530():
+    raw = hashlib.sha256(b"abc").digest()
+    out = _upload._format_content_digest("sha-256", raw)
+    assert out == "sha-256=:" + base64.b64encode(raw).decode("ascii") + ":"
+
+
+def test_parse_content_digest_roundtrip():
+    raw = hashlib.sha256(b"abc").digest()
+    header = _upload._format_content_digest("sha-256", raw)
+    assert _upload._parse_content_digest(header) == ("sha-256", raw)
+
+
+def test_parse_content_digest_picks_first_supported():
+    raw = hashlib.sha512(b"abc").digest()
+    header = (
+        "md5=:"
+        + base64.b64encode(b"x").decode()
+        + ":, sha-512=:"
+        + (base64.b64encode(raw).decode() + ":")
+    )
+    assert _upload._parse_content_digest(header) == ("sha-512", raw)
+
+
+def test_parse_content_digest_rejects_unparseable():
+    assert _upload._parse_content_digest("sha-256=not-a-byte-sequence") is None
+    assert _upload._parse_content_digest("sha-256=:!!!notbase64!!!:") is None
+    assert (
+        _upload._parse_content_digest("md5=:" + base64.b64encode(b"x").decode() + ":")
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("content_type", "accept", "ok"),
+    [
+        ("text/plain", ["text/plain"], True),
+        ("text/plain; charset=utf-8", ["text/plain"], True),
+        ("text/plain", ["text/*"], True),
+        ("text/plain", ["*/*"], True),
+        ("application/json", ["text/*"], False),
+        ("application/json", ["text/*", "application/json"], True),
+        (None, ["text/*"], False),
+        ("not-a-media-type", ["*/*"], False),
+    ],
+)
+def test_media_type_accepted(content_type, accept, ok):
+    assert _upload._media_type_accepted(content_type, accept) is ok

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -82,12 +82,9 @@ def test_parse_content_digest_roundtrip():
 
 def test_parse_content_digest_picks_first_supported():
     raw = hashlib.sha512(b"abc").digest()
-    header = (
-        "md5=:"
-        + base64.b64encode(b"x").decode()
-        + ":, sha-512=:"
-        + (base64.b64encode(raw).decode() + ":")
-    )
+    md5_b64 = base64.b64encode(b"x").decode()
+    sha512_b64 = base64.b64encode(raw).decode()
+    header = f"md5=:{md5_b64}:, sha-512=:{sha512_b64}:"
     assert _upload._parse_content_digest(header) == ("sha-512", raw)
 
 
@@ -98,6 +95,24 @@ def test_parse_content_digest_rejects_unparseable():
         _upload._parse_content_digest("md5=:" + base64.b64encode(b"x").decode() + ":")
         is None
     )
+
+
+def test_parse_content_digest_ignores_member_params():
+    raw = hashlib.sha256(b"abc").digest()
+    b64 = base64.b64encode(raw).decode()
+    # RFC 8941 member parameters after the byte sequence are stripped, not rejected.
+    assert _upload._parse_content_digest(f"sha-256=:{b64}:;preference=3") == (
+        "sha-256",
+        raw,
+    )
+
+
+def test_parse_content_digest_supported_malformed_does_not_fall_through():
+    raw = hashlib.sha512(b"abc").digest()
+    b64 = base64.b64encode(raw).decode()
+    # A supported algo with corrupt bytes is rejected outright, not skipped in
+    # favour of a later well-formed member.
+    assert _upload._parse_content_digest(f"sha-256=:!!!:, sha-512=:{b64}:") is None
 
 
 @pytest.mark.parametrize(
@@ -111,6 +126,8 @@ def test_parse_content_digest_rejects_unparseable():
         ("application/json", ["text/*", "application/json"], True),
         (None, ["text/*"], False),
         ("not-a-media-type", ["*/*"], False),
+        ("*/*", ["application/octet-stream"], False),
+        ("*/*", ["*/*"], True),
     ],
 )
 def test_media_type_accepted(content_type, accept, ok):

--- a/tests/_file_exchange/test_upload_e2e.py
+++ b/tests/_file_exchange/test_upload_e2e.py
@@ -1,0 +1,108 @@
+"""End-to-end upload push: server A sends, server B mints + receives.
+
+Exercises the whole ``upload`` data plane together — ``upload_receiver_mint``,
+``register_file_exchange_routes`` (upload route mounted on a real ASGI app),
+``select_sink``, and ``upload_sender_consume`` — over a loopback ASGI transport.
+The SSRF guard is replaced with one that routes to server B's app, because we are
+exercising the push flow, not the guard (which has its own tests).
+"""
+
+import contextlib
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _routes, _upload
+from fastmcp_pvl_core._file_exchange._selection import select_sink
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+pytestmark = pytest.mark.anyio
+
+
+class _BytesSource:
+    def __init__(self, key, body):
+        self._key, self._body = key, body
+
+    async def open_artifact(self, key):
+        import io
+
+        assert key == self._key
+        return io.BytesIO(self._body), ArtifactMetadata(
+            name="a", mimeType="application/octet-stream", size=len(self._body)
+        )
+
+
+class _CapturingSink:
+    def __init__(self):
+        self.calls = []
+
+    async def store_artifact(self, artifact_id, metadata, stream):
+        self.calls.append((artifact_id, metadata, stream.read()))
+
+
+class _FakeGuarded:
+    def __init__(self, status):
+        self.status = status
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+async def test_two_server_push_upload(monkeypatch):
+    body = b"end-to-end-upload-payload" * 64
+
+    # Server B: receiver mint + upload route on a real ASGI app.
+    store = _store()
+    sink = _CapturingSink()
+    recv = FastMCP("receiver")
+    _routes.register_file_exchange_routes(
+        recv, token_store=store, sink=sink, config=ServerConfig()
+    )
+    app_b = recv.http_app()
+
+    # Server A's guard, redirected at B's ASGI app (no real network / SSRF check).
+    @contextlib.asynccontextmanager
+    async def guard_to_app_b(
+        method, url, *, config, transport, headers=None, content=None
+    ):
+        client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app_b), base_url="http://recv.test"
+        )
+        try:
+            path = url.split("recv.test", 1)[1]
+            req = client.build_request(
+                method, path, headers=headers or {}, content=content
+            )
+            resp = await client.send(req)
+            try:
+                yield _FakeGuarded(resp.status_code)
+            finally:
+                await resp.aclose()
+        finally:
+            await client.aclose()
+
+    monkeypatch.setattr(_upload, "guarded_stream", guard_to_app_b)
+
+    # B mints an intake ticket; A selects the upload sink and pushes.
+    ticket = await _upload.upload_receiver_mint(
+        "art-e2e", token_store=store, base_url="https://recv.test", ttl=300.0
+    )
+    descriptor = select_sink(ticket)
+    assert descriptor is not None and descriptor.transport == "upload"
+
+    await _upload.upload_sender_consume(
+        descriptor, _BytesSource("k", body), "k", config=ServerConfig()
+    )
+
+    # The bytes landed in B's sink, correlated to artifactId.
+    assert len(sink.calls) == 1
+    assert sink.calls[0][0] == "art-e2e"
+    assert sink.calls[0][2] == body
+    # The single-use token was consumed by the completed upload.
+    assert await store.lookup(descriptor.url.rsplit("/", 1)[1]) is None

--- a/tests/test_file_exchange_namespace.py
+++ b/tests/test_file_exchange_namespace.py
@@ -170,3 +170,13 @@ def test_download_data_plane_names_reexported():
         assert name in file_exchange.__all__, name
     # DOWNLOAD_PREFIX is internal route shape, not part of the public surface.
     assert not hasattr(file_exchange, "DOWNLOAD_PREFIX")
+
+
+def test_upload_data_plane_names_reexported():
+    from fastmcp_pvl_core import file_exchange
+
+    for name in ("upload_receiver_mint", "register_file_exchange_routes"):
+        assert hasattr(file_exchange, name), name
+        assert name in file_exchange.__all__, name
+    # UPLOAD_PREFIX is internal route shape, not part of the public surface.
+    assert not hasattr(file_exchange, "UPLOAD_PREFIX")

--- a/tests/test_file_exchange_namespace.py
+++ b/tests/test_file_exchange_namespace.py
@@ -175,7 +175,11 @@ def test_download_data_plane_names_reexported():
 def test_upload_data_plane_names_reexported():
     from fastmcp_pvl_core import file_exchange
 
-    for name in ("upload_receiver_mint", "register_file_exchange_routes"):
+    for name in (
+        "upload_receiver_mint",
+        "upload_sender_consume",
+        "register_file_exchange_routes",
+    ):
         assert hasattr(file_exchange, name), name
         assert name in file_exchange.__all__, name
     # UPLOAD_PREFIX is internal route shape, not part of the public surface.


### PR DESCRIPTION
## Summary
Adds the `upload` transport data plane (EPIC #138, 8/10): receiver mint, the PUT/POST serving route with verify-before-use, and the SSRF-guarded sender. Plus a behavior-preserving refactor that extracts `_staging.py` (shared digest/chunk primitives) and moves `register_file_exchange_routes` into `_routes.py` (the new cross-transport entry point), making `source` optional and adding `sink`/`config` for the upload branch.

**Three role primitives + one route:**
- `upload_receiver_mint(artifact_id, *, token_store, base_url, ttl, expected=None, method="PUT") -> IntakeTicket` — mint only, no hook runs.
- `register_upload_route(mcp, *, token_store, sink, config)` — PUT/POST `<UPLOAD_PREFIX>/{token}` route: streams the request body to a transient temp file (hashing), enforces `acceptMimeTypes` (RFC 7231 media-range), verifies `Content-Digest` (RFC 9530 + RFC 8941 member-param stripping), and `requireDigest` algorithm-list match — all **before** depositing through `sink.store_artifact`. Single-success-per-URL (consume only on success). Ambient credentials ignored. Body-free 4xx/5xx; temp deleted on every path.
- `upload_sender_consume(sink, source, key, *, config)` — stages to temp (single-pass SHA-256), pushes via `guarded_stream` with `Content-Length` / `Content-Digest` / optional `Content-Type`; non-2xx → `TRANSFER_FAILED`; guard refusal propagates coded.

**§148 boundary:** this PR ships the primitives + routes. Threading real `token_store`/`source`/`sink`/`config` from server bootstrap (and Tasks integration for large transfers) is #148.

**Concurrency contract documented:** the route docstring + the strengthened `ArtifactSink.store_artifact` contract together pin that two concurrent PUTs may both reach `store_artifact` (single-use is not a concurrency lock), and that sinks MUST finish reading the stream before returning.

## Test plan
- [x] `uv run pytest` — 993 passed, 1 skipped (GITHUB_TOKEN-gated spec sync); upload suite alone 44 + e2e
- [x] `uv run ruff format --check . && uv run ruff check . && uv run mypy src` — clean
- [x] Cross-version: `uv run --python 3.10/3.13 pytest tests/_file_exchange/test_upload*.py` — green on both
- [x] Five rounds of local `preflight-circus`; converged clean at the ≥80 bar
- [x] Coverage includes: receiver mint, helper unit (RFC 9530 / RFC 7231 / RFC 8941 edge cases incl. supported-malformed-no-fall-through, member-param stripping, `*/*` client-wildcard guard, multi-algo digest round-trip), route happy + replay-404 / 413 (operator-cap and ticket-cap, both directions) / 415 / 400 (digest mismatch + missing-required-digest + algo-list mismatch) / 500 (sink failure body-free) / consume-after-store-failure-still-204, temp-file unlinked on every failure path, flush+close OSError-mapping regression guards (mirrors merged #145 download tests), ambient-creds ignored, sender headers / non-2xx / guard refusal / temp-unlinked / close-after-flush-keeps-transfer-error, two-server push e2e.

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)