### PR TITLE
feat(file-exchange): upload transport data plane (#146) — Tasks 1-5

### DIFF
--- a/docs/superpowers/plans/2026-05-27-file-exchange-146-upload-data-plane-v4.md
+++ b/docs/superpowers/plans/2026-05-27-file-exchange-146-upload-data-plane-v4.md
@@ -1,0 +1,2351 @@
+# File-Exchange #146 Upload Data Plane — TDD-First Implementation Plan (v4)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the `upload` transport's data plane (route + receiver mint + sender consume) as the mirror of the merged #145 download data plane, driven test-by-test by the 2026-05-27 failure-mode matrix, on a fresh branch with no carry-over sediment from the three abandoned attempts (#163 / #164 / #165).
+
+**Architecture:** One new private module per concern — `_staging.py` for the digest+chunk primitives shared with the download fetcher, `_upload.py` for the upload role helpers + route registrar + RFC 9530/7231 helpers, `_routes.py` for the cross-transport `register_file_exchange_routes` registrar. Existing `_download.py` is refactored in place to import the shared primitives and to expose its own `register_download_route`; `register_file_exchange_routes` moves to `_routes.py`. Public re-exports in `file_exchange.py` and the subpackage `__init__.py` stay alphabetical, with the public name `register_file_exchange_routes` unchanged.
+
+**Tech Stack:** Python 3.10–3.13, `pydantic`, `starlette` (via `fastmcp.custom_route`), `httpx` (via `_outbound.guarded_stream`), `asyncio.to_thread` for blocking I/O off-loading, `hashlib` for digest, `pytest` (`asyncio_mode = "auto"`).
+
+**Spec:** `docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md`
+**Failure-mode matrix:** `docs/superpowers/specs/2026-05-27-file-exchange-146-failure-modes.md`
+**Mirror reference:** `src/fastmcp_pvl_core/_file_exchange/_download.py` on `main`.
+
+**PR-shape rule:** After each Task, decide whether the diff so far is independently mergeable with a small review surface. If yes, push; if not, continue. Do **not** pre-commit to "one PR" or "five PRs" — let the work shape its packaging. The three-abandon memory (`feedback_three_abandons_means_scope`) warns against grinding sediment; the abandon-rule (`feedback_high_recall_bot_iteration_limits`) warns against ignoring iteration spirals. Both apply.
+
+**Discipline at every Task boundary:**
+
+- `uv run pytest tests/_file_exchange/test_download.py tests/_file_exchange/test_download_e2e.py` — the download suite must stay green.
+- `uv run ruff format .` then `uv run ruff check .` then `uv run mypy src` — every commit.
+- The matrix row IDs (A1–G2) are referenced in each step's test docstring so reviewers can trace each test back to its enumerated failure mode.
+
+---
+
+## Task 1 — Extract shared staging primitives (matrix rows G1, B1 mirror, B2 mirror, B3 mirror)
+
+**Goal:** Move the chunk-write / digest-verifier / `_CHUNK` / `_HASHLIB_BY_LABEL` primitives out of `_download.py` into `_staging.py` without changing observable behaviour. This unblocks `_upload.py` from re-deriving them. It is a pure refactor — every existing download test must remain green.
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_staging.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_download.py`
+- Test: `tests/_file_exchange/test_staging.py`
+
+- [ ] **Step 1.1: Write the failing test for `_staging` re-exports.**
+
+```python
+# tests/_file_exchange/test_staging.py
+"""Matrix row G1: extracted staging primitives match the download originals."""
+
+import hashlib
+
+from fastmcp_pvl_core._file_exchange import _staging
+
+
+def test_chunk_constant_is_one_megabyte():
+    assert _staging._CHUNK == 1024 * 1024
+
+
+def test_hashlib_label_map_covers_sha_256_384_512():
+    assert _staging._HASHLIB_BY_LABEL == {
+        "sha-256": "sha256",
+        "sha-384": "sha384",
+        "sha-512": "sha512",
+    }
+
+
+def test_digest_verifier_unknown_label_unverifiable():
+    hasher, expected_hex, unverifiable = _staging._digest_verifier("md5:abcd")
+    assert hasher is None
+    assert expected_hex == "abcd"
+    assert unverifiable is True
+
+
+def test_digest_verifier_known_label_returns_hasher():
+    hasher, expected_hex, unverifiable = _staging._digest_verifier(
+        "sha-256:" + "0" * 64
+    )
+    assert isinstance(hasher, type(hashlib.sha256()))
+    assert expected_hex == "0" * 64
+    assert unverifiable is False
+
+
+def test_digest_verifier_none_declared_no_op():
+    assert _staging._digest_verifier(None) == (None, None, False)
+
+
+def test_write_chunk_writes_and_hashes(tmp_path):
+    target = tmp_path / "buf.bin"
+    with target.open("wb") as fh:
+        h = hashlib.new("sha256")
+        _staging._write_chunk(fh, h, b"abc")
+        _staging._write_chunk(fh, h, b"def")
+    assert target.read_bytes() == b"abcdef"
+    assert h.hexdigest() == hashlib.sha256(b"abcdef").hexdigest()
+
+
+def test_write_chunk_no_hasher_writes_only(tmp_path):
+    target = tmp_path / "buf.bin"
+    with target.open("wb") as fh:
+        _staging._write_chunk(fh, None, b"abc")
+    assert target.read_bytes() == b"abc"
+```
+
+- [ ] **Step 1.2: Run the test — confirm it fails.**
+
+```bash
+uv run pytest tests/_file_exchange/test_staging.py -v
+```
+Expected: `ModuleNotFoundError: No module named 'fastmcp_pvl_core._file_exchange._staging'`.
+
+- [ ] **Step 1.3: Create `_staging.py` with the extracted primitives.**
+
+```python
+# src/fastmcp_pvl_core/_file_exchange/_staging.py
+"""Shared digest + chunk-write primitives for the file-exchange data planes.
+
+Both ``_download`` (fetcher: write incoming HTTP body to a temp) and
+``_upload`` (route: write incoming PUT body to a temp; sender: write outgoing
+hook stream to a temp before hashing) share the same per-chunk
+write-and-hash pattern and the same declared-digest verifier semantics.
+Centralising the primitives here keeps the contract — every temp-file op
+maps to ``transfer-failed`` or is suppressed for cleanup, and an
+unsupported digest label fails verification rather than silently skipping
+— from being re-derived divergently between transports (matrix row G1,
+spec §15, mirror ``_download.py`` lines 47–302).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import IO
+
+_CHUNK = 1024 * 1024
+
+# Declared-digest label -> hashlib name; an unsupported label fails
+# verification (cannot verify -> digest-mismatch), never silently skips.
+_HASHLIB_BY_LABEL = {"sha-256": "sha256", "sha-384": "sha384", "sha-512": "sha512"}
+
+
+def _digest_verifier(
+    declared: str | None,
+) -> tuple[hashlib._Hash | None, str | None, bool]:
+    """Return ``(hasher | None, expected_hex | None, unverifiable)``.
+
+    ``unverifiable`` is True when a digest is declared with an unsupported
+    label — verification must then fail (cannot verify), never silently
+    skip (§15).
+    """
+    if declared is None:
+        return None, None, False
+    label, _, expected_hex = declared.partition(":")
+    name = _HASHLIB_BY_LABEL.get(label.lower())
+    if name is None:
+        return None, expected_hex, True
+    return hashlib.new(name), expected_hex.lower(), False
+
+
+def _write_chunk(
+    tmp: IO[bytes], hasher: hashlib._Hash | None, chunk: bytes
+) -> None:
+    """Write a body chunk to the temp file and fold it into the running hash.
+
+    Both ops run off the event loop in a single ``asyncio.to_thread`` dispatch.
+    """
+    tmp.write(chunk)
+    if hasher is not None:
+        hasher.update(chunk)
+```
+
+- [ ] **Step 1.4: Run the staging test — confirm it passes.**
+
+```bash
+uv run pytest tests/_file_exchange/test_staging.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 1.5: Rewire `_download.py` to import the primitives.**
+
+In `src/fastmcp_pvl_core/_file_exchange/_download.py`:
+
+1. Delete the local `_CHUNK = 1024 * 1024`, `_HASHLIB_BY_LABEL = {...}`, `_digest_verifier(...)`, and `_write_chunk(...)` definitions.
+2. Add the import near the existing imports:
+
+```python
+from fastmcp_pvl_core._file_exchange._staging import (
+    _CHUNK,
+    _HASHLIB_BY_LABEL,
+    _digest_verifier,
+    _write_chunk,
+)
+```
+
+3. Leave every other line of `_download.py` untouched. The names are unchanged; only their source module is.
+
+- [ ] **Step 1.6: Run the download suite — confirm it still passes.**
+
+```bash
+uv run pytest tests/_file_exchange/test_download.py tests/_file_exchange/test_download_e2e.py -v
+```
+Expected: PASS, identical to pre-refactor.
+
+- [ ] **Step 1.7: Format, lint, type-check, commit.**
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run mypy src
+git add src/fastmcp_pvl_core/_file_exchange/_staging.py \
+        src/fastmcp_pvl_core/_file_exchange/_download.py \
+        tests/_file_exchange/test_staging.py
+git commit -m "$(cat <<'EOF'
+refactor(file-exchange): extract _staging.py from _download.py (#146)
+
+Move _CHUNK, _HASHLIB_BY_LABEL, _digest_verifier, _write_chunk out of
+_download.py into a new _staging.py. Pure refactor: no observable
+behaviour change; download tests stay green. Unblocks #146's upload
+data plane from re-deriving the primitives.
+
+Matrix row G1. Refs #146.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+**Task 1 PR-shape checkpoint:** This refactor is independently reviewable in ~50 lines. If you want to push and open a PR for it alone, do so now and pause for review before Task 2. Otherwise continue.
+
+---
+
+## Task 2 — `upload_receiver_mint` (matrix rows E1, E4)
+
+**Goal:** The smallest upload primitive: token mint + `IntakeTicket` build. No I/O.
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+- Test: `tests/_file_exchange/test_upload_mint.py`
+
+- [ ] **Step 2.1: Write the failing tests for mint.**
+
+```python
+# tests/_file_exchange/test_upload_mint.py
+"""Matrix row E1, E4: upload_receiver_mint builds an IntakeTicket."""
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints, UploadSink
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+async def test_mint_returns_intake_ticket_with_one_upload_sink():
+    store = _store()
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://b.example",
+        ttl=120.0,
+    )
+    assert ticket.type == TICKET_TYPE
+    assert ticket.version == SPEC_VERSION
+    assert ticket.artifactId == "art-1"
+    assert ticket.expected is None
+    assert len(ticket.sinks) == 1
+    sink = ticket.sinks[0]
+    assert isinstance(sink, UploadSink)
+    assert sink.transport == "upload"
+    assert sink.url.startswith("https://b.example/fx/u/")
+    assert sink.method == "PUT"
+    token = sink.url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata == {"artifact_id": "art-1", "expected": None}
+    assert rec.single_use is True
+
+
+async def test_mint_method_post_threads_through():
+    store = _store()
+    ticket = await _upload.upload_receiver_mint(
+        "art-2",
+        token_store=store,
+        base_url="https://b.example",
+        ttl=120.0,
+        method="POST",
+    )
+    assert ticket.sinks[0].method == "POST"
+
+
+async def test_mint_expected_round_trips_onto_ticket_and_metadata():
+    store = _store()
+    expected = ArtifactConstraints(
+        maxSize=1024, acceptMimeTypes=["application/json"], requireDigest=["sha-256"]
+    )
+    ticket = await _upload.upload_receiver_mint(
+        "art-3",
+        token_store=store,
+        base_url="https://b.example",
+        ttl=120.0,
+        expected=expected,
+    )
+    assert ticket.expected == expected
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata["artifact_id"] == "art-3"
+    assert rec.metadata["expected"] == expected.model_dump()
+
+
+async def test_mint_calls_do_not_collide_for_same_artifact_id():
+    """E1: minting twice yields two distinct tokens, both valid."""
+    store = _store()
+    t1 = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://b.example", ttl=120.0
+    )
+    t2 = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://b.example", ttl=120.0
+    )
+    tok1 = t1.sinks[0].url.rsplit("/", 1)[1]
+    tok2 = t2.sinks[0].url.rsplit("/", 1)[1]
+    assert tok1 != tok2
+    assert (await store.lookup(tok1)) is not None
+    assert (await store.lookup(tok2)) is not None
+```
+
+- [ ] **Step 2.2: Run the tests — confirm they fail.**
+
+```bash
+uv run pytest tests/_file_exchange/test_upload_mint.py -v
+```
+Expected: `ModuleNotFoundError: No module named 'fastmcp_pvl_core._file_exchange._upload'`.
+
+- [ ] **Step 2.3: Create `_upload.py` with `upload_receiver_mint` and `UPLOAD_PREFIX`.**
+
+```python
+# src/fastmcp_pvl_core/_file_exchange/_upload.py
+"""The ``upload`` transport data plane (#146).
+
+Three free helpers — ``upload_receiver_mint``, ``upload_sender_consume``,
+and ``register_upload_route`` — that mirror ``_download.py``'s pull plane.
+The route accepts an HTTPS ``PUT``/``POST`` capability URL, streams the
+request body to a transient temp file with size + digest verification,
+and on a clean verify deposits the bytes into the receiver's
+``ArtifactSink`` (#142). The sender stages the offered bytes (hook stream
+→ temp + hash) and ``PUT``s them through the #147 SSRF guard.
+
+See ``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``
+for the contract and ``…2026-05-27-file-exchange-146-failure-modes.md`` for
+the enumerated failure modes each test in this module exercises.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._tokens import capability_url
+from fastmcp_pvl_core._file_exchange._wire import IntakeTicket, UploadSink
+
+if TYPE_CHECKING:
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+    from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
+
+# pvl-core's upload route shape (§12 capability URL path). A constant, not a
+# kwarg — route structure is a pvl-core shape decision.
+UPLOAD_PREFIX = "/fx/u"
+
+
+async def upload_receiver_mint(
+    artifact_id: str,
+    *,
+    token_store: CapabilityTokenStore,
+    base_url: str,
+    ttl: float,
+    expected: ArtifactConstraints | None = None,
+    method: Literal["PUT", "POST"] = "PUT",
+) -> IntakeTicket:
+    """Receiver role (push): mint an upload token and emit an IntakeTicket.
+
+    Mint-only — no hook is called, no bytes move. The token stores the
+    ``artifact_id`` and the ``expected`` constraints so the route can
+    correlate received bytes back to a wire id and enforce limits at
+    deposit time. The token store treats the metadata as opaque (#144).
+    """
+    minted = await token_store.mint(
+        {
+            "artifact_id": artifact_id,
+            "expected": expected.model_dump() if expected is not None else None,
+        },
+        ttl=ttl,
+        single_use=True,
+    )
+    url = capability_url(base_url, UPLOAD_PREFIX, minted.token)
+    return IntakeTicket(
+        type=TICKET_TYPE,
+        version=SPEC_VERSION,
+        artifactId=artifact_id,
+        expected=expected,
+        sinks=[
+            UploadSink(
+                transport="upload",
+                url=url,
+                method=method,
+                expiresAt=minted.expires_at,
+            )
+        ],
+    )
+```
+
+- [ ] **Step 2.4: Run the mint tests — confirm they pass.**
+
+```bash
+uv run pytest tests/_file_exchange/test_upload_mint.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 2.5: Format, lint, type-check, commit.**
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run mypy src
+git add src/fastmcp_pvl_core/_file_exchange/_upload.py \
+        tests/_file_exchange/test_upload_mint.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): upload_receiver_mint (#146)
+
+Mint a single-use capability token and build an IntakeTicket carrying
+one UploadSink. No I/O, no hook calls — pure token-store mint plus
+descriptor construction. The token's opaque metadata carries the
+artifact_id and the optional ArtifactConstraints so the route (next
+task) can correlate received bytes and enforce limits.
+
+Matrix rows E1, E4. Refs #146.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 — RFC 9530 `Content-Digest` parser + formatter (matrix rows F1, F2, D4, D5)
+
+**Goal:** Hand-rolled parse/format for the structured-field dictionary form `algo=:base64:`. Used by both the route (parse incoming header) and the sender (format outgoing header).
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+- Test: `tests/_file_exchange/test_upload_helpers.py`
+
+- [ ] **Step 3.1: Write the failing tests.**
+
+```python
+# tests/_file_exchange/test_upload_helpers.py
+"""Matrix rows F1, F2, F3, F4, D4, D5: pure-function helpers in _upload."""
+
+import base64
+import hashlib
+
+import pytest
+
+from fastmcp_pvl_core._file_exchange._upload import (
+    _content_digest_format,
+    _content_digest_parse,
+    _media_range_matches,
+)
+
+
+# --- Content-Digest parse (F1, D4, D5) ---
+
+
+def test_content_digest_parse_sha256_well_formed():
+    payload = b"hello"
+    raw = hashlib.sha256(payload).digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    header = f"sha-256=:{b64}:"
+    algo, decoded = _content_digest_parse(header)
+    assert algo == "sha-256"
+    assert decoded == raw
+
+
+def test_content_digest_parse_sha512_well_formed():
+    raw = hashlib.sha512(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    algo, decoded = _content_digest_parse(f"sha-512=:{b64}:")
+    assert algo == "sha-512"
+    assert decoded == raw
+
+
+def test_content_digest_parse_tolerates_whitespace():
+    raw = hashlib.sha256(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    algo, decoded = _content_digest_parse(f"  sha-256 = :{b64}:  ")
+    assert algo == "sha-256"
+    assert decoded == raw
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "garbage",
+        "sha-256:abcd",  # missing structured-field colons
+        "md5=:YWJjZA==:",  # unsupported algo label
+        "sha-256=::",  # empty value
+        "sha-256=:not-base64!:",
+        "sha-256=:YWJjZA",  # missing trailing colon
+        "",
+    ],
+)
+def test_content_digest_parse_malformed_or_unknown_returns_none(header):
+    """D4 + D5: present-but-unparseable / unsupported-algo -> None."""
+    assert _content_digest_parse(header) is None
+
+
+# --- Content-Digest format (F2) ---
+
+
+def test_content_digest_format_round_trips():
+    raw = hashlib.sha256(b"hello").digest()
+    header = _content_digest_format("sha-256", raw)
+    parsed = _content_digest_parse(header)
+    assert parsed == ("sha-256", raw)
+
+
+# --- Media-range matching (F3, F4) ---
+
+
+@pytest.mark.parametrize(
+    "content_type,accept,expected",
+    [
+        ("application/json", ["application/json"], True),
+        ("application/json; charset=utf-8", ["application/json"], True),
+        ("image/png", ["image/*"], True),
+        ("text/plain", ["image/*"], False),
+        ("application/octet-stream", ["*/*"], True),
+        ("APPLICATION/JSON", ["application/json"], True),  # case-insensitive
+        ("application/json", ["text/plain", "application/json"], True),
+        ("application/json", ["text/plain", "text/html"], False),
+        ("", ["application/json"], False),
+        ("application/json", [], False),
+    ],
+)
+def test_media_range_matches_table(content_type, accept, expected):
+    """F3."""
+    assert _media_range_matches(content_type, accept) is expected
+```
+
+- [ ] **Step 3.2: Run — confirm failure.**
+
+```bash
+uv run pytest tests/_file_exchange/test_upload_helpers.py -v
+```
+Expected: `ImportError: cannot import name '_content_digest_parse' from 'fastmcp_pvl_core._file_exchange._upload'`.
+
+- [ ] **Step 3.3: Add the helpers to `_upload.py`.**
+
+Add to the bottom of `_upload.py` (above the existing `upload_receiver_mint`, or below — order doesn't matter for behaviour; module-internal helpers conventionally near the top):
+
+```python
+import base64 as _b64
+import binascii
+
+from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL
+
+
+def _content_digest_parse(header: str) -> tuple[str, bytes] | None:
+    """Parse an RFC 9530 ``Content-Digest`` structured-field dictionary entry.
+
+    Returns ``(algo_label, raw_digest_bytes)`` on success, or ``None`` for any
+    malformed input or unsupported algorithm — the caller treats ``None`` as a
+    verification failure (``digest-mismatch``), never a silent skip
+    (matrix rows D4, D5; spec §10.3).
+
+    Only a single-algorithm dictionary entry is accepted (the form pvl-core's
+    sender produces); ``sha-256``/``sha-384``/``sha-512`` are the supported
+    labels.
+    """
+    if not header:
+        return None
+    entry = header.split(",", 1)[0].strip()
+    label, sep, rest = entry.partition("=")
+    if sep != "=":
+        return None
+    label = label.strip().lower()
+    if label not in _HASHLIB_BY_LABEL:
+        return None
+    rest = rest.strip()
+    if len(rest) < 2 or not rest.startswith(":") or not rest.endswith(":"):
+        return None
+    b64 = rest[1:-1]
+    if not b64:
+        return None
+    try:
+        raw = _b64.b64decode(b64, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    return label, raw
+
+
+def _content_digest_format(label: str, raw: bytes) -> str:
+    """Format ``(label, raw_digest_bytes)`` as ``algo=:base64:`` per RFC 9530."""
+    return f"{label}=:{_b64.b64encode(raw).decode('ascii')}:"
+
+
+def _media_range_matches(content_type: str, accept: list[str]) -> bool:
+    """RFC 7231 §3.1.1.1 media-range match: parameters ignored, case-insensitive.
+
+    ``type/*`` matches any subtype; ``*/*`` matches anything. An empty
+    ``content_type`` or an empty ``accept`` list never matches
+    (matrix rows F3, F4).
+    """
+    if not content_type or not accept:
+        return False
+    main = content_type.split(";", 1)[0].strip().lower()
+    if "/" not in main:
+        return False
+    main_type, main_sub = main.split("/", 1)
+    for entry in accept:
+        if not entry:
+            continue
+        entry_main = entry.split(";", 1)[0].strip().lower()
+        if "/" not in entry_main:
+            continue
+        e_type, e_sub = entry_main.split("/", 1)
+        if (e_type == "*" or e_type == main_type) and (
+            e_sub == "*" or e_sub == main_sub
+        ):
+            return True
+    return False
+```
+
+- [ ] **Step 3.4: Run — confirm pass.**
+
+```bash
+uv run pytest tests/_file_exchange/test_upload_helpers.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 3.5: Format, lint, type-check, commit.**
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run mypy src
+git add src/fastmcp_pvl_core/_file_exchange/_upload.py \
+        tests/_file_exchange/test_upload_helpers.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): RFC 9530 Content-Digest + RFC 7231 media-range helpers (#146)
+
+Hand-rolled parse/format for the structured-field dictionary form
+`algo=:base64:` (sha-256/384/512 only) plus an RFC 7231 §3.1.1.1
+media-range matcher. All three are pure functions, exhaustively
+covered with table-driven tests. Present-but-unparseable headers and
+unsupported algorithm labels return None / False — never a silent
+skip (spec §10.3, matrix rows F1–F4, D4, D5).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 — `register_upload_route` happy path (matrix row A1 success arm, F4)
+
+**Goal:** The route handler. Start with the happy PUT — body streams to a temp, digest verifies, sink stores, token consumes, 204 returned. Edge modes (A2–A6, B1–B6, C1–C2, D4–D8) are added in **Task 5** one by one; this task lands the skeleton so each subsequent edge-mode test attaches to a working baseline.
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+- Test: `tests/_file_exchange/test_upload_route.py`
+
+- [ ] **Step 4.1: Write the failing happy-path test.**
+
+```python
+# tests/_file_exchange/test_upload_route.py
+"""Matrix rows A1–A6, B1, B4, B6, C1–C2, D4–D8, F4, F5: upload route."""
+
+import hashlib
+import os
+from typing import BinaryIO
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints, ArtifactMetadata
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str | None, ArtifactMetadata, bytes]] = []
+
+    async def store_artifact(
+        self, artifact_id: str | None, metadata: ArtifactMetadata, stream: BinaryIO
+    ) -> None:
+        data = stream.read()
+        self.calls.append((artifact_id, metadata, data))
+
+
+async def _mount(sink, *, config=None):
+    cfg = config or ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_token_ttl=3600.0,
+        file_exchange_max_artifact_size=10 * 1024 * 1024,
+    )
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("test")
+    _upload.register_upload_route(mcp, token_store=store, sink=sink, config=cfg)
+    return mcp, store
+
+
+async def _client(mcp):
+    transport = httpx.ASGITransport(app=mcp.http_app())
+    return httpx.AsyncClient(transport=transport, base_url="http://test")
+
+
+async def test_route_happy_put_deposits_and_consumes():
+    """A1 success: PUT 204 -> sink called once, token consumed."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="http://test",
+        ttl=120.0,
+    )
+    url = ticket.sinks[0].url
+    token = url.rsplit("/", 1)[1]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            url, content=b"hello world", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+    aid, meta, body = sink.calls[0]
+    assert aid == "art-1"
+    assert body == b"hello world"
+    assert meta.mimeType == "text/plain"
+    assert meta.size == len(b"hello world")
+    assert meta.digest == "sha-256:" + hashlib.sha256(b"hello world").hexdigest()
+    # Token consumed
+    assert await store.lookup(token) is None
+
+
+async def test_route_unknown_token_404():
+    """A1 prelude: lookup miss -> 404."""
+    sink = _RecordingSink()
+    mcp, _ = await _mount(sink)
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            "/fx/u/does-not-exist", content=b"x", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 404
+    assert sink.calls == []
+```
+
+- [ ] **Step 4.2: Run — confirm failure.**
+
+```bash
+uv run pytest tests/_file_exchange/test_upload_route.py -v
+```
+Expected: `ImportError: cannot import name 'register_upload_route'`.
+
+- [ ] **Step 4.3: Implement the route in `_upload.py`.**
+
+Add the imports and the registrar. Place this after the helpers (`_content_digest_parse`, `_media_range_matches`) added in Task 3:
+
+```python
+import asyncio
+import contextlib
+import hashlib
+import logging
+import os
+import tempfile
+from typing import TYPE_CHECKING, cast
+
+from fastmcp_pvl_core._file_exchange._staging import _CHUNK, _write_chunk
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink
+
+logger = logging.getLogger(__name__)
+
+
+def register_upload_route(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    sink: ArtifactSink,
+    config: ServerConfig,
+) -> None:
+    """Mount ``PUT``/``POST <UPLOAD_PREFIX>/{token}`` on ``mcp``.
+
+    The route serves §12 capability URLs minted by ``upload_receiver_mint``;
+    ambient credentials are ignored — the in-URL token is the only
+    authorization. ``config.file_exchange_max_artifact_size`` is the operator
+    body-size cap; per-mint ``expected.maxSize`` is the smaller of the two when
+    set. See the failure-mode matrix for the full per-status-code contract.
+    """
+    from starlette.responses import Response
+
+    async def _handle(request: Request) -> Response:
+        token = request.path_params["token"]
+        rec = await token_store.lookup(token)
+        if rec is None:
+            return Response(status_code=404)
+        artifact_id = cast("str", rec.metadata["artifact_id"])
+        expected_raw = rec.metadata.get("expected")
+        expected = (
+            ArtifactConstraints.model_validate(expected_raw)
+            if expected_raw is not None
+            else None
+        )
+
+        content_type = request.headers.get("content-type", "")
+        if expected is not None and expected.acceptMimeTypes is not None:
+            if not _media_range_matches(content_type, expected.acceptMimeTypes):
+                return Response(status_code=415)
+
+        cap_per_mint = expected.maxSize if expected is not None else None
+        cap_operator = config.file_exchange_max_artifact_size
+        # The smaller-of-two cap is the effective cap; if neither is set, no cap.
+        cap: int | None
+        if cap_per_mint is None:
+            cap = cap_operator
+        elif cap_operator is None:
+            cap = cap_per_mint
+        else:
+            cap = min(cap_per_mint, cap_operator)
+
+        # Stage to a transient temp file (hash on the fly).
+        try:
+            fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-")
+        except OSError:
+            logger.exception("file-exchange: upload mkstemp failed")
+            return Response(status_code=500)
+        try:
+            try:
+                tmp = os.fdopen(fd, "wb")
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                raise
+            hasher = hashlib.new("sha256")
+            received = 0
+            too_large = False
+            try:
+                try:
+                    async for chunk in request.stream():
+                        if not chunk:
+                            continue
+                        if cap is not None and received + len(chunk) > cap:
+                            too_large = True
+                            break
+                        await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                        received += len(chunk)
+                except OSError:
+                    logger.exception("file-exchange: upload temp write failed")
+                    return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(tmp.close)
+
+            if too_large:
+                return Response(status_code=413)
+
+            # Verify Content-Digest BEFORE the sink sees the bytes
+            cd_header = request.headers.get("content-digest")
+            if cd_header is not None:
+                parsed = _content_digest_parse(cd_header)
+                if parsed is None:
+                    return Response(status_code=400)
+                cd_algo, cd_raw = parsed
+                if cd_algo == "sha-256":
+                    if hasher.digest() != cd_raw:
+                        return Response(status_code=400)
+                else:
+                    # Re-hash the temp in the declared algorithm.
+                    rehash = hashlib.new(_HASHLIB_BY_LABEL[cd_algo])
+                    try:
+                        with open(tmp_path, "rb") as fh:
+                            while True:
+                                buf = await asyncio.to_thread(fh.read, _CHUNK)
+                                if not buf:
+                                    break
+                                rehash.update(buf)
+                    except OSError:
+                        logger.exception(
+                            "file-exchange: upload rehash read failed"
+                        )
+                        return Response(status_code=500)
+                    if rehash.digest() != cd_raw:
+                        return Response(status_code=400)
+            elif expected is not None and expected.requireDigest is not None:
+                # require-digest with missing header
+                return Response(status_code=400)
+
+            meta = ArtifactMetadata(
+                mimeType=content_type or None,
+                size=received,
+                digest="sha-256:" + hasher.hexdigest(),
+            )
+            try:
+                f = await asyncio.to_thread(open, tmp_path, "rb")
+            except OSError:
+                logger.exception("file-exchange: upload temp re-open failed")
+                return Response(status_code=500)
+            try:
+                try:
+                    await sink.store_artifact(artifact_id, meta, f)
+                except Exception:
+                    logger.exception("file-exchange: upload sink store_artifact failed")
+                    return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(f.close)
+
+            # Single-success-per-URL: consume ONLY after the sink succeeds.
+            with contextlib.suppress(Exception):
+                await token_store.consume(token)
+            return Response(status_code=204)
+        finally:
+            with contextlib.suppress(OSError):
+                await asyncio.to_thread(os.unlink, tmp_path)
+
+    mcp.custom_route(f"{UPLOAD_PREFIX}/{{token}}", methods=["PUT", "POST"])(_handle)
+```
+
+Also add to the existing imports at the top of `_upload.py`:
+
+```python
+from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL
+```
+
+(If it was already added in Task 3, leave it.)
+
+- [ ] **Step 4.4: Run the two happy-path tests — confirm they pass.**
+
+```bash
+uv run pytest tests/_file_exchange/test_upload_route.py -v
+```
+Expected: `test_route_happy_put_deposits_and_consumes` PASS; `test_route_unknown_token_404` PASS.
+
+- [ ] **Step 4.5: Format, lint, type-check, commit.**
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run mypy src
+git add src/fastmcp_pvl_core/_file_exchange/_upload.py \
+        tests/_file_exchange/test_upload_route.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): upload route happy path + 404 lookup miss (#146)
+
+Mount PUT/POST /fx/u/{token}. The handler streams the body to a temp
+file with sha-256 hashing, verifies an optional Content-Digest header
+BEFORE the sink sees the bytes (verify-before-use), deposits to the
+sink, and consumes the single-use token only after a successful store.
+This commit lands the skeleton; edge modes (415/413/400/sink-raises,
+fd-leak guards, concurrency) are added one matrix row per commit in
+the next task.
+
+Matrix rows A1 (success arm), F4 (no acceptMimeTypes constraint).
+Refs #146.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 — Upload route edge modes (matrix rows A2–A6, B1, B4, B6, C1, C2, D4–D8, F5)
+
+**Goal:** Add one TDD micro-cycle per edge mode. Each adds a test, runs it (fail), adds whatever code change makes it pass, commits.
+
+> Pattern for every micro-cycle below: (a) add the test to `tests/_file_exchange/test_upload_route.py`, (b) run it to confirm a meaningful failure, (c) make the minimal code change in `_upload.py`'s `_handle`, (d) re-run, (e) `ruff/mypy`, (f) commit with a message naming the matrix row.
+
+The route skeleton from Task 4 already covers most edge behaviour structurally (415/413/400 short-circuits, sink-raise → 500, temp unlink in `finally`). The cycles here exist to **prove** that coverage with a test before declaring the row done.
+
+- [ ] **Step 5.1: A1 — second PUT after success returns 404 (test only; no code change expected).**
+
+```python
+async def test_route_second_put_after_success_returns_404():
+    """A1 ordering: token consumed after first success; second PUT -> 404."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+    url = ticket.sinks[0].url
+    async with await _client(mcp) as c:
+        r1 = await c.put(url, content=b"a", headers={"Content-Type": "text/plain"})
+        r2 = await c.put(url, content=b"b", headers={"Content-Type": "text/plain"})
+    assert r1.status_code == 204
+    assert r2.status_code == 404
+    assert len(sink.calls) == 1
+```
+
+Run → expect PASS (the skeleton already does this). Commit: `test(file-exchange): cover A1 second-PUT-after-success (#146)`.
+
+- [ ] **Step 5.2: A2 — sink raise does NOT consume the token.**
+
+```python
+class _RaisingSink:
+    def __init__(self) -> None:
+        self.attempts = 0
+
+    async def store_artifact(self, artifact_id, metadata, stream):
+        self.attempts += 1
+        stream.read()
+        if self.attempts == 1:
+            raise RuntimeError("boom")
+
+
+async def test_route_sink_raise_does_not_consume_token():
+    """A2: sink raises -> 500, token still valid, retry succeeds."""
+    sink = _RaisingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+    url = ticket.sinks[0].url
+    async with await _client(mcp) as c:
+        r1 = await c.put(url, content=b"a", headers={"Content-Type": "text/plain"})
+        r2 = await c.put(url, content=b"b", headers={"Content-Type": "text/plain"})
+    assert r1.status_code == 500
+    assert r2.status_code == 204
+    assert sink.attempts == 2
+```
+
+Run → expect PASS (skeleton consumes only after a successful store). Commit.
+
+- [ ] **Step 5.3: A3 — acceptMimeTypes mismatch returns 415, no consume, no sink call.**
+
+```python
+async def test_route_accept_mime_mismatch_415():
+    """A3: Content-Type not in acceptMimeTypes -> 415, no consume, no sink."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="http://test",
+        ttl=120.0,
+        expected=ArtifactConstraints(acceptMimeTypes=["application/json"]),
+    )
+    url = ticket.sinks[0].url
+    token = url.rsplit("/", 1)[1]
+    async with await _client(mcp) as c:
+        resp = await c.put(url, content=b"hi", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 415
+    assert sink.calls == []
+    assert await store.lookup(token) is not None  # not consumed
+```
+
+Run → expect PASS. Commit.
+
+- [ ] **Step 5.4: A4 — too-large returns 413 (per-mint cap and operator cap).**
+
+```python
+async def test_route_too_large_per_mint_cap_413():
+    """A4: body exceeds expected.maxSize -> 413, no consume, no sink."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="http://test",
+        ttl=120.0,
+        expected=ArtifactConstraints(maxSize=4),
+    )
+    url = ticket.sinks[0].url
+    token = url.rsplit("/", 1)[1]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            url, content=b"too-many-bytes", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 413
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+
+async def test_route_too_large_operator_cap_413():
+    """A4: body exceeds operator cap -> 413."""
+    sink = _RecordingSink()
+    cfg = ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_token_ttl=3600.0,
+        file_exchange_max_artifact_size=4,
+    )
+    mcp, store = await _mount(sink, config=cfg)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+    url = ticket.sinks[0].url
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            url, content=b"too-many", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 413
+```
+
+Run → expect PASS. Commit.
+
+- [ ] **Step 5.5: A5 — Content-Digest mismatch returns 400, no consume, no sink.**
+
+```python
+async def test_route_content_digest_mismatch_400():
+    """A5: wrong Content-Digest -> 400, no sink call (verify-before-use)."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+    url = ticket.sinks[0].url
+    token = url.rsplit("/", 1)[1]
+    bad = "sha-256=:" + "A" * 44 + ":"  # wrong digest
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            url,
+            content=b"hello",
+            headers={"Content-Type": "text/plain", "Content-Digest": bad},
+        )
+    assert resp.status_code == 400
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+```
+
+Run → expect PASS. Commit.
+
+- [ ] **Step 5.6: A6, D4, D5 — require-digest missing, unparseable, unsupported algo.**
+
+```python
+async def test_route_require_digest_but_missing_header_400():
+    """A6: requireDigest set + no Content-Digest -> 400."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="http://test",
+        ttl=120.0,
+        expected=ArtifactConstraints(requireDigest=["sha-256"]),
+    )
+    url = ticket.sinks[0].url
+    async with await _client(mcp) as c:
+        resp = await c.put(url, content=b"hi", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 400
+    assert sink.calls == []
+
+
+async def test_route_content_digest_unparseable_400():
+    """D4: present-but-unparseable Content-Digest -> 400."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+    url = ticket.sinks[0].url
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            url,
+            content=b"hi",
+            headers={"Content-Type": "text/plain", "Content-Digest": "garbage"},
+        )
+    assert resp.status_code == 400
+
+
+async def test_route_content_digest_unsupported_algo_400():
+    """D5: unsupported algo label -> 400."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+    url = ticket.sinks[0].url
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            url,
+            content=b"hi",
+            headers={
+                "Content-Type": "text/plain",
+                "Content-Digest": "md5=:YWJjZA==:",
+            },
+        )
+    assert resp.status_code == 400
+```
+
+Run → expect PASS. Commit.
+
+- [ ] **Step 5.7: B1 — fd leak between `mkstemp` and the staging `try` (monkey-patch hashlib).**
+
+```python
+async def test_route_hashlib_failure_does_not_leak_fd(monkeypatch):
+    """B1: simulated post-fdopen pre-staging failure -> fd closed, temp unlinked."""
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+    url = ticket.sinks[0].url
+
+    # Track temp paths created so we can assert they are gone.
+    created: list[str] = []
+    real_mkstemp = up.tempfile.mkstemp
+
+    def spy_mkstemp(**kw):
+        fd, path = real_mkstemp(**kw)
+        created.append(path)
+        return fd, path
+
+    monkeypatch.setattr(up.tempfile, "mkstemp", spy_mkstemp)
+
+    # Force hashlib.new("sha256") (the route's running hasher) to raise.
+    real_hashlib_new = up.hashlib.new
+
+    def boom(name):
+        if name == "sha256":
+            raise RuntimeError("FIPS")
+        return real_hashlib_new(name)
+
+    monkeypatch.setattr(up.hashlib, "new", boom)
+
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            url, content=b"hi", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 500
+    # Temp file must have been unlinked despite the early failure.
+    for p in created:
+        assert not os.path.exists(p), f"temp leaked: {p}"
+```
+
+If this fails (it likely will), restructure the route to move `hasher = hashlib.new("sha256")` **inside** the staging `try:` so the `finally` (tmp.close) and the outer `finally` (os.unlink) both fire. Re-run → PASS. Commit.
+
+- [ ] **Step 5.8: B4 + B6 — sink that reads but doesn't close; temp re-open failure.**
+
+```python
+async def test_route_sink_does_not_close_fd_route_closes_it(monkeypatch):
+    """B4: route owns the fd handed to the sink and closes it."""
+    closes: list[bool] = []
+
+    class _SpySink:
+        async def store_artifact(self, artifact_id, metadata, stream):
+            stream.read()
+            original_close = stream.close
+
+            def tracked():
+                closes.append(True)
+                original_close()
+
+            stream.close = tracked  # type: ignore[method-assign]
+
+    mcp, store = await _mount(_SpySink())
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+    url = ticket.sinks[0].url
+    async with await _client(mcp) as c:
+        resp = await c.put(url, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 204
+    assert closes == [True]  # route closed the stream after the sink returned
+
+
+async def test_route_temp_reopen_failure_500(monkeypatch):
+    """B6: open(tmp_path, 'rb') raises -> 500, sink not called, temp unlinked."""
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+    url = ticket.sinks[0].url
+
+    original_open = up.open if hasattr(up, "open") else __builtins__["open"]
+    # The route uses `open(tmp_path, "rb")` via the module's namespace —
+    # patch builtins.open and key on the prefix.
+    import builtins
+    real_open = builtins.open
+
+    def fake_open(path, mode="r", *a, **kw):
+        if isinstance(path, str) and "fx-upload-" in path and "rb" in mode:
+            raise OSError("simulated")
+        return real_open(path, mode, *a, **kw)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    async with await _client(mcp) as c:
+        resp = await c.put(url, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 500
+    assert sink.calls == []
+```
+
+Run → expect PASS (skeleton already handles both; the spy test asserts the contract). Commit.
+
+- [ ] **Step 5.9: D6, D7, D8 — sink raises `FileExchangeTransferError`; sink raises plain `Exception`; temp write `OSError`.**
+
+```python
+class _FxFailSink:
+    async def store_artifact(self, artifact_id, metadata, stream):
+        from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+        from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+        stream.read()
+        raise FileExchangeTransferError(
+            TransferErrorCode.TRANSFER_FAILED, transport="upload", detail="x"
+        )
+
+
+async def test_route_sink_raises_file_exchange_error_500():
+    """D6."""
+    mcp, store = await _mount(_FxFailSink())
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            ticket.sinks[0].url, content=b"x", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 500
+    assert resp.content == b""
+
+
+async def test_route_temp_write_oserror_500(monkeypatch):
+    """D8: OSError mid-stream -> 500, sink not called, temp unlinked."""
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+
+    def boom(tmp, hasher, chunk):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(up, "_write_chunk", boom)
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            ticket.sinks[0].url,
+            content=b"hello",
+            headers={"Content-Type": "text/plain"},
+        )
+    assert resp.status_code == 500
+    assert sink.calls == []
+```
+
+Run → expect PASS. Commit.
+
+- [ ] **Step 5.10: F5 — ambient `Authorization`/`Cookie` headers are ignored.**
+
+```python
+async def test_route_ambient_authorization_ignored():
+    """F5: ambient Authorization on a valid token is ignored (still 204)."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            ticket.sinks[0].url,
+            content=b"x",
+            headers={
+                "Content-Type": "text/plain",
+                "Authorization": "Bearer fake",
+                "Cookie": "session=abc",
+            },
+        )
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+
+
+async def test_route_ambient_authorization_on_invalid_token_still_404():
+    """F5: ambient Authorization does not rescue an invalid token."""
+    sink = _RecordingSink()
+    mcp, _ = await _mount(sink)
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            "/fx/u/nope",
+            content=b"x",
+            headers={
+                "Content-Type": "text/plain",
+                "Authorization": "Bearer admin",
+            },
+        )
+    assert resp.status_code == 404
+```
+
+Run → expect PASS. Commit.
+
+- [ ] **Step 5.11: C1 — two concurrent PUTs, at most one consumes.**
+
+```python
+import asyncio as _asyncio
+
+
+async def test_route_concurrent_puts_at_most_one_consumes():
+    """C1: two concurrent PUTs -> at-most-one consume, both may store."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="http://test", ttl=120.0
+    )
+    url = ticket.sinks[0].url
+    token = url.rsplit("/", 1)[1]
+    async with await _client(mcp) as c:
+        r1, r2 = await _asyncio.gather(
+            c.put(url, content=b"a", headers={"Content-Type": "text/plain"}),
+            c.put(url, content=b"b", headers={"Content-Type": "text/plain"}),
+        )
+    statuses = sorted([r1.status_code, r2.status_code])
+    # Either (204, 204) — both raced past lookup before consume — or
+    # (204, 404) — second one's lookup landed after consume. Never both 404.
+    assert statuses in ([204, 204], [204, 404])
+    assert await store.lookup(token) is None  # consumed
+```
+
+Run → expect PASS. Commit.
+
+- [ ] **Step 5.12: Re-run the whole route suite + download suite. Format, lint, type-check. Final route commit if any cleanup landed.**
+
+```bash
+uv run pytest tests/_file_exchange/test_upload_route.py tests/_file_exchange/test_download.py -v
+uv run ruff format .
+uv run ruff check .
+uv run mypy src
+```
+
+**Task 5 PR-shape checkpoint:** Tasks 1–5 plus mint + helpers are ~600 lines of code + tests. The route is now feature-complete for matrix rows A1–A6, B1, B4, B6, C1, D4–D8, F4, F5. **Push and open a draft PR here.** Wait for a clean preflight-circus before adding Tasks 6+. This is the natural decomposition the matrix's work order points at.
+
+---
+
+## Task 6 — `register_file_exchange_routes` cross-transport registrar (matrix rows A7, A8, E2, E3)
+
+**Goal:** Move the public name `register_file_exchange_routes` out of `_download.py` (where it lives on `main`) into a new `_routes.py`, and add the upload-route arm with strict precondition validation.
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_routes.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_download.py` (rename the registrar to `register_download_route`)
+- Modify: `src/fastmcp_pvl_core/_file_exchange/__init__.py` (re-export `register_file_exchange_routes` from `_routes`)
+- Test: `tests/_file_exchange/test_routes_registrar.py`
+
+- [ ] **Step 6.1: Write the failing tests for the cross-transport registrar.**
+
+```python
+# tests/_file_exchange/test_routes_registrar.py
+"""Matrix rows A7, A8, E2, E3: register_file_exchange_routes shape."""
+
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _routes
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+
+
+class _Sink:
+    async def store_artifact(self, artifact_id, metadata, stream):  # pragma: no cover
+        raise AssertionError
+
+
+class _Source:
+    async def open_artifact(self, key):  # pragma: no cover
+        raise AssertionError
+
+
+def _cfg():
+    return ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_token_ttl=3600.0,
+        file_exchange_max_artifact_size=1024,
+    )
+
+
+def test_registrar_both_none_raises_value_error():
+    """E2: source=None, sink=None is misconfiguration."""
+    cfg = _cfg()
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("t")
+    with pytest.raises(ValueError):
+        _routes.register_file_exchange_routes(
+            mcp, token_store=store, source=None, sink=None, config=cfg
+        )
+
+
+def test_registrar_sink_without_config_raises_value_error():
+    """E3: sink requires config (operator size cap)."""
+    cfg = _cfg()
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("t")
+    with pytest.raises(ValueError):
+        _routes.register_file_exchange_routes(
+            mcp, token_store=store, source=None, sink=_Sink(), config=None
+        )
+
+
+def test_registrar_source_only_mounts_download_route():
+    """A8: source-only mounts only the download route."""
+    cfg = _cfg()
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("t")
+    _routes.register_file_exchange_routes(
+        mcp, token_store=store, source=_Source(), sink=None, config=None
+    )
+    paths = {r.path for r in mcp.http_app().routes}
+    assert any(p.startswith("/fx/d") for p in paths)
+    assert not any(p.startswith("/fx/u") for p in paths)
+
+
+def test_registrar_sink_only_mounts_upload_route():
+    """A8: sink-only mounts only the upload route."""
+    cfg = _cfg()
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("t")
+    _routes.register_file_exchange_routes(
+        mcp, token_store=store, source=None, sink=_Sink(), config=cfg
+    )
+    paths = {r.path for r in mcp.http_app().routes}
+    assert any(p.startswith("/fx/u") for p in paths)
+    assert not any(p.startswith("/fx/d") for p in paths)
+
+
+def test_registrar_both_mounts_both():
+    """A8: source+sink mounts both routes."""
+    cfg = _cfg()
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("t")
+    _routes.register_file_exchange_routes(
+        mcp, token_store=store, source=_Source(), sink=_Sink(), config=cfg
+    )
+    paths = {r.path for r in mcp.http_app().routes}
+    assert any(p.startswith("/fx/d") for p in paths)
+    assert any(p.startswith("/fx/u") for p in paths)
+
+
+def test_registrar_precondition_failure_mounts_nothing():
+    """A7: ValueError from precondition validation -> no routes mounted."""
+    cfg = _cfg()
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("t")
+    # sink without config: should raise before either route is mounted.
+    with pytest.raises(ValueError):
+        _routes.register_file_exchange_routes(
+            mcp, token_store=store, source=_Source(), sink=_Sink(), config=None
+        )
+    paths = {r.path for r in mcp.http_app().routes}
+    assert not any(p.startswith("/fx/") for p in paths)
+```
+
+- [ ] **Step 6.2: Run — confirm failure (module missing).**
+
+```bash
+uv run pytest tests/_file_exchange/test_routes_registrar.py -v
+```
+
+- [ ] **Step 6.3: Rename in `_download.py`.**
+
+In `src/fastmcp_pvl_core/_file_exchange/_download.py`, rename the function `register_file_exchange_routes` to `register_download_route`. Update its docstring's first sentence to remove the umbrella framing — it is now an internal-to-`_routes` helper:
+
+```python
+def register_download_route(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    source: ArtifactSource,
+) -> None:
+    """Mount the ``download`` GET route on ``mcp`` (called by _routes).
+    ...
+    """
+```
+
+- [ ] **Step 6.4: Create `_routes.py`.**
+
+```python
+# src/fastmcp_pvl_core/_file_exchange/_routes.py
+"""Cross-transport route registrar (#146).
+
+``register_file_exchange_routes`` is the single public mount point for the
+file-exchange data planes. It validates all preconditions before mounting
+any route (matrix row A7), then delegates to per-transport registrars.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from fastmcp_pvl_core._file_exchange._download import register_download_route
+from fastmcp_pvl_core._file_exchange._upload import register_upload_route
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+
+
+def register_file_exchange_routes(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    source: ArtifactSource | None = None,
+    sink: ArtifactSink | None = None,
+    config: ServerConfig | None = None,
+) -> None:
+    """Mount the file-exchange data-plane routes on ``mcp``.
+
+    Mounts the ``download`` GET route iff ``source`` is given, and the
+    ``upload`` PUT/POST route iff ``sink`` is given — supporting
+    download-only, upload-only, or both. Mounting the upload route requires
+    ``config`` (the operator body-size cap is load-bearing for §15 untrusted
+    bytes). All preconditions are validated **before** any route is mounted
+    (matrix row A7).
+    """
+    if source is None and sink is None:
+        raise ValueError(
+            "register_file_exchange_routes: at least one of source/sink "
+            "must be given"
+        )
+    if sink is not None and config is None:
+        raise ValueError(
+            "register_file_exchange_routes: sink requires config for "
+            "file_exchange_max_artifact_size"
+        )
+    # Preconditions validated; safe to mount.
+    if source is not None:
+        register_download_route(mcp, token_store=token_store, source=source)
+    if sink is not None:
+        register_upload_route(
+            mcp,
+            token_store=token_store,
+            sink=sink,
+            config=cast("ServerConfig", config),
+        )
+```
+
+- [ ] **Step 6.5: Update `__init__.py` re-export.**
+
+In `src/fastmcp_pvl_core/_file_exchange/__init__.py`, change the `_download` import line:
+
+```python
+from fastmcp_pvl_core._file_exchange._download import (
+    download_fetcher_consume,
+    download_provider_mint,
+)
+```
+
+(remove `register_file_exchange_routes` from this block.) Then add:
+
+```python
+from fastmcp_pvl_core._file_exchange._routes import register_file_exchange_routes
+from fastmcp_pvl_core._file_exchange._upload import (
+    upload_receiver_mint,
+)
+```
+
+Update `__all__` alphabetically to include `upload_receiver_mint` (and `upload_sender_consume` once Task 7 lands).
+
+- [ ] **Step 6.6: Update `file_exchange.py` re-export the same way.**
+
+Add `upload_receiver_mint` to the imports and to `__all__` (alphabetically).
+
+- [ ] **Step 6.7: Update `tests/_file_exchange/test_download.py` if it references `_download.register_file_exchange_routes`.**
+
+Grep first:
+
+```bash
+grep -n "register_file_exchange_routes\|_download\." tests/_file_exchange/test_download.py tests/_file_exchange/test_download_e2e.py
+```
+
+Replace any local-import call sites with `from fastmcp_pvl_core._file_exchange._routes import register_file_exchange_routes` (or use the public `file_exchange.register_file_exchange_routes`). The `register_download_route` rename is internal — only update test references if they import the inner name. The download e2e test that previously called `register_file_exchange_routes(..., source=...)` continues to work because the new registrar accepts source-only.
+
+- [ ] **Step 6.8: Run the full file-exchange suite — confirm pass.**
+
+```bash
+uv run pytest tests/_file_exchange -v
+```
+
+- [ ] **Step 6.9: Format, lint, type-check, commit.**
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run mypy src
+git add -A
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): cross-transport register_file_exchange_routes (#146)
+
+Move the public registrar from _download.py to a new _routes.py and
+add the upload-route arm. Preconditions (source-or-sink, sink-needs-
+config) are validated BEFORE any route is mounted (matrix row A7).
+_download.py's inner helper is renamed to register_download_route;
+the public name register_file_exchange_routes is unchanged.
+
+Matrix rows A7, A8, E2, E3. Refs #146.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7 — `upload_sender_consume` (matrix rows B2, B3, B5, C3, D1, D2, D3, D9, F6)
+
+**Goal:** Stage the source bytes to a temp (hash on the fly), then `PUT` the temp through the SSRF guard with `Content-Type`, `Content-Length`, and `Content-Digest` headers. Non-2xx → `transfer-failed`; guard refusal propagates.
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/__init__.py` + `src/fastmcp_pvl_core/file_exchange.py` (add `upload_sender_consume` to imports and `__all__`)
+- Test: `tests/_file_exchange/test_upload_sender.py`
+
+- [ ] **Step 7.1: Write the failing happy-path test.**
+
+```python
+# tests/_file_exchange/test_upload_sender.py
+"""Matrix rows B2, B3, B5, C3, D1, D2, D3, D9, F6: upload_sender_consume."""
+
+import base64
+import contextlib
+import hashlib
+import os
+from typing import BinaryIO
+
+import pytest
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+from fastmcp_pvl_core._file_exchange._wire import (
+    ArtifactMetadata,
+    UploadSink,
+)
+from datetime import datetime, timezone
+
+
+def _sink() -> UploadSink:
+    return UploadSink(
+        transport="upload",
+        url="https://b.example/fx/u/tok",
+        method="PUT",
+        expiresAt=datetime.now(timezone.utc),
+    )
+
+
+def _cfg():
+    return ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_token_ttl=3600.0,
+        file_exchange_http_timeout=30.0,
+    )
+
+
+class _StreamSource:
+    """ArtifactSource that yields a fixed payload."""
+
+    def __init__(self, payload: bytes, mime: str | None = "text/plain"):
+        self.payload = payload
+        self.mime = mime
+
+    async def open_artifact(self, key):
+        import io
+        return io.BytesIO(self.payload), ArtifactMetadata(mimeType=self.mime)
+
+
+@contextlib.asynccontextmanager
+async def _fake_guarded_stream_factory(captured: dict, status: int = 204):
+    """Patch guarded_stream so we capture headers/body and return a status."""
+
+    class _Resp:
+        def __init__(self, st):
+            self.status = st
+
+    @contextlib.asynccontextmanager
+    async def fake(method, url, *, config, transport, headers=None, content=None):
+        captured["method"] = method
+        captured["url"] = url
+        captured["transport"] = transport
+        captured["headers"] = dict(headers or {})
+        # Drain the content iterator (the sender passes an async iterator).
+        body = b""
+        if content is not None:
+            async for chunk in content:
+                body += chunk
+        captured["body"] = body
+        yield _Resp(status)
+
+    yield fake
+
+
+async def test_sender_happy_path_puts_with_headers(monkeypatch):
+    """F6 + D1 success arm."""
+    captured: dict = {}
+    async with _fake_guarded_stream_factory(captured, status=204) as fake:
+        monkeypatch.setattr(_upload, "guarded_stream", fake)
+        await _upload.upload_sender_consume(
+            _sink(),
+            _StreamSource(b"hello world"),
+            "art-1",
+            config=_cfg(),
+        )
+    assert captured["method"] == "PUT"
+    assert captured["url"] == "https://b.example/fx/u/tok"
+    assert captured["transport"] == "upload"
+    headers = {k.lower(): v for k, v in captured["headers"].items()}
+    assert headers["content-type"] == "text/plain"
+    assert headers["content-length"] == str(len(b"hello world"))
+    raw = hashlib.sha256(b"hello world").digest()
+    assert headers["content-digest"] == "sha-256=:" + base64.b64encode(raw).decode() + ":"
+    assert captured["body"] == b"hello world"
+    # No stray fx-upload temp files
+    assert not any(n.startswith("fx-upload-") for n in os.listdir("/tmp"))
+
+
+async def test_sender_non_2xx_maps_to_transfer_failed(monkeypatch):
+    """D1."""
+    captured: dict = {}
+    async with _fake_guarded_stream_factory(captured, status=500) as fake:
+        monkeypatch.setattr(_upload, "guarded_stream", fake)
+        with pytest.raises(FileExchangeTransferError) as ei:
+            await _upload.upload_sender_consume(
+                _sink(), _StreamSource(b"x"), "art-1", config=_cfg()
+            )
+    assert ei.value.code == TransferErrorCode.TRANSFER_FAILED
+    assert ei.value.transport == "upload"
+
+
+async def test_sender_guard_refusal_propagates(monkeypatch):
+    """C3."""
+
+    @contextlib.asynccontextmanager
+    async def refusing(method, url, **kw):
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE, transport="upload", detail="blocked"
+        )
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(_upload, "guarded_stream", refusing)
+    with pytest.raises(FileExchangeTransferError) as ei:
+        await _upload.upload_sender_consume(
+            _sink(), _StreamSource(b"x"), "art-1", config=_cfg()
+        )
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_sender_source_raises_propagates_no_temp_leak():
+    """D2."""
+    class _Boom:
+        async def open_artifact(self, key):
+            raise RuntimeError("hook failure")
+
+    with pytest.raises(RuntimeError):
+        await _upload.upload_sender_consume(
+            _sink(), _Boom(), "art-1", config=_cfg()
+        )
+    assert not any(n.startswith("fx-upload-") for n in os.listdir("/tmp"))
+
+
+async def test_sender_mkstemp_failure_maps_to_transfer_failed(monkeypatch):
+    """D3."""
+    def boom(**kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(_upload.tempfile, "mkstemp", boom)
+    with pytest.raises(FileExchangeTransferError) as ei:
+        await _upload.upload_sender_consume(
+            _sink(), _StreamSource(b"x"), "art-1", config=_cfg()
+        )
+    assert ei.value.code == TransferErrorCode.TRANSFER_FAILED
+
+
+async def test_sender_closes_source_stream():
+    """B5: source stream closed on success."""
+    class _TrackedBytes:
+        def __init__(self, data: bytes):
+            self._buf = bytearray(data)
+            self.closed = False
+
+        def read(self, n=-1):
+            if n is None or n < 0:
+                data, self._buf = bytes(self._buf), bytearray()
+                return data
+            data = bytes(self._buf[:n])
+            del self._buf[:n]
+            return data
+
+        def close(self):
+            self.closed = True
+
+    tracked = _TrackedBytes(b"hello")
+
+    class _S:
+        async def open_artifact(self, key):
+            return tracked, ArtifactMetadata(mimeType="text/plain")
+
+    captured: dict = {}
+
+    @contextlib.asynccontextmanager
+    async def fake(method, url, **kw):
+        async for _ in kw.get("content") or []:
+            pass
+
+        class R:
+            status = 204
+        yield R()
+
+    import contextlib as _ctx
+    async with _fake_guarded_stream_factory(captured, status=204) as fake_gs:
+        import builtins
+        monkey = pytest.MonkeyPatch()
+        monkey.setattr(_upload, "guarded_stream", fake_gs)
+        try:
+            await _upload.upload_sender_consume(
+                _sink(), _S(), "art-1", config=_cfg()
+            )
+        finally:
+            monkey.undo()
+    assert tracked.closed is True
+```
+
+- [ ] **Step 7.2: Run — confirm failure.**
+
+```bash
+uv run pytest tests/_file_exchange/test_upload_sender.py -v
+```
+Expected: `AttributeError: module 'fastmcp_pvl_core._file_exchange._upload' has no attribute 'upload_sender_consume'`.
+
+- [ ] **Step 7.3: Implement `upload_sender_consume` in `_upload.py`.**
+
+Add to `_upload.py` (re-using the temp-file primitives from `_staging` and `_outbound.guarded_stream`):
+
+```python
+# add near the other imports:
+from collections.abc import AsyncIterator
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+from fastmcp_pvl_core._file_exchange._outbound import guarded_stream
+
+if TYPE_CHECKING:
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSource
+
+
+async def upload_sender_consume(
+    sink: UploadSink,
+    source: ArtifactSource,
+    key: str,
+    *,
+    config: ServerConfig,
+) -> None:
+    """Sender role (push): stage ``source[key]`` and PUT it to ``sink.url``.
+
+    Streams the source bytes through a transient temp file (hashing on the
+    fly), then sends the temp through the #147 SSRF guard with
+    ``Content-Type``/``Content-Length``/``Content-Digest`` headers. Non-2xx
+    -> ``transfer-failed``; guard refusals propagate verbatim. The temp is
+    deleted on every path (matrix rows B2, B3, B5, C3, D1, D2, D3, D9, F6).
+    """
+    stream, metadata = await source.open_artifact(key)
+    try:
+        try:
+            fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-")
+        except OSError as exc:
+            raise FileExchangeTransferError(
+                TransferErrorCode.TRANSFER_FAILED,
+                transport="upload",
+                detail="failed to create a temporary file",
+            ) from exc
+        try:
+            try:
+                tmp = os.fdopen(fd, "wb")
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                raise
+            try:
+                hasher = hashlib.new("sha256")
+                size = 0
+                while True:
+                    chunk = await asyncio.to_thread(stream.read, _CHUNK)
+                    if not chunk:
+                        break
+                    try:
+                        await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                    except OSError as exc:
+                        raise FileExchangeTransferError(
+                            TransferErrorCode.TRANSFER_FAILED,
+                            transport="upload",
+                            detail="failed to stage the artifact",
+                        ) from exc
+                    size += len(chunk)
+                try:
+                    await asyncio.to_thread(tmp.flush)
+                except OSError as exc:
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.TRANSFER_FAILED,
+                        transport="upload",
+                        detail="failed to flush the staged artifact",
+                    ) from exc
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(tmp.close)
+
+            cd_header = _content_digest_format("sha-256", hasher.digest())
+            headers: dict[str, str] = {
+                "Content-Length": str(size),
+                "Content-Digest": cd_header,
+            }
+            if metadata.mimeType:
+                headers["Content-Type"] = metadata.mimeType
+
+            async def _body() -> AsyncIterator[bytes]:
+                f = await asyncio.to_thread(open, tmp_path, "rb")
+                try:
+                    while True:
+                        chunk = await asyncio.to_thread(f.read, _CHUNK)
+                        if not chunk:
+                            break
+                        yield chunk
+                finally:
+                    with contextlib.suppress(OSError):
+                        await asyncio.to_thread(f.close)
+
+            async with guarded_stream(
+                sink.method,
+                sink.url,
+                config=config,
+                transport="upload",
+                headers=headers,
+                content=_body(),
+            ) as resp:
+                if not (200 <= resp.status < 300):
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.TRANSFER_FAILED,
+                        transport="upload",
+                        detail="unexpected upload response status",
+                    )
+        finally:
+            with contextlib.suppress(OSError):
+                await asyncio.to_thread(os.unlink, tmp_path)
+    finally:
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(stream.close)
+```
+
+- [ ] **Step 7.4: Run the sender tests — confirm pass.**
+
+```bash
+uv run pytest tests/_file_exchange/test_upload_sender.py -v
+```
+
+If any individual test fails, add the smallest possible fix and re-run; commit after each clean cycle. **Do not** add code that no test exercises.
+
+- [ ] **Step 7.5: Add `upload_sender_consume` to public re-exports.**
+
+In `src/fastmcp_pvl_core/_file_exchange/__init__.py`, the `_upload` import block becomes:
+
+```python
+from fastmcp_pvl_core._file_exchange._upload import (
+    upload_receiver_mint,
+    upload_sender_consume,
+)
+```
+
+Update `__all__` alphabetically. Do the same in `src/fastmcp_pvl_core/file_exchange.py`.
+
+- [ ] **Step 7.6: Full suite + lint + type-check + commit.**
+
+```bash
+uv run pytest tests/_file_exchange -v
+uv run ruff format .
+uv run ruff check .
+uv run mypy src
+git add -A
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): upload_sender_consume (#146)
+
+Stage the source bytes to a transient temp file (hashing on the fly),
+then PUT the temp through guarded_stream with Content-Type / Length /
+Digest headers. Non-2xx maps to transfer-failed; guard refusals
+propagate as not-accessible; mkstemp / write / flush OSErrors map to
+transfer-failed; the temp is deleted on every path.
+
+Matrix rows B2, B3, B5, C3, D1, D2, D3, D9, F6. Refs #146.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8 — End-to-end push test (matrix row implicit; ties together A1+B+C+D+F across two servers)
+
+**Goal:** Two pvl-core-built mock servers — Server B (receiver) mints + serves; Server A (sender) selects + sends — push transport only.
+
+**Files:**
+- Test: `tests/_file_exchange/test_upload_e2e.py`
+
+- [ ] **Step 8.1: Write the e2e test.**
+
+```python
+# tests/_file_exchange/test_upload_e2e.py
+"""End-to-end push: sender + guard + receiver route + sink."""
+
+import hashlib
+from typing import BinaryIO
+
+import httpx
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._routes import register_file_exchange_routes
+from fastmcp_pvl_core._file_exchange._selection import select_sink
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+
+class _Sink:
+    def __init__(self):
+        self.received: tuple[str | None, ArtifactMetadata, bytes] | None = None
+
+    async def store_artifact(self, artifact_id, metadata, stream: BinaryIO):
+        self.received = (artifact_id, metadata, stream.read())
+
+
+class _Src:
+    def __init__(self, data: bytes):
+        self.data = data
+
+    async def open_artifact(self, key):
+        import io
+        return io.BytesIO(self.data), ArtifactMetadata(mimeType="application/json")
+
+
+async def test_e2e_push_two_servers(monkeypatch):
+    payload = b'{"hello":"world"}'
+
+    # Receiver (server B)
+    cfg_b = ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_token_ttl=3600.0,
+        file_exchange_max_artifact_size=1024,
+    )
+    store_b = build_capability_token_store(cfg_b)
+    sink_b = _Sink()
+    mcp_b = FastMCP("B")
+    register_file_exchange_routes(
+        mcp_b, token_store=store_b, sink=sink_b, config=cfg_b
+    )
+
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store_b, base_url="http://b.test", ttl=120.0
+    )
+
+    # Sender (server A): patch guarded_stream so the request lands on B's ASGI
+    # rather than the network. The real guard's behaviour is exercised in
+    # test_outbound.py; here we are testing the e2e wiring.
+    import contextlib
+
+    transport_b = httpx.ASGITransport(app=mcp_b.http_app())
+    client_b = httpx.AsyncClient(transport=transport_b, base_url="http://b.test")
+
+    @contextlib.asynccontextmanager
+    async def fake_guarded_stream(method, url, *, config, transport, headers=None, content=None):
+        assert transport == "upload"
+        # Build body
+        body = b""
+        if content is not None:
+            async for chunk in content:
+                body += chunk
+        resp = await client_b.request(
+            method, url, headers=headers, content=body
+        )
+
+        class R:
+            status = resp.status_code
+        yield R()
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guarded_stream)
+
+    cfg_a = ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_http_timeout=30.0,
+    )
+    selected = select_sink(ticket)
+    await _upload.upload_sender_consume(selected, _Src(payload), "art-1", config=cfg_a)
+    await client_b.aclose()
+
+    assert sink_b.received is not None
+    aid, meta, body = sink_b.received
+    assert aid == "art-1"
+    assert body == payload
+    assert meta.size == len(payload)
+    assert meta.digest == "sha-256:" + hashlib.sha256(payload).hexdigest()
+    # Token consumed on B
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    assert await store_b.lookup(token) is None
+```
+
+- [ ] **Step 8.2: Run — fix any wiring issues, commit.**
+
+```bash
+uv run pytest tests/_file_exchange/test_upload_e2e.py -v
+```
+
+If `select_sink` doesn't pick the upload sink because no `expected_role` is set or similar, follow its existing pattern (see `tests/_file_exchange/test_selection.py` and `_filesystem.py`'s caller) and adjust the test to the same calling convention.
+
+- [ ] **Step 8.3: Full suite + lint + mypy + commit.**
+
+```bash
+uv run pytest -v
+uv run ruff format .
+uv run ruff check .
+uv run mypy src
+git add -A
+git commit -m "$(cat <<'EOF'
+test(file-exchange): end-to-end push two-server upload (#146)
+
+Two FastMCP-built mock servers wired through ASGITransport: receiver
+mints + serves the upload route; sender selects + sends through a
+guarded_stream patched to land on the receiver's ASGI app. Bytes,
+metadata, digest, and single-success consume verified.
+
+Refs #146.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9 — Multi-Python sanity + push
+
+**Goal:** Match CI's matrix (3.10, 3.11, 3.12, 3.13) locally before pushing, per the saved feedback `feedback_test_python_version_matrix`.
+
+- [ ] **Step 9.1: Run the suite on min and max Python.**
+
+```bash
+uv run --python 3.10 pytest tests/_file_exchange -v
+uv run --python 3.13 pytest tests/_file_exchange -v
+```
+
+If either fails, fix the version-dependent code (often: `typing` syntax, `Path.resolve(strict=)` symlink behaviour, stdlib `hashlib` availability). Commit each fix individually.
+
+- [ ] **Step 9.2: Run the local preflight-circus.**
+
+Invoke the `preflight-circus` skill against the diff (`main..HEAD`). Address findings scoring ≥80 per the saved calibration (`feedback_circus_scoring_calibration`); push at the first clean round (`feedback_circus_push_at_first_clean`).
+
+- [ ] **Step 9.3: Push and open the PR.**
+
+```bash
+git push -u origin feat/146-upload-data-plane-v2
+gh pr create --title "feat(file-exchange): upload transport data plane (#146)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Implements the `upload` transport's push data plane as the mirror of
+the merged #145 download data plane:
+
+- `upload_receiver_mint` — token mint + IntakeTicket
+- `register_upload_route` — PUT/POST `/fx/u/{token}` with body cap,
+  RFC 7231 media-range, RFC 9530 Content-Digest verify-before-use,
+  single-success-per-URL via atomic consume
+- `upload_sender_consume` — stage + PUT through the SSRF guard
+- `register_file_exchange_routes` — moved to `_routes.py`, now mounts
+  download and/or upload based on source/sink presence with strict
+  precondition validation
+
+This is the fourth attempt after #163, #164, #165 each abandoned mid
+bot-iteration. The new discipline: the failure-mode matrix at
+`docs/superpowers/specs/2026-05-27-file-exchange-146-failure-modes.md`
+enumerates every ordering / lifecycle / concurrency / failure-path /
+reentrancy / wire-format mode the implementation must address, with
+one test per row, written **before** the implementation. The matrix's
+seeded rows include every finding the three prior PRs' bot rounds
+surfaced.
+
+Closes #146.
+
+## Test plan
+
+- [x] `uv run pytest tests/_file_exchange -v` on 3.10 and 3.13
+- [x] `uv run ruff format --check . && uv run ruff check .`
+- [x] `uv run mypy src`
+- [x] Local preflight-circus clean at ≥80
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" --draft
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+| Spec section | Tasks |
+|---|---|
+| `upload_receiver_mint` signature + behaviour | Task 2 |
+| Upload route (`PUT`/`POST /fx/u/{token}`): lookup → ACCEPT → cap → stage → verify → sink → consume | Tasks 4–5 |
+| Token consumed only after successful store | Tasks 4 (skeleton), 5.1, 5.2 |
+| `acceptMimeTypes` RFC 7231 | Tasks 3 (helper), 5.3 |
+| `Content-Digest` RFC 9530 parse/format/verify | Tasks 3 (helpers), 4 (route uses it), 5.5, 5.6 |
+| Body-size caps (per-mint + operator) | Task 5.4 |
+| 404/415/413/400/500/204 status mapping | Tasks 4, 5.* |
+| `upload_sender_consume` happy + edges | Task 7 |
+| `register_file_exchange_routes` cross-transport shape | Task 6 |
+| `_staging.py` extraction | Task 1 |
+| Public re-exports + `__all__` | Tasks 6, 7 |
+| End-to-end push test | Task 8 |
+| Multi-Python + circus + push | Task 9 |
+
+**Placeholder scan:** No "TBD"/"TODO"/"similar to" — every step has its code block, test, or command. The conditional language in Task 5 ("expect PASS — skeleton already does this") is intentional: that's how TDD verifies the skeleton is honest about what it claims to do.
+
+**Type consistency:**
+
+- `register_upload_route(mcp, *, token_store, sink, config)` — same signature used in Tasks 4, 5, 6, 8.
+- `upload_receiver_mint(artifact_id, *, token_store, base_url, ttl, expected=None, method="PUT")` — same signature used in Tasks 2, 4–8.
+- `upload_sender_consume(sink, source, key, *, config)` — same signature in Tasks 7, 8.
+- `register_file_exchange_routes(mcp, *, token_store, source=None, sink=None, config=None)` — same signature in Tasks 6, 8.
+
+All names match across tasks.
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-27-file-exchange-146-upload-data-plane-v4.md`.**
+
+Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-27-file-exchange-146-failure-modes.md
+++ b/docs/superpowers/specs/2026-05-27-file-exchange-146-failure-modes.md
@@ -1,0 +1,153 @@
+# File-Exchange #146 — upload data plane failure-mode matrix
+
+> **Status:** Process artifact for the fourth (TDD-first) attempt at #146.
+> The behavioural contract is unchanged: see
+> `2026-05-24-file-exchange-146-upload-data-plane-design.md` for the
+> spec. This document enumerates the failure modes the implementation
+> must address **before** any test or implementation code is written,
+> per the `CLAUDE.md` "Test-driven discipline" section. Three prior
+> attempts (PR #163, #164, #165) failed at integration time precisely
+> because these modes were discovered post-hoc as bot findings; this
+> matrix flips the order.
+
+## How this is used
+
+Test order = matrix order. Each row below becomes one (or a small
+group of closely-related) failing tests, then the implementation code
+that makes those tests pass. **No row is implemented before its test
+exists and fails.** A row that cannot be tested mechanically is a
+design hole, not an acceptable carve-out.
+
+The matrix's row count is the size of the contract's edge surface.
+If a row is missing on first read, **add it here** rather than
+discover it in review.
+
+## Source attribution
+
+Rows are sourced from:
+
+- **Spec** — the §10.3 / §12 / §15 / §13 obligations recorded in
+  `2026-05-24-file-exchange-146-upload-data-plane-design.md`.
+- **Mirror** — failure modes already handled by the merged #145
+  download data plane (`_download.py` on `main`) that the upload side
+  must mirror coherently.
+- **Bot finding history** — modes flagged in PR #163, #164, #165 bot
+  rounds. These are the cheapest signal we have about which modes
+  this kind of code consistently misses; treating them as gold is
+  the central lesson of the three-abandon spiral.
+
+Each row tags its primary source in square brackets.
+
+## A. Ordering modes
+
+| # | Trigger | Required behaviour | Test |
+|---|---|---|---|
+| A1 | Receiver mints a token, the route's first PUT succeeds, a second PUT against the same URL arrives. [spec §10.3, bot-165 finding 2 inverse] | The second PUT returns `404`. `token_store.consume` was called exactly once (after the first store). The sink was called exactly once. | Route test: mint → PUT (204) → PUT (404); sink call count == 1; consume call count == 1. |
+| A2 | The sink raises mid-`store_artifact`. [spec §10.3 single-success-per-URL, bot-163 round] | The token is **not** consumed. A subsequent PUT against the same URL succeeds (the slot is not burned). | Route test: PUT with a sink that raises → 500, then PUT with a sink that succeeds → 204; consume called once total, at the end. |
+| A3 | `acceptMimeTypes` mismatch on a PUT. [spec §10.3 RFC 7231, bot-163] | `415`, sink **not** called, token **not** consumed. | Route test: mint with `expected.acceptMimeTypes=["application/json"]`, PUT `text/plain` → 415; sink call count == 0; consume call count == 0. |
+| A4 | Body exceeds `expected.maxSize` or `config.file_exchange_max_artifact_size` (whichever is smaller). [spec §15] | `413`, sink **not** called, token **not** consumed, body read stopped within one chunk past the cap. | Route test: cap=N, send N+1 bytes → 413; sink call count == 0; assert the staging helper read at most N + one-chunk bytes. |
+| A5 | `Content-Digest` mismatch. [spec §10.3 verify-before-use, bot-165] | `400`, sink **not** called, token **not** consumed. The verification happens **after** the full body is staged but **before** the sink is called. | Route test: send a body with a deliberately wrong `Content-Digest` → 400; sink not called; consume not called. |
+| A6 | `expected.requireDigest` lists `sha-256` and the request has **no** `Content-Digest` header. [spec §10.3, bot-163] | `400`, sink **not** called, token **not** consumed. | Route test: mint with `requireDigest=["sha-256"]`, PUT without `Content-Digest` → 400. |
+| A7 | Atomicity of `register_file_exchange_routes`. [bot-165 finding 2] | If `sink` is given without `config`, raise `ValueError` **before** any route is mounted. If both sides are given and the download registrar raises after the upload check passes, the upload route is also not mounted (best-effort: validate everything first, mount second). | Unit test on the registrar: a precondition violation does not mount either route; validate this by injecting a mock `mcp.custom_route` and asserting call count == 0 in the failure case. |
+| A8 | Mounting order: `register_file_exchange_routes` accepts source-only, sink-only, or both, in any caller order. [spec] | Each combination mounts exactly the routes that are asked for, never the other. | Registrar test: three combinations, each asserts the mounted-path set. |
+
+## B. Lifecycle modes
+
+| # | Trigger | Required behaviour | Test |
+|---|---|---|---|
+| B1 | The route opens a `mkstemp` and `fdopen`s it; any exception before the staging `try/finally` would leak the fd. [bot-165 finding 1, mirror `_download.py` lines 53–61] | The fd is closed on **every** error path between `mkstemp` and the staging `try/finally`. The temp file is unlinked on every exit path. | Route test: monkey-patch `hashlib.new` to raise after `fdopen` but before staging; assert the OS-level fd is closed (e.g. via a sentinel `fd` wrapper that tracks close) and the temp path no longer exists. |
+| B2 | Staging-loop close failure: `tmp.close()` raises after the body is staged. [mirror `_download.py` line 256] | The close failure is suppressed — it must not replace an in-flight `FileExchangeTransferError` or HTTP error response with a raw `OSError`. | Sender test: force `tmp.close` to raise on a happy-path send; assert the function returns normally and the temp is unlinked. |
+| B3 | Unlink failure: `os.unlink(tmp_path)` raises during cleanup. [mirror `_download.py` line 302] | Suppressed — cleanup failure must not mask the in-flight outcome. | Route + sender test: monkey-patch `os.unlink` to raise; happy path still returns 204 / completes normally. |
+| B4 | The sink reads but does not close the stream (hook contract). [spec / `_hooks.py`] | The route closes the fd handed to the sink itself, in a `finally`, with `OSError` suppression. | Route test: a sink that just reads → bytes deposit correctly, fd is closed afterwards. |
+| B5 | Sender's source stream close: `source.open_artifact` returns a stream that the sender owns; the sender must close it on every path. [mirror download fetcher] | The sender closes the source stream on success and failure paths alike (suppressed). | Sender test: a source whose stream tracks close; assert close called exactly once on happy + on guard-refusal + on non-2xx + on sink raise. |
+| B6 | Temp file open after staging for the sink: the temp is opened sync (`open(tmp_path, "rb")`); the open itself can fail (`OSError`). [mirror `_download.py` lines 281–289] | An open failure maps to `500` (route) / `transfer-failed` (sender), with the temp still unlinked. | Route test: monkey-patch the open to raise; 500 returned; temp gone. |
+
+## C. Concurrency modes
+
+| # | Trigger | Required behaviour | Test |
+|---|---|---|---|
+| C1 | Two PUTs against the same URL arrive concurrently, the first one already past the `lookup` but not past `consume`. [spec §10.3 at-most-once "successful upload" semantics] | At most one of them consumes the token; both may successfully invoke `store_artifact` (the duplicate-sink-call tolerance is on the sink contract — observation 4539). The route does not need an in-memory lock; the atomic `consume` provides at-most-one. | Route test: two concurrent PUTs (both with valid bodies) → one returns 204, the other returns either 204 or 404; the **`consume`** boolean ledger shows exactly one `True`. The sink may be called 1 or 2 times. |
+| C2 | A PUT arrives concurrently with a `revoke`. [spec §15] | Revoke that lands before the route's `lookup` makes the PUT a `404`. Revoke that lands after `lookup` but before `consume` does not retroactively undo a store that has already been written to the sink — from the wire, the upload succeeded; revoke racing the consume just means the consume returns `False`, the response is `204`. The bytes are in the sink either way; this is the spec's at-most-once semantics, not at-most-once-and-rollback. | Route test: two-step sequence: (a) revoke → PUT → 404; (b) PUT held mid-body via a controllable sink, revoke fires while the sink awaits → sink completes, consume returns False, response is 204. |
+| C3 | A guard refusal arises from `guarded_stream` mid-send. [spec; mirror `_outbound.py`] | The sender propagates `FileExchangeTransferError(not-accessible, transport="upload")`; the temp is unlinked. | Sender test: `guarded_stream` raises `FileExchangeTransferError(NOT_ACCESSIBLE)` synchronously; assert it propagates verbatim (same code, transport label correct) and the temp is gone. |
+
+## D. Failure-path modes (non-2xx, exception classification)
+
+| # | Trigger | Required behaviour | Test |
+|---|---|---|---|
+| D1 | The sender's send returns a 4xx/5xx response. [spec; observation 4480] | `FileExchangeTransferError(transfer-failed, transport="upload")`. | Sender test: mock guarded_stream yielding a 500 response; assert TRANSFER_FAILED is raised. |
+| D2 | The sender's `source.open_artifact` raises. [spec error-handling] | The exception propagates (the offering-side hook contract permits any exception); no temp file is created. | Sender test: source that raises → propagates; assert no leftover `fx-upload-*` temp files. |
+| D3 | The sender's `tempfile.mkstemp` raises (disk full). [mirror `_download.py` lines 47–52] | `FileExchangeTransferError(transfer-failed)`. | Sender test: monkey-patch `mkstemp` to raise `OSError` → TRANSFER_FAILED. |
+| D4 | The route's `Content-Digest` header is **present but unparseable** (e.g. malformed RFC 9530 structured-field). [spec §10.3, bot-165 false-alarm clarification] | `400` (`digest-mismatch`) — never a silent skip; matches `_digest_verifier`'s `unverifiable` semantics. | Route test: PUT with `Content-Digest: garbage` → 400; sink not called. |
+| D5 | The route's `Content-Digest` declares an **unsupported algo label** (e.g. `md5`). [spec §10.3] | `400` (`digest-mismatch`). | Route test: PUT with `Content-Digest: md5=:...:` → 400. |
+| D6 | The sink raises a `FileExchangeTransferError`. [parity with download fetcher] | Route maps to `500`; the original exception is **not** echoed in the response body (it may carry server-internal detail). Logged locally. | Route test: sink raises `FileExchangeTransferError(transfer-failed)` → 500 with no body; log captured. |
+| D7 | The sink raises a generic `Exception`. [parity with download fetcher] | Route maps to `500`; logged; no body. | Route test: sink raises `RuntimeError("oops")` → 500. |
+| D8 | The route's body read raises `OSError` mid-stream (disk full on the temp file). [mirror `_download.py` lines 213–222] | `500` body-free, temp unlinked, sink not called, token not consumed. | Route test: monkey-patch `_write_chunk` to raise on the 2nd chunk → 500; temp gone. |
+| D9 | The sender's body iteration raises an `OSError` reading the staged temp. [parity] | `FileExchangeTransferError(transfer-failed)`, temp unlinked. | Sender test: force the body iterator to raise OSError mid-send → TRANSFER_FAILED. |
+
+## E. Reentrancy & boundary modes
+
+| # | Trigger | Required behaviour | Test |
+|---|---|---|---|
+| E1 | `upload_receiver_mint` called twice for the same `artifact_id`. [spec] | Two distinct tokens minted, both valid until consumed/expired (the token store is the source of truth; mint is stateless beyond it). | Mint test: two mints → two different URLs; both look up to records with the same `artifact_id`. |
+| E2 | `register_file_exchange_routes` called with `source=None, sink=None`. [spec — the no-op shape] | Either: (a) raises `ValueError` (nothing to mount is a misuse), or (b) is a no-op. Pick **(a)** so misconfigurations are visible at registration time; document the choice. | Registrar test: `register_file_exchange_routes(mcp, token_store=..., source=None, sink=None)` raises `ValueError`. |
+| E3 | A registrar precondition violation must raise `ValueError`, not `TypeError`. [bot-165 finding 3] | The spec calls for `ValueError` on `sink-without-config`; this is a deliberate narrowing from "Python's native `TypeError: missing kw"`. Document the rationale; the only callers in this repo are the umbrella in #148 + tests. | Registrar test: `sink-without-config` raises `ValueError` (not `TypeError`). |
+| E4 | Public re-export surface. [spec] | `fastmcp_pvl_core.file_exchange.upload_receiver_mint`, `.upload_sender_consume`, `.register_file_exchange_routes` are importable; `__all__` updated alphabetically. | Test: importable, in `__all__`. |
+
+## F. Wire / protocol modes
+
+| # | Trigger | Required behaviour | Test |
+|---|---|---|---|
+| F1 | RFC 9530 `Content-Digest` parsing — well-formed `sha-256=:<b64>:`. [spec] | Parse succeeds, returns `("sha-256", <raw bytes>)`. Whitespace tolerated where the structured-fields grammar tolerates it. | Parser unit test, table-driven; at minimum the RFC 9530 §3 example `sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:` plus malformed variants (missing colons, unknown algo, double-`=`, empty value) each yielding the `(unverifiable=True)` branch. |
+| F2 | RFC 9530 `Content-Digest` format — sender produces `sha-256=:<b64>:` from a sha-256 digest of staged bytes. [spec] | Header is well-formed and re-parseable. | Sender test: round-trip parse of the produced header. |
+| F3 | RFC 7231 media-range matching for `acceptMimeTypes`. [spec] | `image/*` matches `image/png`; `*/*` matches anything; `application/json` does not match `application/json; charset=utf-8` parameters-only-ignored; case is media-type-insensitive. | Matcher unit test, table-driven. |
+| F4 | `acceptMimeTypes=None` (no constraint). [spec] | All content types accepted. | Route test: PUT with any Content-Type when `expected` is `None` or `acceptMimeTypes` is unset → 204. |
+| F5 | Ambient `Authorization`/`Cookie` headers on a PUT. [spec — token is the only authorization] | Ignored; outcome is the same as without them. | Route test: PUT with `Authorization: Bearer foo` succeeds normally; PUT with an invalid token URL + `Authorization` still 404. |
+| F6 | `upload_sender_consume` always sends `Content-Digest`. [spec] | The PUT request carries `Content-Digest: sha-256=:<b64>:`, `Content-Length: <size>`, and `Content-Type: <metadata.mimeType>` when known. | Sender test: assert headers on the captured request to `guarded_stream`. |
+
+## G. Spec parity modes (#145 ↔ #146 contract symmetry)
+
+| # | Required behaviour | Test |
+|---|---|---|
+| G1 | The `_staging.py` extraction does not change observable download behaviour — every existing download test still passes after the extraction. | Run `tests/_file_exchange/test_download*.py` against the post-refactor tree as part of the matrix's first commit. |
+| G2 | The error-code envelope (`FileExchangeTransferError(code, transport="upload", ...)`) uses the same code constants as the download side. No "upload-only" code is introduced. | Static check: grep the `TransferErrorCode` enum usage; assert the upload code paths use only the codes the download side already uses. |
+
+## Implementation work order
+
+The matrix's row count drives the work order:
+
+1. `_staging.py` extraction (G1 + B1 + B2 + B3 mirror parity). Tests
+   first: write the staging-helper contract tests, **then** move the
+   code; download tests must stay green.
+2. `upload_receiver_mint` (E1 + E4). Smallest, no I/O.
+3. RFC 9530 parser/formatter (F1, F2, D4, D5). Pure functions.
+4. RFC 7231 media-range matcher (F3, F4). Pure function.
+5. The upload route (A1–A6, B1, B4, B6, C1–C2, D4–D8, F4, F5). The
+   bulk of the work.
+6. `register_file_exchange_routes` shape change (A7, A8, E2, E3).
+7. `upload_sender_consume` (D1–D3, D9, B2, B3, B5, C3, F6).
+8. End-to-end test (push two-server flow).
+
+After each step, decide: is this an independently mergeable PR with a
+small review surface, or does the next step belong with it? The
+abandon-rule is the guide — **do not pre-commit to "one PR" or
+"five PRs"**; let the work shape its packaging.
+
+## Out of scope for this matrix
+
+- The umbrella `register_file_exchange_*` helpers, shared token-store
+  construction, and Tasks integration — those are #148.
+- Any change to the wire spec or to `docs/specs/`.
+- Any change to the merged download data plane's observable
+  behaviour (only its module layout moves).
+
+## References
+
+- `2026-05-24-file-exchange-146-upload-data-plane-design.md` — the
+  behavioural contract this matrix maps onto.
+- `2026-05-24-file-exchange-145-download-data-plane-design.md` and
+  `src/fastmcp_pvl_core/_file_exchange/_download.py` (on `main`) —
+  the mirror.
+- PR #163, #164, #165 bot findings — the empirical source for the
+  rows in B1, A1, A2, A7, D4, E3.
+- `CLAUDE.md` "Test-driven discipline" — the discipline this matrix
+  operationalises.

--- a/src/fastmcp_pvl_core/_file_exchange/__init__.py
+++ b/src/fastmcp_pvl_core/_file_exchange/__init__.py
@@ -67,7 +67,10 @@ from fastmcp_pvl_core._file_exchange._tokens import (
     build_capability_token_store,
     capability_url,
 )
-from fastmcp_pvl_core._file_exchange._upload import upload_receiver_mint
+from fastmcp_pvl_core._file_exchange._upload import (
+    upload_receiver_mint,
+    upload_sender_consume,
+)
 from fastmcp_pvl_core._file_exchange._validation import (
     WireFormatError,
     validate_wire,
@@ -142,5 +145,6 @@ __all__ = [
     "select_sink",
     "select_source",
     "upload_receiver_mint",
+    "upload_sender_consume",
     "validate_wire",
 ]

--- a/src/fastmcp_pvl_core/_file_exchange/__init__.py
+++ b/src/fastmcp_pvl_core/_file_exchange/__init__.py
@@ -19,7 +19,6 @@ from fastmcp_pvl_core._file_exchange._codes import (
 from fastmcp_pvl_core._file_exchange._download import (
     download_fetcher_consume,
     download_provider_mint,
-    register_file_exchange_routes,
 )
 from fastmcp_pvl_core._file_exchange._errors import (
     FileExchangeTransferError,
@@ -44,6 +43,7 @@ from fastmcp_pvl_core._file_exchange._paths import (
     load_volume_map,
     resolve_filesystem_uri,
 )
+from fastmcp_pvl_core._file_exchange._routes import register_file_exchange_routes
 from fastmcp_pvl_core._file_exchange._selection import (
     select_sink,
     select_source,
@@ -67,6 +67,7 @@ from fastmcp_pvl_core._file_exchange._tokens import (
     build_capability_token_store,
     capability_url,
 )
+from fastmcp_pvl_core._file_exchange._upload import upload_receiver_mint
 from fastmcp_pvl_core._file_exchange._validation import (
     WireFormatError,
     validate_wire,
@@ -140,5 +141,6 @@ __all__ = [
     "resolve_filesystem_uri",
     "select_sink",
     "select_source",
+    "upload_receiver_mint",
     "validate_wire",
 ]

--- a/src/fastmcp_pvl_core/_file_exchange/_download.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_download.py
@@ -319,13 +319,15 @@ def _parse_range(header: str | None, size: int | None) -> tuple[int, int | None]
     return start, end
 
 
-def register_file_exchange_routes(
+def register_download_route(
     mcp: FastMCP,
     *,
     token_store: CapabilityTokenStore,
     source: ArtifactSource,
 ) -> None:
-    """Mount the ``download`` GET route on ``mcp`` (serves §12 capability URLs).
+    """Mount the ``download`` GET route on ``mcp`` (called by _routes).
+
+    Serves §12 capability URLs.
 
     ``GET <DOWNLOAD_PREFIX>/{token}`` looks the token up in ``token_store``,
     serves the artifact via ``source.open_artifact`` (streamed, ``Range``

--- a/src/fastmcp_pvl_core/_file_exchange/_download.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_download.py
@@ -19,12 +19,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import hashlib
 import logging
 import os
 import tempfile
 from collections.abc import AsyncGenerator
-from typing import IO, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import httpx
 from starlette.responses import Response, StreamingResponse
@@ -33,6 +32,11 @@ from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
 from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
 from fastmcp_pvl_core._file_exchange._outbound import guarded_stream
 from fastmcp_pvl_core._file_exchange._spec import HANDLE_TYPE, SPEC_VERSION
+from fastmcp_pvl_core._file_exchange._staging import (
+    _CHUNK,
+    _digest_verifier,
+    _write_chunk,
+)
 from fastmcp_pvl_core._file_exchange._tokens import capability_url
 from fastmcp_pvl_core._file_exchange._wire import DownloadSource, TransferHandle
 
@@ -51,10 +55,6 @@ logger = logging.getLogger(__name__)
 # kwarg — route structure is a pvl-core shape decision.
 DOWNLOAD_PREFIX = "/fx/d"
 
-_CHUNK = 1024 * 1024
-# Declared-digest label -> hashlib name; an unsupported label fails verification
-# (cannot verify -> digest-mismatch), never silently skips. Mirrors _filesystem.
-_HASHLIB_BY_LABEL = {"sha-256": "sha256", "sha-384": "sha384", "sha-512": "sha512"}
 # Max mid-stream reconnects before giving up on a dropped download.
 _MAX_RECONNECTS = 5
 
@@ -91,33 +91,6 @@ async def download_provider_mint(
             )
         ],
     )
-
-
-def _digest_verifier(
-    declared: str | None,
-) -> tuple[hashlib._Hash | None, str | None, bool]:
-    """Return (hasher | None, expected_hex | None, unverifiable).
-
-    ``unverifiable`` is True when a digest is declared with an unsupported label
-    — verification must then fail (cannot verify), never silently skip (§15).
-    """
-    if declared is None:
-        return None, None, False
-    label, _, expected_hex = declared.partition(":")
-    name = _HASHLIB_BY_LABEL.get(label.lower())
-    if name is None:
-        return None, expected_hex, True
-    return hashlib.new(name), expected_hex.lower(), False
-
-
-def _write_chunk(tmp: IO[bytes], hasher: hashlib._Hash | None, chunk: bytes) -> None:
-    """Write a body chunk to the temp file and fold it into the running hash.
-
-    Both ops run off the event loop in a single ``asyncio.to_thread`` dispatch.
-    """
-    tmp.write(chunk)
-    if hasher is not None:
-        hasher.update(chunk)
 
 
 async def download_fetcher_consume(

--- a/src/fastmcp_pvl_core/_file_exchange/_routes.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_routes.py
@@ -1,0 +1,57 @@
+"""Cross-transport route registrar (#146).
+
+``register_file_exchange_routes`` is the single public mount point for the
+file-exchange data planes. It validates all preconditions before mounting
+any route (matrix row A7), then delegates to per-transport registrars.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from fastmcp_pvl_core._file_exchange._download import register_download_route
+from fastmcp_pvl_core._file_exchange._upload import register_upload_route
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+
+
+def register_file_exchange_routes(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    source: ArtifactSource | None = None,
+    sink: ArtifactSink | None = None,
+    config: ServerConfig | None = None,
+) -> None:
+    """Mount the file-exchange data-plane routes on ``mcp``.
+
+    Mounts the ``download`` GET route iff ``source`` is given, and the
+    ``upload`` PUT/POST route iff ``sink`` is given — supporting
+    download-only, upload-only, or both. Mounting the upload route requires
+    ``config`` (the operator body-size cap is load-bearing for §15 untrusted
+    bytes). All preconditions are validated **before** any route is mounted
+    (matrix row A7).
+    """
+    if source is None and sink is None:
+        raise ValueError(
+            "register_file_exchange_routes: at least one of source/sink must be given"
+        )
+    if sink is not None and config is None:
+        raise ValueError(
+            "register_file_exchange_routes: sink requires config for "
+            "file_exchange_max_artifact_size"
+        )
+    if source is not None:
+        register_download_route(mcp, token_store=token_store, source=source)
+    if sink is not None:
+        register_upload_route(
+            mcp,
+            token_store=token_store,
+            sink=sink,
+            config=cast("ServerConfig", config),
+        )

--- a/src/fastmcp_pvl_core/_file_exchange/_staging.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_staging.py
@@ -1,0 +1,49 @@
+"""Shared digest + chunk-write primitives for the file-exchange data planes.
+
+Both ``_download`` (fetcher: write incoming HTTP body to a temp) and
+``_upload`` (route: write incoming PUT body to a temp; sender: write outgoing
+hook stream to a temp before hashing) share the same per-chunk
+write-and-hash pattern and the same declared-digest verifier semantics.
+Centralising the primitives here keeps the contract — every temp-file op
+maps to ``transfer-failed`` or is suppressed for cleanup, and an
+unsupported digest label fails verification rather than silently skipping
+— from being re-derived divergently between transports (matrix row G1,
+spec §15, mirror ``_download.py`` lines 47–302).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import IO
+
+_CHUNK = 1024 * 1024
+
+_HASHLIB_BY_LABEL = {"sha-256": "sha256", "sha-384": "sha384", "sha-512": "sha512"}
+
+
+def _digest_verifier(
+    declared: str | None,
+) -> tuple[hashlib._Hash | None, str | None, bool]:
+    """Return ``(hasher | None, expected_hex | None, unverifiable)``.
+
+    ``unverifiable`` is True when a digest is declared with an unsupported
+    label — verification must then fail (cannot verify), never silently
+    skip (§15).
+    """
+    if declared is None:
+        return None, None, False
+    label, _, expected_hex = declared.partition(":")
+    name = _HASHLIB_BY_LABEL.get(label.lower())
+    if name is None:
+        return None, expected_hex, True
+    return hashlib.new(name), expected_hex.lower(), False
+
+
+def _write_chunk(tmp: IO[bytes], hasher: hashlib._Hash | None, chunk: bytes) -> None:
+    """Write a body chunk to the temp file and fold it into the running hash.
+
+    Both ops run off the event loop in a single ``asyncio.to_thread`` dispatch.
+    """
+    tmp.write(chunk)
+    if hasher is not None:
+        hasher.update(chunk)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -5,12 +5,9 @@ This module accrues the upload-transport helpers task by task:
 - ``upload_receiver_mint`` — receiver role: mint a single-use capability
   token and emit an :class:`IntakeTicket` carrying one
   :class:`UploadSink`.
-- ``_content_digest_parse`` / ``_content_digest_format`` — RFC 9530
-  ``Content-Digest`` structured-field dictionary parse and format
-  (sha-256/384/512 only).
-- ``_media_range_matches`` — RFC 7231 §3.1.1.1 media-range matcher
-  used to validate request ``Content-Type`` against the ticket's
-  ``expected.contentType`` allowlist (this commit).
+- ``_content_digest_parse`` / ``_content_digest_format`` / ``_media_range_matches``
+  — RFC 9530 Content-Digest dictionary-entry parse + format, and an RFC 7231
+  media-range matcher used by the route to enforce ``acceptMimeTypes``.
 - The serving route and the sender land in subsequent commits per
   the implementation plan.
 

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -252,11 +252,16 @@ def register_upload_route(
                 return Response(status_code=413)
 
             cd_header = request.headers.get("content-digest")
+            required = expected.requireDigest if expected is not None else None
             if cd_header is not None:
                 parsed = _content_digest_parse(cd_header)
                 if parsed is None:
                     return Response(status_code=400)
                 cd_algo, cd_raw = parsed
+                if required is not None and cd_algo not in required:
+                    # requireDigest lists specific algorithms; a digest in a
+                    # different algorithm does not satisfy the requirement.
+                    return Response(status_code=400)
                 if cd_algo == "sha-256":
                     if hasher.digest() != cd_raw:
                         return Response(status_code=400)
@@ -274,7 +279,7 @@ def register_upload_route(
                         return Response(status_code=500)
                     if rehash.digest() != cd_raw:
                         return Response(status_code=400)
-            elif expected is not None and expected.requireDigest is not None:
+            elif required is not None:
                 return Response(status_code=400)
 
             meta = ArtifactMetadata(
@@ -297,8 +302,13 @@ def register_upload_route(
                 with contextlib.suppress(OSError):
                     await asyncio.to_thread(f.close)
 
-            with contextlib.suppress(Exception):
+            try:
                 await token_store.consume(token)
+            except Exception:
+                logger.warning(
+                    "file-exchange: upload token consume failed after store; "
+                    "token may remain usable to TTL"
+                )
             return Response(status_code=204)
         finally:
             with contextlib.suppress(OSError):

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -1,0 +1,69 @@
+"""The ``upload`` transport data plane (#146).
+
+Three free helpers — ``upload_receiver_mint``, ``upload_sender_consume``,
+and ``register_upload_route`` — that mirror ``_download.py``'s pull plane.
+The route accepts an HTTPS ``PUT``/``POST`` capability URL, streams the
+request body to a transient temp file with size + digest verification,
+and on a clean verify deposits the bytes into the receiver's
+``ArtifactSink`` (#142). The sender stages the offered bytes (hook stream
+→ temp + hash) and ``PUT``s them through the #147 SSRF guard.
+
+See ``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``
+for the contract and ``…2026-05-27-file-exchange-146-failure-modes.md`` for
+the enumerated failure modes each test in this module exercises.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._tokens import capability_url
+from fastmcp_pvl_core._file_exchange._wire import IntakeTicket, UploadSink
+
+if TYPE_CHECKING:
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+    from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
+
+UPLOAD_PREFIX = "/fx/u"
+
+
+async def upload_receiver_mint(
+    artifact_id: str,
+    *,
+    token_store: CapabilityTokenStore,
+    base_url: str,
+    ttl: float,
+    expected: ArtifactConstraints | None = None,
+    method: Literal["PUT", "POST"] = "PUT",
+) -> IntakeTicket:
+    """Receiver role (push): mint an upload token and emit an IntakeTicket.
+
+    Mint-only — no hook is called, no bytes move. The token stores the
+    ``artifact_id`` and the ``expected`` constraints so the route can
+    correlate received bytes back to a wire id and enforce limits at
+    deposit time. The token store treats the metadata as opaque (#144).
+    """
+    minted = await token_store.mint(
+        {
+            "artifact_id": artifact_id,
+            "expected": expected.model_dump() if expected is not None else None,
+        },
+        ttl=ttl,
+        single_use=True,
+    )
+    url = capability_url(base_url, UPLOAD_PREFIX, minted.token)
+    return IntakeTicket(
+        type=TICKET_TYPE,
+        version=SPEC_VERSION,
+        artifactId=artifact_id,
+        expected=expected,
+        sinks=[
+            UploadSink(
+                transport="upload",
+                url=url,
+                method=method,
+                expiresAt=minted.expires_at,
+            )
+        ],
+    )

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -114,35 +114,39 @@ async def upload_receiver_mint(
 def _content_digest_parse(header: str) -> tuple[str, bytes] | None:
     """Parse an RFC 9530 ``Content-Digest`` structured-field dictionary entry.
 
-    Returns ``(algo_label, raw_digest_bytes)`` on success, or ``None`` for any
-    malformed input or unsupported algorithm — the caller treats ``None`` as a
-    verification failure (``digest-mismatch``), never a silent skip
+    Returns ``(algo_label, raw_digest_bytes)`` on success, or ``None`` if no
+    supported, well-formed entry is present. Unsupported algorithms within a
+    dictionary are silently skipped (RFC 9530 §3: a recipient MUST ignore
+    digest values associated with algorithms that it does not support); the
+    function returns the first supported, well-formed entry it finds. ``None``
+    is treated by the caller as a verification failure (``digest-mismatch``),
+    never a silent skip of a header that did declare a known algorithm
     (matrix rows D4, D5; spec §10.3).
-
-    Only a single-algorithm dictionary entry is accepted (the form pvl-core's
-    sender produces); ``sha-256``/``sha-384``/``sha-512`` are the supported
-    labels.
     """
     if not header:
         return None
-    entry = header.split(",", 1)[0].strip()
-    label, sep, rest = entry.partition("=")
-    if sep != "=":
-        return None
-    label = label.strip().lower()
-    if label not in _HASHLIB_BY_LABEL:
-        return None
-    rest = rest.strip()
-    if len(rest) < 2 or not rest.startswith(":") or not rest.endswith(":"):
-        return None
-    b64 = rest[1:-1]
-    if not b64:
-        return None
-    try:
-        raw = _b64.b64decode(b64, validate=True)
-    except (binascii.Error, ValueError):
-        return None
-    return label, raw
+    for entry in header.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        label, sep, rest = entry.partition("=")
+        if sep != "=":
+            continue
+        label = label.strip().lower()
+        if label not in _HASHLIB_BY_LABEL:
+            continue
+        rest = rest.strip()
+        if len(rest) < 2 or not rest.startswith(":") or not rest.endswith(":"):
+            continue
+        b64 = rest[1:-1]
+        if not b64:
+            continue
+        try:
+            raw = _b64.b64decode(b64, validate=True)
+        except (binascii.Error, ValueError):
+            continue
+        return label, raw
+    return None
 
 
 def _content_digest_format(label: str, raw: bytes) -> str:
@@ -192,6 +196,7 @@ def register_upload_route(
     body-size cap; per-mint ``expected.maxSize`` is the smaller of the two when
     set. See the failure-mode matrix for the full per-status-code contract.
     """
+    from starlette.requests import ClientDisconnect
     from starlette.responses import Response
 
     async def _handle(request: Request) -> Response:
@@ -251,6 +256,11 @@ def register_upload_route(
                             break
                         await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
                         received += len(chunk)
+                except ClientDisconnect:
+                    # Client dropped mid-upload — no response needed; outer
+                    # finally still unlinks the temp.
+                    logger.debug("file-exchange: upload client disconnected mid-stream")
+                    raise
                 except OSError:
                     logger.exception("file-exchange: upload temp write failed")
                     return Response(status_code=500)
@@ -259,7 +269,7 @@ def register_upload_route(
                     await asyncio.to_thread(tmp.close)
 
             if too_large:
-                return Response(status_code=413)
+                return Response(status_code=413, headers={"Connection": "close"})
 
             cd_header = request.headers.get("content-digest")
             required = expected.requireDigest if expected is not None else None
@@ -278,12 +288,16 @@ def register_upload_route(
                 else:
                     rehash = hashlib.new(_HASHLIB_BY_LABEL[cd_algo])
                     try:
-                        with open(tmp_path, "rb") as fh:
+                        fh = await asyncio.to_thread(open, tmp_path, "rb")
+                        try:
                             while True:
                                 buf = await asyncio.to_thread(fh.read, _CHUNK)
                                 if not buf:
                                     break
                                 rehash.update(buf)
+                        finally:
+                            with contextlib.suppress(OSError):
+                                await asyncio.to_thread(fh.close)
                     except OSError:
                         logger.exception("file-exchange: upload rehash read failed")
                         return Response(status_code=500)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -397,10 +397,24 @@ async def upload_sender_consume(
                 headers["Content-Type"] = metadata.mimeType
 
             async def _body() -> AsyncIterator[bytes]:
-                f = await asyncio.to_thread(open, tmp_path, "rb")
+                try:
+                    f = await asyncio.to_thread(open, tmp_path, "rb")
+                except OSError as exc:
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.TRANSFER_FAILED,
+                        transport="upload",
+                        detail="failed to read the staged artifact",
+                    ) from exc
                 try:
                     while True:
-                        chunk = await asyncio.to_thread(f.read, _CHUNK)
+                        try:
+                            chunk = await asyncio.to_thread(f.read, _CHUNK)
+                        except OSError as exc:
+                            raise FileExchangeTransferError(
+                                TransferErrorCode.TRANSFER_FAILED,
+                                transport="upload",
+                                detail="failed to read the staged artifact",
+                            ) from exc
                         if not chunk:
                             break
                         yield chunk

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -13,8 +13,10 @@ This module accrues the upload-transport helpers task by task:
   ``Content-Digest`` before the sink sees the bytes, deposits to
   :class:`ArtifactSink`, and consumes the single-use token only after a
   successful store.
-- The sender (``upload_sender_consume``) lands in a subsequent commit per
-  the implementation plan.
+- ``upload_sender_consume`` — sender role (push): stage the source bytes to a
+  transient temp file (hashing on the fly), then PUT them through the #147
+  SSRF guard with ``Content-Type``/``Content-Length``/``Content-Digest``
+  headers. Non-2xx maps to ``transfer-failed``; guard refusals propagate.
 
 See ``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``
 for the behavioural contract and ``…2026-05-27-file-exchange-146-failure-modes.md``
@@ -31,8 +33,12 @@ import hashlib
 import logging
 import os
 import tempfile
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Literal, cast
 
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+from fastmcp_pvl_core._file_exchange._outbound import guarded_stream
 from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
 from fastmcp_pvl_core._file_exchange._staging import (
     _CHUNK,
@@ -53,7 +59,7 @@ if TYPE_CHECKING:
     from starlette.responses import Response
 
     from fastmcp_pvl_core._config import ServerConfig
-    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink, ArtifactSource
     from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
 
 
@@ -319,3 +325,106 @@ def register_upload_route(
                 await asyncio.to_thread(os.unlink, tmp_path)
 
     mcp.custom_route(f"{UPLOAD_PREFIX}/{{token}}", methods=["PUT", "POST"])(_handle)
+
+
+async def upload_sender_consume(
+    sink: UploadSink,
+    source: ArtifactSource,
+    key: str,
+    *,
+    config: ServerConfig,
+) -> None:
+    """Sender role (push): stage ``source[key]`` and PUT it to ``sink.url``.
+
+    Streams the source bytes through a transient temp file (hashing on the
+    fly), then sends the temp through the #147 SSRF guard with
+    ``Content-Type`` / ``Content-Length`` / ``Content-Digest`` headers.
+    Non-2xx maps to ``transfer-failed``; guard refusals propagate verbatim.
+    The temp is deleted on every path (matrix rows B2, B3, B5, C3, D1, D2,
+    D3, D9, F6).
+    """
+    stream, metadata = await source.open_artifact(key)
+    try:
+        try:
+            fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-")
+        except OSError as exc:
+            raise FileExchangeTransferError(
+                TransferErrorCode.TRANSFER_FAILED,
+                transport="upload",
+                detail="failed to create a temporary file",
+            ) from exc
+        try:
+            try:
+                tmp = os.fdopen(fd, "wb")
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                raise
+            try:
+                hasher = hashlib.new("sha256")
+                size = 0
+                while True:
+                    chunk = await asyncio.to_thread(stream.read, _CHUNK)
+                    if not chunk:
+                        break
+                    try:
+                        await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                    except OSError as exc:
+                        raise FileExchangeTransferError(
+                            TransferErrorCode.TRANSFER_FAILED,
+                            transport="upload",
+                            detail="failed to stage the artifact",
+                        ) from exc
+                    size += len(chunk)
+                try:
+                    await asyncio.to_thread(tmp.flush)
+                except OSError as exc:
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.TRANSFER_FAILED,
+                        transport="upload",
+                        detail="failed to flush the staged artifact",
+                    ) from exc
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(tmp.close)
+
+            cd_header = _content_digest_format("sha-256", hasher.digest())
+            headers: dict[str, str] = {
+                "Content-Length": str(size),
+                "Content-Digest": cd_header,
+            }
+            if metadata.mimeType:
+                headers["Content-Type"] = metadata.mimeType
+
+            async def _body() -> AsyncIterator[bytes]:
+                f = await asyncio.to_thread(open, tmp_path, "rb")
+                try:
+                    while True:
+                        chunk = await asyncio.to_thread(f.read, _CHUNK)
+                        if not chunk:
+                            break
+                        yield chunk
+                finally:
+                    with contextlib.suppress(OSError):
+                        await asyncio.to_thread(f.close)
+
+            async with guarded_stream(
+                sink.method,
+                sink.url,
+                config=config,
+                transport="upload",
+                headers=headers,
+                content=_body(),
+            ) as resp:
+                if not (200 <= resp.status < 300):
+                    raise FileExchangeTransferError(
+                        TransferErrorCode.TRANSFER_FAILED,
+                        transport="upload",
+                        detail="unexpected upload response status",
+                    )
+        finally:
+            with contextlib.suppress(OSError):
+                await asyncio.to_thread(os.unlink, tmp_path)
+    finally:
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(stream.close)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -8,7 +8,12 @@ This module accrues the upload-transport helpers task by task:
 - ``_content_digest_parse`` / ``_content_digest_format`` / ``_media_range_matches``
   — RFC 9530 Content-Digest dictionary-entry parse + format, and an RFC 7231
   media-range matcher used by the route to enforce ``acceptMimeTypes``.
-- The serving route and the sender land in subsequent commits per
+- ``register_upload_route`` — mount ``PUT``/``POST <UPLOAD_PREFIX>/{token}``
+  on a FastMCP server: streams the body to a temp file, verifies an optional
+  ``Content-Digest`` before the sink sees the bytes, deposits to
+  :class:`ArtifactSink`, and consumes the single-use token only after a
+  successful store.
+- The sender (``upload_sender_consume``) lands in a subsequent commit per
   the implementation plan.
 
 See ``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``
@@ -18,18 +23,41 @@ for the enumerated failure modes each test in this module exercises.
 
 from __future__ import annotations
 
+import asyncio
 import base64 as _b64
 import binascii
-from typing import TYPE_CHECKING, Literal
+import contextlib
+import hashlib
+import logging
+import os
+import tempfile
+from typing import TYPE_CHECKING, Literal, cast
 
 from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
-from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL
+from fastmcp_pvl_core._file_exchange._staging import (
+    _CHUNK,
+    _HASHLIB_BY_LABEL,
+    _write_chunk,
+)
 from fastmcp_pvl_core._file_exchange._tokens import capability_url
-from fastmcp_pvl_core._file_exchange._wire import IntakeTicket, UploadSink
+from fastmcp_pvl_core._file_exchange._wire import (
+    ArtifactConstraints,
+    ArtifactMetadata,
+    IntakeTicket,
+    UploadSink,
+)
 
 if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink
     from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
-    from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
+
+
+logger = logging.getLogger(__name__)
 
 # pvl-core's upload route shape (§12 capability URL path). A constant, not a
 # kwarg — route structure is a pvl-core shape decision.
@@ -141,3 +169,139 @@ def _media_range_matches(content_type: str, accept: list[str]) -> bool:
         ):
             return True
     return False
+
+
+def register_upload_route(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    sink: ArtifactSink,
+    config: ServerConfig,
+) -> None:
+    """Mount ``PUT``/``POST <UPLOAD_PREFIX>/{token}`` on ``mcp``.
+
+    The route serves §12 capability URLs minted by ``upload_receiver_mint``;
+    ambient credentials are ignored — the in-URL token is the only
+    authorization. ``config.file_exchange_max_artifact_size`` is the operator
+    body-size cap; per-mint ``expected.maxSize`` is the smaller of the two when
+    set. See the failure-mode matrix for the full per-status-code contract.
+    """
+    from starlette.responses import Response
+
+    async def _handle(request: Request) -> Response:
+        token = request.path_params["token"]
+        rec = await token_store.lookup(token)
+        if rec is None:
+            return Response(status_code=404)
+        artifact_id = cast("str", rec.metadata["artifact_id"])
+        expected_raw = rec.metadata.get("expected")
+        expected = (
+            ArtifactConstraints.model_validate(expected_raw)
+            if expected_raw is not None
+            else None
+        )
+
+        content_type = request.headers.get("content-type", "")
+        if expected is not None and expected.acceptMimeTypes is not None:
+            if not _media_range_matches(content_type, expected.acceptMimeTypes):
+                return Response(status_code=415)
+
+        cap_per_mint = expected.maxSize if expected is not None else None
+        cap_operator = config.file_exchange_max_artifact_size
+        cap: int | None
+        if cap_per_mint is None:
+            cap = cap_operator
+        elif cap_operator is None:
+            cap = cap_per_mint
+        else:
+            cap = min(cap_per_mint, cap_operator)
+
+        try:
+            fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-")
+        except OSError:
+            logger.exception("file-exchange: upload mkstemp failed")
+            return Response(status_code=500)
+        try:
+            try:
+                tmp = os.fdopen(fd, "wb")
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                raise
+            try:
+                hasher = hashlib.new("sha256")
+                received = 0
+                too_large = False
+                try:
+                    async for chunk in request.stream():
+                        if not chunk:
+                            continue
+                        if cap is not None and received + len(chunk) > cap:
+                            too_large = True
+                            break
+                        await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                        received += len(chunk)
+                except OSError:
+                    logger.exception("file-exchange: upload temp write failed")
+                    return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(tmp.close)
+
+            if too_large:
+                return Response(status_code=413)
+
+            cd_header = request.headers.get("content-digest")
+            if cd_header is not None:
+                parsed = _content_digest_parse(cd_header)
+                if parsed is None:
+                    return Response(status_code=400)
+                cd_algo, cd_raw = parsed
+                if cd_algo == "sha-256":
+                    if hasher.digest() != cd_raw:
+                        return Response(status_code=400)
+                else:
+                    rehash = hashlib.new(_HASHLIB_BY_LABEL[cd_algo])
+                    try:
+                        with open(tmp_path, "rb") as fh:
+                            while True:
+                                buf = await asyncio.to_thread(fh.read, _CHUNK)
+                                if not buf:
+                                    break
+                                rehash.update(buf)
+                    except OSError:
+                        logger.exception("file-exchange: upload rehash read failed")
+                        return Response(status_code=500)
+                    if rehash.digest() != cd_raw:
+                        return Response(status_code=400)
+            elif expected is not None and expected.requireDigest is not None:
+                return Response(status_code=400)
+
+            meta = ArtifactMetadata(
+                mimeType=content_type or None,
+                size=received,
+                digest="sha-256:" + hasher.hexdigest(),
+            )
+            try:
+                f = await asyncio.to_thread(open, tmp_path, "rb")
+            except OSError:
+                logger.exception("file-exchange: upload temp re-open failed")
+                return Response(status_code=500)
+            try:
+                try:
+                    await sink.store_artifact(artifact_id, meta, f)
+                except Exception:
+                    logger.exception("file-exchange: upload sink store_artifact failed")
+                    return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(f.close)
+
+            with contextlib.suppress(Exception):
+                await token_store.consume(token)
+            return Response(status_code=204)
+        finally:
+            with contextlib.suppress(OSError):
+                await asyncio.to_thread(os.unlink, tmp_path)
+
+    mcp.custom_route(f"{UPLOAD_PREFIX}/{{token}}", methods=["PUT", "POST"])(_handle)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -4,9 +4,15 @@ This module accrues the upload-transport helpers task by task:
 
 - ``upload_receiver_mint`` — receiver role: mint a single-use capability
   token and emit an :class:`IntakeTicket` carrying one
-  :class:`UploadSink` (this commit).
-- The serving route, the sender, and the RFC 9530 / 7231 helpers land
-  in subsequent commits per the implementation plan.
+  :class:`UploadSink`.
+- ``_content_digest_parse`` / ``_content_digest_format`` — RFC 9530
+  ``Content-Digest`` structured-field dictionary parse and format
+  (sha-256/384/512 only).
+- ``_media_range_matches`` — RFC 7231 §3.1.1.1 media-range matcher
+  used to validate request ``Content-Type`` against the ticket's
+  ``expected.contentType`` allowlist (this commit).
+- The serving route and the sender land in subsequent commits per
+  the implementation plan.
 
 See ``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``
 for the behavioural contract and ``…2026-05-27-file-exchange-146-failure-modes.md``
@@ -15,9 +21,12 @@ for the enumerated failure modes each test in this module exercises.
 
 from __future__ import annotations
 
+import base64 as _b64
+import binascii
 from typing import TYPE_CHECKING, Literal
 
 from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL
 from fastmcp_pvl_core._file_exchange._tokens import capability_url
 from fastmcp_pvl_core._file_exchange._wire import IntakeTicket, UploadSink
 
@@ -69,3 +78,69 @@ async def upload_receiver_mint(
             )
         ],
     )
+
+
+def _content_digest_parse(header: str) -> tuple[str, bytes] | None:
+    """Parse an RFC 9530 ``Content-Digest`` structured-field dictionary entry.
+
+    Returns ``(algo_label, raw_digest_bytes)`` on success, or ``None`` for any
+    malformed input or unsupported algorithm — the caller treats ``None`` as a
+    verification failure (``digest-mismatch``), never a silent skip
+    (matrix rows D4, D5; spec §10.3).
+
+    Only a single-algorithm dictionary entry is accepted (the form pvl-core's
+    sender produces); ``sha-256``/``sha-384``/``sha-512`` are the supported
+    labels.
+    """
+    if not header:
+        return None
+    entry = header.split(",", 1)[0].strip()
+    label, sep, rest = entry.partition("=")
+    if sep != "=":
+        return None
+    label = label.strip().lower()
+    if label not in _HASHLIB_BY_LABEL:
+        return None
+    rest = rest.strip()
+    if len(rest) < 2 or not rest.startswith(":") or not rest.endswith(":"):
+        return None
+    b64 = rest[1:-1]
+    if not b64:
+        return None
+    try:
+        raw = _b64.b64decode(b64, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    return label, raw
+
+
+def _content_digest_format(label: str, raw: bytes) -> str:
+    """Format ``(label, raw_digest_bytes)`` as ``algo=:base64:`` per RFC 9530."""
+    return f"{label}=:{_b64.b64encode(raw).decode('ascii')}:"
+
+
+def _media_range_matches(content_type: str, accept: list[str]) -> bool:
+    """RFC 7231 §3.1.1.1 media-range match: parameters ignored, case-insensitive.
+
+    ``type/*`` matches any subtype; ``*/*`` matches anything. An empty
+    ``content_type`` or an empty ``accept`` list never matches
+    (matrix rows F3, F4).
+    """
+    if not content_type or not accept:
+        return False
+    main = content_type.split(";", 1)[0].strip().lower()
+    if "/" not in main:
+        return False
+    main_type, main_sub = main.split("/", 1)
+    for entry in accept:
+        if not entry:
+            continue
+        entry_main = entry.split(";", 1)[0].strip().lower()
+        if "/" not in entry_main:
+            continue
+        e_type, e_sub = entry_main.split("/", 1)
+        if (e_type == "*" or e_type == main_type) and (
+            e_sub == "*" or e_sub == main_sub
+        ):
+            return True
+    return False

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -229,7 +229,11 @@ def register_upload_route(
                     os.close(fd)
                 raise
             try:
-                hasher = hashlib.new("sha256")
+                try:
+                    hasher = hashlib.new("sha256")
+                except Exception:
+                    logger.exception("file-exchange: upload hasher init failed")
+                    return Response(status_code=500)
                 received = 0
                 too_large = False
                 try:

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -1,16 +1,16 @@
 """The ``upload`` transport data plane (#146).
 
-Three free helpers — ``upload_receiver_mint``, ``upload_sender_consume``,
-and ``register_upload_route`` — that mirror ``_download.py``'s pull plane.
-The route accepts an HTTPS ``PUT``/``POST`` capability URL, streams the
-request body to a transient temp file with size + digest verification,
-and on a clean verify deposits the bytes into the receiver's
-``ArtifactSink`` (#142). The sender stages the offered bytes (hook stream
-→ temp + hash) and ``PUT``s them through the #147 SSRF guard.
+This module accrues the upload-transport helpers task by task:
+
+- ``upload_receiver_mint`` — receiver role: mint a single-use capability
+  token and emit an :class:`IntakeTicket` carrying one
+  :class:`UploadSink` (this commit).
+- The serving route, the sender, and the RFC 9530 / 7231 helpers land
+  in subsequent commits per the implementation plan.
 
 See ``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``
-for the contract and ``…2026-05-27-file-exchange-146-failure-modes.md`` for
-the enumerated failure modes each test in this module exercises.
+for the behavioural contract and ``…2026-05-27-file-exchange-146-failure-modes.md``
+for the enumerated failure modes each test in this module exercises.
 """
 
 from __future__ import annotations
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
     from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
     from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
 
+# pvl-core's upload route shape (§12 capability URL path). A constant, not a
+# kwarg — route structure is a pvl-core shape decision.
 UPLOAD_PREFIX = "/fx/u"
 
 

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -70,6 +70,7 @@ from fastmcp_pvl_core._file_exchange import (
     select_sink,
     select_source,
     upload_receiver_mint,
+    upload_sender_consume,
     validate_wire,
 )
 
@@ -128,5 +129,6 @@ __all__ = [
     "select_sink",
     "select_source",
     "upload_receiver_mint",
+    "upload_sender_consume",
     "validate_wire",
 ]

--- a/src/fastmcp_pvl_core/file_exchange.py
+++ b/src/fastmcp_pvl_core/file_exchange.py
@@ -69,6 +69,7 @@ from fastmcp_pvl_core._file_exchange import (
     resolve_filesystem_uri,
     select_sink,
     select_source,
+    upload_receiver_mint,
     validate_wire,
 )
 
@@ -126,5 +127,6 @@ __all__ = [
     "resolve_filesystem_uri",
     "select_sink",
     "select_source",
+    "upload_receiver_mint",
     "validate_wire",
 ]

--- a/tests/_file_exchange/test_download.py
+++ b/tests/_file_exchange/test_download.py
@@ -430,7 +430,7 @@ class _BytesSource:
 
 def _route_client(store, source):
     mcp = FastMCP("test")
-    _download.register_file_exchange_routes(mcp, token_store=store, source=source)
+    _download.register_download_route(mcp, token_store=store, source=source)
     app = mcp.http_app()
     return httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://route.test"

--- a/tests/_file_exchange/test_download_e2e.py
+++ b/tests/_file_exchange/test_download_e2e.py
@@ -64,7 +64,7 @@ async def test_two_server_pull_download(monkeypatch):
     # Server A: provider mint + serving route on a real ASGI app.
     store = _store()
     mcp = FastMCP("provider")
-    _download.register_file_exchange_routes(
+    _download.register_download_route(
         mcp, token_store=store, source=_BytesSource("doc", body)
     )
     app_a = mcp.http_app()

--- a/tests/_file_exchange/test_public_surface.py
+++ b/tests/_file_exchange/test_public_surface.py
@@ -1,0 +1,28 @@
+"""Matrix row E4: upload helpers are reachable via the public namespace
+and listed in __all__."""
+
+from fastmcp_pvl_core import file_exchange
+
+
+def test_upload_helpers_importable_via_public_namespace():
+    assert hasattr(file_exchange, "upload_receiver_mint")
+    assert hasattr(file_exchange, "upload_sender_consume")
+    assert hasattr(file_exchange, "register_file_exchange_routes")
+
+
+def test_upload_helpers_in_all():
+    assert "upload_receiver_mint" in file_exchange.__all__
+    assert "upload_sender_consume" in file_exchange.__all__
+    assert "register_file_exchange_routes" in file_exchange.__all__
+
+
+def test_all_is_alphabetical():
+    # The repo's existing __all__ convention is ASCII case-sensitive sort
+    # (Capitalized names first, then lowercase) — same as
+    # ``fastmcp_pvl_core.__all__`` and ``fastmcp_pvl_core._file_exchange.__all__``.
+    # The point of pinning this is to catch "someone appended at the end"
+    # bugs that drift the surface from its canonical order.
+    names = list(file_exchange.__all__)
+    assert names == sorted(names), (
+        "file_exchange.__all__ must be ASCII-sorted (matches repo convention)"
+    )

--- a/tests/_file_exchange/test_routes_registrar.py
+++ b/tests/_file_exchange/test_routes_registrar.py
@@ -1,0 +1,100 @@
+"""Matrix rows A7, A8, E2, E3: register_file_exchange_routes shape."""
+
+import pytest
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _routes
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+
+
+class _Sink:
+    async def store_artifact(self, artifact_id, metadata, stream):  # pragma: no cover
+        raise AssertionError
+
+
+class _Source:
+    async def open_artifact(self, key):  # pragma: no cover
+        raise AssertionError
+
+
+def _cfg():
+    return ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_token_ttl=3600.0,
+        file_exchange_max_artifact_size=1024,
+    )
+
+
+def test_registrar_both_none_raises_value_error():
+    """E2: source=None, sink=None is misconfiguration."""
+    cfg = _cfg()
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("t")
+    with pytest.raises(ValueError):
+        _routes.register_file_exchange_routes(
+            mcp, token_store=store, source=None, sink=None, config=cfg
+        )
+
+
+def test_registrar_sink_without_config_raises_value_error():
+    """E3: sink requires config (operator size cap)."""
+    cfg = _cfg()
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("t")
+    with pytest.raises(ValueError):
+        _routes.register_file_exchange_routes(
+            mcp, token_store=store, source=None, sink=_Sink(), config=None
+        )
+
+
+def test_registrar_source_only_mounts_download_route():
+    """A8: source-only mounts only the download route."""
+    cfg = _cfg()
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("t")
+    _routes.register_file_exchange_routes(
+        mcp, token_store=store, source=_Source(), sink=None, config=None
+    )
+    paths = {r.path for r in mcp.http_app().routes}
+    assert any(p.startswith("/fx/d") for p in paths)
+    assert not any(p.startswith("/fx/u") for p in paths)
+
+
+def test_registrar_sink_only_mounts_upload_route():
+    """A8: sink-only mounts only the upload route."""
+    cfg = _cfg()
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("t")
+    _routes.register_file_exchange_routes(
+        mcp, token_store=store, source=None, sink=_Sink(), config=cfg
+    )
+    paths = {r.path for r in mcp.http_app().routes}
+    assert any(p.startswith("/fx/u") for p in paths)
+    assert not any(p.startswith("/fx/d") for p in paths)
+
+
+def test_registrar_both_mounts_both():
+    """A8: source+sink mounts both routes."""
+    cfg = _cfg()
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("t")
+    _routes.register_file_exchange_routes(
+        mcp, token_store=store, source=_Source(), sink=_Sink(), config=cfg
+    )
+    paths = {r.path for r in mcp.http_app().routes}
+    assert any(p.startswith("/fx/d") for p in paths)
+    assert any(p.startswith("/fx/u") for p in paths)
+
+
+def test_registrar_precondition_failure_mounts_nothing():
+    """A7: ValueError from precondition validation -> no routes mounted."""
+    cfg = _cfg()
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("t")
+    with pytest.raises(ValueError):
+        _routes.register_file_exchange_routes(
+            mcp, token_store=store, source=_Source(), sink=_Sink(), config=None
+        )
+    paths = {r.path for r in mcp.http_app().routes}
+    assert not any(p.startswith("/fx/") for p in paths)

--- a/tests/_file_exchange/test_staging.py
+++ b/tests/_file_exchange/test_staging.py
@@ -1,0 +1,54 @@
+"""Matrix row G1: extracted staging primitives match the download originals."""
+
+import hashlib
+
+from fastmcp_pvl_core._file_exchange import _staging
+
+
+def test_chunk_constant_is_one_megabyte():
+    assert _staging._CHUNK == 1024 * 1024
+
+
+def test_hashlib_label_map_covers_sha_256_384_512():
+    assert _staging._HASHLIB_BY_LABEL == {
+        "sha-256": "sha256",
+        "sha-384": "sha384",
+        "sha-512": "sha512",
+    }
+
+
+def test_digest_verifier_unknown_label_unverifiable():
+    hasher, expected_hex, unverifiable = _staging._digest_verifier("md5:abcd")
+    assert hasher is None
+    assert expected_hex == "abcd"
+    assert unverifiable is True
+
+
+def test_digest_verifier_known_label_returns_hasher():
+    hasher, expected_hex, unverifiable = _staging._digest_verifier(
+        "sha-256:" + "0" * 64
+    )
+    assert isinstance(hasher, type(hashlib.sha256()))
+    assert expected_hex == "0" * 64
+    assert unverifiable is False
+
+
+def test_digest_verifier_none_declared_no_op():
+    assert _staging._digest_verifier(None) == (None, None, False)
+
+
+def test_write_chunk_writes_and_hashes(tmp_path):
+    target = tmp_path / "buf.bin"
+    with target.open("wb") as fh:
+        h = hashlib.new("sha256")
+        _staging._write_chunk(fh, h, b"abc")
+        _staging._write_chunk(fh, h, b"def")
+    assert target.read_bytes() == b"abcdef"
+    assert h.hexdigest() == hashlib.sha256(b"abcdef").hexdigest()
+
+
+def test_write_chunk_no_hasher_writes_only(tmp_path):
+    target = tmp_path / "buf.bin"
+    with target.open("wb") as fh:
+        _staging._write_chunk(fh, None, b"abc")
+    assert target.read_bytes() == b"abc"

--- a/tests/_file_exchange/test_upload_e2e.py
+++ b/tests/_file_exchange/test_upload_e2e.py
@@ -1,0 +1,110 @@
+"""End-to-end push: sender + guard + receiver route + sink.
+
+Two FastMCP-built mock servers wired through ASGITransport: server B
+mints + serves the upload route; server A selects + sends through a
+guarded_stream patched to land on B's ASGI app. The SSRF guard is
+replaced because we are exercising the push flow, not the guard
+(which has its own tests).
+"""
+
+import contextlib
+import hashlib
+import io
+from typing import BinaryIO
+
+import httpx
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange._routes import register_file_exchange_routes
+from fastmcp_pvl_core._file_exchange._selection import select_sink
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata, UploadSink
+
+
+class _Sink:
+    def __init__(self) -> None:
+        self.received: tuple[str, ArtifactMetadata, bytes] | None = None
+
+    async def store_artifact(
+        self, artifact_id: str, metadata: ArtifactMetadata, stream: BinaryIO
+    ) -> None:
+        self.received = (artifact_id, metadata, stream.read())
+
+
+class _Src:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+    async def open_artifact(self, key: str) -> tuple[io.BytesIO, ArtifactMetadata]:
+        return io.BytesIO(self.data), ArtifactMetadata(mimeType="application/json")
+
+
+async def test_e2e_push_two_servers(monkeypatch):
+    payload = b'{"hello":"world"}'
+
+    # Server B (receiver): mint + serve the upload route on a real ASGI app.
+    cfg_b = ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_token_ttl=3600.0,
+        file_exchange_max_artifact_size=1024,
+    )
+    store_b = build_capability_token_store(cfg_b)
+    sink_b = _Sink()
+    mcp_b = FastMCP("B")
+    register_file_exchange_routes(mcp_b, token_store=store_b, sink=sink_b, config=cfg_b)
+
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store_b, base_url="https://b.test", ttl=120.0
+    )
+
+    transport_b = httpx.ASGITransport(app=mcp_b.http_app())
+    client_b = httpx.AsyncClient(transport=transport_b, base_url="https://b.test")
+
+    # Server A's guard, redirected at B's ASGI app — no real network /
+    # SSRF check (the guard is exercised elsewhere; here we test the push
+    # flow). The fake mirrors the production GuardedResponse surface that
+    # ``upload_sender_consume`` consumes (``status`` only).
+    @contextlib.asynccontextmanager
+    async def fake_guarded_stream(
+        method, url, *, config, transport, headers=None, content=None
+    ):
+        assert transport == "upload"
+        body = b""
+        if content is not None:
+            async for chunk in content:
+                body += chunk
+        resp = await client_b.request(method, url, headers=headers, content=body)
+
+        class R:
+            status = resp.status_code
+
+        yield R()
+
+    monkeypatch.setattr(_upload, "guarded_stream", fake_guarded_stream)
+
+    # Server A (sender): select the sink, push the bytes.
+    cfg_a = ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_http_timeout=30.0,
+    )
+    selected = select_sink(ticket)
+    assert isinstance(selected, UploadSink)
+    try:
+        await _upload.upload_sender_consume(
+            selected, _Src(payload), "art-1", config=cfg_a
+        )
+    finally:
+        await client_b.aclose()
+
+    assert sink_b.received is not None
+    aid, meta, body = sink_b.received
+    assert aid == "art-1"
+    assert body == payload
+    assert meta.size == len(payload)
+    assert meta.digest == "sha-256:" + hashlib.sha256(payload).hexdigest()
+
+    # The single-use token was consumed by the completed deposit.
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    assert await store_b.lookup(token) is None

--- a/tests/_file_exchange/test_upload_helpers.py
+++ b/tests/_file_exchange/test_upload_helpers.py
@@ -38,14 +38,30 @@ def test_content_digest_parse_sha384_well_formed():
     assert decoded == raw
 
 
-def test_content_digest_parse_multi_algo_dict_takes_first_entry():
-    """Documented scoping: only the first dictionary entry is parsed."""
+def test_content_digest_parse_multi_algo_dict_returns_first_supported():
+    """RFC 9530 §3: when a dictionary lists multiple algorithms, return the
+    first supported one in order. (sha-256 is supported; sha-512 is also
+    supported but appears second.)"""
     raw256 = hashlib.sha256(b"x").digest()
     raw512 = hashlib.sha512(b"x").digest()
     b256 = base64.b64encode(raw256).decode("ascii")
     b512 = base64.b64encode(raw512).decode("ascii")
     parsed = _content_digest_parse(f"sha-256=:{b256}:, sha-512=:{b512}:")
     assert parsed == ("sha-256", raw256)
+
+
+def test_content_digest_parse_skips_unsupported_then_takes_supported():
+    """RFC 9530 §3 MUST-ignore: unsupported algorithm at first position is
+    skipped, the supported algorithm later in the dictionary is used."""
+    raw256 = hashlib.sha256(b"hello").digest()
+    b256 = base64.b64encode(raw256).decode("ascii")
+    parsed = _content_digest_parse(f"md5=:YWJjZA==:, sha-256=:{b256}:")
+    assert parsed == ("sha-256", raw256)
+
+
+def test_content_digest_parse_all_unsupported_returns_none():
+    """If every dictionary entry is in an unsupported algorithm, return None."""
+    assert _content_digest_parse("md5=:YWJjZA==:, sha-3=:YWJjZA==:") is None
 
 
 def test_content_digest_parse_tolerates_whitespace():

--- a/tests/_file_exchange/test_upload_helpers.py
+++ b/tests/_file_exchange/test_upload_helpers.py
@@ -1,0 +1,82 @@
+"""Matrix rows F1, F2, F3, F4, D4, D5: pure-function helpers in _upload."""
+
+import base64
+import hashlib
+
+import pytest
+
+from fastmcp_pvl_core._file_exchange._upload import (
+    _content_digest_format,
+    _content_digest_parse,
+    _media_range_matches,
+)
+
+
+def test_content_digest_parse_sha256_well_formed():
+    payload = b"hello"
+    raw = hashlib.sha256(payload).digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    header = f"sha-256=:{b64}:"
+    algo, decoded = _content_digest_parse(header)
+    assert algo == "sha-256"
+    assert decoded == raw
+
+
+def test_content_digest_parse_sha512_well_formed():
+    raw = hashlib.sha512(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    algo, decoded = _content_digest_parse(f"sha-512=:{b64}:")
+    assert algo == "sha-512"
+    assert decoded == raw
+
+
+def test_content_digest_parse_tolerates_whitespace():
+    raw = hashlib.sha256(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    algo, decoded = _content_digest_parse(f"  sha-256 = :{b64}:  ")
+    assert algo == "sha-256"
+    assert decoded == raw
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "garbage",
+        "sha-256:abcd",  # missing structured-field colons
+        "md5=:YWJjZA==:",  # unsupported algo label
+        "sha-256=::",  # empty value
+        "sha-256=:not-base64!:",
+        "sha-256=:YWJjZA",  # missing trailing colon
+        "",
+    ],
+)
+def test_content_digest_parse_malformed_or_unknown_returns_none(header):
+    """D4 + D5: present-but-unparseable / unsupported-algo -> None."""
+    assert _content_digest_parse(header) is None
+
+
+def test_content_digest_format_round_trips():
+    raw = hashlib.sha256(b"hello").digest()
+    header = _content_digest_format("sha-256", raw)
+    parsed = _content_digest_parse(header)
+    assert parsed == ("sha-256", raw)
+
+
+@pytest.mark.parametrize(
+    "content_type,accept,expected",
+    [
+        ("application/json", ["application/json"], True),
+        ("application/json; charset=utf-8", ["application/json"], True),
+        ("image/png", ["image/*"], True),
+        ("text/plain", ["image/*"], False),
+        ("application/octet-stream", ["*/*"], True),
+        ("APPLICATION/JSON", ["application/json"], True),
+        ("application/json", ["text/plain", "application/json"], True),
+        ("application/json", ["text/plain", "text/html"], False),
+        ("", ["application/json"], False),
+        ("application/json", [], False),
+    ],
+)
+def test_media_range_matches_table(content_type, accept, expected):
+    """F3."""
+    assert _media_range_matches(content_type, accept) is expected

--- a/tests/_file_exchange/test_upload_helpers.py
+++ b/tests/_file_exchange/test_upload_helpers.py
@@ -30,6 +30,24 @@ def test_content_digest_parse_sha512_well_formed():
     assert decoded == raw
 
 
+def test_content_digest_parse_sha384_well_formed():
+    raw = hashlib.sha384(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    algo, decoded = _content_digest_parse(f"sha-384=:{b64}:")
+    assert algo == "sha-384"
+    assert decoded == raw
+
+
+def test_content_digest_parse_multi_algo_dict_takes_first_entry():
+    """Documented scoping: only the first dictionary entry is parsed."""
+    raw256 = hashlib.sha256(b"x").digest()
+    raw512 = hashlib.sha512(b"x").digest()
+    b256 = base64.b64encode(raw256).decode("ascii")
+    b512 = base64.b64encode(raw512).decode("ascii")
+    parsed = _content_digest_parse(f"sha-256=:{b256}:, sha-512=:{b512}:")
+    assert parsed == ("sha-256", raw256)
+
+
 def test_content_digest_parse_tolerates_whitespace():
     raw = hashlib.sha256(b"x").digest()
     b64 = base64.b64encode(raw).decode("ascii")
@@ -73,6 +91,7 @@ def test_content_digest_format_round_trips():
         ("APPLICATION/JSON", ["application/json"], True),
         ("application/json", ["text/plain", "application/json"], True),
         ("application/json", ["text/plain", "text/html"], False),
+        ("application/json", ["bogus", "application/json"], True),
         ("", ["application/json"], False),
         ("application/json", [], False),
     ],

--- a/tests/_file_exchange/test_upload_mint.py
+++ b/tests/_file_exchange/test_upload_mint.py
@@ -1,0 +1,86 @@
+"""Matrix row E1, E4: upload_receiver_mint builds an IntakeTicket."""
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints, UploadSink
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+async def test_mint_returns_intake_ticket_with_one_upload_sink():
+    store = _store()
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://b.example",
+        ttl=120.0,
+    )
+    assert ticket.type == TICKET_TYPE
+    assert ticket.version == SPEC_VERSION
+    assert ticket.artifactId == "art-1"
+    assert ticket.expected is None
+    assert len(ticket.sinks) == 1
+    sink = ticket.sinks[0]
+    assert isinstance(sink, UploadSink)
+    assert sink.transport == "upload"
+    assert sink.url.startswith("https://b.example/fx/u/")
+    assert sink.method == "PUT"
+    token = sink.url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata == {"artifact_id": "art-1", "expected": None}
+    assert rec.single_use is True
+
+
+async def test_mint_method_post_threads_through():
+    store = _store()
+    ticket = await _upload.upload_receiver_mint(
+        "art-2",
+        token_store=store,
+        base_url="https://b.example",
+        ttl=120.0,
+        method="POST",
+    )
+    assert ticket.sinks[0].method == "POST"
+
+
+async def test_mint_expected_round_trips_onto_ticket_and_metadata():
+    store = _store()
+    expected = ArtifactConstraints(
+        maxSize=1024, acceptMimeTypes=["application/json"], requireDigest=["sha-256"]
+    )
+    ticket = await _upload.upload_receiver_mint(
+        "art-3",
+        token_store=store,
+        base_url="https://b.example",
+        ttl=120.0,
+        expected=expected,
+    )
+    assert ticket.expected == expected
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata["artifact_id"] == "art-3"
+    assert rec.metadata["expected"] == expected.model_dump()
+
+
+async def test_mint_calls_do_not_collide_for_same_artifact_id():
+    """E1: minting twice yields two distinct tokens, both valid."""
+    store = _store()
+    t1 = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://b.example", ttl=120.0
+    )
+    t2 = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://b.example", ttl=120.0
+    )
+    tok1 = t1.sinks[0].url.rsplit("/", 1)[1]
+    tok2 = t2.sinks[0].url.rsplit("/", 1)[1]
+    assert tok1 != tok2
+    assert (await store.lookup(tok1)) is not None
+    assert (await store.lookup(tok2)) is not None

--- a/tests/_file_exchange/test_upload_mint.py
+++ b/tests/_file_exchange/test_upload_mint.py
@@ -70,8 +70,9 @@ async def test_mint_expected_round_trips_onto_ticket_and_metadata():
     assert rec.metadata["expected"] == expected.model_dump()
 
 
-async def test_mint_calls_do_not_collide_for_same_artifact_id():
-    """E1: minting twice yields two distinct tokens, both valid."""
+async def test_repeated_mint_yields_distinct_tokens_with_same_artifact_id():
+    """E1: minting twice for the same artifact_id yields two distinct
+    tokens; both lookups round-trip to the same artifact_id metadata."""
     store = _store()
     t1 = await _upload.upload_receiver_mint(
         "art-1", token_store=store, base_url="https://b.example", ttl=120.0
@@ -82,5 +83,8 @@ async def test_mint_calls_do_not_collide_for_same_artifact_id():
     tok1 = t1.sinks[0].url.rsplit("/", 1)[1]
     tok2 = t2.sinks[0].url.rsplit("/", 1)[1]
     assert tok1 != tok2
-    assert (await store.lookup(tok1)) is not None
-    assert (await store.lookup(tok2)) is not None
+    rec1 = await store.lookup(tok1)
+    rec2 = await store.lookup(tok2)
+    assert rec1 is not None and rec2 is not None
+    assert rec1.metadata["artifact_id"] == "art-1"
+    assert rec2.metadata["artifact_id"] == "art-1"

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -450,7 +450,18 @@ async def test_route_ambient_authorization_on_invalid_token_still_404():
 
 
 async def test_route_concurrent_puts_at_most_one_consumes():
-    """C1."""
+    """C1: two concurrent PUTs against one token do not crash, the token
+    is consumed exactly once, and the response set never contains two
+    404s.
+
+    Under ASGITransport's single-event-loop driver, the actual
+    interleaving window between ``token_store.lookup`` and
+    ``token_store.consume`` is not forced — the test pins the
+    observable contract (consume-exactly-once, response-set sanity)
+    rather than the specific race timing. A forced-interleaving test
+    that injects an awaitable barrier into the token store would be a
+    legitimate follow-up but is not required for the matrix row.
+    """
     sink = _RecordingSink()
     mcp, store = await _mount(sink)
     ticket = await _upload.upload_receiver_mint(

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -1,6 +1,8 @@
 """Matrix rows A1–A6, B1, B4, B6, C1–C2, D4–D8, F4, F5: upload route."""
 
+import asyncio as _asyncio
 import hashlib
+import os
 from typing import BinaryIO
 
 import httpx
@@ -114,3 +116,181 @@ async def test_route_require_digest_algorithm_mismatch_400():
         )
     assert resp.status_code == 400
     assert sink.calls == []
+
+
+async def test_route_second_put_after_success_returns_404():
+    """A1 ordering: token consumed after first success; second PUT -> 404."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        r1 = await c.put(path, content=b"a", headers={"Content-Type": "text/plain"})
+        r2 = await c.put(path, content=b"b", headers={"Content-Type": "text/plain"})
+    assert r1.status_code == 204
+    assert r2.status_code == 404
+    assert len(sink.calls) == 1
+
+
+class _RaisingSink:
+    def __init__(self) -> None:
+        self.attempts = 0
+
+    async def store_artifact(self, artifact_id, metadata, stream):
+        self.attempts += 1
+        stream.read()
+        if self.attempts == 1:
+            raise RuntimeError("boom")
+
+
+async def test_route_sink_raise_does_not_consume_token():
+    """A2: sink raises -> 500, token still valid, retry succeeds."""
+    sink = _RaisingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        r1 = await c.put(path, content=b"a", headers={"Content-Type": "text/plain"})
+        r2 = await c.put(path, content=b"b", headers={"Content-Type": "text/plain"})
+    assert r1.status_code == 500
+    assert r2.status_code == 204
+    assert sink.attempts == 2
+
+
+async def test_route_accept_mime_mismatch_415():
+    """A3."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+        expected=ArtifactConstraints(acceptMimeTypes=["application/json"]),
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"hi", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 415
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+
+async def test_route_too_large_per_mint_cap_413():
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+        expected=ArtifactConstraints(maxSize=4),
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path, content=b"too-many-bytes", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 413
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+
+async def test_route_too_large_operator_cap_413():
+    sink = _RecordingSink()
+    cfg = ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_token_ttl=3600.0,
+        file_exchange_max_artifact_size=4,
+    )
+    mcp, store = await _mount(sink, config=cfg)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path, content=b"too-many", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 413
+
+
+async def test_route_content_digest_mismatch_400():
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    bad = "sha-256=:" + "A" * 44 + ":"
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=b"hello",
+            headers={"Content-Type": "text/plain", "Content-Digest": bad},
+        )
+    assert resp.status_code == 400
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+
+async def test_route_require_digest_but_missing_header_400():
+    """A6."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+        expected=ArtifactConstraints(requireDigest=["sha-256"]),
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"hi", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 400
+    assert sink.calls == []
+
+
+async def test_route_content_digest_unparseable_400():
+    """D4."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=b"hi",
+            headers={"Content-Type": "text/plain", "Content-Digest": "garbage"},
+        )
+    assert resp.status_code == 400
+
+
+async def test_route_content_digest_unsupported_algo_400():
+    """D5."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=b"hi",
+            headers={
+                "Content-Type": "text/plain",
+                "Content-Digest": "md5=:YWJjZA==:",
+            },
+        )
+    assert resp.status_code == 400

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -497,3 +497,128 @@ async def test_route_content_digest_unsupported_algo_400():
             },
         )
     assert resp.status_code == 400
+
+
+async def test_route_tmp_close_failure_suppressed(monkeypatch):
+    """B2: tmp.close() raises on the success path -> suppressed, route still 204."""
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+
+    real_fdopen = up.os.fdopen
+    raised: list[bool] = []
+
+    def wrap(*a, **kw):
+        f = real_fdopen(*a, **kw)
+        real_close = f.close
+
+        def tracked_close():
+            raised.append(True)
+            real_close()
+            raise OSError("close failed")
+
+        f.close = tracked_close  # type: ignore[method-assign]
+        return f
+
+    monkeypatch.setattr(up.os, "fdopen", wrap)
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path, content=b"hello", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+    assert raised, "tmp.close should have been called"
+    assert await store.lookup(token) is None
+
+
+async def test_route_unlink_failure_suppressed_on_success(monkeypatch):
+    """B3: os.unlink raises during cleanup -> suppressed, response still 204."""
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+
+    real_unlink = up.os.unlink
+
+    def boom(p):
+        # Only fail for fx-upload temps; let other unlinks (if any) proceed.
+        if "fx-upload-" in str(p):
+            raise OSError("simulated unlink failure")
+        return real_unlink(p)
+
+    monkeypatch.setattr(up.os, "unlink", boom)
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+
+
+async def test_route_revoke_before_put_returns_404():
+    """C2 (a): revoke wins the race before lookup -> 404, no sink call."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    await store.revoke(token)
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 404
+    assert sink.calls == []
+
+
+async def test_route_revoke_after_lookup_still_succeeds():
+    """C2 (b): revoke fires between lookup and consume -> sink succeeded,
+    consume returns False, response still 204 (the bytes are in the sink;
+    spec is at-most-once-success, not at-most-once-with-rollback).
+    """
+    import asyncio as _aio
+
+    revoke_signal = _aio.Event()
+    consume_signal = _aio.Event()
+
+    class _SlowSink:
+        def __init__(self):
+            self.calls: list[bytes] = []
+
+        async def store_artifact(self, artifact_id, metadata, stream):
+            # Allow the test to revoke the token while the sink is mid-store.
+            revoke_signal.set()
+            await consume_signal.wait()
+            self.calls.append(stream.read())
+
+    sink = _SlowSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+
+    async def driver():
+        await revoke_signal.wait()
+        await store.revoke(token)
+        consume_signal.set()
+
+    async with await _client(mcp) as c:
+        results = await _asyncio.gather(
+            c.put(path, content=b"x", headers={"Content-Type": "text/plain"}),
+            driver(),
+        )
+    resp = results[0]
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+    # Token is gone (consume returned False, but revoke deleted it).
+    assert await store.lookup(token) is None

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -1,0 +1,87 @@
+"""Matrix rows A1–A6, B1, B4, B6, C1–C2, D4–D8, F4, F5: upload route."""
+
+import hashlib
+from typing import BinaryIO
+
+import httpx
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str | None, ArtifactMetadata, bytes]] = []
+
+    async def store_artifact(
+        self, artifact_id: str | None, metadata: ArtifactMetadata, stream: BinaryIO
+    ) -> None:
+        data = stream.read()
+        self.calls.append((artifact_id, metadata, data))
+
+
+async def _mount(sink, *, config=None):
+    cfg = config or ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_token_ttl=3600.0,
+        file_exchange_max_artifact_size=10 * 1024 * 1024,
+    )
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("test")
+    _upload.register_upload_route(mcp, token_store=store, sink=sink, config=cfg)
+    return mcp, store
+
+
+async def _client(mcp):
+    transport = httpx.ASGITransport(app=mcp.http_app())
+    return httpx.AsyncClient(transport=transport, base_url="http://test")
+
+
+async def test_route_happy_put_deposits_and_consumes():
+    """A1 success: PUT 204 -> sink called once, token consumed."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+    )
+    url = ticket.sinks[0].url
+    token = url.rsplit("/", 1)[1]
+    path = "/" + url.split("/", 3)[3]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path, content=b"hello world", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+    aid, meta, body = sink.calls[0]
+    assert aid == "art-1"
+    assert body == b"hello world"
+    assert meta.mimeType == "text/plain"
+    assert meta.size == len(b"hello world")
+    assert meta.digest == "sha-256:" + hashlib.sha256(b"hello world").hexdigest()
+    # Token consumed
+    assert await store.lookup(token) is None
+
+
+async def test_route_unknown_token_404():
+    """A1 prelude: lookup miss -> 404."""
+    sink = _RecordingSink()
+    mcp, _ = await _mount(sink)
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            "/fx/u/does-not-exist", content=b"x", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 404
+    assert sink.calls == []

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -449,6 +449,25 @@ async def test_route_ambient_authorization_on_invalid_token_still_404():
     assert resp.status_code == 404
 
 
+async def test_route_concurrent_puts_at_most_one_consumes():
+    """C1."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    async with await _client(mcp) as c:
+        r1, r2 = await _asyncio.gather(
+            c.put(path, content=b"a", headers={"Content-Type": "text/plain"}),
+            c.put(path, content=b"b", headers={"Content-Type": "text/plain"}),
+        )
+    statuses = sorted([r1.status_code, r2.status_code])
+    assert statuses in ([204, 204], [204, 404])
+    assert await store.lookup(token) is None
+
+
 async def test_route_content_digest_unsupported_algo_400():
     """D5."""
     sink = _RecordingSink()

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -9,7 +9,7 @@ from fastmcp import FastMCP
 from fastmcp_pvl_core._config import ServerConfig
 from fastmcp_pvl_core._file_exchange import _upload
 from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
-from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints, ArtifactMetadata
 
 
 def _store():
@@ -84,4 +84,33 @@ async def test_route_unknown_token_404():
             "/fx/u/does-not-exist", content=b"x", headers={"Content-Type": "text/plain"}
         )
     assert resp.status_code == 404
+    assert sink.calls == []
+
+
+async def test_route_require_digest_algorithm_mismatch_400():
+    """A6 tightening: requireDigest=[sha-256] but client sends sha-512 -> 400."""
+    import base64
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+        expected=ArtifactConstraints(requireDigest=["sha-256"]),
+    )
+    url = ticket.sinks[0].url
+    path = url[len("https://route.test") :]
+    # Compute a correct sha-512 digest of the body so the header parses cleanly.
+    body = b"hello"
+    raw512 = hashlib.sha512(body).digest()
+    header = "sha-512=:" + base64.b64encode(raw512).decode("ascii") + ":"
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=body,
+            headers={"Content-Type": "text/plain", "Content-Digest": header},
+        )
+    assert resp.status_code == 400
     assert sink.calls == []

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -6,6 +6,7 @@ import os
 from typing import BinaryIO
 
 import httpx
+import pytest
 from fastmcp import FastMCP
 
 from fastmcp_pvl_core._config import ServerConfig
@@ -622,3 +623,32 @@ async def test_route_revoke_after_lookup_still_succeeds():
     assert len(sink.calls) == 1
     # Token is gone (consume returned False, but revoke deleted it).
     assert await store.lookup(token) is None
+
+
+async def test_route_client_disconnect_propagates_without_500_response(monkeypatch):
+    """starlette.requests.ClientDisconnect during request.stream() must
+    propagate, not be caught as a generic OSError and turned into 500."""
+    from starlette.requests import ClientDisconnect
+
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+
+    # Patch _write_chunk to raise ClientDisconnect when called (simulates
+    # the body iterator yielding then the connection dropping).
+    def disconnect(tmp, hasher, chunk):
+        raise ClientDisconnect()
+
+    monkeypatch.setattr(up, "_write_chunk", disconnect)
+    async with await _client(mcp) as c:
+        with pytest.raises(ClientDisconnect):
+            await c.put(path, content=b"hello", headers={"Content-Type": "text/plain"})
+    # Token not consumed (no response was produced)
+    assert await store.lookup(token) is not None
+    assert sink.calls == []

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -276,6 +276,179 @@ async def test_route_content_digest_unparseable_400():
     assert resp.status_code == 400
 
 
+async def test_route_hashlib_failure_does_not_leak_fd(monkeypatch):
+    """B1: simulated post-fdopen pre-staging failure -> fd closed, temp unlinked."""
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+
+    created: list[str] = []
+    real_mkstemp = up.tempfile.mkstemp
+
+    def spy_mkstemp(**kw):
+        fd, path_ = real_mkstemp(**kw)
+        created.append(path_)
+        return fd, path_
+
+    monkeypatch.setattr(up.tempfile, "mkstemp", spy_mkstemp)
+
+    real_hashlib_new = up.hashlib.new
+
+    def boom(name):
+        if name == "sha256":
+            raise RuntimeError("FIPS")
+        return real_hashlib_new(name)
+
+    monkeypatch.setattr(up.hashlib, "new", boom)
+
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"hi", headers={"Content-Type": "text/plain"})
+    # 500 is the expected mapping for an unexpected RuntimeError inside the handler.
+    assert resp.status_code == 500
+    for p in created:
+        assert not os.path.exists(p), f"temp leaked: {p}"
+
+
+async def test_route_sink_does_not_close_fd_route_closes_it():
+    """B4: route owns the fd handed to the sink and closes it."""
+    closes: list[bool] = []
+
+    class _SpySink:
+        async def store_artifact(self, artifact_id, metadata, stream):
+            stream.read()
+            original_close = stream.close
+
+            def tracked():
+                closes.append(True)
+                original_close()
+
+            stream.close = tracked  # type: ignore[method-assign]
+
+    mcp, store = await _mount(_SpySink())
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 204
+    assert closes == [True]
+
+
+async def test_route_temp_reopen_failure_500(monkeypatch):
+    """B6: open(tmp_path, 'rb') raises -> 500, sink not called."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+
+    import builtins
+
+    real_open = builtins.open
+
+    def fake_open(p, mode="r", *a, **kw):
+        if isinstance(p, str) and "fx-upload-" in p and "rb" in mode:
+            raise OSError("simulated")
+        return real_open(p, mode, *a, **kw)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 500
+    assert sink.calls == []
+
+
+class _FxFailSink:
+    async def store_artifact(self, artifact_id, metadata, stream):
+        from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+        from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+
+        stream.read()
+        raise FileExchangeTransferError(
+            TransferErrorCode.TRANSFER_FAILED, transport="upload", detail="x"
+        )
+
+
+async def test_route_sink_raises_file_exchange_error_500():
+    """D6."""
+    mcp, store = await _mount(_FxFailSink())
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 500
+    assert resp.content == b""
+
+
+async def test_route_temp_write_oserror_500(monkeypatch):
+    """D8."""
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+
+    def boom(tmp, hasher, chunk):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(up, "_write_chunk", boom)
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path, content=b"hello", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 500
+    assert sink.calls == []
+
+
+async def test_route_ambient_authorization_ignored():
+    """F5."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=b"x",
+            headers={
+                "Content-Type": "text/plain",
+                "Authorization": "Bearer fake",
+                "Cookie": "session=abc",
+            },
+        )
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+
+
+async def test_route_ambient_authorization_on_invalid_token_still_404():
+    sink = _RecordingSink()
+    mcp, _ = await _mount(sink)
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            "/fx/u/nope",
+            content=b"x",
+            headers={
+                "Content-Type": "text/plain",
+                "Authorization": "Bearer admin",
+            },
+        )
+    assert resp.status_code == 404
+
+
 async def test_route_content_digest_unsupported_algo_400():
     """D5."""
     sink = _RecordingSink()

--- a/tests/_file_exchange/test_upload_sender.py
+++ b/tests/_file_exchange/test_upload_sender.py
@@ -1,0 +1,191 @@
+"""Matrix rows B2, B3, B5, C3, D1, D2, D3, D9, F6: upload_sender_consume."""
+
+import base64
+import contextlib
+import hashlib
+import io
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+from fastmcp_pvl_core._file_exchange._wire import (
+    ArtifactMetadata,
+    UploadSink,
+)
+
+
+def _sink() -> UploadSink:
+    return UploadSink(
+        transport="upload",
+        url="https://b.example/fx/u/tok",
+        method="PUT",
+        expiresAt=datetime.now(timezone.utc),
+    )
+
+
+def _cfg():
+    return ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_token_ttl=3600.0,
+        file_exchange_http_timeout=30.0,
+    )
+
+
+class _StreamSource:
+    """ArtifactSource that yields a fixed payload."""
+
+    def __init__(self, payload: bytes, mime: str | None = "text/plain"):
+        self.payload = payload
+        self.mime = mime
+
+    async def open_artifact(self, key):
+        return io.BytesIO(self.payload), ArtifactMetadata(mimeType=self.mime)
+
+
+def _fake_guarded_stream(captured: dict, *, status: int = 204):
+    """Return a patch for guarded_stream that captures request and returns status."""
+
+    @contextlib.asynccontextmanager
+    async def fake(method, url, *, config, transport, headers=None, content=None):
+        captured["method"] = method
+        captured["url"] = url
+        captured["transport"] = transport
+        captured["headers"] = dict(headers or {})
+        body = b""
+        if content is not None:
+            async for chunk in content:
+                body += chunk
+        captured["body"] = body
+
+        class _Resp:
+            def __init__(self, st: int):
+                self.status = st
+
+        yield _Resp(status)
+
+    return fake
+
+
+async def test_sender_happy_path_puts_with_headers(monkeypatch, tmp_path):
+    """F6 + D1 success arm."""
+    captured: dict = {}
+    monkeypatch.setattr(_upload, "guarded_stream", _fake_guarded_stream(captured))
+    # Sandbox temp creation into tmp_path so we can assert no leftovers.
+    monkeypatch.setattr(_upload.tempfile, "tempdir", str(tmp_path))
+
+    await _upload.upload_sender_consume(
+        _sink(),
+        _StreamSource(b"hello world"),
+        "art-1",
+        config=_cfg(),
+    )
+    assert captured["method"] == "PUT"
+    assert captured["url"] == "https://b.example/fx/u/tok"
+    assert captured["transport"] == "upload"
+    headers = {k.lower(): v for k, v in captured["headers"].items()}
+    assert headers["content-type"] == "text/plain"
+    assert headers["content-length"] == str(len(b"hello world"))
+    raw = hashlib.sha256(b"hello world").digest()
+    expected_cd = "sha-256=:" + base64.b64encode(raw).decode("ascii") + ":"
+    assert headers["content-digest"] == expected_cd
+    assert captured["body"] == b"hello world"
+    # No stray fx-upload temp files in our sandbox
+    assert not any(n.startswith("fx-upload-") for n in os.listdir(str(tmp_path)))
+
+
+async def test_sender_non_2xx_maps_to_transfer_failed(monkeypatch, tmp_path):
+    """D1."""
+    captured: dict = {}
+    monkeypatch.setattr(
+        _upload, "guarded_stream", _fake_guarded_stream(captured, status=500)
+    )
+    monkeypatch.setattr(_upload.tempfile, "tempdir", str(tmp_path))
+    with pytest.raises(FileExchangeTransferError) as ei:
+        await _upload.upload_sender_consume(
+            _sink(), _StreamSource(b"x"), "art-1", config=_cfg()
+        )
+    assert ei.value.code == TransferErrorCode.TRANSFER_FAILED
+    assert ei.value.transport == "upload"
+
+
+async def test_sender_guard_refusal_propagates(monkeypatch, tmp_path):
+    """C3."""
+
+    @contextlib.asynccontextmanager
+    async def refusing(method, url, **kw):
+        raise FileExchangeTransferError(
+            TransferErrorCode.NOT_ACCESSIBLE, transport="upload", detail="blocked"
+        )
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(_upload, "guarded_stream", refusing)
+    monkeypatch.setattr(_upload.tempfile, "tempdir", str(tmp_path))
+    with pytest.raises(FileExchangeTransferError) as ei:
+        await _upload.upload_sender_consume(
+            _sink(), _StreamSource(b"x"), "art-1", config=_cfg()
+        )
+    assert ei.value.code == TransferErrorCode.NOT_ACCESSIBLE
+
+
+async def test_sender_source_raises_propagates_no_temp_leak(monkeypatch, tmp_path):
+    """D2."""
+
+    class _Boom:
+        async def open_artifact(self, key):
+            raise RuntimeError("hook failure")
+
+    monkeypatch.setattr(_upload.tempfile, "tempdir", str(tmp_path))
+    with pytest.raises(RuntimeError):
+        await _upload.upload_sender_consume(_sink(), _Boom(), "art-1", config=_cfg())
+    assert not any(n.startswith("fx-upload-") for n in os.listdir(str(tmp_path)))
+
+
+async def test_sender_mkstemp_failure_maps_to_transfer_failed(monkeypatch):
+    """D3."""
+
+    def boom(**kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(_upload.tempfile, "mkstemp", boom)
+    with pytest.raises(FileExchangeTransferError) as ei:
+        await _upload.upload_sender_consume(
+            _sink(), _StreamSource(b"x"), "art-1", config=_cfg()
+        )
+    assert ei.value.code == TransferErrorCode.TRANSFER_FAILED
+
+
+async def test_sender_closes_source_stream(monkeypatch, tmp_path):
+    """B5: source stream closed on success."""
+
+    class _TrackedBytes:
+        def __init__(self, data: bytes):
+            self._buf = bytearray(data)
+            self.closed = False
+
+        def read(self, n=-1):
+            if n is None or n < 0:
+                data, self._buf = bytes(self._buf), bytearray()
+                return data
+            data = bytes(self._buf[:n])
+            del self._buf[:n]
+            return data
+
+        def close(self):
+            self.closed = True
+
+    tracked = _TrackedBytes(b"hello")
+
+    class _S:
+        async def open_artifact(self, key):
+            return tracked, ArtifactMetadata(mimeType="text/plain")
+
+    captured: dict = {}
+    monkeypatch.setattr(_upload, "guarded_stream", _fake_guarded_stream(captured))
+    monkeypatch.setattr(_upload.tempfile, "tempdir", str(tmp_path))
+    await _upload.upload_sender_consume(_sink(), _S(), "art-1", config=_cfg())
+    assert tracked.closed is True

--- a/tests/_file_exchange/test_upload_sender.py
+++ b/tests/_file_exchange/test_upload_sender.py
@@ -189,3 +189,39 @@ async def test_sender_closes_source_stream(monkeypatch, tmp_path):
     monkeypatch.setattr(_upload.tempfile, "tempdir", str(tmp_path))
     await _upload.upload_sender_consume(_sink(), _S(), "art-1", config=_cfg())
     assert tracked.closed is True
+
+
+async def test_sender_body_iter_oserror_maps_to_transfer_failed(monkeypatch, tmp_path):
+    """D9: OSError while iterating the staged body -> TRANSFER_FAILED."""
+    import builtins
+
+    monkeypatch.setattr(_upload.tempfile, "tempdir", str(tmp_path))
+
+    # Stub guarded_stream so the response is 204 if we ever get there (we won't).
+    captured: dict = {}
+    monkeypatch.setattr(_upload, "guarded_stream", _fake_guarded_stream(captured))
+
+    real_open = builtins.open
+
+    class _BadFile:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def read(self, n=-1):
+            raise OSError("simulated read failure")
+
+        def close(self):
+            self._inner.close()
+
+    def wrap(path, mode="r", *a, **kw):
+        f = real_open(path, mode, *a, **kw)
+        if isinstance(path, str) and "fx-upload-" in path and "rb" in mode:
+            return _BadFile(f)
+        return f
+
+    monkeypatch.setattr(builtins, "open", wrap)
+    with pytest.raises(FileExchangeTransferError) as ei:
+        await _upload.upload_sender_consume(
+            _sink(), _StreamSource(b"hello world"), "art-1", config=_cfg()
+        )
+    assert ei.value.code == TransferErrorCode.TRANSFER_FAILED


### PR DESCRIPTION
## Summary

Fourth attempt at #146 after #163/#164/#165 abandoned mid bot-iteration. Restarted from `main` with explicit TDD-first discipline driven by an enumerated failure-mode matrix.

**Approach:** before any test or implementation code was written, every ordering / lifecycle / concurrency / failure-path / reentrancy / wire-format mode the implementation must address was enumerated in `docs/superpowers/specs/2026-05-27-file-exchange-146-failure-modes.md` — seeded from the spec contract, the merged #145 download mirror, and every finding the three prior PRs surfaced. Each of the 37 matrix rows has at least one test in this diff (the gap-closing commit `dd56f3f` finalised the last 5).

## What's in the PR

- `_staging.py` — shared digest/chunk primitives extracted from `_download.py` (pure refactor, download suite untouched)
- `upload_receiver_mint` — token mint + `IntakeTicket` build, no I/O
- RFC 9530 `Content-Digest` parse/format + RFC 7231 §3.1.1.1 media-range matcher — pure functions, table-driven tests covering sha-256/384/512 + every malformed input
- `register_upload_route` — `PUT`/`POST /fx/u/{token}` with body cap (smaller of per-mint `expected.maxSize` and operator `file_exchange_max_artifact_size`), `acceptMimeTypes` enforcement, verify-before-use digest check (`requireDigest` enforces algorithm membership, not just presence), single-success-per-URL via atomic `consume`, fd/temp cleanup on every path
- `register_file_exchange_routes` — moved from `_download.py` to `_routes.py`, now mounts download and/or upload based on `source`/`sink` presence with strict precondition validation (matrix row A7: validate before mount)
- `upload_sender_consume` — stage source bytes to a temp + sha-256 hash, then `PUT` through `guarded_stream` with `Content-Type` / `Content-Length` / `Content-Digest` headers; non-2xx → `transfer-failed`; guard refusals propagate
- End-to-end push test wiring two FastMCP-built mock servers via `ASGITransport`

## Bot-finding pre-coverage

Every defect the three prior PRs' bots flagged has a dedicated test seeded into the matrix:
- `test_route_hashlib_failure_does_not_leak_fd` — B1 fd-leak between fdopen and staging-try
- `test_registrar_precondition_failure_mounts_nothing` — A7 partial-mount atomicity
- `test_route_content_digest_unparseable_400` / `_unsupported_algo_400` — D4, D5
- `test_route_require_digest_but_missing_header_400` / `_algorithm_mismatch_400` — A6 (with the requireDigest algo-membership tightening landed in `a9911a2`)
- `test_route_sink_raise_does_not_consume_token` — A2 single-success-per-URL on failure
- `test_route_second_put_after_success_returns_404` — A1 ordering

## Test plan

- [x] `uv run pytest tests/_file_exchange -v` — 627 passed
- [x] `uv run --python 3.10 pytest tests/_file_exchange -q` — 627 passed
- [x] `uv run --python 3.13 pytest tests/_file_exchange -q` — 627 passed
- [x] `uv run ruff format --check . && uv run ruff check src tests`
- [x] `uv run mypy src` — no issues in 34 source files
- [x] Per-task two-stage review (spec compliance + code quality) on Tasks 1–7
- [x] Final outside-in coherence + matrix-coverage review (gap-closing commit added the last 5 tests)

Refs #146, #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)