### PR TITLE
feat(file-exchange): upload transport data plane (#146)

### DIFF
--- a/docs/superpowers/plans/2026-05-24-file-exchange-146-upload-data-plane.md
+++ b/docs/superpowers/plans/2026-05-24-file-exchange-146-upload-data-plane.md
@@ -1,0 +1,1606 @@
+# File-Exchange #146 — Upload Data Plane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the `upload` transport's push data plane — a receiver that mints a capability URL + the `PUT`/`POST` route that deposits the pushed bytes through the `ArtifactSink`, and a sender that pushes an artifact through the SSRF guard with an RFC 9530 `Content-Digest`.
+
+**Architecture:** Mirror of the merged #145 download plane. First refactor merged #145 code: extract shared digest/chunk primitives into `_staging.py`, and move the cross-transport route registrar `register_file_exchange_routes` into a new `_routes.py` (extracting `register_download_route` from `_download.py`). Then add `_upload.py` with `upload_receiver_mint`, the upload route, `upload_sender_consume`, and the RFC 9530 (`Content-Digest`) / RFC 7231 (media-range) helpers. The route streams the request body to a transient temp file (hashing + size-bounded), verifies digest/constraints **before** the sink sees the bytes, then consumes the single-use token only on a successful store.
+
+**Tech Stack:** Python 3.10–3.13, FastMCP (`@mcp.custom_route`), Starlette `Request`/`Response`, httpx (via `guarded_stream`), Pydantic v2 wire models, `pytest` + `pytest-asyncio`, `httpx.ASGITransport` for route/e2e tests.
+
+**Design doc:** `docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md`
+
+---
+
+## File Structure
+
+- **Create `src/fastmcp_pvl_core/_file_exchange/_staging.py`** — shared primitives moved out of `_download.py`: `_CHUNK`, `_HASHLIB_BY_LABEL`, `_digest_verifier`, `_write_chunk`. Imported by both `_download.py` and `_upload.py` (independent leaf modules; no circular import).
+- **Modify `src/fastmcp_pvl_core/_file_exchange/_download.py`** — import the four primitives from `_staging`; remove their local definitions and the now-unused `import hashlib`. Rename `register_file_exchange_routes` → `register_download_route` (signature `register_download_route(mcp, *, token_store, source)`; body unchanged).
+- **Create `src/fastmcp_pvl_core/_file_exchange/_routes.py`** — `register_file_exchange_routes(mcp, *, token_store, source=None, sink=None, config=None)`; mounts the download route iff `source`, the upload route iff `sink` (which requires `config`).
+- **Create `src/fastmcp_pvl_core/_file_exchange/_upload.py`** — `UPLOAD_PREFIX`, `upload_receiver_mint`, `register_upload_route`, `upload_sender_consume`, and the helpers `_format_content_digest`, `_parse_content_digest`, `_media_type_accepted`.
+- **Modify `src/fastmcp_pvl_core/_file_exchange/__init__.py`** and **`src/fastmcp_pvl_core/file_exchange.py`** — re-export `register_file_exchange_routes` from `._routes` (was `._download`); add `upload_receiver_mint`, `upload_sender_consume`.
+- **Create `tests/_file_exchange/test_upload.py`** — unit tests (receiver mint, helpers, route, sender).
+- **Create `tests/_file_exchange/test_upload_e2e.py`** — two-server push end-to-end.
+- **Modify `tests/test_file_exchange_namespace.py`** — assert the upload names are re-exported.
+
+---
+
+### Task 1: Extract `_staging.py` (refactor merged #145)
+
+This is a pure move refactor — no behaviour change. The existing download test suite is the regression gate.
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_staging.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_download.py`
+- Test (regression): `tests/_file_exchange/test_download.py`
+
+- [ ] **Step 1: Create `_staging.py` with the moved primitives**
+
+```python
+"""Shared temp-file staging + digest primitives for the HTTP transports.
+
+The download fetcher (#145) and the upload route/sender (#146) both buffer a
+byte stream to a transient temp file with hashing and a size bound, and verify a
+declared digest. These primitives factor out the common parts. Each transport
+keeps its own read loop (download resumes via ``Range``; upload reads
+``request.stream()`` or a hook stream) and applies the
+``OSError -> transfer-failed`` mapping / cleanup-suppression contract around
+them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import IO
+
+# Streaming chunk size for temp-file staging (1 MiB).
+_CHUNK = 1024 * 1024
+
+# Declared-digest label -> hashlib name; an unsupported label fails verification
+# (cannot verify -> digest-mismatch), never silently skips (§15).
+_HASHLIB_BY_LABEL = {"sha-256": "sha256", "sha-384": "sha384", "sha-512": "sha512"}
+
+
+def _digest_verifier(
+    declared: str | None,
+) -> tuple[hashlib._Hash | None, str | None, bool]:
+    """Return (hasher | None, expected_hex | None, unverifiable).
+
+    ``unverifiable`` is True when a digest is declared with an unsupported label
+    — verification must then fail (cannot verify), never silently skip (§15).
+    """
+    if declared is None:
+        return None, None, False
+    label, _, expected_hex = declared.partition(":")
+    name = _HASHLIB_BY_LABEL.get(label.lower())
+    if name is None:
+        return None, expected_hex, True
+    return hashlib.new(name), expected_hex.lower(), False
+
+
+def _write_chunk(tmp: IO[bytes], hasher: hashlib._Hash | None, chunk: bytes) -> None:
+    """Write a body chunk to the temp file and fold it into the running hash.
+
+    Both ops run off the event loop in a single ``asyncio.to_thread`` dispatch.
+    """
+    tmp.write(chunk)
+    if hasher is not None:
+        hasher.update(chunk)
+```
+
+- [ ] **Step 2: Point `_download.py` at `_staging`**
+
+In `src/fastmcp_pvl_core/_file_exchange/_download.py`:
+
+1. Delete the local definitions of `_CHUNK` (line ~54), `_HASHLIB_BY_LABEL` (line ~57), `_digest_verifier` (lines ~96–110), and `_write_chunk` (lines ~113–120). Leave `DOWNLOAD_PREFIX` and `_MAX_RECONNECTS` in place.
+2. Remove `import hashlib` (now unused in `_download.py`).
+3. Add this import alongside the other `_file_exchange` imports:
+
+```python
+from fastmcp_pvl_core._file_exchange._staging import (
+    _CHUNK,
+    _HASHLIB_BY_LABEL,
+    _digest_verifier,
+    _write_chunk,
+)
+```
+
+`_HASHLIB_BY_LABEL` is still referenced by `_download.py`'s fetcher status-check path, so keep it in the import even though `_digest_verifier` also uses it.
+
+- [ ] **Step 3: Run the download suite + gates to verify no behaviour change**
+
+Run: `uv run pytest tests/_file_exchange/test_download.py tests/_file_exchange/test_download_e2e.py -q`
+Expected: PASS (same counts as before the refactor).
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean (in particular, no "imported but unused" for `hashlib`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_staging.py src/fastmcp_pvl_core/_file_exchange/_download.py
+git commit -m "refactor(file-exchange): extract shared staging primitives (#146)"
+```
+
+---
+
+### Task 2: Move `register_file_exchange_routes` to `_routes.py`
+
+Extract the download route registrar into `_download.py` as `register_download_route`, and create `_routes.py` to own the public cross-transport `register_file_exchange_routes` (download-only for now; the upload branch is added in Task 5). Pure move — existing tests are the gate.
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_download.py`
+- Create: `src/fastmcp_pvl_core/_file_exchange/_routes.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/__init__.py`
+- Modify: `src/fastmcp_pvl_core/file_exchange.py`
+- Modify: `tests/_file_exchange/test_download_e2e.py`
+
+- [ ] **Step 1: Rename the registrar in `_download.py`**
+
+In `src/fastmcp_pvl_core/_file_exchange/_download.py`, rename the function `register_file_exchange_routes` (line ~349) to `register_download_route`. Its body (the `@mcp.custom_route` GET handler `_serve_download`) is unchanged. The signature stays `(mcp: FastMCP, *, token_store: CapabilityTokenStore, source: ArtifactSource)` — `source` stays required here; optionality lives in `_routes.py`. Update the first docstring line to read:
+
+```python
+    """Mount the ``download`` GET route on ``mcp`` (serves §12 capability URLs).
+```
+
+(unchanged — only the function name changes).
+
+- [ ] **Step 2: Create `_routes.py`**
+
+```python
+"""Cross-transport FastMCP route registration for the file-exchange HTTP transports.
+
+``register_file_exchange_routes`` mounts the ``download`` GET route (when a
+``source`` hook is given) and the ``upload`` PUT/POST route (when a ``sink`` hook
+is given). Each transport's registrar lives in its own leaf module
+(``_download``/``_upload``); this module is the single public entry point #148
+threads ``token_store``/``source``/``sink``/``config`` into.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastmcp_pvl_core._file_exchange._download import register_download_route
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+
+
+def register_file_exchange_routes(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    source: ArtifactSource | None = None,
+    sink: ArtifactSink | None = None,
+    config: ServerConfig | None = None,
+) -> None:
+    """Mount the file-exchange HTTP routes on ``mcp``.
+
+    Mounts the ``download`` GET route iff ``source`` is given. (The ``upload``
+    PUT/POST route — mounted iff ``sink`` is given — is added in #146 Task 5.)
+    ``token_store``/``source``/``sink``/``config`` are threaded by #148.
+    """
+    if source is not None:
+        register_download_route(mcp, token_store=token_store, source=source)
+```
+
+Note: `sink`/`config` are accepted now so the public signature is stable across Task 5 (which adds the upload branch). They are intentionally unused until then.
+
+- [ ] **Step 3: Re-export `register_file_exchange_routes` from `_routes`**
+
+In `src/fastmcp_pvl_core/_file_exchange/__init__.py`, change the `_download` import block (lines ~19–23) to drop `register_file_exchange_routes`:
+
+```python
+from fastmcp_pvl_core._file_exchange._download import (
+    download_fetcher_consume,
+    download_provider_mint,
+)
+```
+
+and add a new import block (keep import blocks grouped by module, alphabetical by module name — `_routes` sorts after `_paths`/`_selection`? place it after the `_paths` block and before `_selection`):
+
+```python
+from fastmcp_pvl_core._file_exchange._routes import register_file_exchange_routes
+```
+
+`__all__` already lists `register_file_exchange_routes` — leave it.
+
+In `src/fastmcp_pvl_core/file_exchange.py`, the names are imported in one combined block from `fastmcp_pvl_core._file_exchange` (the subpackage), so no per-module change is needed there — `register_file_exchange_routes` still resolves. Leave `file_exchange.py` unchanged in this task.
+
+- [ ] **Step 4: Update the download e2e import**
+
+`tests/_file_exchange/test_download_e2e.py` calls `_download.register_file_exchange_routes(...)` (line ~67). It must now use the public registrar. Change the import (line ~18) and the call:
+
+```python
+from fastmcp_pvl_core._file_exchange import _download, _routes
+```
+
+```python
+    _routes.register_file_exchange_routes(
+        mcp, token_store=store, source=_BytesSource("doc", body)
+    )
+```
+
+(`_download` is still imported — the test monkeypatches `_download.guarded_stream` and calls `_download.download_provider_mint`/`download_fetcher_consume`.)
+
+- [ ] **Step 5: Run download tests + namespace test + gates**
+
+Run: `uv run pytest tests/_file_exchange/test_download.py tests/_file_exchange/test_download_e2e.py tests/test_file_exchange_namespace.py -q`
+Expected: PASS. `test_download_data_plane_names_reexported` still passes (the public name is unchanged).
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_download.py src/fastmcp_pvl_core/_file_exchange/_routes.py src/fastmcp_pvl_core/_file_exchange/__init__.py tests/_file_exchange/test_download_e2e.py
+git commit -m "refactor(file-exchange): move route registrar to _routes, source optional (#146)"
+```
+
+---
+
+### Task 3: `upload_receiver_mint` + `UPLOAD_PREFIX`
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/__init__.py`
+- Modify: `src/fastmcp_pvl_core/file_exchange.py`
+- Test: `tests/_file_exchange/test_upload.py`
+- Modify: `tests/test_file_exchange_namespace.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/_file_exchange/test_upload.py`:
+
+```python
+"""Tests for the ``upload`` transport data plane (#146)."""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _routes, _upload
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import (
+    ArtifactConstraints,
+    ArtifactMetadata,
+    IntakeTicket,
+    UploadSink,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+async def test_receiver_mint_returns_ticket_with_upload_sink():
+    store = _store()
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://recv.test", ttl=300.0
+    )
+    assert isinstance(ticket, IntakeTicket)
+    assert ticket.artifactId == "art-1"
+    assert len(ticket.sinks) == 1
+    sink = ticket.sinks[0]
+    assert isinstance(sink, UploadSink)
+    assert sink.transport == "upload"
+    assert sink.method == "PUT"
+    assert sink.url.startswith("https://recv.test/fx/u/")
+    token = sink.url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata["artifact_id"] == "art-1"
+    assert rec.metadata["expected"] is None
+
+
+async def test_receiver_mint_threads_method_and_expected():
+    store = _store()
+    expected = ArtifactConstraints(maxSize=1024, acceptMimeTypes=["text/*"])
+    ticket = await _upload.upload_receiver_mint(
+        "art-2",
+        token_store=store,
+        base_url="https://recv.test",
+        ttl=300.0,
+        expected=expected,
+        method="POST",
+    )
+    assert ticket.expected == expected
+    assert ticket.sinks[0].method == "POST"
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata["expected"] == {
+        "maxSize": 1024,
+        "acceptMimeTypes": ["text/*"],
+        "requireDigest": None,
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -q`
+Expected: FAIL with `ModuleNotFoundError`/`AttributeError` (`_upload` has no `upload_receiver_mint`).
+
+- [ ] **Step 3: Create `_upload.py` with the constant + receiver mint**
+
+```python
+"""The ``upload`` transport data plane (#146).
+
+Three role helpers (receiver mint, the PUT/POST serving route, sender) plus the
+RFC 9530 / RFC 7231 HTTP helpers the route and sender need, free functions
+mirroring ``_filesystem.py`` / ``_download.py``. The receiver mints a capability
+URL backed by the #144 token store; the route streams the pushed body to a
+transient temp file, verifies the declared ``Content-Digest`` and the ticket's
+``expected`` constraints **before** handing the #142 ``ArtifactSink`` a real sync
+fd, then consumes the single-use token only on a successful store; the sender
+stages the artifact, computes a ``Content-Digest``, and pushes it through the
+#147 ``guarded_stream``. See
+``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal
+
+from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._tokens import capability_url
+from fastmcp_pvl_core._file_exchange._wire import IntakeTicket, UploadSink
+
+if TYPE_CHECKING:
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+    from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
+
+logger = logging.getLogger(__name__)
+
+# pvl-core's upload route shape (§12 capability URL path). A constant, not a
+# kwarg — route structure is a pvl-core shape decision (mirrors DOWNLOAD_PREFIX).
+UPLOAD_PREFIX = "/fx/u"
+
+
+async def upload_receiver_mint(
+    artifact_id: str,
+    *,
+    token_store: CapabilityTokenStore,
+    base_url: str,
+    ttl: float,
+    expected: ArtifactConstraints | None = None,
+    method: Literal["PUT", "POST"] = "PUT",
+) -> IntakeTicket:
+    """Receiver role (push): mint an upload token and emit an IntakeTicket.
+
+    ``artifact_id`` is the server's opaque identifier for the artifact slot,
+    stored in the token for the route to correlate the pushed bytes; ``expected``
+    is the §7.4 constraint set the route enforces at ingest (stored opaquely too).
+    ``base_url`` is the server's public https origin; ``ttl`` is clamped by the
+    token store's ceiling. Minting only — no hook runs and no bytes move (the
+    sink is threaded into the route, where the bytes actually arrive).
+    """
+    minted = await token_store.mint(
+        {
+            "artifact_id": artifact_id,
+            "expected": expected.model_dump(mode="json") if expected else None,
+        },
+        ttl=ttl,
+        single_use=True,
+    )
+    url = capability_url(base_url, UPLOAD_PREFIX, minted.token)
+    return IntakeTicket(
+        type=TICKET_TYPE,
+        version=SPEC_VERSION,
+        artifactId=artifact_id,
+        expected=expected,
+        sinks=[
+            UploadSink(
+                transport="upload",
+                url=url,
+                method=method,
+                expiresAt=minted.expires_at,
+            )
+        ],
+    )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -q`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Re-export `upload_receiver_mint` + update namespace test**
+
+In `src/fastmcp_pvl_core/_file_exchange/__init__.py`, add an import block for `_upload` (place after the `_tokens` block, before `_validation`):
+
+```python
+from fastmcp_pvl_core._file_exchange._upload import (
+    upload_receiver_mint,
+)
+```
+
+and add `"upload_receiver_mint"` to `__all__` (alphabetical — after `select_source`, before `validate_wire`).
+
+In `src/fastmcp_pvl_core/file_exchange.py`, add `upload_receiver_mint` to the combined import (alphabetical, after `select_source`) and to `__all__` (after `select_source`).
+
+In `tests/test_file_exchange_namespace.py`, add a new test:
+
+```python
+def test_upload_data_plane_names_reexported():
+    from fastmcp_pvl_core import file_exchange
+
+    for name in (
+        "upload_receiver_mint",
+        "upload_sender_consume",
+        "register_file_exchange_routes",
+    ):
+        assert hasattr(file_exchange, name), name
+        assert name in file_exchange.__all__, name
+    # UPLOAD_PREFIX is internal route shape, not part of the public surface.
+    assert not hasattr(file_exchange, "UPLOAD_PREFIX")
+```
+
+(`upload_sender_consume` is added in Task 6 — this test will fail until then; that is expected and acceptable for the incremental sequence, but to keep every task green, add `upload_sender_consume` to both `__all__`s and the imports as a forward reference now is NOT possible since the symbol doesn't exist. Instead: in THIS task, write the test referencing only `upload_receiver_mint` and `register_file_exchange_routes`; Task 6 extends it to include `upload_sender_consume`.)
+
+Replace the test body above with the Task-3 version:
+
+```python
+def test_upload_data_plane_names_reexported():
+    from fastmcp_pvl_core import file_exchange
+
+    for name in ("upload_receiver_mint", "register_file_exchange_routes"):
+        assert hasattr(file_exchange, name), name
+        assert name in file_exchange.__all__, name
+    # UPLOAD_PREFIX is internal route shape, not part of the public surface.
+    assert not hasattr(file_exchange, "UPLOAD_PREFIX")
+```
+
+- [ ] **Step 6: Run namespace test + gates**
+
+Run: `uv run pytest tests/test_file_exchange_namespace.py tests/_file_exchange/test_upload.py -q`
+Expected: PASS.
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_upload.py src/fastmcp_pvl_core/_file_exchange/__init__.py src/fastmcp_pvl_core/file_exchange.py tests/_file_exchange/test_upload.py tests/test_file_exchange_namespace.py
+git commit -m "feat(file-exchange): add upload_receiver_mint + IntakeTicket (#146)"
+```
+
+---
+
+### Task 4: `Content-Digest` (RFC 9530) + media-range (RFC 7231) helpers
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+- Test: `tests/_file_exchange/test_upload.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/_file_exchange/test_upload.py`:
+
+```python
+def test_format_content_digest_rfc9530():
+    raw = hashlib.sha256(b"abc").digest()
+    out = _upload._format_content_digest("sha-256", raw)
+    assert out == "sha-256=:" + base64.b64encode(raw).decode("ascii") + ":"
+
+
+def test_parse_content_digest_roundtrip():
+    raw = hashlib.sha256(b"abc").digest()
+    header = _upload._format_content_digest("sha-256", raw)
+    assert _upload._parse_content_digest(header) == ("sha-256", raw)
+
+
+def test_parse_content_digest_picks_first_supported():
+    raw = hashlib.sha512(b"abc").digest()
+    header = "md5=:" + base64.b64encode(b"x").decode() + ":, sha-512=:" + (
+        base64.b64encode(raw).decode() + ":"
+    )
+    assert _upload._parse_content_digest(header) == ("sha-512", raw)
+
+
+def test_parse_content_digest_rejects_unparseable():
+    assert _upload._parse_content_digest("sha-256=not-a-byte-sequence") is None
+    assert _upload._parse_content_digest("sha-256=:!!!notbase64!!!:") is None
+    assert _upload._parse_content_digest("md5=:" + base64.b64encode(b"x").decode() + ":") is None
+
+
+@pytest.mark.parametrize(
+    ("content_type", "accept", "ok"),
+    [
+        ("text/plain", ["text/plain"], True),
+        ("text/plain; charset=utf-8", ["text/plain"], True),
+        ("text/plain", ["text/*"], True),
+        ("text/plain", ["*/*"], True),
+        ("application/json", ["text/*"], False),
+        ("application/json", ["text/*", "application/json"], True),
+        (None, ["text/*"], False),
+        ("not-a-media-type", ["*/*"], False),
+    ],
+)
+def test_media_type_accepted(content_type, accept, ok):
+    assert _upload._media_type_accepted(content_type, accept) is ok
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -k "content_digest or media_type" -q`
+Expected: FAIL (`AttributeError`: helpers not defined).
+
+- [ ] **Step 3: Implement the helpers**
+
+Add to the imports at the top of `_upload.py`:
+
+```python
+import base64
+import binascii
+```
+
+Add to the constants section of `_upload.py` (after `UPLOAD_PREFIX`):
+
+```python
+# Default digest algorithm for the receiver's recorded ArtifactMetadata.digest
+# and the sender's Content-Digest (pvl-core's shape). Members of _HASHLIB_BY_LABEL
+# are also accepted on an inbound Content-Digest.
+_DEFAULT_DIGEST_LABEL = "sha-256"
+```
+
+Add `_HASHLIB_BY_LABEL` to the `_staging` import (the helpers need it):
+
+```python
+from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL
+```
+
+Add the helpers:
+
+```python
+def _format_content_digest(label: str, raw: bytes) -> str:
+    """Format a raw digest as an RFC 9530 ``Content-Digest`` member: ``label=:b64:``.
+
+    The Structured-Field byte-sequence form (base64 wrapped in colons) — distinct
+    from the wire ``ArtifactMetadata.digest`` field's ``label:hex`` form.
+    """
+    return f"{label}=:{base64.b64encode(raw).decode('ascii')}:"
+
+
+def _parse_content_digest(header: str) -> tuple[str, bytes] | None:
+    """Parse the first supported RFC 9530 ``Content-Digest`` member.
+
+    Returns ``(label, raw_digest_bytes)`` for the first member whose algorithm is
+    in :data:`_HASHLIB_BY_LABEL` and whose value is a well-formed byte sequence,
+    or ``None`` when the header has no supported, well-formed member. A present
+    header that parses to ``None`` is unverifiable -> the route rejects it
+    (digest-mismatch), never silently skips (§15).
+    """
+    for member in header.split(","):
+        label, sep, value = member.strip().partition("=")
+        if sep != "=":
+            continue
+        label = label.strip().lower()
+        value = value.strip()
+        if label not in _HASHLIB_BY_LABEL:
+            continue
+        if len(value) < 2 or value[0] != ":" or value[-1] != ":":
+            continue
+        try:
+            raw = base64.b64decode(value[1:-1], validate=True)
+        except (binascii.Error, ValueError):
+            continue
+        return label, raw
+    return None
+
+
+def _media_type_accepted(content_type: str | None, accept: list[str]) -> bool:
+    """Match a request media type against RFC 7231 §3.1.1.1 media-ranges.
+
+    ``type/subtype`` matches exactly; ``type/*`` matches any subtype of ``type``;
+    ``*/*`` matches anything. Parameters (``; charset=...``) are ignored. A
+    missing or malformed ``Content-Type`` matches nothing (the route rejects).
+    """
+    media = (content_type or "").split(";", 1)[0].strip().lower()
+    if "/" not in media:
+        return False
+    main, sub = media.split("/", 1)
+    for entry in accept:
+        candidate = entry.split(";", 1)[0].strip().lower()
+        if candidate == "*/*":
+            return True
+        if "/" not in candidate:
+            continue
+        cand_main, cand_sub = candidate.split("/", 1)
+        if cand_main == main and cand_sub in ("*", sub):
+            return True
+    return False
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -k "content_digest or media_type" -q`
+Expected: PASS.
+
+- [ ] **Step 5: Gates**
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_upload.py tests/_file_exchange/test_upload.py
+git commit -m "feat(file-exchange): add Content-Digest (RFC 9530) + media-range helpers (#146)"
+```
+
+---
+
+### Task 5: The upload route + wire `sink`/`config` into `register_file_exchange_routes`
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_routes.py`
+- Test: `tests/_file_exchange/test_upload.py`
+
+- [ ] **Step 1: Write the failing route tests**
+
+Append to `tests/_file_exchange/test_upload.py`:
+
+```python
+class _CapturingSink:
+    def __init__(self):
+        self.calls = []
+
+    async def store_artifact(self, artifact_id, metadata, stream):
+        self.calls.append((artifact_id, metadata, stream.read()))
+
+
+class _BoomSink:
+    async def store_artifact(self, artifact_id, metadata, stream):
+        raise RuntimeError("sink failure with /secret/path detail")
+
+
+def _mount(sink, *, config=None):
+    store = _store()
+    mcp = FastMCP("receiver")
+    _routes.register_file_exchange_routes(
+        mcp, token_store=store, sink=sink, config=config or ServerConfig()
+    )
+    return store, mcp
+
+
+def _client(mcp):
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=mcp.http_app()), base_url="http://up.test"
+    )
+
+
+async def _mint_token(store, *, artifact_id="art-1", expected=None):
+    minted = await store.mint(
+        {
+            "artifact_id": artifact_id,
+            "expected": expected.model_dump(mode="json") if expected else None,
+        },
+        ttl=300.0,
+        single_use=True,
+    )
+    return minted.token
+
+
+async def test_upload_route_unknown_token_404():
+    _store_, mcp = _mount(_CapturingSink())
+    async with _client(mcp) as client:
+        resp = await client.put("/fx/u/nonexistent", content=b"x")
+    assert resp.status_code == 404
+
+
+async def test_upload_route_happy_deposits_and_consumes():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    body = b"upload-payload" * 100
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=body)
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+    artifact_id, meta, deposited = sink.calls[0]
+    assert artifact_id == "art-1"
+    assert deposited == body
+    assert meta.size == len(body)
+    assert meta.digest == "sha-256:" + hashlib.sha256(body).hexdigest()
+    # Single-use token consumed -> a replay is 404.
+    assert await store.lookup(token) is None
+    async with _client(mcp) as client:
+        resp2 = await client.put(f"/fx/u/{token}", content=body)
+    assert resp2.status_code == 404
+
+
+async def test_upload_route_oversize_413_no_consume():
+    store, mcp = _mount(
+        sink := _CapturingSink(),
+        config=ServerConfig(file_exchange_max_artifact_size=16),
+    )
+    token = await _mint_token(store)
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"x" * 64)
+    assert resp.status_code == 413
+    assert sink.calls == []
+    assert await store.lookup(token) is not None  # not consumed
+
+
+async def test_upload_route_maxsize_constraint_413():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store, expected=ArtifactConstraints(maxSize=8))
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"x" * 64)
+    assert resp.status_code == 413
+    assert sink.calls == []
+
+
+async def test_upload_route_mime_reject_415_no_consume():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(
+        store, expected=ArtifactConstraints(acceptMimeTypes=["text/*"])
+    )
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}", content=b"{}", headers={"content-type": "application/json"}
+        )
+    assert resp.status_code == 415
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+
+async def test_upload_route_valid_content_digest_verifies():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    body = b"digest-checked-body"
+    cd = _upload._format_content_digest("sha-256", hashlib.sha256(body).digest())
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}", content=body, headers={"content-digest": cd}
+        )
+    assert resp.status_code == 204
+    assert sink.calls[0][2] == body
+
+
+async def test_upload_route_digest_mismatch_400_no_sink_call():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    body = b"the-real-body"
+    wrong = _upload._format_content_digest("sha-256", hashlib.sha256(b"other").digest())
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}", content=body, headers={"content-digest": wrong}
+        )
+    assert resp.status_code == 400
+    assert sink.calls == []  # verify-before-use: sink never saw the bytes
+    assert await store.lookup(token) is not None  # not consumed
+
+
+async def test_upload_route_require_digest_missing_header_400():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(
+        store, expected=ArtifactConstraints(requireDigest=["sha-256"])
+    )
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"no-digest-header")
+    assert resp.status_code == 400
+    assert sink.calls == []
+
+
+async def test_upload_route_ambient_credentials_ignored():
+    store, mcp = _mount(sink := _CapturingSink())
+    token = await _mint_token(store)
+    async with _client(mcp) as client:
+        resp = await client.put(
+            f"/fx/u/{token}",
+            content=b"ok",
+            headers={"authorization": "Bearer bogus", "cookie": "x=y"},
+        )
+    assert resp.status_code == 204
+    assert sink.calls[0][2] == b"ok"
+
+
+async def test_upload_route_sink_failure_500_no_consume():
+    store, mcp = _mount(_BoomSink())
+    token = await _mint_token(store)
+    async with _client(mcp) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"data")
+    assert resp.status_code == 500
+    assert resp.content == b""  # body-free: no hook detail echoed
+    assert await store.lookup(token) is not None  # not consumed -> retryable
+
+
+async def test_register_routes_upload_requires_config():
+    store = _store()
+    mcp = FastMCP("receiver")
+    with pytest.raises(ValueError, match="config"):
+        _routes.register_file_exchange_routes(
+            mcp, token_store=store, sink=_CapturingSink(), config=None
+        )
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -k "route or requires_config" -q`
+Expected: FAIL (route + `register_upload_route` not implemented; `register_file_exchange_routes` does not mount upload).
+
+- [ ] **Step 3: Implement the upload route in `_upload.py`**
+
+Add to the imports at the top of `_upload.py`:
+
+```python
+import asyncio
+import contextlib
+import hashlib
+import os
+import tempfile
+```
+
+(extend the existing TYPE_CHECKING block):
+
+```python
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from starlette.requests import Request
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+    from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
+```
+
+Add the runtime imports (these are used at runtime, not just typing):
+
+```python
+from starlette.responses import Response
+
+from fastmcp_pvl_core._file_exchange._staging import _CHUNK, _HASHLIB_BY_LABEL, _write_chunk
+from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints, ArtifactMetadata
+```
+
+(Consolidate the `_wire` / `_staging` imports — do not import a name twice. `ArtifactConstraints` moves from the TYPE_CHECKING block to the runtime block because the route calls `ArtifactConstraints.model_validate`.)
+
+Add the registrar:
+
+```python
+def register_upload_route(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    sink: ArtifactSink,
+    config: ServerConfig,
+) -> None:
+    """Mount the ``upload`` PUT/POST route on ``mcp`` (serves §12 capability URLs).
+
+    ``PUT``/``POST <UPLOAD_PREFIX>/{token}`` looks the token up, streams the
+    request body to a transient temp file (hashing, bounded by the operator cap
+    ``config.file_exchange_max_artifact_size`` and the ticket's
+    ``expected.maxSize``), enforces ``acceptMimeTypes`` and verifies a declared
+    ``Content-Digest`` **before** depositing through ``sink.store_artifact``, and
+    consumes the single-use token only on a successful store (§10.3). Ambient
+    credentials are ignored — the in-URL token is the only authorization.
+    ``token_store``/``sink``/``config`` are threaded by #148.
+    """
+    max_artifact = config.file_exchange_max_artifact_size
+
+    @mcp.custom_route(f"{UPLOAD_PREFIX}/{{token}}", methods=["PUT", "POST"])
+    async def _serve_upload(request: Request) -> Response:
+        token = request.path_params["token"]
+        rec = await token_store.lookup(token)
+        if rec is None:
+            return Response(status_code=404)
+        artifact_id = rec.metadata["artifact_id"]
+        expected_raw = rec.metadata.get("expected")
+        expected: ArtifactConstraints | None = (
+            ArtifactConstraints.model_validate(expected_raw)
+            if expected_raw is not None
+            else None
+        )
+
+        content_type = request.headers.get("content-type")
+        if (
+            expected is not None
+            and expected.acceptMimeTypes
+            and not _media_type_accepted(content_type, expected.acceptMimeTypes)
+        ):
+            return Response(status_code=415)
+
+        cd_header = request.headers.get("content-digest")
+        require_digest = bool(expected is not None and expected.requireDigest)
+        cd = _parse_content_digest(cd_header) if cd_header is not None else None
+        if cd_header is not None and cd is None:
+            # A present but unverifiable Content-Digest is a verification
+            # failure, never a silent skip (§15).
+            return Response(status_code=400)
+        if cd is None and require_digest:
+            return Response(status_code=400)
+        algo_label = cd[0] if cd is not None else _DEFAULT_DIGEST_LABEL
+
+        # Smaller of the operator cap and the per-ticket cap, each when set.
+        size_cap = max_artifact
+        if expected is not None and expected.maxSize is not None:
+            size_cap = (
+                expected.maxSize
+                if size_cap is None
+                else min(size_cap, expected.maxSize)
+            )
+
+        try:
+            fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-")
+        except OSError:
+            logger.exception("file-exchange: upload temp create failed")
+            return Response(status_code=500)
+        try:
+            try:
+                tmp = os.fdopen(fd, "wb")
+            except OSError:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                logger.exception("file-exchange: upload temp open failed")
+                return Response(status_code=500)
+            hasher = hashlib.new(_HASHLIB_BY_LABEL[algo_label])
+            received = 0
+            try:
+                try:
+                    async for chunk in request.stream():
+                        if not chunk:
+                            continue
+                        received += len(chunk)
+                        if size_cap is not None and received > size_cap:
+                            return Response(status_code=413)
+                        await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                    await asyncio.to_thread(tmp.flush)
+                except OSError:
+                    logger.exception("file-exchange: upload temp write failed")
+                    return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    tmp.close()
+
+            # Verify-before-use: an uploaded body is untrusted, so the digest is
+            # checked before the sink ever sees the bytes.
+            if cd is not None and hasher.digest() != cd[1]:
+                return Response(status_code=400)
+
+            meta = ArtifactMetadata(
+                mimeType=content_type,
+                size=received,
+                digest=f"{algo_label}:{hasher.hexdigest()}",
+            )
+            try:
+                ingest = await asyncio.to_thread(open, tmp_path, "rb")
+            except OSError:
+                logger.exception("file-exchange: upload staged open failed")
+                return Response(status_code=500)
+            try:
+                await sink.store_artifact(artifact_id, meta, ingest)
+            except Exception:
+                # The hook may carry server paths in its message — never echo it;
+                # log locally, body-free 500. The token is not consumed (nothing
+                # stored), so the sender can re-request a ticket and retry.
+                logger.exception("file-exchange: upload sink store_artifact failed")
+                return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    ingest.close()
+
+            # Single-success-per-URL: consume only after a successful store.
+            try:
+                await token_store.consume(token)
+            except Exception:
+                # The artifact was stored; a consume failure must not fail the
+                # request. Log it (no token — redaction): the single-use token
+                # may remain usable until it expires.
+                logger.warning(
+                    "file-exchange: upload token consume failed after store; "
+                    "token may remain usable to TTL"
+                )
+            return Response(status_code=204)
+        finally:
+            with contextlib.suppress(OSError):
+                await asyncio.to_thread(os.unlink, tmp_path)
+```
+
+- [ ] **Step 4: Wire the upload branch into `register_file_exchange_routes`**
+
+In `src/fastmcp_pvl_core/_file_exchange/_routes.py`, add the `_upload` import and the upload branch:
+
+```python
+from fastmcp_pvl_core._file_exchange._download import register_download_route
+from fastmcp_pvl_core._file_exchange._upload import register_upload_route
+```
+
+Replace the body of `register_file_exchange_routes` and its docstring tail:
+
+```python
+    """Mount the file-exchange HTTP routes on ``mcp``.
+
+    Mounts the ``download`` GET route iff ``source`` is given and the ``upload``
+    PUT/POST route iff ``sink`` is given. Mounting the upload route requires
+    ``config`` (the operator size cap bounds untrusted request bodies). All of
+    ``token_store``/``source``/``sink``/``config`` are threaded by #148.
+    """
+    if source is not None:
+        register_download_route(mcp, token_store=token_store, source=source)
+    if sink is not None:
+        if config is None:
+            raise ValueError(
+                "register_file_exchange_routes: mounting the upload route "
+                "requires `config` for the operator size cap"
+            )
+        register_upload_route(mcp, token_store=token_store, sink=sink, config=config)
+```
+
+- [ ] **Step 5: Run the route tests**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -q`
+Expected: PASS (all unit + route tests).
+
+- [ ] **Step 6: Gates**
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_upload.py src/fastmcp_pvl_core/_file_exchange/_routes.py tests/_file_exchange/test_upload.py
+git commit -m "feat(file-exchange): add upload PUT/POST route with verify-before-use (#146)"
+```
+
+---
+
+### Task 6: `upload_sender_consume`
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/__init__.py`
+- Modify: `src/fastmcp_pvl_core/file_exchange.py`
+- Test: `tests/_file_exchange/test_upload.py`
+- Modify: `tests/test_file_exchange_namespace.py`
+
+- [ ] **Step 1: Write the failing sender tests**
+
+Append to `tests/_file_exchange/test_upload.py`:
+
+```python
+class _BytesSource:
+    def __init__(self, key, body, *, mime="application/octet-stream"):
+        self._key, self._body, self._mime = key, body, mime
+
+    async def open_artifact(self, key):
+        import io
+
+        assert key == self._key
+        return io.BytesIO(self._body), ArtifactMetadata(
+            name="a", mimeType=self._mime, size=len(self._body)
+        )
+
+
+class _FakeGuarded:
+    def __init__(self, status):
+        self.status = status
+
+
+def _upload_sink(method="PUT"):
+    return UploadSink(
+        transport="upload",
+        url="https://up.test/fx/u/tok",
+        method=method,
+        expiresAt=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+
+async def test_sender_stages_and_sends_with_headers(monkeypatch):
+    body = b"sender-payload" * 50
+    captured: dict = {}
+
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        captured["method"] = method
+        captured["url"] = url
+        captured["transport"] = transport
+        captured["headers"] = dict(headers or {})
+        captured["body"] = b"".join([chunk async for chunk in content])
+        yield _FakeGuarded(204)
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    await _upload.upload_sender_consume(
+        _upload_sink(), _BytesSource("k", body, mime="text/plain"), "k",
+        config=ServerConfig(),
+    )
+    assert captured["method"] == "PUT"
+    assert captured["url"] == "https://up.test/fx/u/tok"
+    assert captured["transport"] == "upload"
+    assert captured["body"] == body
+    assert captured["headers"]["Content-Length"] == str(len(body))
+    assert captured["headers"]["Content-Type"] == "text/plain"
+    assert captured["headers"]["Content-Digest"] == (
+        "sha-256=:" + base64.b64encode(hashlib.sha256(body).digest()).decode() + ":"
+    )
+
+
+async def test_sender_omits_content_type_when_unknown(monkeypatch):
+    captured: dict = {}
+
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        async for _ in content:
+            pass
+        captured["headers"] = dict(headers or {})
+        yield _FakeGuarded(201)
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+
+    class _NoMimeSource:
+        async def open_artifact(self, key):
+            import io
+
+            return io.BytesIO(b"x"), ArtifactMetadata(size=1)
+
+    await _upload.upload_sender_consume(
+        _upload_sink(), _NoMimeSource(), "k", config=ServerConfig()
+    )
+    assert "Content-Type" not in captured["headers"]
+
+
+async def test_sender_non_2xx_raises_transfer_failed(monkeypatch):
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        async for _ in content:
+            pass
+        yield _FakeGuarded(500)
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    with pytest.raises(FileExchangeTransferError) as exc:
+        await _upload.upload_sender_consume(
+            _upload_sink(), _BytesSource("k", b"data"), "k", config=ServerConfig()
+        )
+    assert exc.value.code == TransferErrorCode.TRANSFER_FAILED
+    assert exc.value.transport == "upload"
+
+
+async def test_sender_guard_refusal_propagates(monkeypatch):
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE, transport="upload", detail="blocked"
+        )
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+    with pytest.raises(FileExchangeTransferError) as exc:
+        await _upload.upload_sender_consume(
+            _upload_sink(), _BytesSource("k", b"data"), "k", config=ServerConfig()
+        )
+    assert exc.value.code == TransferErrorCode.NOT_ACCESSIBLE
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -k sender -q`
+Expected: FAIL (`AttributeError`: `upload_sender_consume` not defined).
+
+- [ ] **Step 3: Implement `upload_sender_consume`**
+
+Add the runtime imports to `_upload.py` (consolidate with the existing import lines — add the new names, do not duplicate):
+
+```python
+from collections.abc import AsyncIterator
+
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+from fastmcp_pvl_core._file_exchange._outbound import guarded_stream
+```
+
+Extend the runtime TYPE_CHECKING / `_wire` imports so `UploadSink` and `ArtifactSource` are available — `UploadSink` is already imported at runtime; add `ArtifactSource` to the TYPE_CHECKING block:
+
+```python
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
+```
+
+Add the function:
+
+```python
+async def upload_sender_consume(
+    sink: UploadSink,
+    source: ArtifactSource,
+    key: str,
+    *,
+    config: ServerConfig,
+) -> None:
+    """Sender role (push): stage ``source[key]`` and push it to ``sink``.
+
+    Selection (``select_sink``) is the caller's step. Stages the artifact to a
+    transient temp file (single pass, hashing), computes an RFC 9530
+    ``Content-Digest``, and streams the temp through the #147 ``guarded_stream``
+    (which strips ambient credentials and refuses redirects on a bodied request).
+    A non-2xx response maps to ``transfer-failed``; a guard refusal arrives coded
+    and propagates. The temp is deleted on every path.
+
+    Staging is required: the hook stream is non-seekable and the ``Content-Digest``
+    must be hashed before it can be sent in the request header, so a single hook
+    read cannot both hash-first and stream-from-the-hook.
+    """
+    stream, meta = await source.open_artifact(key)
+    try:
+        fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-send-")
+    except OSError as exc:
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(stream.close)
+        raise FileExchangeTransferError(
+            TransferErrorCode.TRANSFER_FAILED,
+            transport="upload",
+            detail="failed to create a temporary file",
+        ) from exc
+    try:
+        try:
+            tmp = os.fdopen(fd, "wb")
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        hasher = hashlib.sha256()
+        size = 0
+        try:
+            try:
+                while True:
+                    chunk = await asyncio.to_thread(stream.read, _CHUNK)
+                    if not chunk:
+                        break
+                    size += len(chunk)
+                    await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                await asyncio.to_thread(tmp.flush)
+            except OSError as exc:
+                raise FileExchangeTransferError(
+                    TransferErrorCode.TRANSFER_FAILED,
+                    transport="upload",
+                    detail="failed to stage the artifact for upload",
+                ) from exc
+            finally:
+                with contextlib.suppress(OSError):
+                    tmp.close()
+        finally:
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(stream.close)
+
+        headers = {
+            "Content-Length": str(size),
+            "Content-Digest": _format_content_digest(
+                _DEFAULT_DIGEST_LABEL, hasher.digest()
+            ),
+        }
+        if meta.mimeType is not None:
+            headers["Content-Type"] = meta.mimeType
+
+        async def _content() -> AsyncIterator[bytes]:
+            handle = await asyncio.to_thread(open, tmp_path, "rb")
+            try:
+                while True:
+                    chunk = await asyncio.to_thread(handle.read, _CHUNK)
+                    if not chunk:
+                        break
+                    yield chunk
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(handle.close)
+
+        try:
+            async with guarded_stream(
+                sink.method,
+                sink.url,
+                config=config,
+                transport="upload",
+                headers=headers,
+                content=_content(),
+            ) as resp:
+                if not 200 <= resp.status < 300:
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.TRANSFER_FAILED,
+                        transport="upload",
+                        detail="upload endpoint returned a non-success status",
+                    )
+        except OSError as exc:
+            # A temp read surfacing from the content generator during send.
+            raise FileExchangeTransferError(
+                TransferErrorCode.TRANSFER_FAILED,
+                transport="upload",
+                detail="failed to read the staged artifact during upload",
+            ) from exc
+    finally:
+        with contextlib.suppress(OSError):
+            await asyncio.to_thread(os.unlink, tmp_path)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py -k sender -q`
+Expected: PASS.
+
+- [ ] **Step 5: Re-export `upload_sender_consume` + extend namespace test**
+
+In `src/fastmcp_pvl_core/_file_exchange/__init__.py`, extend the `_upload` import block:
+
+```python
+from fastmcp_pvl_core._file_exchange._upload import (
+    upload_receiver_mint,
+    upload_sender_consume,
+)
+```
+
+and add `"upload_sender_consume"` to `__all__` (alphabetical — after `upload_receiver_mint`).
+
+In `src/fastmcp_pvl_core/file_exchange.py`, add `upload_sender_consume` to the combined import (after `upload_receiver_mint`) and `__all__` (after `upload_receiver_mint`).
+
+In `tests/test_file_exchange_namespace.py`, extend `test_upload_data_plane_names_reexported`:
+
+```python
+def test_upload_data_plane_names_reexported():
+    from fastmcp_pvl_core import file_exchange
+
+    for name in (
+        "upload_receiver_mint",
+        "upload_sender_consume",
+        "register_file_exchange_routes",
+    ):
+        assert hasattr(file_exchange, name), name
+        assert name in file_exchange.__all__, name
+    # UPLOAD_PREFIX is internal route shape, not part of the public surface.
+    assert not hasattr(file_exchange, "UPLOAD_PREFIX")
+```
+
+- [ ] **Step 6: Run namespace + full upload suite + gates**
+
+Run: `uv run pytest tests/_file_exchange/test_upload.py tests/test_file_exchange_namespace.py -q`
+Expected: PASS.
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_file_exchange/_upload.py src/fastmcp_pvl_core/_file_exchange/__init__.py src/fastmcp_pvl_core/file_exchange.py tests/_file_exchange/test_upload.py tests/test_file_exchange_namespace.py
+git commit -m "feat(file-exchange): add upload_sender_consume (#146)"
+```
+
+---
+
+### Task 7: Two-server push end-to-end
+
+**Files:**
+- Create: `tests/_file_exchange/test_upload_e2e.py`
+
+- [ ] **Step 1: Write the failing e2e test**
+
+```python
+"""End-to-end upload push: server A sends, server B mints + receives.
+
+Exercises the whole ``upload`` data plane together — ``upload_receiver_mint``,
+``register_file_exchange_routes`` (upload route mounted on a real ASGI app),
+``select_sink``, and ``upload_sender_consume`` — over a loopback ASGI transport.
+The SSRF guard is replaced with one that routes to server B's app, because we are
+exercising the push flow, not the guard (which has its own tests).
+"""
+
+import contextlib
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _routes, _upload
+from fastmcp_pvl_core._file_exchange._selection import select_sink
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+pytestmark = pytest.mark.anyio
+
+
+class _BytesSource:
+    def __init__(self, key, body):
+        self._key, self._body = key, body
+
+    async def open_artifact(self, key):
+        import io
+
+        assert key == self._key
+        return io.BytesIO(self._body), ArtifactMetadata(
+            name="a", mimeType="application/octet-stream", size=len(self._body)
+        )
+
+
+class _CapturingSink:
+    def __init__(self):
+        self.calls = []
+
+    async def store_artifact(self, artifact_id, metadata, stream):
+        self.calls.append((artifact_id, metadata, stream.read()))
+
+
+class _FakeGuarded:
+    def __init__(self, status):
+        self.status = status
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+async def test_two_server_push_upload(monkeypatch):
+    body = b"end-to-end-upload-payload" * 64
+
+    # Server B: receiver mint + upload route on a real ASGI app.
+    store = _store()
+    sink = _CapturingSink()
+    recv = FastMCP("receiver")
+    _routes.register_file_exchange_routes(
+        recv, token_store=store, sink=sink, config=ServerConfig()
+    )
+    app_b = recv.http_app()
+
+    # Server A's guard, redirected at B's ASGI app (no real network / SSRF check).
+    @contextlib.asynccontextmanager
+    async def guard_to_app_b(
+        method, url, *, config, transport, headers=None, content=None
+    ):
+        client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app_b), base_url="http://recv.test"
+        )
+        try:
+            path = url.split("recv.test", 1)[1]
+            req = client.build_request(
+                method, path, headers=headers or {}, content=content
+            )
+            resp = await client.send(req)
+            try:
+                yield _FakeGuarded(resp.status_code)
+            finally:
+                await resp.aclose()
+        finally:
+            await client.aclose()
+
+    monkeypatch.setattr(_upload, "guarded_stream", guard_to_app_b)
+
+    # B mints an intake ticket; A selects the upload sink and pushes.
+    ticket = await _upload.upload_receiver_mint(
+        "art-e2e", token_store=store, base_url="https://recv.test", ttl=300.0
+    )
+    descriptor = select_sink(ticket)
+    assert descriptor is not None and descriptor.transport == "upload"
+
+    await _upload.upload_sender_consume(
+        descriptor, _BytesSource("k", body), "k", config=ServerConfig()
+    )
+
+    # The bytes landed in B's sink, correlated to artifactId.
+    assert len(sink.calls) == 1
+    assert sink.calls[0][0] == "art-e2e"
+    assert sink.calls[0][2] == body
+    # The single-use token was consumed by the completed upload.
+    assert await store.lookup(descriptor.url.rsplit("/", 1)[1]) is None
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `uv run pytest tests/_file_exchange/test_upload_e2e.py -q`
+Expected: PASS (the implementation already exists from Tasks 3–6; this is an integration check, so it should pass on the first run — if it fails, the failure is a real integration gap to fix before committing).
+
+- [ ] **Step 3: Gates**
+
+Run: `uv run ruff format --check . && uv run ruff check . && uv run mypy src`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/_file_exchange/test_upload_e2e.py
+git commit -m "test(file-exchange): two-server push e2e for upload data plane (#146)"
+```
+
+---
+
+### Task 8: Full suite, quality gates, preflight-circus, draft PR
+
+**Files:** none (verification + PR).
+
+- [ ] **Step 1: Full local check matrix (matches CI's dependency state)**
+
+```bash
+uv sync --all-extras
+uv run pytest
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
+```
+Expected: all green; the new `test_upload.py` + `test_upload_e2e.py` tests are included; download tests unchanged.
+
+- [ ] **Step 2: Cross-version check (min + max interpreter)**
+
+```bash
+uv run --python 3.10 pytest tests/_file_exchange/test_upload.py tests/_file_exchange/test_upload_e2e.py -q
+uv run --python 3.13 pytest tests/_file_exchange/test_upload.py tests/_file_exchange/test_upload_e2e.py -q
+```
+Expected: PASS on both (no version-dependent behaviour in the upload path; this guards against the 3.10/3.13 split that bit #152).
+
+- [ ] **Step 3: Preflight-circus on the cumulative diff**
+
+Invoke the `preflight-circus` skill against `BASE..HEAD` (`BASE = $(git merge-base HEAD origin/main)`). It is a normative-content change (the design doc cites RFC 9530 / RFC 7231 / spec §10.3 but is **informative**, not a wire spec — lens 6 fires only if a `docs/specs/` wire-format file changes, which it does not here). Resolve every finding surviving the ≥80 filter before pushing.
+
+- [ ] **Step 4: Open the draft PR**
+
+Confirm an issue exists (#146). Push the branch and open as draft:
+
+```bash
+git push -u origin feat/146-upload-data-plane
+gh pr create --draft --title "feat(file-exchange): upload transport data plane (#146)" --body "$(cat <<'EOF'
+## Summary
+- Adds the `upload` transport data plane (EPIC #138, 8/10): `upload_receiver_mint` (token + IntakeTicket/UploadSink), the PUT/POST route (stream-to-temp, `acceptMimeTypes` RFC 7231, `Content-Digest` RFC 9530 verify, single-success-per-URL, verify-before-use into the `ArtifactSink`), and `upload_sender_consume` (stage + `Content-Digest` + `guarded_stream`).
+- Refactor: extracts shared digest/chunk primitives into `_staging.py`; moves `register_file_exchange_routes` into `_routes.py` (now mounts download iff `source`, upload iff `sink`+`config`).
+- #148 threads `source`/`sink`/`config` + adds Tasks integration; this PR ships the primitives + route.
+
+## Test plan
+- [ ] `uv run pytest` green (new `test_upload.py` + `test_upload_e2e.py`; download suite unchanged)
+- [ ] `uv run ruff format --check . && uv run ruff check . && uv run mypy src` clean
+- [ ] Cross-version: `uv run --python 3.10/3.13 pytest tests/_file_exchange/test_upload*.py`
+- [ ] Receiver mint, route happy+consume / replay-404 / oversize-413 / mime-415 / digest-verify+mismatch-400 / requireDigest-missing-400 / ambient-creds-ignored / sink-failure-500, sender headers+non-2xx+guard-refusal, two-server push e2e
+
+Closes #146.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Bot iteration (capped) → flip ready**
+
+Read the `claude-review` body (not just the check status). Address any finding per the iteration cap (re-run the full `preflight-circus` before each fix push). Once local circus was clean, bot bodies LGTM, and CI is green, flip ready: `gh pr ready <N>`.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (design doc → task):
+- `upload_receiver_mint` (token stores `artifact_id`+`expected`; IntakeTicket+UploadSink) → Task 3. ✓
+- `register_file_exchange_routes` optional `source`/`sink`/`config`; download-only / upload-only / both; upload requires `config` → Task 2 (download + optional source) + Task 5 (sink/config + ValueError guard). ✓
+- Upload route: 404 / acceptMimeTypes-415 / stream-to-temp + size-cap-413 / Content-Digest verify (present→verify, requireDigest→required) / verify-before-use / store + 204 / consume-only-on-success / ambient-creds-ignored / hook-fail-500 → Task 5. ✓
+- `upload_sender_consume`: stage + Content-Digest + `guarded_stream` content body + non-2xx→transfer-failed + guard-refusal propagates + temp cleanup + omit Content-Type when unknown → Task 6. ✓
+- §10.3 Content-Digest RFC 9530 (`label=:b64:`, verify in declared algo, metadata `label:hex`) + acceptMimeTypes RFC 7231 media-range → Task 4 (helpers) + Task 5 (route use). ✓
+- File structure: `_staging.py` (Task 1), `_routes.py` (Task 2), `_upload.py` (Tasks 3–6); temp-IO OSError contract from #145 preserved (route→body-free 500; sender→transfer-failed) → Tasks 5/6. ✓
+- Public surface re-exports + namespace test → Tasks 3/6. ✓
+- Testing (unit + route + sender + e2e) → Tasks 3–7. ✓
+
+**2. Placeholder scan:** No "TBD"/"implement later"/"add error handling"/"write tests for the above". Every code/test step shows complete code. The only deferred items are explicitly out of scope (#148 threading; sender-side mime pre-check deferred per the design's §10.3 rationale).
+
+**3. Type consistency:**
+- `register_download_route(mcp, *, token_store, source)` — defined Task 2, called from `_routes.py` Task 2. ✓
+- `register_upload_route(mcp, *, token_store, sink, config)` — defined Task 5, called from `_routes.py` Task 5. ✓
+- `register_file_exchange_routes(mcp, *, token_store, source=None, sink=None, config=None)` — Task 2 (download branch + sink/config params present) → Task 5 (upload branch added). Signature stable across both. ✓
+- `upload_receiver_mint(artifact_id, *, token_store, base_url, ttl, expected=None, method="PUT")` — Task 3 def; same shape in e2e (Task 7) and unit (Task 3). ✓
+- `upload_sender_consume(sink, source, key, *, config)` — Task 6 def; same call in sender tests (Task 6) + e2e (Task 7). ✓
+- Helpers `_format_content_digest(label, raw)`, `_parse_content_digest(header) -> (label, raw)|None`, `_media_type_accepted(content_type, accept) -> bool` — Task 4 def; used in Task 5 route + Task 6 sender + tests. ✓
+- `_staging` exports `_CHUNK`, `_HASHLIB_BY_LABEL`, `_digest_verifier`, `_write_chunk` — Task 1; imported by `_download` (Task 1) and `_upload` (Tasks 4–6). ✓
+- Token metadata keys `"artifact_id"` / `"expected"` — written by `upload_receiver_mint` (Task 3) and the route's `_mint_token` helper (Task 5), read by the route (Task 5). Consistent. ✓
+- `ArtifactMetadata(mimeType=, size=, digest=)` with all-optional fields (≥1 required) — the route always sets size+digest, so the invariant holds. ✓

--- a/docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md
+++ b/docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md
@@ -1,0 +1,285 @@
+# File-Exchange #146 — upload data plane (route + receiver/sender)
+
+> **Status:** Contemporaneous design record for issue #146 (8/10 of EPIC
+> #138). The implementation in the same PR is the source of truth; this
+> captures the shape agreed before implementation. This is **not** a wire
+> spec — #146 is pvl-core's own implementation of the `upload` transport's
+> data plane, governed by `CLAUDE.md` and the project's framing principle,
+> not by `mcp-file-exchange-ext`. No `docs/specs/` wire-format file is touched.
+
+**Goal:** Implement the `upload` transport's push data plane, the mirror of the
+#145 `download` pull plane: the receiver mints a capability URL backed by the
+#144 token store, an HTTPS `PUT`/`POST` route on the receiver's own server
+accepts the artifact bytes and deposits them through the #142 `ArtifactSink`, and
+the sender pushes them through the #147 SSRF guard with a `Content-Digest`.
+Everything streams — no artifact is buffered whole in memory.
+
+## Scope (from #138's decomposition + #146's scope statement)
+
+#146 owns the three `upload` role primitives and the serving route:
+`upload_receiver_mint`, the upload `PUT`/`POST` route, and
+`upload_sender_consume`. It builds on three merged dependencies:
+`CapabilityTokenStore` (#144), `guarded_stream` (#147 — which already accepts a
+request `content` body), and the `ArtifactSource`/`ArtifactSink` hooks (#142). It
+does **not** build the top-level `register_file_exchange_*` umbrella, the shared
+token-store construction, or Tasks integration — those are #148. The primitives
+take their dependencies (token store / sink / source / config) as parameters;
+#148 constructs and threads them.
+
+## File structure
+
+The EPIC's pattern is one module per transport (`_filesystem.py`, `_download.py`),
+so upload gets its own module, and the cross-transport route registrar moves to a
+neutral home:
+
+- **New `_upload.py`** — `upload_receiver_mint`, `upload_sender_consume`, the
+  upload route registrar (`register_upload_route`, internal), and the
+  upload-specific HTTP helpers (`Content-Digest` RFC 9530 parse/format,
+  `acceptMimeTypes` RFC 7231 media-range matching).
+- **New `_routes.py`** — `register_file_exchange_routes` moves here from
+  `_download.py` (it is cross-transport, not download-specific). It calls
+  `register_download_route` (extracted from `_download.py`) and
+  `register_upload_route` (from `_upload.py`). `_download` and `_upload` stay
+  independent leaf modules — no circular imports.
+- **New `_staging.py`** — the digest/chunk primitives shared by both transports:
+  `_HASHLIB_BY_LABEL`, `_digest_verifier`, `_write_chunk`, `_CHUNK`, and a
+  temp-file staging helper that writes an async byte stream to a `mkstemp` temp
+  with hashing + a size bound, **preserving the `OSError → transfer-failed`
+  mapping / cleanup-suppression contract established in #145** (the download
+  fetcher's hard-won temp-IO error sweep must not be re-derived divergently in
+  upload). The download fetcher's `Range`-resume loop stays in `_download.py`
+  (download-specific); only the per-chunk write/hash/verify primitives are
+  shared. The exact split of "shared helper vs. per-transport loop" is the
+  plan's call; the contract (every temp-file op maps to `transfer-failed` or is
+  suppressed for cleanup) is not.
+
+This refactors merged #145 code (moving `register_file_exchange_routes`,
+extracting `_staging.py`). The re-export surface is updated to import
+`register_file_exchange_routes` from `_routes` (the public name is unchanged).
+
+## register_file_exchange_routes shape
+
+```python
+def register_file_exchange_routes(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    source: ArtifactSource | None = None,
+    sink: ArtifactSink | None = None,
+    config: ServerConfig | None = None,
+) -> None: ...
+```
+
+Mounts the download `GET` route iff `source` is given, and the upload
+`PUT`/`POST` route iff `sink` is given — supporting download-only, upload-only,
+or both. This makes #145's `source` parameter optional (it was required); safe
+because no downstream has adopted the hooks yet (#148 threads them).
+`config` carries the operator size cap (`file_exchange_max_artifact_size`) the
+upload route needs to bound untrusted request bodies (§15); the download route
+ignores it. **Mounting the upload route requires `config`** — `sink` given
+without `config` raises `ValueError` at registration, since an upload route with
+no operator cap could accept an unbounded body. `UPLOAD_PREFIX` is a pvl-core
+route-shape constant (e.g. `/fx/u`), not a kwarg, not exported — mirroring
+`DOWNLOAD_PREFIX`.
+
+## Components (mirroring #145's provider/fetcher)
+
+### `upload_receiver_mint`
+
+```python
+async def upload_receiver_mint(
+    artifact_id: str,
+    *,
+    token_store: CapabilityTokenStore,
+    base_url: str,
+    ttl: float,
+    expected: ArtifactConstraints | None = None,
+    method: Literal["PUT", "POST"] = "PUT",
+) -> IntakeTicket: ...
+```
+
+- `minted = await token_store.mint({"artifact_id": artifact_id, "expected":
+  expected.model_dump() if expected else None}, ttl=ttl, single_use=True)`. The
+  token stores the `artifact_id` and the `expected` constraints so the route can
+  correlate received bytes and enforce limits; the token store treats the
+  metadata as opaque (#144).
+- `url = capability_url(base_url, UPLOAD_PREFIX, minted.token)`.
+- Returns `IntakeTicket(type=TICKET_TYPE, version=SPEC_VERSION,
+  artifactId=artifact_id, expected=expected, sinks=[UploadSink(transport="upload",
+  url=url, method=method, expiresAt=minted.expires_at)])`.
+
+Minting only — no hook is called, no bytes move (mirrors
+`filesystem_receiver_mint`). The receiver's `ArtifactSink` is threaded into the
+route (not into mint), since the bytes arrive at the route, not at mint time.
+
+### The upload route (`register_upload_route` → `PUT`/`POST <UPLOAD_PREFIX>/{token}`)
+
+Mounted via `@mcp.custom_route`. Handler (Starlette `Request` → `Response`):
+
+1. `rec = await token_store.lookup(token)`; if `None` → **`404`** (uniform for
+   unknown / expired / already-consumed — leaks no token state).
+2. Read `artifact_id` and `expected` (re-hydrated to `ArtifactConstraints`) from
+   `rec.metadata`.
+3. **`acceptMimeTypes` (RFC 7231 §3.1.1.1 media-range):** if `expected.acceptMimeTypes`
+   is set, match the request `Content-Type` (media type, parameters ignored)
+   against the list (`type/*` matches a subtype, `*/*` matches anything). No
+   match → **`415`** (no token consumed).
+4. **Stream the request body to a transient temp file** (`request.stream()` →
+   temp, hashing + counting via the shared staging helper). Enforce the byte
+   bound — reject with **`413`** (no consume) when the received count exceeds
+   either `expected.maxSize` or `config.file_exchange_max_artifact_size` (each
+   enforced when set), bounding consumption to the smaller cap + one chunk.
+5. **Verify-before-use:** after the body completes, verify `Content-Digest`
+   (RFC 9530) against the received bytes **if the header is present**; if
+   `expected.requireDigest` is set, a **missing** or **mismatched** digest →
+   **`400`** (`digest-mismatch`, §13). Uploaded bytes are untrusted, so this
+   happens **before** the sink sees them.
+6. Only on a clean verify, construct `meta = ArtifactMetadata(mimeType=<request
+   Content-Type>, size=<received>, digest="sha-256:<hex>")` and
+   `await sink.store_artifact(artifact_id, meta, <temp fd>)` — the same real sync
+   fd / temp-file async→sync bridge as the download fetcher.
+7. **Single-success-per-URL:** `await token_store.consume(token)` **only after a
+   successful store** (§10.3: at most one successful upload). A rejected upload
+   (415/413/400) or a sink failure never consumes, so the slot is not burned.
+8. Success → **`204`** (body-free). The temp file is deleted on every path.
+   Ambient credentials are ignored — the in-URL token is the only authorization.
+
+### `upload_sender_consume`
+
+```python
+async def upload_sender_consume(
+    sink: UploadSink,
+    source: ArtifactSource,
+    key: str,
+    *,
+    config: ServerConfig,
+) -> None: ...
+```
+
+Selection (`select_sink`) is the caller's step (consistent with `_filesystem`).
+The sender:
+
+- Opens `source.open_artifact(key) -> (stream, metadata)` and **stages the bytes
+  to a transient temp file** (single pass, hashing). Staging is required because
+  the hook stream is non-seekable and `Content-Digest` must be computed (hashed)
+  before it can be sent in the request header — a single-pass read can't both
+  hash-first and stream-from-the-hook.
+- Sends via `guarded_stream(sink.method, sink.url, config=config,
+  transport="upload", content=<async iterator over the temp file>,
+  headers={"Content-Type": metadata.mimeType (if known), "Content-Length":
+  <size>, "Content-Digest": "sha-256=:<base64>:"})`. The body streams from the
+  temp (not buffered in memory); the guard re-resolves/pins and strips ambient
+  credentials (#147).
+- Treats a non-2xx response as `FileExchangeTransferError(transfer-failed,
+  transport="upload")`; a guard refusal already arrives coded (`not-accessible`)
+  and propagates. The temp is deleted on every path.
+- **Deferred (per §10.3 SHOULD):** the sender does **not** pre-check
+  `acceptMimeTypes`. The receiver rejects a mismatch *before* consuming the
+  token, so a mismatch never burns the slot — the pre-check is only a round-trip
+  saving, and adding it would require threading `expected` into the sender. The
+  sender always sends `Content-Digest` (it stages+hashes anyway), which satisfies
+  `requireDigest` without needing `expected`.
+
+## §10.3 specifics
+
+- **`Content-Digest` (RFC 9530):** the wire header form is a Structured-Field
+  dictionary `algo=:base64:` (e.g. `sha-256=:<base64 of the raw digest>:`) —
+  **distinct** from the `ArtifactMetadata.digest` field's `sha-256:<hex>` form.
+  A small hand-rolled parse (receiver) and format (sender) for the
+  `sha-256/384/512` labels in `_HASHLIB_BY_LABEL` is sufficient; an unsupported
+  or unparseable `Content-Digest` is a verification failure (`digest-mismatch`),
+  never a silent skip (§15, mirroring `_digest_verifier`). The receiver verifies
+  the header in **its declared algorithm** (hashing the received bytes with that
+  algorithm) and separately records `ArtifactMetadata.digest` in pvl-core's
+  `sha-256:<hex>` form; when the sender used `sha-256` (pvl-core's sender always
+  does) a single hash serves both. The sender always sends a `sha-256`
+  `Content-Digest`, which satisfies any `requireDigest` that lists `sha-256`.
+- **HTTP status mapping** (pvl-core shape, not §13 — the route serves a possibly
+  non-MCP HTTP client): `204` success; `404` unknown/expired/consumed token;
+  `413` over the size bound; `415` `acceptMimeTypes` reject; `400`
+  digest-mismatch / missing-required-digest; hook failure → body-free `500`
+  (the sink's exception message may carry server detail — log locally, never
+  echo). `upload_sender_consume` raises the §13-coded `FileExchangeTransferError`.
+
+## #146 ↔ #148 boundary
+
+#146 ships the three primitives + the route registrars. #148 builds the shared
+token store, threads `source`/`sink`/`config` into `register_file_exchange_routes`,
+registers the routes on the server, exposes the umbrella, and wires the §14 Tasks
+path (large-artifact transfers). Same boundary as #145.
+
+## Error handling
+
+- `upload_sender_consume`: guard refusals arrive as
+  `FileExchangeTransferError(not-accessible, transport="upload")` and propagate;
+  a non-2xx response or any other failure maps to `transfer-failed`; the temp is
+  removed on every path (`finally`), with the temp-IO `OSError` contract from
+  #145 (map to `transfer-failed`, suppress cleanup-close).
+- `upload_receiver_mint` is an offering-side op (§16): a token-store failure
+  during minting propagates unwrapped to the offering tool's handler (matching
+  `filesystem_receiver_mint` / `download_provider_mint`).
+- The route maps failures to HTTP status (above); a hook/store failure mid-deposit
+  does **not** consume the token, so the sender can retry or re-request a ticket.
+
+## Testing (`tests/_file_exchange/test_upload.py`, plus an e2e module)
+
+Unit:
+
+1. `upload_receiver_mint` — returns an `IntakeTicket` with one `UploadSink`
+   whose `url` is `capability_url(base_url, UPLOAD_PREFIX, token)`, `method`
+   threads through, `expiresAt` is the minted (clamped) expiry; the token stores
+   `{"artifact_id", "expected"}`; `expected` round-trips onto the ticket.
+2. Route (via `httpx.ASGITransport` on `mcp.http_app()`): unknown/expired/consumed
+   token → `404`; happy `PUT` deposits the bytes into the sink and consumes the
+   token (second `PUT` → `404`); over `maxSize`/cap → `413` (no consume); a
+   `Content-Type` not in `acceptMimeTypes` → `415` (no consume); a valid
+   `Content-Digest` verifies; a mismatched `Content-Digest` → `400` and the sink
+   is **not** called (verify-before-use); `requireDigest` with a missing header →
+   `400`; ambient `Authorization`/`Cookie` ignored; the temp file is gone after
+   every outcome.
+3. `upload_sender_consume` — happy path stages and `PUT`s with `Content-Type` /
+   `Content-Length` / `Content-Digest` headers asserted (mock `guarded_stream`);
+   a non-2xx response → `transfer-failed`; a guard refusal → `not-accessible`;
+   the temp file is gone after every outcome.
+
+End-to-end (`test_upload_e2e.py`): two pvl-core-built mock servers. Server B
+(receiver) mints via `upload_receiver_mint` and serves via the upload route
+mounted on a real ASGI app; server A (sender) selects the `upload` sink and runs
+`upload_sender_consume` against B's route through `guarded_stream` (pointed at
+B's app) — bytes land in B's `ArtifactSink`, correlated to `artifactId`, with the
+`Content-Digest` verified. Upload transport only.
+
+Namespace re-export: each new public name reachable via
+`fastmcp_pvl_core.file_exchange`.
+
+## Public surface
+
+Re-exported via `file_exchange.py` and the subpackage `__init__.py` (both
+`__all__`s updated, alphabetical), transport-qualified beside the `filesystem_*`
+and `download_*` ops:
+
+- `upload_receiver_mint`, `upload_sender_consume` — the two role ops.
+- `register_file_exchange_routes` — unchanged public name (now from `_routes`),
+  with the added optional `sink` and now-optional `source`.
+
+`UPLOAD_PREFIX` is a module constant (pvl-core route shape) — not re-exported, not
+configurable. `FileExchangeTransferError`, `UploadSink`, `IntakeTicket`,
+`ArtifactConstraints`, `CapabilityTokenStore`, `capability_url`,
+`ArtifactSource`/`ArtifactSink`, `guarded_stream` are reused, not re-declared.
+
+## References
+
+- EPIC #138 (adopt mcp-file-exchange-ext v0.1); this is 8/10. Depends on #144
+  (token store — merged), #147 (SSRF guard — merged), #142 (hooks — merged).
+  Mirror of #145 (download data plane — merged).
+- #148 (top-level `register_file_exchange_*` helpers + Tasks integration +
+  adoption docs) — threads `source`/`sink`/`config` and exposes the umbrella.
+- Wire spec (`mcp-file-exchange-ext`, pinned commit `5f50a4e…`): §7.4
+  (`IntakeTicket`), §8.2 (push flow), §10.3 (`upload` transport obligations —
+  receiver single-success/digest/constraints, sender method/Content-Digest/
+  no-ambient-creds, RFC 7231 media-range, RFC 9530 `Content-Digest`), §12
+  (capability URLs), §13 (error codes), §15 (security — integrity, untrusted
+  bytes, resource exhaustion). This document is **not** a wire spec.
+- `CLAUDE.md` — route structure is a pvl-core shape decision (constant, not
+  kwarg); URL/credential-redaction discipline; the temp-IO error contract and
+  verify-before-use carried over from #145.

--- a/src/fastmcp_pvl_core/_file_exchange/__init__.py
+++ b/src/fastmcp_pvl_core/_file_exchange/__init__.py
@@ -19,7 +19,6 @@ from fastmcp_pvl_core._file_exchange._codes import (
 from fastmcp_pvl_core._file_exchange._download import (
     download_fetcher_consume,
     download_provider_mint,
-    register_file_exchange_routes,
 )
 from fastmcp_pvl_core._file_exchange._errors import (
     FileExchangeTransferError,
@@ -44,6 +43,7 @@ from fastmcp_pvl_core._file_exchange._paths import (
     load_volume_map,
     resolve_filesystem_uri,
 )
+from fastmcp_pvl_core._file_exchange._routes import register_file_exchange_routes
 from fastmcp_pvl_core._file_exchange._selection import (
     select_sink,
     select_source,

--- a/src/fastmcp_pvl_core/_file_exchange/__init__.py
+++ b/src/fastmcp_pvl_core/_file_exchange/__init__.py
@@ -67,6 +67,10 @@ from fastmcp_pvl_core._file_exchange._tokens import (
     build_capability_token_store,
     capability_url,
 )
+from fastmcp_pvl_core._file_exchange._upload import (
+    upload_receiver_mint,
+    upload_sender_consume,
+)
 from fastmcp_pvl_core._file_exchange._validation import (
     WireFormatError,
     validate_wire,
@@ -140,5 +144,7 @@ __all__ = [
     "resolve_filesystem_uri",
     "select_sink",
     "select_source",
+    "upload_receiver_mint",
+    "upload_sender_consume",
     "validate_wire",
 ]

--- a/src/fastmcp_pvl_core/_file_exchange/_download.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_download.py
@@ -19,12 +19,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import hashlib
 import logging
 import os
 import tempfile
 from collections.abc import AsyncGenerator
-from typing import IO, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import httpx
 from starlette.responses import Response, StreamingResponse
@@ -33,6 +32,12 @@ from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
 from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
 from fastmcp_pvl_core._file_exchange._outbound import guarded_stream
 from fastmcp_pvl_core._file_exchange._spec import HANDLE_TYPE, SPEC_VERSION
+from fastmcp_pvl_core._file_exchange._staging import (
+    _CHUNK,
+    _HASHLIB_BY_LABEL,  # noqa: F401 — re-exported for tests that reference _download._HASHLIB_BY_LABEL
+    _digest_verifier,
+    _write_chunk,
+)
 from fastmcp_pvl_core._file_exchange._tokens import capability_url
 from fastmcp_pvl_core._file_exchange._wire import DownloadSource, TransferHandle
 
@@ -51,10 +56,6 @@ logger = logging.getLogger(__name__)
 # kwarg — route structure is a pvl-core shape decision.
 DOWNLOAD_PREFIX = "/fx/d"
 
-_CHUNK = 1024 * 1024
-# Declared-digest label -> hashlib name; an unsupported label fails verification
-# (cannot verify -> digest-mismatch), never silently skips. Mirrors _filesystem.
-_HASHLIB_BY_LABEL = {"sha-256": "sha256", "sha-384": "sha384", "sha-512": "sha512"}
 # Max mid-stream reconnects before giving up on a dropped download.
 _MAX_RECONNECTS = 5
 
@@ -91,33 +92,6 @@ async def download_provider_mint(
             )
         ],
     )
-
-
-def _digest_verifier(
-    declared: str | None,
-) -> tuple[hashlib._Hash | None, str | None, bool]:
-    """Return (hasher | None, expected_hex | None, unverifiable).
-
-    ``unverifiable`` is True when a digest is declared with an unsupported label
-    — verification must then fail (cannot verify), never silently skip (§15).
-    """
-    if declared is None:
-        return None, None, False
-    label, _, expected_hex = declared.partition(":")
-    name = _HASHLIB_BY_LABEL.get(label.lower())
-    if name is None:
-        return None, expected_hex, True
-    return hashlib.new(name), expected_hex.lower(), False
-
-
-def _write_chunk(tmp: IO[bytes], hasher: hashlib._Hash | None, chunk: bytes) -> None:
-    """Write a body chunk to the temp file and fold it into the running hash.
-
-    Both ops run off the event loop in a single ``asyncio.to_thread`` dispatch.
-    """
-    tmp.write(chunk)
-    if hasher is not None:
-        hasher.update(chunk)
 
 
 async def download_fetcher_consume(
@@ -346,7 +320,7 @@ def _parse_range(header: str | None, size: int | None) -> tuple[int, int | None]
     return start, end
 
 
-def register_file_exchange_routes(
+def register_download_route(
     mcp: FastMCP,
     *,
     token_store: CapabilityTokenStore,

--- a/src/fastmcp_pvl_core/_file_exchange/_filesystem.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_filesystem.py
@@ -34,6 +34,7 @@ from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
 from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
 from fastmcp_pvl_core._file_exchange._paths import atomic_write, resolve_filesystem_uri
 from fastmcp_pvl_core._file_exchange._spec import HANDLE_TYPE, SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._staging import _CHUNK, _HASHLIB_BY_LABEL
 from fastmcp_pvl_core._file_exchange._wire import (
     FilesystemSink,
     FilesystemSource,
@@ -87,12 +88,6 @@ _DIGEST_LABEL = "sha-256"
 # Fixed deposit/staged-file mode (#155): owner rw, group rw, other r — so a
 # different-uid party on a shared volume can read what pvl-core writes.
 _DEPOSIT_MODE = 0o664
-
-# Verifier maps a declared `<label>:` to a hashlib name; an unsupported label
-# fails verification (cannot verify -> digest-mismatch), never silently skips.
-_HASHLIB_BY_LABEL = {"sha-256": "sha256", "sha-384": "sha384", "sha-512": "sha512"}
-
-_CHUNK = 1024 * 1024
 
 logger = logging.getLogger(__name__)
 

--- a/src/fastmcp_pvl_core/_file_exchange/_hooks.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_hooks.py
@@ -58,5 +58,14 @@ class ArtifactSink(Protocol):
         as the sink reads); the sink reads but does **not** close it, and
         MUST NOT assume the stream's concrete type. Return ``None`` on
         success; raise on failure.
+
+        **Ownership contract:** the caller closes ``stream`` and MAY delete
+        its backing storage immediately after this method returns, so the
+        sink MUST finish reading before returning. The sink may read on the
+        event loop or off-load reads to a thread, but MUST NOT retain the
+        handle for deferred reads after return. (The upload route's outer
+        temp-file ``os.unlink`` relies on this contract — a sink that keeps
+        the handle open may see the file disappear under it on POSIX, or
+        cause an access error on Windows.)
         """
         ...

--- a/src/fastmcp_pvl_core/_file_exchange/_routes.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_routes.py
@@ -63,4 +63,5 @@ def register_file_exchange_routes(
     if sink is not None:
         from fastmcp_pvl_core._file_exchange._upload import register_upload_route
 
+        assert config is not None  # validated above; assertion narrows type for mypy
         register_upload_route(mcp, token_store=token_store, sink=sink, config=config)

--- a/src/fastmcp_pvl_core/_file_exchange/_routes.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_routes.py
@@ -1,0 +1,66 @@
+"""Cross-transport FastMCP route registration for the file-exchange HTTP transports.
+
+``register_file_exchange_routes`` mounts the ``download`` GET route (when a
+``source`` hook is given) and the ``upload`` PUT/POST route (when a ``sink``
+hook is given). Each transport's registrar lives in its own leaf module
+(``_download``/``_upload``); this module is the single public entry point
+#148 threads ``token_store``/``source``/``sink``/``config`` into.
+
+Validation is all-or-nothing: ALL preconditions are checked BEFORE any route
+is mounted so a misconfigured call never partially mounts routes.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastmcp_pvl_core._file_exchange._download import register_download_route
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+
+
+def register_file_exchange_routes(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    source: ArtifactSource | None = None,
+    sink: ArtifactSink | None = None,
+    config: ServerConfig | None = None,
+) -> None:
+    """Mount the file-exchange HTTP routes on ``mcp``.
+
+    Mounts the ``download`` GET route iff ``source`` is given, and the
+    ``upload`` PUT/POST route iff ``sink`` is given. Supports
+    download-only (``source`` only), upload-only (``sink`` + ``config``
+    only), or both. At least one of ``source`` / ``sink`` MUST be given.
+    Mounting the upload route requires ``config`` (for the operator size
+    cap — an upload route with no cap could accept an unbounded body).
+
+    All preconditions are validated BEFORE any route is mounted: a
+    misconfigured call never partially registers routes.
+
+    ``token_store``/``source``/``sink``/``config`` are threaded by #148.
+    """
+    # Validate all preconditions atomically before touching mcp.
+    if source is None and sink is None:
+        raise ValueError(
+            "register_file_exchange_routes: at least one of `source` or `sink` "
+            "must be provided"
+        )
+    if sink is not None and config is None:
+        raise ValueError(
+            "register_file_exchange_routes: mounting the upload route "
+            "requires `config` for the operator size cap"
+        )
+
+    if source is not None:
+        register_download_route(mcp, token_store=token_store, source=source)
+    if sink is not None:
+        from fastmcp_pvl_core._file_exchange._upload import register_upload_route
+
+        register_upload_route(mcp, token_store=token_store, sink=sink, config=config)

--- a/src/fastmcp_pvl_core/_file_exchange/_routes.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_routes.py
@@ -12,7 +12,7 @@ is mounted so a misconfigured call never partially mounts routes.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from fastmcp_pvl_core._file_exchange._download import register_download_route
 
@@ -63,5 +63,10 @@ def register_file_exchange_routes(
     if sink is not None:
         from fastmcp_pvl_core._file_exchange._upload import register_upload_route
 
-        assert config is not None  # validated above; assertion narrows type for mypy
-        register_upload_route(mcp, token_store=token_store, sink=sink, config=config)
+        # config is validated above; cast survives `python -O` (unlike assert).
+        register_upload_route(
+            mcp,
+            token_store=token_store,
+            sink=sink,
+            config=cast("ServerConfig", config),
+        )

--- a/src/fastmcp_pvl_core/_file_exchange/_staging.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_staging.py
@@ -1,0 +1,72 @@
+"""Shared temp-file staging + digest primitives for the HTTP transports.
+
+The download fetcher (#145) and the upload route/sender (#146) both buffer a
+byte stream to a transient temp file with hashing and a size bound, and verify
+a declared digest. These primitives factor out the common parts.
+
+**Universal items** (used by both HTTP transports and by ``_filesystem.py``):
+
+- ``_CHUNK`` — streaming chunk size (1 MiB), the I/O unit for all temp-staging
+  loops.
+- ``_HASHLIB_BY_LABEL`` — the supported ``sha-256``/``sha-384``/``sha-512``
+  label set; an unsupported label fails verification, never silently skips (§15).
+
+**Download + upload transport items** (HTTP-specific):
+
+- ``_digest_verifier`` — used by the download fetcher to parse
+  ``ArtifactMetadata.digest`` and by the upload route to hash received bytes;
+  also called by ``_filesystem.py``'s verification path.
+- ``_write_chunk`` — used by both HTTP-transport staging loops (single
+  ``asyncio.to_thread`` dispatch to write+hash a chunk); NOT used by the
+  filesystem transport (which goes through ``shutil.copyfileobj`` in
+  ``atomic_write``).
+
+Each transport keeps its own read loop (download resumes via ``Range``; upload
+reads ``request.stream()`` or a hook stream) and applies the
+``OSError -> transfer-failed`` mapping / cleanup-suppression contract around
+these shared primitives.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import IO
+
+# Streaming chunk size for temp-file staging (1 MiB). Universal — applies to
+# all transports that buffer bytes in a staging loop.
+_CHUNK = 1024 * 1024
+
+# Declared-digest label -> hashlib name; an unsupported label fails verification
+# (cannot verify -> digest-mismatch), never silently skips (§15). Mirrors the
+# same set in _filesystem.py; both must be kept in sync with the wire spec's
+# supported-digest section.
+_HASHLIB_BY_LABEL = {"sha-256": "sha256", "sha-384": "sha384", "sha-512": "sha512"}
+
+
+def _digest_verifier(
+    declared: str | None,
+) -> tuple[hashlib._Hash | None, str | None, bool]:
+    """Return (hasher | None, expected_hex | None, unverifiable).
+
+    ``unverifiable`` is True when a digest is declared with an unsupported label
+    — verification must then fail (cannot verify), never silently skip (§15).
+    """
+    if declared is None:
+        return None, None, False
+    label, _, expected_hex = declared.partition(":")
+    name = _HASHLIB_BY_LABEL.get(label.lower())
+    if name is None:
+        return None, expected_hex, True
+    return hashlib.new(name), expected_hex.lower(), False
+
+
+def _write_chunk(tmp: IO[bytes], hasher: hashlib._Hash | None, chunk: bytes) -> None:
+    """Write a body chunk to the temp file and fold it into the running hash.
+
+    Both ops run off the event loop in a single ``asyncio.to_thread`` dispatch.
+    HTTP-transport only — the filesystem transport uses ``shutil.copyfileobj``
+    via ``atomic_write``.
+    """
+    tmp.write(chunk)
+    if hasher is not None:
+        hasher.update(chunk)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -311,6 +311,8 @@ def register_upload_route(
             try:
                 tmp = os.fdopen(fd, "wb")
             except OSError:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
                 logger.exception("file-exchange: upload fdopen failed")
                 return Response(status_code=500)
             except BaseException:
@@ -504,9 +506,25 @@ async def upload_sender_consume(
         )
 
     # Stage: open the source hook and write bytes to a temp file, hashing as we go.
+    # Open the source hook FIRST (B1 — wrap hook failures as TRANSFER_FAILED).
+    # Acquiring this before the temp file means a hook failure leaks nothing.
+    try:
+        stream, meta = await source.open_artifact(key)
+    except FileExchangeTransferError:
+        raise
+    except Exception as exc:
+        raise FileExchangeTransferError(
+            TransferErrorCode.TRANSFER_FAILED,
+            transport="upload",
+            detail="failed to open the artifact source",
+        ) from exc
+
+    # Now create the temp file. On failure, close the hook stream we just got.
     try:
         fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-send-")
     except OSError as exc:
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(stream.close)
         raise FileExchangeTransferError(
             TransferErrorCode.TRANSFER_FAILED,
             transport="upload",
@@ -514,12 +532,15 @@ async def upload_sender_consume(
         ) from exc
 
     try:
-        # Open the fd; guard against fd leak on BaseException (A2).
+        # Open the fd; guard against fd leak on OSError AND BaseException (A2).
+        # On both failure paths, close both the fd and the hook stream.
         try:
             tmp = os.fdopen(fd, "wb")
         except OSError as exc:
             with contextlib.suppress(OSError):
                 os.close(fd)
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(stream.close)
             raise FileExchangeTransferError(
                 TransferErrorCode.TRANSFER_FAILED,
                 transport="upload",
@@ -528,19 +549,9 @@ async def upload_sender_consume(
         except BaseException:
             with contextlib.suppress(OSError):
                 os.close(fd)
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(stream.close)
             raise
-
-        # Open the source hook (B1 — wrap hook failures as TRANSFER_FAILED).
-        try:
-            stream, meta = await source.open_artifact(key)
-        except FileExchangeTransferError:
-            raise
-        except Exception as exc:
-            raise FileExchangeTransferError(
-                TransferErrorCode.TRANSFER_FAILED,
-                transport="upload",
-                detail="failed to open the artifact source",
-            ) from exc
 
         hasher = hashlib.new(_HASHLIB_BY_LABEL[digest_algo])
         size = 0

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -1,0 +1,650 @@
+"""The ``upload`` transport data plane (#146).
+
+Two role helpers (receiver, sender — ``upload`` is push-only) plus a serving
+route, mirroring ``_download.py``. The receiver mints a capability URL backed
+by the #144 token store; the upload ``PUT``/``POST`` route accepts the artifact
+bytes, streams them to a transient temp file (hashing + size-bounded), verifies
+the ``Content-Digest`` (RFC 9530) and constraints **before** the sink sees the
+bytes (verify-before-use, §15), deposits them through the #142
+``ArtifactSink``, and consumes the single-use token only on a successful store.
+The sender stages the source bytes to a temp (hashing in a single pass), then
+pushes through the #147 ``guarded_stream`` with ``Content-Digest``. See
+``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``.
+
+``UPLOAD_PREFIX`` is a pvl-core route-shape constant, not a kwarg and not
+exported — route structure is a pvl-core shape decision (``CLAUDE.md``).
+
+Concurrency note: ``single-use`` means the first successful store burns the
+token (§10.3), not a concurrency lock. Two concurrent PUTs begun before either
+completes can both pass verification and reach ``store_artifact`` before one
+``consume`` wins. The ``ArtifactSink`` MUST therefore tolerate duplicate
+``store_artifact`` calls for the same ``artifact_id`` within the token's TTL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import hashlib
+import hmac
+import logging
+import os
+import tempfile
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Literal
+
+import httpx
+from starlette.responses import Response
+
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+from fastmcp_pvl_core._file_exchange._outbound import guarded_stream
+from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._staging import (
+    _CHUNK,
+    _HASHLIB_BY_LABEL,
+    _write_chunk,
+)
+from fastmcp_pvl_core._file_exchange._tokens import capability_url
+from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints, UploadSink
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from starlette.requests import Request
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+    from fastmcp_pvl_core._file_exchange._wire import IntakeTicket
+
+logger = logging.getLogger(__name__)
+
+# pvl-core's upload route shape (§12 capability URL path). A constant, not a
+# kwarg — route structure is a pvl-core shape decision.  Not re-exported.
+UPLOAD_PREFIX = "/fx/u"
+
+# pvl-core always sends (and prefers) sha-256. The supported set is inherited
+# from _HASHLIB_BY_LABEL; this is just the default.
+_DEFAULT_DIGEST_LABEL = "sha-256"
+
+
+# ---------------------------------------------------------------------------
+# RFC 9530 Content-Digest helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_content_digest(algo: str, raw_digest: bytes) -> str:
+    """Format a raw digest as an RFC 9530 Structured-Field member.
+
+    Returns e.g. ``sha-256=:<base64>:``. ``algo`` must be a key in
+    ``_HASHLIB_BY_LABEL``; callers are responsible for validation.
+    """
+    return f"{algo}=:{base64.b64encode(raw_digest).decode()}:"
+
+
+def _parse_content_digest(header: str | None) -> tuple[str, bytes] | None:
+    """Parse the first supported member of a ``Content-Digest`` header.
+
+    Implements first-supported-member semantics (§15): iterates members in
+    order; the first member whose algorithm is in ``_HASHLIB_BY_LABEL`` is
+    returned as ``(label, raw_bytes)``. An unsupported algorithm member is
+    skipped (a later supported member can still win). A supported-but-malformed
+    member returns ``None`` immediately — it does NOT fall through to a later
+    member (§15 "never silently skip a supported digest").
+
+    RFC 8941 member parameters (e.g. ``sha-256;foo=bar=:...:`` are stripped
+    before processing.
+
+    Returns ``None`` when the header is absent, when no supported member is
+    present, or when a supported member is malformed or carries an empty
+    digest.
+    """
+    if header is None:
+        return None
+    for raw_member in header.split(","):
+        raw_member = raw_member.strip()
+        if not raw_member:
+            continue
+        # Strip RFC 8941 member parameters (e.g. `;foo=bar`) before the value.
+        # The parameter separator appears after the key= but before the value :...:
+        # e.g. "sha-256;params=:b64:". Split on ";" to isolate any params, then
+        # re-join key= with the value portion.
+        algo_part, _, rest = raw_member.partition("=")
+        algo_part = algo_part.strip()
+        if not algo_part:
+            continue
+        # Strip any RFC 8941 parameters from the algo name (e.g. algo;p=1)
+        algo_label = algo_part.split(";", 1)[0].strip()
+        # Strip RFC 8941 parameters from the value portion before the colon-wrap.
+        value_raw = rest.strip()
+        value = value_raw.split(";", 1)[0].strip() if ";" in value_raw else value_raw
+        if algo_label.lower() not in _HASHLIB_BY_LABEL:
+            # Unsupported algorithm — skip; a later supported member may win.
+            continue
+        # Supported algorithm found. If malformed, return None immediately
+        # (never fall through to a later member per §15).
+        if not value.startswith(":") or not value.endswith(":"):
+            return None  # supported but malformed — no fall-through
+        inner = value[1:-1]
+        # length guard: "::" is a 2-char string that decodes to b"" (empty digest).
+        if len(value) <= 2:
+            return None  # empty digest — reject
+        try:
+            raw_bytes = base64.b64decode(inner, validate=True)
+        except Exception:
+            return None
+        if not raw_bytes:
+            return None  # decoded to empty — reject
+        return algo_label.lower(), raw_bytes
+    return None
+
+
+def _media_type_accepted(
+    content_type: str | None, accept_mime_types: list[str]
+) -> bool:
+    """Return True iff ``content_type`` matches any pattern in ``accept_mime_types``.
+
+    Applies RFC 7231 §3.1.1.1 media-range matching: parameters are stripped,
+    ``type/*`` matches any subtype of ``type``, ``*/*`` matches anything.
+    A missing (``None``) ``content_type`` is treated as no match.
+    """
+    if content_type is None:
+        return False
+    # Strip parameters: "text/plain; charset=utf-8" -> "text/plain"
+    media = content_type.split(";", 1)[0].strip().lower()
+    if not media or "/" not in media:
+        return False
+    req_type, _, req_subtype = media.partition("/")
+    for pattern in accept_mime_types:
+        pattern = pattern.strip().lower()
+        if pattern == "*/*":
+            return True
+        pat_type, _, pat_sub = pattern.partition("/")
+        if pat_type == req_type and (pat_sub == "*" or pat_sub == req_subtype):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# upload_receiver_mint
+# ---------------------------------------------------------------------------
+
+
+async def upload_receiver_mint(
+    artifact_id: str,
+    *,
+    token_store: CapabilityTokenStore,
+    base_url: str,
+    ttl: float,
+    expected: ArtifactConstraints | None = None,
+    method: Literal["PUT", "POST"] = "PUT",
+) -> IntakeTicket:
+    """Receiver role (push): mint an upload capability token and emit an IntakeTicket.
+
+    Minting only — no hook is called and no bytes move (mirrors
+    ``filesystem_receiver_mint``). The ``ArtifactSink`` is threaded into the
+    route (not into mint), since bytes arrive at the route, not at mint time.
+
+    The token stores ``{"artifact_id": artifact_id, "expected": ...}`` so
+    the route can correlate received bytes and enforce constraints. The token
+    store treats the metadata as opaque (#144).
+
+    ``base_url`` must be an ``https://`` origin (§12). ``ttl`` is clamped by
+    the token store's ceiling. A token-store failure propagates unwrapped
+    (offering-side op, per §16 — same as ``download_provider_mint``).
+    """
+    from fastmcp_pvl_core._file_exchange._wire import IntakeTicket
+
+    minted = await token_store.mint(
+        {
+            "artifact_id": artifact_id,
+            "expected": expected.model_dump() if expected is not None else None,
+        },
+        ttl=ttl,
+        single_use=True,
+    )
+    url = capability_url(base_url, UPLOAD_PREFIX, minted.token)
+    return IntakeTicket(
+        type=TICKET_TYPE,
+        version=SPEC_VERSION,
+        artifactId=artifact_id,
+        expected=expected,
+        sinks=[
+            UploadSink(
+                transport="upload",
+                url=url,
+                method=method,
+                expiresAt=minted.expires_at,
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# register_upload_route
+# ---------------------------------------------------------------------------
+
+
+def register_upload_route(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    sink: ArtifactSink,
+    config: ServerConfig,
+) -> None:
+    """Mount the ``upload`` PUT/POST route on ``mcp`` (serves §12 capability URLs).
+
+    ``PUT``/``POST <UPLOAD_PREFIX>/{token}`` looks the token up in
+    ``token_store``, streams the request body to a transient temp file
+    (hashing + size-bounded), verifies ``Content-Digest`` (RFC 9530) and
+    ``expected`` constraints **before** calling ``sink.store_artifact``
+    (verify-before-use, §15), and consumes the single-use token only on
+    a successful store (§10.3). Ambient credentials are ignored — the
+    in-URL token is the only authorization.
+
+    ``single-use`` means the first successful store burns the token
+    (§10.3), not a concurrency lock: two concurrent PUTs begun before
+    either completes can both pass verification and reach ``store_artifact``
+    before one ``consume`` wins. The ``ArtifactSink`` MUST therefore
+    tolerate duplicate ``store_artifact`` calls for the same ``artifact_id``
+    within the token's TTL window.
+
+    First-supported-member semantics for ``Content-Digest``: a sender that
+    includes multiple members MUST place a required algorithm first.
+    """
+    size_cap = config.file_exchange_max_artifact_size
+
+    @mcp.custom_route(f"{UPLOAD_PREFIX}/{{token}}", methods=["PUT", "POST"])
+    async def _handle_upload(request: Request) -> Response:
+        token = request.path_params["token"]
+
+        # Step 1: look up token — 404 for unknown/expired/consumed (leaks no state).
+        rec = await token_store.lookup(token)
+        if rec is None:
+            return Response(status_code=404)
+
+        # Step 2: re-hydrate metadata from the opaque token payload.
+        artifact_id: str = rec.metadata["artifact_id"]
+        expected_raw = rec.metadata.get("expected")
+        expected: ArtifactConstraints | None = (
+            ArtifactConstraints.model_validate(expected_raw)
+            if expected_raw is not None
+            else None
+        )
+
+        # Step 3: acceptMimeTypes check (RFC 7231 media-range) — 415, no consume.
+        if expected is not None and expected.acceptMimeTypes:
+            if not _media_type_accepted(
+                request.headers.get("content-type"),
+                expected.acceptMimeTypes,
+            ):
+                return Response(status_code=415)
+
+        # Step 4: stream request body to temp file (hashing + size-bounded).
+        # Enforce the byte bound mid-stream: reject 413 when received count
+        # exceeds min(expected.maxSize, config cap) — whichever is set.
+        ticket_cap: int | None = expected.maxSize if expected is not None else None
+        effective_cap: int | None = None
+        if size_cap is not None and ticket_cap is not None:
+            effective_cap = min(size_cap, ticket_cap)
+        elif size_cap is not None:
+            effective_cap = size_cap
+        elif ticket_cap is not None:
+            effective_cap = ticket_cap
+
+        # Determine which digest algorithm the sender is expected to use.
+        # We hash with sha-256 always (for ArtifactMetadata.digest) AND with
+        # whatever algo the Content-Digest declares (for verification).
+        # If the sender used sha-256, a single hasher serves both purposes.
+        sha256_hasher = hashlib.new("sha256")
+
+        try:
+            fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-")
+        except OSError:
+            logger.exception("file-exchange: upload failed to create temp file")
+            return Response(status_code=500)
+
+        tmp_path_to_clean: str | None = tmp_path
+        try:
+            # Open the fd; guard against fd leak on BaseException (A2).
+            try:
+                tmp = os.fdopen(fd, "wb")
+            except OSError:
+                logger.exception("file-exchange: upload fdopen failed")
+                return Response(status_code=500)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                raise
+
+            received = 0
+            try:
+                # Stream body chunks; only _write_chunk and flush are wrapped
+                # in OSError (A3 — ClientDisconnect is non-OSError and propagates).
+                async for chunk in request.stream():
+                    if not chunk:
+                        continue
+                    received += len(chunk)
+                    if effective_cap is not None and received > effective_cap:
+                        # Close the temp before returning 413 (the outer finally
+                        # will unlink; close here so the file handle is freed).
+                        with contextlib.suppress(OSError):
+                            await asyncio.to_thread(tmp.close)
+                        return Response(status_code=413)
+                    try:
+                        await asyncio.to_thread(_write_chunk, tmp, sha256_hasher, chunk)
+                    except OSError:
+                        logger.exception("file-exchange: upload temp write failed")
+                        with contextlib.suppress(OSError):
+                            await asyncio.to_thread(tmp.close)
+                        return Response(status_code=500)
+                try:
+                    await asyncio.to_thread(tmp.flush)
+                except OSError:
+                    logger.exception("file-exchange: upload temp flush failed")
+                    with contextlib.suppress(OSError):
+                        await asyncio.to_thread(tmp.close)
+                    return Response(status_code=500)
+            finally:
+                # Suppress close failure so it can't replace an in-flight error.
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(tmp.close)
+
+            # Step 5: verify-before-use — check Content-Digest and requireDigest.
+            cd = _parse_content_digest(request.headers.get("content-digest"))
+
+            # Determine which algorithms are required (G1).
+            required_algos: set[str] | None = None
+            if expected is not None and expected.requireDigest:
+                required_algos = {a.lower() for a in expected.requireDigest}
+
+            if cd is None and required_algos is not None:
+                # Digest is required but absent.
+                return Response(status_code=400)
+            if (
+                cd is not None
+                and required_algos is not None
+                and cd[0] not in required_algos
+            ):
+                # Digest present but wrong algorithm (G1).
+                return Response(status_code=400)
+
+            if cd is not None:
+                # Verify the digest with the declared algorithm.
+                algo_label, declared_raw = cd
+                if algo_label == "sha-256":
+                    # Re-use the already-computed sha-256 hash.
+                    verify_hasher: hashlib._Hash = sha256_hasher
+                else:
+                    # Need a fresh hasher for a different algo — re-read the temp.
+                    verify_hasher = hashlib.new(_HASHLIB_BY_LABEL[algo_label])
+                    try:
+                        f_verify = await asyncio.to_thread(open, tmp_path, "rb")
+                    except OSError:
+                        logger.exception(
+                            "file-exchange: upload cannot re-open temp for verification"
+                        )
+                        return Response(status_code=500)
+                    try:
+                        while True:
+                            vchunk = await asyncio.to_thread(f_verify.read, _CHUNK)
+                            if not vchunk:
+                                break
+                            verify_hasher.update(vchunk)
+                    finally:
+                        with contextlib.suppress(OSError):
+                            await asyncio.to_thread(f_verify.close)
+
+                computed = verify_hasher.digest()
+                # Constant-time comparison with length pre-check (E2).
+                if len(computed) != len(declared_raw) or not hmac.compare_digest(
+                    computed, declared_raw
+                ):
+                    return Response(status_code=400)
+
+            # Step 6: construct metadata and call sink.store_artifact.
+            from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+            content_type = request.headers.get("content-type")
+            # Strip parameters from mime type for the metadata field.
+            mime = content_type.split(";", 1)[0].strip() if content_type else None
+            sha256_hex = sha256_hasher.hexdigest()
+            meta = ArtifactMetadata(
+                mimeType=mime if mime else None,
+                size=received,
+                digest=f"sha-256:{sha256_hex}",
+            )
+
+            try:
+                ingest = await asyncio.to_thread(open, tmp_path, "rb")
+            except OSError:
+                logger.exception("file-exchange: upload cannot open temp for sink")
+                return Response(status_code=500)
+            try:
+                try:
+                    await sink.store_artifact(artifact_id, meta, ingest)
+                except Exception:
+                    # Sink failure — log locally, never echo. Token NOT consumed.
+                    logger.exception("file-exchange: upload sink store_artifact failed")
+                    return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(ingest.close)
+
+            # Step 7: consume the single-use token after successful store (M1).
+            try:
+                await token_store.consume(token)
+            except Exception:
+                # The bytes are stored; failing the request would mislead the client.
+                # Log with traceback (exception, not warning) and return 204 anyway.
+                logger.exception(
+                    "file-exchange: upload token consume failed after successful "
+                    "store; token may remain usable to TTL"
+                )
+
+            # Step 8: success — body-free 204.
+            return Response(status_code=204)
+
+        finally:
+            # Temp file is deleted on every path (success and all error paths).
+            if tmp_path_to_clean is not None:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(os.unlink, tmp_path_to_clean)
+
+
+# ---------------------------------------------------------------------------
+# upload_sender_consume
+# ---------------------------------------------------------------------------
+
+
+async def upload_sender_consume(
+    sink: UploadSink,
+    source: ArtifactSource,
+    key: str,
+    *,
+    config: ServerConfig,
+    digest_algo: str = _DEFAULT_DIGEST_LABEL,
+) -> None:
+    """Sender role (push): stage ``key``'s bytes and push to ``sink``.
+
+    Selection (``select_sink``) is the caller's step. Opens
+    ``source.open_artifact(key)`` and stages the bytes to a transient temp
+    file in a single pass (hashing with ``digest_algo``). Staging is
+    required because the hook stream is non-seekable and ``Content-Digest``
+    must be computed before the header is sent. Pushes via
+    ``guarded_stream`` (§147 SSRF guard) with ``Content-Type``,
+    ``Content-Length``, and ``Content-Digest`` headers. Strips ambient
+    credentials (guard handles that). Deletes the temp on every path.
+
+    Raises :class:`FileExchangeTransferError`:
+
+    - ``not-accessible`` — guard refusal (SSRF check, non-https, etc.).
+    - ``transfer-failed`` — any other failure (source hook, temp I/O,
+      non-2xx response, network error).
+
+    A non-2xx response is always ``transfer-failed`` — the route's
+    status codes are pvl-core shape, not §13 codes.
+
+    Args:
+        sink: the selected ``UploadSink`` descriptor (from ``select_sink``).
+        source: the ``ArtifactSource`` hook for this server.
+        key: opaque artifact key for ``source.open_artifact``.
+        config: server configuration (SSRF guard, timeout).
+        digest_algo: RFC 9530 label to use for ``Content-Digest``
+            (default ``sha-256``; must be in ``_HASHLIB_BY_LABEL``).
+
+    Raises:
+        ValueError: ``digest_algo`` is not in the supported set.
+    """
+    if digest_algo not in _HASHLIB_BY_LABEL:
+        raise ValueError(
+            f"upload_sender_consume: digest_algo {digest_algo!r} not in supported set "
+            f"{sorted(_HASHLIB_BY_LABEL)}"
+        )
+
+    # Stage: open the source hook and write bytes to a temp file, hashing as we go.
+    try:
+        fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-send-")
+    except OSError as exc:
+        raise FileExchangeTransferError(
+            TransferErrorCode.TRANSFER_FAILED,
+            transport="upload",
+            detail="failed to create a temporary staging file",
+        ) from exc
+
+    try:
+        # Open the fd; guard against fd leak on BaseException (A2).
+        try:
+            tmp = os.fdopen(fd, "wb")
+        except OSError as exc:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise FileExchangeTransferError(
+                TransferErrorCode.TRANSFER_FAILED,
+                transport="upload",
+                detail="failed to open the staging file",
+            ) from exc
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+
+        # Open the source hook (B1 — wrap hook failures as TRANSFER_FAILED).
+        try:
+            stream, meta = await source.open_artifact(key)
+        except FileExchangeTransferError:
+            raise
+        except Exception as exc:
+            raise FileExchangeTransferError(
+                TransferErrorCode.TRANSFER_FAILED,
+                transport="upload",
+                detail="failed to open the artifact source",
+            ) from exc
+
+        hasher = hashlib.new(_HASHLIB_BY_LABEL[digest_algo])
+        size = 0
+
+        try:
+            # Staging loop (A4): separate scopes for _write_chunk, flush, outer.
+            try:
+                while True:
+                    chunk = await asyncio.to_thread(stream.read, _CHUNK)
+                    if not chunk:
+                        break
+                    size += len(chunk)
+                    try:
+                        await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                    except OSError as exc:
+                        raise FileExchangeTransferError(
+                            TransferErrorCode.TRANSFER_FAILED,
+                            transport="upload",
+                            detail="failed to stage the artifact for upload",
+                        ) from exc
+                try:
+                    await asyncio.to_thread(tmp.flush)
+                except OSError as exc:
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.TRANSFER_FAILED,
+                        transport="upload",
+                        detail="failed to stage the artifact for upload",
+                    ) from exc
+            except FileExchangeTransferError:
+                raise  # re-raise without re-wrapping (A4 essential)
+            except Exception as exc:
+                raise FileExchangeTransferError(
+                    TransferErrorCode.TRANSFER_FAILED,
+                    transport="upload",
+                    detail="artifact source read failed",
+                ) from exc
+        finally:
+            # Suppress close failure so it can't replace an in-flight error (A1).
+            with contextlib.suppress(OSError):
+                await asyncio.to_thread(tmp.close)
+            # Also close the source stream.
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(stream.close)
+
+        # Build the headers for the upload request.
+        digest_header = _format_content_digest(digest_algo, hasher.digest())
+        req_headers: dict[str, str] = {
+            "Content-Length": str(size),
+            "Content-Digest": digest_header,
+        }
+        if meta.mimeType is not None:
+            req_headers["Content-Type"] = meta.mimeType
+
+        # Push via guarded_stream: stream from the temp file (not in memory).
+        # C1/C2: async generator, explicit aclose() in finally.
+        async def _content() -> AsyncGenerator[bytes, None]:
+            handle = await asyncio.to_thread(open, tmp_path, "rb")
+            try:
+                while True:
+                    chunk = await asyncio.to_thread(handle.read, _CHUNK)
+                    if not chunk:
+                        break
+                    yield chunk
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(handle.close)
+
+        content_gen = _content()
+        try:
+            # B2: catch both httpx.HTTPError and OSError around guarded_stream.
+            try:
+                async with guarded_stream(
+                    sink.method,
+                    sink.url,
+                    config=config,
+                    transport="upload",
+                    headers=req_headers,
+                    content=content_gen,
+                ) as resp:
+                    if not 200 <= resp.status < 300:
+                        raise FileExchangeTransferError(
+                            TransferErrorCode.TRANSFER_FAILED,
+                            transport="upload",
+                            detail="upload endpoint returned a non-success status",
+                        )
+            except FileExchangeTransferError:
+                raise
+            except httpx.HTTPError as exc:
+                raise FileExchangeTransferError(
+                    TransferErrorCode.TRANSFER_FAILED,
+                    transport="upload",
+                    detail="upload transfer failed due to a network error",
+                ) from exc
+            except OSError as exc:
+                raise FileExchangeTransferError(
+                    TransferErrorCode.TRANSFER_FAILED,
+                    transport="upload",
+                    detail="failed to read the staged artifact during upload",
+                ) from exc
+        finally:
+            with contextlib.suppress(Exception):
+                await content_gen.aclose()
+
+    finally:
+        # Temp is deleted on every path (success and all error paths).
+        with contextlib.suppress(OSError):
+            await asyncio.to_thread(os.unlink, tmp_path)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -354,9 +354,15 @@ def register_upload_route(
                     await asyncio.to_thread(tmp.close)
 
             # Step 5: verify-before-use — check Content-Digest and requireDigest.
-            cd = _parse_content_digest(request.headers.get("content-digest"))
+            cd_header = request.headers.get("content-digest")
+            cd = _parse_content_digest(cd_header)
 
-            # Determine which algorithms are required (G1).
+            # A present-but-unverifiable Content-Digest is a verification failure,
+            # never a silent skip (§15).
+            if cd_header is not None and cd is None:
+                return Response(status_code=400)
+
+            # Determine which algorithms are required.
             required_algos: set[str] | None = None
             if expected is not None and expected.requireDigest:
                 required_algos = {a.lower() for a in expected.requireDigest}
@@ -369,7 +375,7 @@ def register_upload_route(
                 and required_algos is not None
                 and cd[0] not in required_algos
             ):
-                # Digest present but wrong algorithm (G1).
+                # Digest present but wrong algorithm.
                 return Response(status_code=400)
 
             if cd is not None:
@@ -389,11 +395,15 @@ def register_upload_route(
                         )
                         return Response(status_code=500)
                     try:
-                        while True:
-                            vchunk = await asyncio.to_thread(f_verify.read, _CHUNK)
-                            if not vchunk:
-                                break
-                            verify_hasher.update(vchunk)
+                        try:
+                            while True:
+                                vchunk = await asyncio.to_thread(f_verify.read, _CHUNK)
+                                if not vchunk:
+                                    break
+                                verify_hasher.update(vchunk)
+                        except OSError:
+                            logger.exception("file-exchange: upload verify-read failed")
+                            return Response(status_code=500)
                     finally:
                         with contextlib.suppress(OSError):
                             await asyncio.to_thread(f_verify.close)

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -69,6 +69,8 @@ from fastmcp_pvl_core._file_exchange import (
     resolve_filesystem_uri,
     select_sink,
     select_source,
+    upload_receiver_mint,
+    upload_sender_consume,
     validate_wire,
 )
 
@@ -126,5 +128,7 @@ __all__ = [
     "resolve_filesystem_uri",
     "select_sink",
     "select_source",
+    "upload_receiver_mint",
+    "upload_sender_consume",
     "validate_wire",
 ]

--- a/tests/_file_exchange/test_download.py
+++ b/tests/_file_exchange/test_download.py
@@ -9,7 +9,7 @@ import pytest
 from fastmcp import FastMCP
 
 from fastmcp_pvl_core._config import ServerConfig
-from fastmcp_pvl_core._file_exchange import _download
+from fastmcp_pvl_core._file_exchange import _download, _routes
 from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
 from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
 from fastmcp_pvl_core._file_exchange._spec import HANDLE_TYPE, SPEC_VERSION
@@ -430,7 +430,7 @@ class _BytesSource:
 
 def _route_client(store, source):
     mcp = FastMCP("test")
-    _download.register_file_exchange_routes(mcp, token_store=store, source=source)
+    _routes.register_file_exchange_routes(mcp, token_store=store, source=source)
     app = mcp.http_app()
     return httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://route.test"

--- a/tests/_file_exchange/test_download_e2e.py
+++ b/tests/_file_exchange/test_download_e2e.py
@@ -15,7 +15,7 @@ import httpx
 from fastmcp import FastMCP
 
 from fastmcp_pvl_core._config import ServerConfig
-from fastmcp_pvl_core._file_exchange import _download
+from fastmcp_pvl_core._file_exchange import _download, _routes
 from fastmcp_pvl_core._file_exchange._selection import select_source
 from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
 from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
@@ -64,7 +64,7 @@ async def test_two_server_pull_download(monkeypatch):
     # Server A: provider mint + serving route on a real ASGI app.
     store = _store()
     mcp = FastMCP("provider")
-    _download.register_file_exchange_routes(
+    _routes.register_file_exchange_routes(
         mcp, token_store=store, source=_BytesSource("doc", body)
     )
     app_a = mcp.http_app()

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -1,0 +1,1153 @@
+"""Unit tests for the upload transport data plane (#146).
+
+Covers:
+1. upload_receiver_mint — IntakeTicket shape, token storage.
+2. Helper unit tests — _format_content_digest, _parse_content_digest,
+   _media_type_accepted.
+3. Route status matrix — 204 happy, 404 unknown/consumed, 413 oversize,
+   415 mime reject, 400 digest mismatch / missing required / wrong algo,
+   500 sink failure.
+4. Ambient credentials ignored.
+5. Non-sha256 digest verification through route (sha-384, sha-512).
+6. Consume failure after successful store still returns 204.
+7. Temp-file unlinked on every failure path.
+8. Flush/close failure paths.
+9. Sender tests — headers, omit Content-Type when mimeType is None,
+   non-2xx, guard refusal, hook non-OSError wrapped, non-sha-256 digest_algo,
+   unsupported digest_algo -> ValueError, sender temp file unlinked on non-2xx.
+10. register_file_exchange_routes validation — atomicity.
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import hashlib
+import io
+import os
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _routes, _upload
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints, UploadSink
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+def _cfg(*, max_size: int | None = None) -> ServerConfig:
+    return ServerConfig(file_exchange_max_artifact_size=max_size)
+
+
+class _CapturingSink:
+    """ArtifactSink that records the bytes it is given."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.artifact_ids: list[str | None] = []
+        self.deposited: bytes | None = None
+
+    async def store_artifact(self, artifact_id, metadata, stream) -> None:
+        self.calls += 1
+        self.artifact_ids.append(artifact_id)
+        self.deposited = stream.read()
+
+
+class _RaisingSink:
+    async def store_artifact(self, artifact_id, metadata, stream) -> None:
+        raise RuntimeError("sink boom")
+
+
+def _route_client(store, sink, *, max_size: int | None = None):
+    mcp = FastMCP("test")
+    cfg = _cfg(max_size=max_size)
+    _upload.register_upload_route(mcp, token_store=store, sink=sink, config=cfg)
+    app = mcp.http_app()
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://route.test"
+    )
+
+
+async def _mint_upload_token(store, artifact_id="art-1", expected=None):
+    """Mint a raw upload token (bypassing upload_receiver_mint)."""
+    minted = await store.mint(
+        {
+            "artifact_id": artifact_id,
+            "expected": expected.model_dump() if expected is not None else None,
+        },
+        ttl=300.0,
+        single_use=True,
+    )
+    return minted.token
+
+
+def _sha256_content_digest(body: bytes) -> str:
+    raw = hashlib.sha256(body).digest()
+    return f"sha-256=:{base64.b64encode(raw).decode()}:"
+
+
+def _sha384_content_digest(body: bytes) -> str:
+    raw = hashlib.sha384(body).digest()
+    return f"sha-384=:{base64.b64encode(raw).decode()}:"
+
+
+def _sha512_content_digest(body: bytes) -> str:
+    raw = hashlib.sha512(body).digest()
+    return f"sha-512=:{base64.b64encode(raw).decode()}:"
+
+
+# ---------------------------------------------------------------------------
+# 1. upload_receiver_mint
+# ---------------------------------------------------------------------------
+
+
+async def test_receiver_mint_returns_intake_ticket():
+    store = _store()
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://recv.example",
+        ttl=120.0,
+    )
+    assert ticket.type == TICKET_TYPE
+    assert ticket.version == SPEC_VERSION
+    assert ticket.artifactId == "art-1"
+    assert ticket.expected is None
+    assert len(ticket.sinks) == 1
+    sink = ticket.sinks[0]
+    assert isinstance(sink, UploadSink)
+    assert sink.transport == "upload"
+    assert sink.url.startswith("https://recv.example/fx/u/")
+    assert sink.method == "PUT"
+
+
+async def test_receiver_mint_method_threads_through():
+    store = _store()
+    ticket = await _upload.upload_receiver_mint(
+        "art-2",
+        token_store=store,
+        base_url="https://recv.example",
+        ttl=60.0,
+        method="POST",
+    )
+    assert ticket.sinks[0].method == "POST"
+
+
+async def test_receiver_mint_expected_threads_through():
+    store = _store()
+    expected = ArtifactConstraints(
+        maxSize=1024, acceptMimeTypes=["application/json"], requireDigest=["sha-256"]
+    )
+    ticket = await _upload.upload_receiver_mint(
+        "art-3",
+        token_store=store,
+        base_url="https://recv.example",
+        ttl=60.0,
+        expected=expected,
+    )
+    assert ticket.expected == expected
+    # Token stores artifact_id and expected.
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata["artifact_id"] == "art-3"
+    expected_raw = rec.metadata["expected"]
+    assert expected_raw is not None
+    assert expected_raw["maxSize"] == 1024
+    assert expected_raw["acceptMimeTypes"] == ["application/json"]
+
+
+async def test_receiver_mint_token_stores_artifact_id():
+    store = _store()
+    ticket = await _upload.upload_receiver_mint(
+        "my-artifact",
+        token_store=store,
+        base_url="https://recv.example",
+        ttl=60.0,
+    )
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata["artifact_id"] == "my-artifact"
+    assert rec.metadata["expected"] is None
+    assert rec.single_use is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_format_content_digest_sha256():
+    body = b"hello"
+    raw = hashlib.sha256(body).digest()
+    header = _upload._format_content_digest("sha-256", raw)
+    assert header.startswith("sha-256=:")
+    assert header.endswith(":")
+    # Round-trip via parse.
+    result = _upload._parse_content_digest(header)
+    assert result is not None
+    algo, decoded = result
+    assert algo == "sha-256"
+    assert decoded == raw
+
+
+def test_format_parse_round_trip_sha384():
+    body = b"round-trip-384"
+    raw = hashlib.sha384(body).digest()
+    header = _upload._format_content_digest("sha-384", raw)
+    result = _upload._parse_content_digest(header)
+    assert result is not None
+    algo, decoded = result
+    assert algo == "sha-384"
+    assert decoded == raw
+
+
+def test_format_parse_round_trip_sha512():
+    body = b"round-trip-512"
+    raw = hashlib.sha512(body).digest()
+    header = _upload._format_content_digest("sha-512", raw)
+    result = _upload._parse_content_digest(header)
+    assert result is not None
+    algo, decoded = result
+    assert algo == "sha-512"
+    assert decoded == raw
+
+
+def test_parse_content_digest_first_supported_member_wins():
+    body = b"multi-member"
+    raw256 = hashlib.sha256(body).digest()
+    raw384 = hashlib.sha384(body).digest()
+    # sha-256 listed first — it wins.
+    h256 = _upload._format_content_digest("sha-256", raw256)
+    h384 = _upload._format_content_digest("sha-384", raw384)
+    result = _upload._parse_content_digest(f"{h256},{h384}")
+    assert result is not None
+    assert result[0] == "sha-256"
+    assert result[1] == raw256
+
+
+def test_parse_content_digest_unsupported_then_supported():
+    body = b"skip-unsupported"
+    raw = hashlib.sha256(body).digest()
+    h256 = _upload._format_content_digest("sha-256", raw)
+    # sha-1 is unsupported → skip it; sha-256 follows and wins.
+    header = f"sha-1=:AAAA:,{h256}"
+    result = _upload._parse_content_digest(header)
+    assert result is not None
+    assert result[0] == "sha-256"
+    assert result[1] == raw
+
+
+def test_parse_content_digest_member_parameters_stripped():
+    body = b"with-params"
+    raw = hashlib.sha256(body).digest()
+    encoded = base64.b64encode(raw).decode()
+    # RFC 8941 member parameter on the value portion (after the byte-sequence).
+    # Format: key=value;param=val — the semicolon separator follows the value.
+    header = f"sha-256=:{encoded}:;q=0.9"
+    result = _upload._parse_content_digest(header)
+    assert result is not None
+    assert result[0] == "sha-256"
+    assert result[1] == raw
+
+
+def test_parse_content_digest_supported_malformed_does_not_fall_through():
+    body = b"malformed"
+    raw = hashlib.sha256(body).digest()
+    h384 = _upload._format_content_digest("sha-384", raw)
+    # sha-256 is supported but malformed (missing colon-wrap); must return None,
+    # NOT fall through to the valid sha-384 member.
+    header = f"sha-256=NOTBASE64,{h384}"
+    result = _upload._parse_content_digest(header)
+    assert result is None  # supported-but-malformed stops iteration
+
+
+def test_parse_content_digest_rejects_empty_colon_colon():
+    # "::" is 2-char length guard — decodes to empty bytes.
+    result = _upload._parse_content_digest("sha-256=::")
+    assert result is None
+
+
+def test_parse_content_digest_rejects_invalid_base64():
+    result = _upload._parse_content_digest("sha-256=:not!valid!base64:")
+    assert result is None
+
+
+def test_parse_content_digest_rejects_unsupported_only():
+    result = _upload._parse_content_digest("sha-1=:AAAA:")
+    assert result is None
+
+
+def test_parse_content_digest_none_header():
+    assert _upload._parse_content_digest(None) is None
+
+
+def test_parse_content_digest_empty_header():
+    assert _upload._parse_content_digest("") is None
+
+
+def test_media_type_accepted_exact_match():
+    assert _upload._media_type_accepted("application/json", ["application/json"])
+
+
+def test_media_type_accepted_subtype_wildcard():
+    assert _upload._media_type_accepted("text/plain", ["text/*"])
+
+
+def test_media_type_accepted_star_star():
+    assert _upload._media_type_accepted("image/png", ["*/*"])
+
+
+def test_media_type_accepted_strips_parameters():
+    assert _upload._media_type_accepted("text/plain; charset=utf-8", ["text/plain"])
+
+
+def test_media_type_accepted_missing_content_type():
+    assert not _upload._media_type_accepted(None, ["text/plain"])
+
+
+def test_media_type_accepted_no_match():
+    assert not _upload._media_type_accepted("image/png", ["text/plain", "text/*"])
+
+
+def test_media_type_accepted_malformed_content_type():
+    # No slash in media type → no match.
+    assert not _upload._media_type_accepted("notavalidtype", ["*/*"])
+
+
+def test_media_type_accepted_star_star_client_reject():
+    # If the list does NOT contain */* the wildcard isn't applied from client side.
+    assert not _upload._media_type_accepted("application/json", ["text/plain"])
+
+
+# ---------------------------------------------------------------------------
+# 3. Route status matrix
+# ---------------------------------------------------------------------------
+
+
+async def test_route_unknown_token_404():
+    store = _store()
+    sink = _CapturingSink()
+    async with _route_client(store, sink) as client:
+        r = await client.put("/fx/u/unknown-token", content=b"x")
+    assert r.status_code == 404
+
+
+async def test_route_happy_put_204_deposits_bytes():
+    store = _store()
+    body = b"hello-upload-bytes"
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+    async with _route_client(store, sink) as client:
+        r = await client.put(
+            f"/fx/u/{token}",
+            content=body,
+            headers={"Content-Digest": _sha256_content_digest(body)},
+        )
+    assert r.status_code == 204
+    assert r.content == b""
+    assert sink.calls == 1
+    assert sink.deposited == body
+
+
+async def test_route_single_use_token_consumed_after_success():
+    store = _store()
+    body = b"consume-me"
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+    async with _route_client(store, sink) as client:
+        r1 = await client.put(f"/fx/u/{token}", content=body)
+        assert r1.status_code == 204
+        r2 = await client.put(f"/fx/u/{token}", content=body)
+    assert r2.status_code == 404  # consumed
+
+
+async def test_route_oversize_operator_cap_413():
+    store = _store()
+    body = b"x" * 5000
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+    async with _route_client(store, sink, max_size=100) as client:
+        r = await client.put(f"/fx/u/{token}", content=body)
+    assert r.status_code == 413
+    assert sink.calls == 0
+    # Token NOT consumed on oversize.
+    assert await store.lookup(token) is not None
+
+
+async def test_route_oversize_ticket_cap_413():
+    store = _store()
+    body = b"x" * 5000
+    expected = ArtifactConstraints(maxSize=100)
+    token = await _mint_upload_token(store, expected=expected)
+    sink = _CapturingSink()
+    # No operator cap — only the ticket cap applies.
+    async with _route_client(store, sink) as client:
+        r = await client.put(f"/fx/u/{token}", content=body)
+    assert r.status_code == 413
+    assert sink.calls == 0
+
+
+async def test_route_uses_min_of_both_caps_operator_smaller():
+    store = _store()
+    # Operator cap 50, ticket cap 200 → effective = 50.
+    body = b"x" * 100
+    expected = ArtifactConstraints(maxSize=200)
+    token = await _mint_upload_token(store, expected=expected)
+    sink = _CapturingSink()
+    async with _route_client(store, sink, max_size=50) as client:
+        r = await client.put(f"/fx/u/{token}", content=body)
+    assert r.status_code == 413
+    assert sink.calls == 0
+
+
+async def test_route_uses_min_of_both_caps_ticket_smaller():
+    store = _store()
+    # Operator cap 200, ticket cap 50 → effective = 50.
+    body = b"x" * 100
+    expected = ArtifactConstraints(maxSize=50)
+    token = await _mint_upload_token(store, expected=expected)
+    sink = _CapturingSink()
+    async with _route_client(store, sink, max_size=200) as client:
+        r = await client.put(f"/fx/u/{token}", content=body)
+    assert r.status_code == 413
+    assert sink.calls == 0
+
+
+async def test_route_mime_reject_415():
+    store = _store()
+    expected = ArtifactConstraints(acceptMimeTypes=["application/json"])
+    token = await _mint_upload_token(store, expected=expected)
+    sink = _CapturingSink()
+    async with _route_client(store, sink) as client:
+        r = await client.put(
+            f"/fx/u/{token}",
+            content=b"x",
+            headers={"Content-Type": "text/plain"},
+        )
+    assert r.status_code == 415
+    assert sink.calls == 0
+    # Token NOT consumed on mime reject.
+    assert await store.lookup(token) is not None
+
+
+async def test_route_mime_accept_matching_type():
+    store = _store()
+    expected = ArtifactConstraints(acceptMimeTypes=["application/json"])
+    token = await _mint_upload_token(store, expected=expected)
+    sink = _CapturingSink()
+    body = b'{"ok":1}'
+    async with _route_client(store, sink) as client:
+        r = await client.put(
+            f"/fx/u/{token}",
+            content=body,
+            headers={"Content-Type": "application/json"},
+        )
+    assert r.status_code == 204
+    assert sink.calls == 1
+
+
+async def test_route_digest_mismatch_400_sink_not_called():
+    store = _store()
+    body = b"correct-bytes"
+    wrong_digest = _sha256_content_digest(b"wrong-bytes")
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+    async with _route_client(store, sink) as client:
+        r = await client.put(
+            f"/fx/u/{token}",
+            content=body,
+            headers={"Content-Digest": wrong_digest},
+        )
+    assert r.status_code == 400
+    assert sink.calls == 0  # verify-before-use: sink never called on bad digest
+    # Token NOT consumed on digest mismatch.
+    assert await store.lookup(token) is not None
+
+
+async def test_route_missing_required_digest_400():
+    store = _store()
+    expected = ArtifactConstraints(requireDigest=["sha-256"])
+    token = await _mint_upload_token(store, expected=expected)
+    sink = _CapturingSink()
+    async with _route_client(store, sink) as client:
+        r = await client.put(f"/fx/u/{token}", content=b"no-digest-header")
+    assert r.status_code == 400
+    assert sink.calls == 0
+
+
+async def test_route_required_digest_wrong_algo_400():
+    store = _store()
+    body = b"data"
+    expected = ArtifactConstraints(requireDigest=["sha-256"])
+    token = await _mint_upload_token(store, expected=expected)
+    sink = _CapturingSink()
+    # Sending sha-384 when sha-256 is required.
+    async with _route_client(store, sink) as client:
+        r = await client.put(
+            f"/fx/u/{token}",
+            content=body,
+            headers={"Content-Digest": _sha384_content_digest(body)},
+        )
+    assert r.status_code == 400
+    assert sink.calls == 0
+
+
+async def test_route_sink_failure_500_body_free():
+    store = _store()
+    token = await _mint_upload_token(store)
+    async with _route_client(store, _RaisingSink()) as client:
+        r = await client.put(f"/fx/u/{token}", content=b"data")
+    assert r.status_code == 500
+    assert r.content == b""  # no exception message echoed
+    # Token NOT consumed on sink failure.
+    assert await store.lookup(token) is not None
+
+
+# ---------------------------------------------------------------------------
+# 4. Ambient credentials ignored
+# ---------------------------------------------------------------------------
+
+
+async def test_route_ignores_ambient_credentials():
+    store = _store()
+    body = b"data"
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+    async with _route_client(store, sink) as client:
+        r = await client.put(
+            f"/fx/u/{token}",
+            content=body,
+            headers={"Authorization": "Bearer secret", "Cookie": "s=1"},
+        )
+    assert r.status_code == 204
+    assert sink.deposited == body
+
+
+# ---------------------------------------------------------------------------
+# 5. Non-sha256 digest verification through route
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "digest_fn,label",
+    [
+        (_sha384_content_digest, "sha-384"),
+        (_sha512_content_digest, "sha-512"),
+    ],
+)
+async def test_route_non_sha256_digest_verified(digest_fn, label):
+    store = _store()
+    body = b"algo-test-bytes"
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+    async with _route_client(store, sink) as client:
+        r = await client.put(
+            f"/fx/u/{token}",
+            content=body,
+            headers={"Content-Digest": digest_fn(body)},
+        )
+    assert r.status_code == 204
+    assert sink.deposited == body
+
+
+@pytest.mark.parametrize(
+    "digest_fn",
+    [_sha384_content_digest, _sha512_content_digest],
+)
+async def test_route_non_sha256_digest_mismatch_400(digest_fn):
+    store = _store()
+    body = b"algo-test-bytes"
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+    async with _route_client(store, sink) as client:
+        r = await client.put(
+            f"/fx/u/{token}",
+            content=body,
+            headers={"Content-Digest": digest_fn(b"wrong-bytes")},
+        )
+    assert r.status_code == 400
+    assert sink.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# 6. Consume failure after successful store still returns 204
+# ---------------------------------------------------------------------------
+
+
+async def test_route_consume_failure_after_store_returns_204(monkeypatch, caplog):
+    store = _store()
+    body = b"data"
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+
+    async def boom_consume(_token):
+        raise RuntimeError("kv backend down")
+
+    monkeypatch.setattr(store, "consume", boom_consume)
+    async with _route_client(store, sink) as client:
+        import logging
+
+        with caplog.at_level(logging.ERROR):
+            r = await client.put(f"/fx/u/{token}", content=body)
+    assert r.status_code == 204
+    assert sink.calls == 1
+    assert sink.deposited == body
+    # The exception must be logged (not just warned).
+    assert any(
+        "consume failed" in m or "token may remain" in m for m in caplog.messages
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Temp-file unlinked on every failure path
+# ---------------------------------------------------------------------------
+
+
+async def test_route_temp_unlinked_on_413(monkeypatch, tmp_path):
+    real_mkstemp = _upload.tempfile.mkstemp
+    created: list[str] = []
+
+    def spy_mkstemp(*args, **kwargs):
+        kwargs.setdefault("dir", str(tmp_path))
+        fd, path = real_mkstemp(*args, **kwargs)
+        created.append(path)
+        return fd, path
+
+    monkeypatch.setattr(_upload.tempfile, "mkstemp", spy_mkstemp)
+    store = _store()
+    body = b"x" * 5000
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+    async with _route_client(store, sink, max_size=100) as client:
+        r = await client.put(f"/fx/u/{token}", content=body)
+    assert r.status_code == 413
+    assert created
+    assert all(not os.path.exists(p) for p in created)
+
+
+async def test_route_temp_unlinked_on_400_digest(monkeypatch, tmp_path):
+    real_mkstemp = _upload.tempfile.mkstemp
+    created: list[str] = []
+
+    def spy_mkstemp(*args, **kwargs):
+        kwargs.setdefault("dir", str(tmp_path))
+        fd, path = real_mkstemp(*args, **kwargs)
+        created.append(path)
+        return fd, path
+
+    monkeypatch.setattr(_upload.tempfile, "mkstemp", spy_mkstemp)
+    store = _store()
+    body = b"x"
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+    async with _route_client(store, sink) as client:
+        r = await client.put(
+            f"/fx/u/{token}",
+            content=body,
+            headers={"Content-Digest": _sha256_content_digest(b"wrong")},
+        )
+    assert r.status_code == 400
+    assert created
+    assert all(not os.path.exists(p) for p in created)
+
+
+async def test_route_temp_unlinked_on_500_sink_failure(monkeypatch, tmp_path):
+    real_mkstemp = _upload.tempfile.mkstemp
+    created: list[str] = []
+
+    def spy_mkstemp(*args, **kwargs):
+        kwargs.setdefault("dir", str(tmp_path))
+        fd, path = real_mkstemp(*args, **kwargs)
+        created.append(path)
+        return fd, path
+
+    monkeypatch.setattr(_upload.tempfile, "mkstemp", spy_mkstemp)
+    store = _store()
+    token = await _mint_upload_token(store)
+    async with _route_client(store, _RaisingSink()) as client:
+        r = await client.put(f"/fx/u/{token}", content=b"data")
+    assert r.status_code == 500
+    assert created
+    assert all(not os.path.exists(p) for p in created)
+
+
+# ---------------------------------------------------------------------------
+# 8. Flush / close failure paths
+# ---------------------------------------------------------------------------
+
+
+async def test_route_flush_failure_returns_500():
+    store = _store()
+    body = b"payload"
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+    real_fdopen = os.fdopen
+
+    class _FlushFails:
+        def __init__(self, f):
+            self._f = f
+
+        def write(self, b):
+            return self._f.write(b)
+
+        def flush(self):
+            raise OSError("disk full on flush")
+
+        def close(self):
+            return self._f.close()
+
+    import unittest.mock
+
+    with unittest.mock.patch.object(
+        _upload.os,
+        "fdopen",
+        side_effect=lambda fd, mode: _FlushFails(real_fdopen(fd, mode)),
+    ):
+        async with _route_client(store, sink) as client:
+            r = await client.put(f"/fx/u/{token}", content=body)
+    assert r.status_code == 500
+    assert sink.calls == 0
+
+
+async def test_route_close_after_success_still_204():
+    """A close() failure after flush must not turn a 204 into an error."""
+    store = _store()
+    body = b"payload"
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+    real_fdopen = os.fdopen
+
+    class _CloseFailsAfterFlush:
+        def __init__(self, f):
+            self._f = f
+            self._flushed = False
+
+        def write(self, b):
+            return self._f.write(b)
+
+        def flush(self):
+            self._f.flush()
+            self._flushed = True
+
+        def close(self):
+            self._f.close()
+            if self._flushed:
+                raise OSError("disk full on close")
+
+    import unittest.mock
+
+    with unittest.mock.patch.object(
+        _upload.os,
+        "fdopen",
+        side_effect=lambda fd, mode: _CloseFailsAfterFlush(real_fdopen(fd, mode)),
+    ):
+        async with _route_client(store, sink) as client:
+            r = await client.put(f"/fx/u/{token}", content=body)
+    assert r.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# 9. Sender tests
+# ---------------------------------------------------------------------------
+
+
+class _BytesSource:
+    """ArtifactSource serving fixed bytes."""
+
+    def __init__(
+        self, key: str, body: bytes, mime: str | None = "application/octet-stream"
+    ):
+        self._key, self._body, self._mime = key, body, mime
+
+    async def open_artifact(self, key: str):
+        from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+        assert key == self._key
+        meta = ArtifactMetadata(
+            name="test",
+            mimeType=self._mime,
+            size=len(self._body),
+        )
+        return io.BytesIO(self._body), meta
+
+
+class _NoMimeSource:
+    """ArtifactSource with no mimeType."""
+
+    async def open_artifact(self, key: str):
+        from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+        return io.BytesIO(b"no-mime"), ArtifactMetadata(name="x")
+
+
+def _make_sink_descriptor(url: str = "https://recv.example/fx/u/tok") -> UploadSink:
+    return UploadSink(
+        transport="upload",
+        url=url,
+        method="PUT",
+        expiresAt="2099-01-01T00:00:00Z",
+    )
+
+
+def _install_upload_guard(monkeypatch, responder):
+    """Patch _upload.guarded_stream to route through a MockTransport."""
+
+    @contextlib.asynccontextmanager
+    async def fake_guard(method, url, *, config, transport, headers=None, content=None):
+        from fastmcp_pvl_core._file_exchange._outbound import GuardedResponse
+
+        body_bytes = b""
+        if content is not None:
+            async for chunk in content:
+                body_bytes += chunk
+        fake_req = httpx.Request(method, url, headers=headers or {}, content=body_bytes)
+        resp = responder(fake_req)
+        yield GuardedResponse(
+            status=resp.status_code, headers=resp.headers, _response=resp
+        )
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guard)
+
+
+async def test_sender_sends_correct_headers(monkeypatch):
+    body = b"hello-sender"
+    source = _BytesSource("k", body, mime="text/plain")
+    sink_desc = _make_sink_descriptor()
+    config = _cfg()
+
+    seen: dict[str, object] = {}
+
+    @contextlib.asynccontextmanager
+    async def capture_guard(
+        method, url, *, config, transport, headers=None, content=None
+    ):
+        from fastmcp_pvl_core._file_exchange._outbound import GuardedResponse
+
+        body_bytes = b""
+        if content is not None:
+            async for chunk in content:
+                body_bytes += chunk
+        seen["method"] = method
+        seen["headers"] = dict(headers or {})
+        seen["body"] = body_bytes
+        fake_resp = httpx.Response(204)
+        yield GuardedResponse(
+            status=204, headers=fake_resp.headers, _response=fake_resp
+        )
+
+    monkeypatch.setattr(_upload, "guarded_stream", capture_guard)
+
+    await _upload.upload_sender_consume(sink_desc, source, "k", config=config)
+
+    assert seen["method"] == "PUT"
+    h = seen["headers"]
+    assert h["Content-Length"] == str(len(body))
+    assert h["Content-Type"] == "text/plain"
+    assert "Content-Digest" in h
+    # Verify the digest is correct.
+    cd = _upload._parse_content_digest(h["Content-Digest"])
+    assert cd is not None
+    algo, raw = cd
+    assert algo == "sha-256"
+    assert raw == hashlib.sha256(body).digest()
+    # Body streamed correctly.
+    assert seen["body"] == body
+
+
+async def test_sender_omits_content_type_when_mime_none(monkeypatch):
+    source = _NoMimeSource()
+    sink_desc = _make_sink_descriptor()
+    config = _cfg()
+    seen_headers: dict[str, str] = {}
+
+    @contextlib.asynccontextmanager
+    async def capture_guard(
+        method, url, *, config, transport, headers=None, content=None
+    ):
+        from fastmcp_pvl_core._file_exchange._outbound import GuardedResponse
+
+        if content is not None:
+            async for _ in content:
+                pass
+        seen_headers.update(headers or {})
+        fake_resp = httpx.Response(204)
+        yield GuardedResponse(
+            status=204, headers=fake_resp.headers, _response=fake_resp
+        )
+
+    monkeypatch.setattr(_upload, "guarded_stream", capture_guard)
+    await _upload.upload_sender_consume(sink_desc, source, "k", config=config)
+    assert "Content-Type" not in seen_headers
+
+
+async def test_sender_non_2xx_raises_transfer_failed(monkeypatch):
+    body = b"data"
+    source = _BytesSource("k", body)
+    sink_desc = _make_sink_descriptor()
+
+    def responder(req):
+        return httpx.Response(400)
+
+    _install_upload_guard(monkeypatch, responder)
+
+    with pytest.raises(FileExchangeTransferError) as ei:
+        await _upload.upload_sender_consume(sink_desc, source, "k", config=_cfg())
+    assert ei.value.code == TransferErrorCode.TRANSFER_FAILED
+
+
+async def test_sender_guard_refusal_propagates_not_accessible(monkeypatch):
+    source = _BytesSource("k", b"x")
+    sink_desc = _make_sink_descriptor()
+
+    @contextlib.asynccontextmanager
+    async def refusing(method, url, *, config, transport, headers=None, content=None):
+        # Consume the content generator so it doesn't linger.
+        if content is not None:
+            async for _ in content:
+                pass
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE, transport="upload", detail="refused"
+        )
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(_upload, "guarded_stream", refusing)
+
+    with pytest.raises(FileExchangeTransferError) as ei:
+        await _upload.upload_sender_consume(sink_desc, source, "k", config=_cfg())
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_sender_hook_non_oserror_wrapped_as_transfer_failed(monkeypatch):
+    """A non-OSError from the source stream (e.g. ValueError) must be wrapped as
+    TRANSFER_FAILED with the original exception as __cause__."""
+
+    class _ExplodingSource:
+        async def open_artifact(self, key: str):
+            from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+            class _ExplodingStream:
+                def read(self, n: int = -1) -> bytes:
+                    raise ValueError("source exploded")
+
+            return _ExplodingStream(), ArtifactMetadata(name="x")
+
+    sink_desc = _make_sink_descriptor()
+
+    @contextlib.asynccontextmanager
+    async def dummy_guard(
+        method, url, *, config, transport, headers=None, content=None
+    ):
+        if content is not None:
+            async for _ in content:
+                pass
+        from fastmcp_pvl_core._file_exchange._outbound import GuardedResponse
+
+        fake_resp = httpx.Response(204)
+        yield GuardedResponse(
+            status=204, headers=fake_resp.headers, _response=fake_resp
+        )
+
+    monkeypatch.setattr(_upload, "guarded_stream", dummy_guard)
+
+    with pytest.raises(FileExchangeTransferError) as ei:
+        await _upload.upload_sender_consume(
+            sink_desc, _ExplodingSource(), "k", config=_cfg()
+        )
+    assert ei.value.code == TransferErrorCode.TRANSFER_FAILED
+    assert isinstance(ei.value.__cause__, ValueError)
+
+
+async def test_sender_non_sha256_digest_algo(monkeypatch):
+    body = b"algo-test"
+    source = _BytesSource("k", body)
+    sink_desc = _make_sink_descriptor()
+    seen_headers: dict[str, str] = {}
+
+    @contextlib.asynccontextmanager
+    async def capture_guard(
+        method, url, *, config, transport, headers=None, content=None
+    ):
+        from fastmcp_pvl_core._file_exchange._outbound import GuardedResponse
+
+        if content is not None:
+            async for _ in content:
+                pass
+        seen_headers.update(headers or {})
+        fake_resp = httpx.Response(204)
+        yield GuardedResponse(
+            status=204, headers=fake_resp.headers, _response=fake_resp
+        )
+
+    monkeypatch.setattr(_upload, "guarded_stream", capture_guard)
+    await _upload.upload_sender_consume(
+        sink_desc, source, "k", config=_cfg(), digest_algo="sha-384"
+    )
+    cd = _upload._parse_content_digest(seen_headers.get("Content-Digest", ""))
+    assert cd is not None
+    assert cd[0] == "sha-384"
+    assert cd[1] == hashlib.sha384(body).digest()
+
+
+def test_sender_unsupported_digest_algo_raises_value_error():
+    sink_desc = _make_sink_descriptor()
+    source = _BytesSource("k", b"x")
+
+    with pytest.raises(ValueError, match="digest_algo"):
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(
+            _upload.upload_sender_consume(
+                sink_desc, source, "k", config=_cfg(), digest_algo="sha-1"
+            )
+        )
+
+
+async def test_sender_temp_unlinked_on_non_2xx(monkeypatch, tmp_path):
+    real_mkstemp = _upload.tempfile.mkstemp
+    created: list[str] = []
+
+    def spy_mkstemp(*args, **kwargs):
+        kwargs.setdefault("dir", str(tmp_path))
+        fd, path = real_mkstemp(*args, **kwargs)
+        created.append(path)
+        return fd, path
+
+    monkeypatch.setattr(_upload.tempfile, "mkstemp", spy_mkstemp)
+
+    body = b"data"
+    source = _BytesSource("k", body)
+    sink_desc = _make_sink_descriptor()
+
+    def responder(req):
+        return httpx.Response(400)
+
+    _install_upload_guard(monkeypatch, responder)
+
+    with pytest.raises(FileExchangeTransferError):
+        await _upload.upload_sender_consume(sink_desc, source, "k", config=_cfg())
+
+    assert created
+    assert all(not os.path.exists(p) for p in created)
+
+
+async def test_sender_close_after_flush_failure_preserves_fete(monkeypatch):
+    """A close() failure after a flush error must not replace the FETE."""
+    real_fdopen = os.fdopen
+
+    class _FlushAndCloseFail:
+        def __init__(self, f):
+            self._f = f
+
+        def write(self, b):
+            return self._f.write(b)
+
+        def flush(self):
+            raise OSError("disk full on flush")
+
+        def close(self):
+            self._f.close()
+            raise OSError("disk full on close")
+
+    import unittest.mock
+
+    source = _BytesSource("k", b"data")
+    sink_desc = _make_sink_descriptor()
+
+    with unittest.mock.patch.object(
+        _upload.os,
+        "fdopen",
+        side_effect=lambda fd, mode: _FlushAndCloseFail(real_fdopen(fd, mode)),
+    ):
+        with pytest.raises(FileExchangeTransferError) as ei:
+            await _upload.upload_sender_consume(sink_desc, source, "k", config=_cfg())
+    # The flush's FETE must propagate, not the close's raw OSError.
+    assert ei.value.code == TransferErrorCode.TRANSFER_FAILED
+
+
+# ---------------------------------------------------------------------------
+# 10. register_file_exchange_routes validation
+# ---------------------------------------------------------------------------
+
+
+def test_register_requires_source_or_sink():
+    mcp = FastMCP("test")
+    store = _store()
+    with pytest.raises(ValueError, match="at least one"):
+        _routes.register_file_exchange_routes(mcp, token_store=store)
+
+
+def test_register_requires_config_when_sink_given():
+    mcp = FastMCP("test")
+    store = _store()
+    sink = _CapturingSink()
+    with pytest.raises(ValueError, match="requires `config`"):
+        _routes.register_file_exchange_routes(mcp, token_store=store, sink=sink)
+
+
+async def test_register_atomicity_download_not_mounted_when_sink_missing_config():
+    """source=X, sink=Y, config=None must raise ValueError AND the download
+    route must NOT be mounted (atomicity — no partial mounts)."""
+    mcp = FastMCP("test")
+    store = _store()
+    sink = _CapturingSink()
+
+    class _DummySource:
+        async def open_artifact(self, key):
+            from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+            return io.BytesIO(b"x"), ArtifactMetadata(name="x")
+
+    with pytest.raises(ValueError, match="requires `config`"):
+        _routes.register_file_exchange_routes(
+            mcp, token_store=store, source=_DummySource(), sink=sink
+        )
+
+    # Download route must NOT have been mounted (atomicity).
+    app = mcp.http_app()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get("/fx/d/some-token")
+    assert r.status_code == 404  # route not mounted
+
+
+def test_register_source_only_succeeds():
+    """source only (no sink/config) is valid."""
+    mcp = FastMCP("test")
+    store = _store()
+
+    class _DummySource:
+        async def open_artifact(self, key):
+            from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+            return io.BytesIO(b"x"), ArtifactMetadata(name="x")
+
+    # Should not raise.
+    _routes.register_file_exchange_routes(mcp, token_store=store, source=_DummySource())
+
+
+def test_register_sink_with_config_succeeds():
+    """sink + config (no source) is valid."""
+    mcp = FastMCP("test")
+    store = _store()
+    sink = _CapturingSink()
+    # Should not raise.
+    _routes.register_file_exchange_routes(
+        mcp, token_store=store, sink=sink, config=_cfg()
+    )

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -1151,3 +1151,72 @@ def test_register_sink_with_config_succeeds():
     _routes.register_file_exchange_routes(
         mcp, token_store=store, sink=sink, config=_cfg()
     )
+
+
+# ---------------------------------------------------------------------------
+# 11. fd/temp leak regression tests
+# ---------------------------------------------------------------------------
+
+
+async def test_sender_does_not_create_temp_when_source_open_fails(monkeypatch):
+    # Regression for the fd/temp leak gemini found: if source.open_artifact
+    # raises, no temp file should be created (the hook open happens first).
+    captured_paths: list[str] = []
+    real_mkstemp = _upload.tempfile.mkstemp
+
+    def capturing_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        captured_paths.append(path)
+        return fd, path
+
+    monkeypatch.setattr(_upload.tempfile, "mkstemp", capturing_mkstemp)
+
+    class _BoomSource:
+        async def open_artifact(self, _key):
+            raise RuntimeError("hook open boom")
+
+    sink_desc = _make_sink_descriptor()
+    with pytest.raises(FileExchangeTransferError) as exc:
+        await _upload.upload_sender_consume(
+            sink_desc, _BoomSource(), "k", config=_cfg()
+        )
+    assert exc.value.code == TransferErrorCode.TRANSFER_FAILED
+    assert exc.value.transport == "upload"
+    # The hook failed before the temp was ever created.
+    assert captured_paths == [], (
+        f"sender created temp files before opening source: {captured_paths}"
+    )
+
+
+async def test_route_fdopen_oserror_returns_500_and_cleans_up(monkeypatch, tmp_path):
+    # Regression for the route fdopen OSError fd-leak fix: when fdopen raises,
+    # we must close the raw fd AND unlink the temp.
+    captured_paths: list[str] = []
+    real_mkstemp = _upload.tempfile.mkstemp
+
+    def capturing_mkstemp(*args, **kwargs):
+        kwargs.setdefault("dir", str(tmp_path))
+        fd, path = real_mkstemp(*args, **kwargs)
+        captured_paths.append(path)
+        return fd, path
+
+    monkeypatch.setattr(_upload.tempfile, "mkstemp", capturing_mkstemp)
+
+    def boom_fdopen(fd, *args, **kwargs):
+        # Don't consume the fd — the route's except OSError arm must close it.
+        raise OSError("fdopen boom")
+
+    monkeypatch.setattr(_upload.os, "fdopen", boom_fdopen)
+
+    store = _store()
+    sink = _CapturingSink()
+    token = await _mint_upload_token(store)
+    async with _route_client(store, sink) as client:
+        resp = await client.put(f"/fx/u/{token}", content=b"data")
+
+    assert resp.status_code == 500
+    assert captured_paths, "expected mkstemp to have been called"
+    leaked = [p for p in captured_paths if os.path.exists(p)]
+    assert not leaked, f"temp files leaked after fdopen failure: {leaked}"
+    # (We cannot directly assert the fd was closed without /proc introspection;
+    # the explicit os.close(fd) in the route's except OSError arm is the contract.)

--- a/tests/_file_exchange/test_upload.py
+++ b/tests/_file_exchange/test_upload.py
@@ -508,6 +508,29 @@ async def test_route_required_digest_wrong_algo_400():
     assert sink.calls == 0
 
 
+async def test_route_malformed_content_digest_400_without_requiredigest():
+    # Regression for §15 fail-don't-skip: a present-but-unverifiable
+    # Content-Digest header must yield 400 even when requireDigest is absent.
+    # Previously this case was silently skipped (gemini G1, fix-2).
+    store = _store()
+    body = b"some-body-content"
+    # No ArtifactConstraints — requireDigest is absent.
+    token = await _mint_upload_token(store)
+    sink = _CapturingSink()
+    async with _route_client(store, sink) as client:
+        # Send a header the parser cannot resolve (unsupported algorithm
+        # in byte-sequence form). `_parse_content_digest` returns None.
+        r = await client.put(
+            f"/fx/u/{token}",
+            content=body,
+            headers={"Content-Digest": "md5=:abc=:"},  # md5 not in _HASHLIB_BY_LABEL
+        )
+    assert r.status_code == 400
+    assert sink.calls == 0  # no deposit
+    # Token NOT consumed — the sender can retry with a verifiable digest.
+    assert await store.lookup(token) is not None
+
+
 async def test_route_sink_failure_500_body_free():
     store = _store()
     token = await _mint_upload_token(store)

--- a/tests/_file_exchange/test_upload_e2e.py
+++ b/tests/_file_exchange/test_upload_e2e.py
@@ -1,0 +1,220 @@
+"""End-to-end upload push: server B (receiver) mints + serves, server A (sender) pushes.
+
+Exercises the whole ``upload`` data plane together —
+``upload_receiver_mint``, ``register_upload_route`` (mounted on a real
+ASGI app), ``select_sink``, and ``upload_sender_consume`` — over a loopback
+ASGI transport. The SSRF guard is replaced with one that routes to server
+B's app, because we are exercising the push flow, not the guard (which has
+its own tests).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+from fastmcp_pvl_core._file_exchange._selection import select_sink
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+
+class _BytesSource:
+    """ArtifactSource serving fixed bytes for a single key."""
+
+    def __init__(self, key: str, body: bytes) -> None:
+        self._key, self._body = key, body
+
+    async def open_artifact(self, key: str):
+        assert key == self._key
+        return io.BytesIO(self._body), ArtifactMetadata(
+            name="artifact",
+            mimeType="application/octet-stream",
+            size=len(self._body),
+        )
+
+
+class _CapturingSink:
+    """ArtifactSink that records artifact_id, metadata, and bytes received."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.received_id: str | None = None
+        self.received_meta: ArtifactMetadata | None = None
+        self.received_bytes: bytes = b""
+
+    async def store_artifact(self, artifact_id, metadata, stream) -> None:
+        self.calls += 1
+        self.received_id = artifact_id
+        self.received_meta = metadata
+        self.received_bytes = stream.read()
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+async def test_two_server_push_upload(monkeypatch):
+    body = b"end-to-end-upload-payload" * 64
+    expected_sha256 = hashlib.sha256(body).hexdigest()
+
+    # Server B (receiver): mint capability URL + serve the upload route.
+    recv_store = _store()
+    recv_sink = _CapturingSink()
+    recv_mcp = FastMCP("receiver")
+    cfg = ServerConfig()
+    _upload.register_upload_route(
+        recv_mcp, token_store=recv_store, sink=recv_sink, config=cfg
+    )
+    app_b = recv_mcp.http_app()
+
+    # Mint an IntakeTicket on server B.
+    ticket = await _upload.upload_receiver_mint(
+        "artifact-42",
+        token_store=recv_store,
+        base_url="https://recv.test",
+        ttl=300.0,
+    )
+    assert ticket.artifactId == "artifact-42"
+
+    # Server A selects the upload sink.
+    descriptor = select_sink(ticket)
+    assert descriptor is not None
+    assert descriptor.transport == "upload"
+
+    # Replace guarded_stream with one that routes to B's ASGI app.
+    @contextlib.asynccontextmanager
+    async def guard_to_app_b(
+        method, url, *, config, transport, headers=None, content=None
+    ):
+        from fastmcp_pvl_core._file_exchange._outbound import GuardedResponse
+
+        # Collect streaming content into bytes so ASGITransport can replay.
+        body_bytes = b""
+        if content is not None:
+            async for chunk in content:
+                body_bytes += chunk
+
+        client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app_b), base_url="http://recv.test"
+        )
+        try:
+            # Extract path from the URL (strip scheme+host).
+            path = url.split("recv.test", 1)[1] if "recv.test" in url else url
+            req = client.build_request(
+                method, path, headers=headers or {}, content=body_bytes
+            )
+            resp = await client.send(req, stream=True)
+            try:
+                yield GuardedResponse(
+                    status=resp.status_code,
+                    headers=resp.headers,
+                    _response=resp,
+                )
+            finally:
+                await resp.aclose()
+        finally:
+            await client.aclose()
+
+    monkeypatch.setattr(_upload, "guarded_stream", guard_to_app_b)
+
+    # Server A runs upload_sender_consume.
+    source = _BytesSource("doc", body)
+    await _upload.upload_sender_consume(
+        descriptor, source, "doc", config=ServerConfig()
+    )
+
+    # Verify bytes landed in B's sink.
+    assert recv_sink.calls == 1
+    assert recv_sink.received_id == "artifact-42"
+    assert recv_sink.received_bytes == body
+
+    # Metadata: size and sha-256 digest recorded.
+    meta = recv_sink.received_meta
+    assert meta is not None
+    assert meta.size == len(body)
+    assert meta.digest == f"sha-256:{expected_sha256}"
+    assert meta.mimeType == "application/octet-stream"
+
+    # The single-use token was consumed.
+    token = descriptor.url.rsplit("/", 1)[1]
+    assert await recv_store.lookup(token) is None
+
+
+async def test_two_server_push_upload_content_digest_verified(monkeypatch):
+    """Verify that the route actually checks the Content-Digest sent by the sender."""
+    body = b"integrity-check-payload"
+    recv_store = _store()
+    recv_sink = _CapturingSink()
+    recv_mcp = FastMCP("receiver")
+    cfg = ServerConfig()
+    _upload.register_upload_route(
+        recv_mcp, token_store=recv_store, sink=recv_sink, config=cfg
+    )
+    app_b = recv_mcp.http_app()
+
+    ticket = await _upload.upload_receiver_mint(
+        "art-check",
+        token_store=recv_store,
+        base_url="https://recv.test",
+        ttl=300.0,
+    )
+    descriptor = select_sink(ticket)
+    assert descriptor is not None
+
+    # Tamper: replace guarded_stream with one that corrupts the body bytes
+    # but keeps the original Content-Digest header (computed by sender from
+    # the real body). The route must reject with 400.
+    tampered_body = b"corrupted-" + body
+
+    @contextlib.asynccontextmanager
+    async def tamper_guard(
+        method, url, *, config, transport, headers=None, content=None
+    ):
+        from fastmcp_pvl_core._file_exchange._outbound import GuardedResponse
+
+        # Drain the real content but send the corrupted body to the server.
+        if content is not None:
+            async for _ in content:
+                pass
+
+        client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app_b), base_url="http://recv.test"
+        )
+        try:
+            path = url.split("recv.test", 1)[1] if "recv.test" in url else url
+            req = client.build_request(
+                method, path, headers=headers or {}, content=tampered_body
+            )
+            resp = await client.send(req, stream=True)
+            try:
+                yield GuardedResponse(
+                    status=resp.status_code,
+                    headers=resp.headers,
+                    _response=resp,
+                )
+            finally:
+                await resp.aclose()
+        finally:
+            await client.aclose()
+
+    monkeypatch.setattr(_upload, "guarded_stream", tamper_guard)
+
+    source = _BytesSource("doc", body)
+    with pytest.raises(FileExchangeTransferError) as ei:
+        await _upload.upload_sender_consume(
+            descriptor, source, "doc", config=ServerConfig()
+        )
+    # The receiver rejected with 400 (digest mismatch) → sender raises TRANSFER_FAILED.
+    assert ei.value.code.value == "transfer-failed"
+    # Sink never called.
+    assert recv_sink.calls == 0

--- a/tests/test_file_exchange_namespace.py
+++ b/tests/test_file_exchange_namespace.py
@@ -170,3 +170,16 @@ def test_download_data_plane_names_reexported():
         assert name in file_exchange.__all__, name
     # DOWNLOAD_PREFIX is internal route shape, not part of the public surface.
     assert not hasattr(file_exchange, "DOWNLOAD_PREFIX")
+
+
+def test_upload_data_plane_names_reexported():
+    from fastmcp_pvl_core import file_exchange
+
+    for name in (
+        "upload_receiver_mint",
+        "upload_sender_consume",
+    ):
+        assert hasattr(file_exchange, name), name
+        assert name in file_exchange.__all__, name
+    # UPLOAD_PREFIX is internal route shape, not part of the public surface.
+    assert not hasattr(file_exchange, "UPLOAD_PREFIX")


### PR DESCRIPTION
## Summary
Clean re-implementation of #146 (upload transport data plane), 8/10 of EPIC #138. Adds `upload_receiver_mint`, the PUT/POST serving route, and the SSRF-guarded sender. Plus a behaviour-preserving refactor extracting `_staging.py` (shared digest/chunk primitives, consolidated across all three transports including `_filesystem.py`) and moving `register_file_exchange_routes` into a new `_routes.py` (cross-transport entry point with strict precondition validation before any mount).

## Replaces #163 + #164
PR #163 was a spike that ran 4 bot-review rounds + 7 local circus rounds without converging (21 commits). PR #164 was a consolidated push of the spike's final state that continued the spiral. Both abandoned per CLAUDE.md. This PR is the **true** clean re-implementation: written fresh from the design + plan + cumulative findings, in 4 coherent commits, with every lesson baked in from commit 1.

The cumulative lessons (from spike + v2 bot rounds) are encoded as concrete patterns in the code:
- **Async correctness:** all `close()` calls via `await asyncio.to_thread(...)`; `os.fdopen` has BOTH `except OSError` and `except BaseException` arms in route AND sender (fd-leak guard under cancellation); route's `except OSError` narrowed to wrap only `_write_chunk`/`tmp.flush` so Starlette's `ClientDisconnect` propagates cleanly.
- **Sender error contract:** wraps `source.open_artifact`; catches `httpx.HTTPError` alongside `OSError` around `guarded_stream` (network errors mapped to `TRANSFER_FAILED`); staging loop uses separate inner scopes for `_write_chunk`/`tmp.flush` with the outer scope catching hook-side errors as `\"artifact source read failed\"`; `except FileExchangeTransferError: raise` re-raise prevents inner FETE from being re-wrapped.
- **Digest verification:** RFC 9530 `Content-Digest` parser strips RFC 8941 member parameters, rejects `\":\":\"` empty digests (`len(value) <= 2` guard), supported-but-malformed returns `None` (never silently skips per §15); `hmac.compare_digest` with `len(cd[1]) != hasher.digest_size` length pre-check for constant-time mismatched-length handling.
- **`requireDigest` enforcement:** set-membership check on the supplied algorithm; first-supported-member semantics documented in the route docstring.
- **Sender `digest_algo` parameter:** lets callers match arbitrary receiver `requireDigest` constraints (default `sha-256`); `ValueError` on unsupported algorithm.
- **`_content()` generator:** annotated `AsyncGenerator[bytes, None]`; explicit `aclose()` in a finally for Windows safety + cleaner POSIX semantics.
- **`register_file_exchange_routes` atomicity:** validates ALL preconditions BEFORE any `register_*_route` call; no partial-mount-then-raise.
- **`ArtifactSink.store_artifact` contract strengthened** with caller-closes-and-deletes-after-return wording.
- **Concurrency contract documented** in route docstring: single-use is not a lock; sinks MUST tolerate duplicate `store_artifact` calls within TTL.
- **`_filesystem.py`** consolidated to import `_HASHLIB_BY_LABEL` AND `_CHUNK` from `_staging.py` (no silent-drift opportunity).

## Test plan
- [x] `uv run pytest` — 1023 passed, 1 skipped (GITHUB_TOKEN-gated spec sync)
- [x] `uv run ruff format --check . && uv run ruff check . && uv run mypy src` — clean
- [x] Cross-version: `uv run --python 3.10/3.13 pytest tests/_file_exchange/test_upload*.py` — 64 passed on both
- [x] Coverage includes (regression guards from spike+v2 lessons): receiver mint, helper unit (RFC 9530 / 7231 / 8941 edge cases incl. `\":\":\"` rejection, member-param stripping, supported-malformed-no-fall-through, multi-algo digest round-trip), route status matrix (204/404/413/415/400/500), `requireDigest` algo-list enforcement, `digest_algo` happy + ValueError on unsupported algo, ambient-creds ignored, consume-failure-still-204, temp-file unlinked on every failure path (route + sender), flush+close error-mapping mirroring merged #145 download tests, sender hook-stream non-OSError → TRANSFER_FAILED, `register_file_exchange_routes` source-or-sink + config-when-sink + atomicity (download NOT mounted when config-missing ValueError fires), two-server push e2e.

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)