### PR TITLE
feat(file-exchange): upload_receiver_mint + Content-Digest/media-range helpers (slice 2/5 of #146)

### DIFF
--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -80,35 +80,39 @@ async def upload_receiver_mint(
 def _content_digest_parse(header: str) -> tuple[str, bytes] | None:
     """Parse an RFC 9530 ``Content-Digest`` structured-field dictionary entry.
 
-    Returns ``(algo_label, raw_digest_bytes)`` on success, or ``None`` for any
-    malformed input or unsupported algorithm — the caller treats ``None`` as a
-    verification failure (``digest-mismatch``), never a silent skip
+    Returns ``(algo_label, raw_digest_bytes)`` on success, or ``None`` if no
+    supported, well-formed entry is present. Unsupported algorithms within a
+    dictionary are silently skipped (RFC 9530 §3: a recipient MUST ignore
+    digest values associated with algorithms that it does not support); the
+    function returns the first supported, well-formed entry it finds. ``None``
+    is treated by the caller as a verification failure (``digest-mismatch``),
+    never a silent skip of a header that did declare a known algorithm
     (matrix rows D4, D5; spec §10.3).
-
-    Only a single-algorithm dictionary entry is accepted (the form pvl-core's
-    sender produces); ``sha-256``/``sha-384``/``sha-512`` are the supported
-    labels.
     """
     if not header:
         return None
-    entry = header.split(",", 1)[0].strip()
-    label, sep, rest = entry.partition("=")
-    if sep != "=":
-        return None
-    label = label.strip().lower()
-    if label not in _HASHLIB_BY_LABEL:
-        return None
-    rest = rest.strip()
-    if len(rest) < 2 or not rest.startswith(":") or not rest.endswith(":"):
-        return None
-    b64 = rest[1:-1]
-    if not b64:
-        return None
-    try:
-        raw = _b64.b64decode(b64, validate=True)
-    except (binascii.Error, ValueError):
-        return None
-    return label, raw
+    for entry in header.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        label, sep, rest = entry.partition("=")
+        if sep != "=":
+            continue
+        label = label.strip().lower()
+        if label not in _HASHLIB_BY_LABEL:
+            continue
+        rest = rest.strip()
+        if len(rest) < 2 or not rest.startswith(":") or not rest.endswith(":"):
+            continue
+        b64 = rest[1:-1]
+        if not b64:
+            continue
+        try:
+            raw = _b64.b64decode(b64, validate=True)
+        except (binascii.Error, ValueError):
+            continue
+        return label, raw
+    return None
 
 
 def _content_digest_format(label: str, raw: bytes) -> str:

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -5,12 +5,9 @@ This module accrues the upload-transport helpers task by task:
 - ``upload_receiver_mint`` — receiver role: mint a single-use capability
   token and emit an :class:`IntakeTicket` carrying one
   :class:`UploadSink`.
-- ``_content_digest_parse`` / ``_content_digest_format`` — RFC 9530
-  ``Content-Digest`` structured-field dictionary parse and format
-  (sha-256/384/512 only).
-- ``_media_range_matches`` — RFC 7231 §3.1.1.1 media-range matcher
-  used to validate request ``Content-Type`` against the ticket's
-  ``expected.contentType`` allowlist (this commit).
+- ``_content_digest_parse`` / ``_content_digest_format`` / ``_media_range_matches``
+  — RFC 9530 Content-Digest dictionary-entry parse + format, and an RFC 7231
+  media-range matcher used by the route to enforce ``acceptMimeTypes``.
 - The serving route and the sender land in subsequent commits per
   the implementation plan.
 

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -1,0 +1,69 @@
+"""The ``upload`` transport data plane (#146).
+
+Three free helpers — ``upload_receiver_mint``, ``upload_sender_consume``,
+and ``register_upload_route`` — that mirror ``_download.py``'s pull plane.
+The route accepts an HTTPS ``PUT``/``POST`` capability URL, streams the
+request body to a transient temp file with size + digest verification,
+and on a clean verify deposits the bytes into the receiver's
+``ArtifactSink`` (#142). The sender stages the offered bytes (hook stream
+→ temp + hash) and ``PUT``s them through the #147 SSRF guard.
+
+See ``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``
+for the contract and ``…2026-05-27-file-exchange-146-failure-modes.md`` for
+the enumerated failure modes each test in this module exercises.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._tokens import capability_url
+from fastmcp_pvl_core._file_exchange._wire import IntakeTicket, UploadSink
+
+if TYPE_CHECKING:
+    from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
+    from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
+
+UPLOAD_PREFIX = "/fx/u"
+
+
+async def upload_receiver_mint(
+    artifact_id: str,
+    *,
+    token_store: CapabilityTokenStore,
+    base_url: str,
+    ttl: float,
+    expected: ArtifactConstraints | None = None,
+    method: Literal["PUT", "POST"] = "PUT",
+) -> IntakeTicket:
+    """Receiver role (push): mint an upload token and emit an IntakeTicket.
+
+    Mint-only — no hook is called, no bytes move. The token stores the
+    ``artifact_id`` and the ``expected`` constraints so the route can
+    correlate received bytes back to a wire id and enforce limits at
+    deposit time. The token store treats the metadata as opaque (#144).
+    """
+    minted = await token_store.mint(
+        {
+            "artifact_id": artifact_id,
+            "expected": expected.model_dump() if expected is not None else None,
+        },
+        ttl=ttl,
+        single_use=True,
+    )
+    url = capability_url(base_url, UPLOAD_PREFIX, minted.token)
+    return IntakeTicket(
+        type=TICKET_TYPE,
+        version=SPEC_VERSION,
+        artifactId=artifact_id,
+        expected=expected,
+        sinks=[
+            UploadSink(
+                transport="upload",
+                url=url,
+                method=method,
+                expiresAt=minted.expires_at,
+            )
+        ],
+    )

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -62,7 +62,13 @@ async def upload_receiver_mint(
     minted = await token_store.mint(
         {
             "artifact_id": artifact_id,
-            "expected": expected.model_dump() if expected is not None else None,
+            # ``mode="json"`` coerces any forward-compat extra fields
+            # (``_WireBase`` has ``extra="allow"``) to JSON-native
+            # primitives so the KV backend's serialiser never sees a
+            # Python object it cannot handle.
+            "expected": (
+                expected.model_dump(mode="json") if expected is not None else None
+            ),
         },
         ttl=ttl,
         single_use=True,

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -11,9 +11,10 @@ This module accrues the upload-transport helpers task by task:
 - The serving route and the sender land in subsequent commits per
   the implementation plan.
 
-See ``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``
-for the behavioural contract and ``…2026-05-27-file-exchange-146-failure-modes.md``
-for the enumerated failure modes each test in this module exercises.
+See ``docs/superpowers/specs/2026-05-27-file-exchange-146-failure-modes.md``
+for the enumerated failure modes each test in this module exercises and
+``docs/superpowers/plans/2026-05-27-file-exchange-146-upload-data-plane-v4.md``
+for the implementation plan this module is built against.
 """
 
 from __future__ import annotations
@@ -35,6 +36,13 @@ if TYPE_CHECKING:
 # kwarg — route structure is a pvl-core shape decision.
 UPLOAD_PREFIX = "/fx/u"
 
+# pvl-core's upload route HTTP method. A constant, not a kwarg — the method
+# choice is a shape decision (CLAUDE.md classification test: pvl-core can
+# pick PUT and downstream has no domain-specific basis to disagree). If a
+# future downstream genuinely needs POST, the resolution is to evolve the
+# spec and migrate all downstreams, not to grow an override kwarg.
+_UPLOAD_METHOD: Literal["PUT"] = "PUT"
+
 
 async def upload_receiver_mint(
     artifact_id: str,
@@ -43,7 +51,6 @@ async def upload_receiver_mint(
     base_url: str,
     ttl: float,
     expected: ArtifactConstraints | None = None,
-    method: Literal["PUT", "POST"] = "PUT",
 ) -> IntakeTicket:
     """Receiver role (push): mint an upload token and emit an IntakeTicket.
 
@@ -70,7 +77,7 @@ async def upload_receiver_mint(
             UploadSink(
                 transport="upload",
                 url=url,
-                method=method,
+                method=_UPLOAD_METHOD,
                 expiresAt=minted.expires_at,
             )
         ],
@@ -88,6 +95,11 @@ def _content_digest_parse(header: str) -> tuple[str, bytes] | None:
     is treated by the caller as a verification failure (``digest-mismatch``),
     never a silent skip of a header that did declare a known algorithm
     (matrix rows D4, D5; spec §10.3).
+
+    Per RFC 8941 §3.2 a dictionary item may carry parameters
+    (``sha-256=:<b64>:;foo=bar``); RFC 9530 §3 requires unknown parameters
+    to be ignored, so they are stripped before the byte-sequence boundary
+    check.
     """
     if not header:
         return None
@@ -101,10 +113,11 @@ def _content_digest_parse(header: str) -> tuple[str, bytes] | None:
         label = label.strip().lower()
         if label not in _HASHLIB_BY_LABEL:
             continue
-        rest = rest.strip()
-        if len(rest) < 2 or not rest.startswith(":") or not rest.endswith(":"):
+        item, _, _ = rest.strip().partition(";")
+        item = item.strip()
+        if not item.startswith(":") or not item.endswith(":") or len(item) < 2:
             continue
-        b64 = rest[1:-1]
+        b64 = item[1:-1]
         if not b64:
             continue
         try:
@@ -123,9 +136,10 @@ def _content_digest_format(label: str, raw: bytes) -> str:
 def _media_range_matches(content_type: str, accept: list[str]) -> bool:
     """RFC 7231 §3.1.1.1 media-range match: parameters ignored, case-insensitive.
 
-    ``type/*`` matches any subtype; ``*/*`` matches anything. An empty
-    ``content_type`` or an empty ``accept`` list never matches
-    (matrix rows F3, F4).
+    ``type/*`` matches any subtype; ``*/*`` matches anything. The
+    grammatically invalid ``*/subtype`` form is rejected, not treated as
+    a wildcard. An empty ``content_type`` or an empty ``accept`` list
+    never matches (matrix rows F3, F4).
     """
     if not content_type or not accept:
         return False
@@ -140,6 +154,10 @@ def _media_range_matches(content_type: str, accept: list[str]) -> bool:
         if "/" not in entry_main:
             continue
         e_type, e_sub = entry_main.split("/", 1)
+        if e_type == "*" and e_sub != "*":
+            # RFC 7231 §3.1.1.1 grammar only allows */* and type/*; reject
+            # the invalid */subtype form rather than silently honouring it.
+            continue
         if (e_type == "*" or e_type == main_type) and (
             e_sub == "*" or e_sub == main_sub
         ):

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -4,9 +4,15 @@ This module accrues the upload-transport helpers task by task:
 
 - ``upload_receiver_mint`` — receiver role: mint a single-use capability
   token and emit an :class:`IntakeTicket` carrying one
-  :class:`UploadSink` (this commit).
-- The serving route, the sender, and the RFC 9530 / 7231 helpers land
-  in subsequent commits per the implementation plan.
+  :class:`UploadSink`.
+- ``_content_digest_parse`` / ``_content_digest_format`` — RFC 9530
+  ``Content-Digest`` structured-field dictionary parse and format
+  (sha-256/384/512 only).
+- ``_media_range_matches`` — RFC 7231 §3.1.1.1 media-range matcher
+  used to validate request ``Content-Type`` against the ticket's
+  ``expected.contentType`` allowlist (this commit).
+- The serving route and the sender land in subsequent commits per
+  the implementation plan.
 
 See ``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``
 for the behavioural contract and ``…2026-05-27-file-exchange-146-failure-modes.md``
@@ -15,9 +21,12 @@ for the enumerated failure modes each test in this module exercises.
 
 from __future__ import annotations
 
+import base64 as _b64
+import binascii
 from typing import TYPE_CHECKING, Literal
 
 from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL
 from fastmcp_pvl_core._file_exchange._tokens import capability_url
 from fastmcp_pvl_core._file_exchange._wire import IntakeTicket, UploadSink
 
@@ -69,3 +78,69 @@ async def upload_receiver_mint(
             )
         ],
     )
+
+
+def _content_digest_parse(header: str) -> tuple[str, bytes] | None:
+    """Parse an RFC 9530 ``Content-Digest`` structured-field dictionary entry.
+
+    Returns ``(algo_label, raw_digest_bytes)`` on success, or ``None`` for any
+    malformed input or unsupported algorithm — the caller treats ``None`` as a
+    verification failure (``digest-mismatch``), never a silent skip
+    (matrix rows D4, D5; spec §10.3).
+
+    Only a single-algorithm dictionary entry is accepted (the form pvl-core's
+    sender produces); ``sha-256``/``sha-384``/``sha-512`` are the supported
+    labels.
+    """
+    if not header:
+        return None
+    entry = header.split(",", 1)[0].strip()
+    label, sep, rest = entry.partition("=")
+    if sep != "=":
+        return None
+    label = label.strip().lower()
+    if label not in _HASHLIB_BY_LABEL:
+        return None
+    rest = rest.strip()
+    if len(rest) < 2 or not rest.startswith(":") or not rest.endswith(":"):
+        return None
+    b64 = rest[1:-1]
+    if not b64:
+        return None
+    try:
+        raw = _b64.b64decode(b64, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    return label, raw
+
+
+def _content_digest_format(label: str, raw: bytes) -> str:
+    """Format ``(label, raw_digest_bytes)`` as ``algo=:base64:`` per RFC 9530."""
+    return f"{label}=:{_b64.b64encode(raw).decode('ascii')}:"
+
+
+def _media_range_matches(content_type: str, accept: list[str]) -> bool:
+    """RFC 7231 §3.1.1.1 media-range match: parameters ignored, case-insensitive.
+
+    ``type/*`` matches any subtype; ``*/*`` matches anything. An empty
+    ``content_type`` or an empty ``accept`` list never matches
+    (matrix rows F3, F4).
+    """
+    if not content_type or not accept:
+        return False
+    main = content_type.split(";", 1)[0].strip().lower()
+    if "/" not in main:
+        return False
+    main_type, main_sub = main.split("/", 1)
+    for entry in accept:
+        if not entry:
+            continue
+        entry_main = entry.split(";", 1)[0].strip().lower()
+        if "/" not in entry_main:
+            continue
+        e_type, e_sub = entry_main.split("/", 1)
+        if (e_type == "*" or e_type == main_type) and (
+            e_sub == "*" or e_sub == main_sub
+        ):
+            return True
+    return False

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -1,16 +1,16 @@
 """The ``upload`` transport data plane (#146).
 
-Three free helpers — ``upload_receiver_mint``, ``upload_sender_consume``,
-and ``register_upload_route`` — that mirror ``_download.py``'s pull plane.
-The route accepts an HTTPS ``PUT``/``POST`` capability URL, streams the
-request body to a transient temp file with size + digest verification,
-and on a clean verify deposits the bytes into the receiver's
-``ArtifactSink`` (#142). The sender stages the offered bytes (hook stream
-→ temp + hash) and ``PUT``s them through the #147 SSRF guard.
+This module accrues the upload-transport helpers task by task:
+
+- ``upload_receiver_mint`` — receiver role: mint a single-use capability
+  token and emit an :class:`IntakeTicket` carrying one
+  :class:`UploadSink` (this commit).
+- The serving route, the sender, and the RFC 9530 / 7231 helpers land
+  in subsequent commits per the implementation plan.
 
 See ``docs/superpowers/specs/2026-05-24-file-exchange-146-upload-data-plane-design.md``
-for the contract and ``…2026-05-27-file-exchange-146-failure-modes.md`` for
-the enumerated failure modes each test in this module exercises.
+for the behavioural contract and ``…2026-05-27-file-exchange-146-failure-modes.md``
+for the enumerated failure modes each test in this module exercises.
 """
 
 from __future__ import annotations
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
     from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
     from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
 
+# pvl-core's upload route shape (§12 capability URL path). A constant, not a
+# kwarg — route structure is a pvl-core shape decision.
 UPLOAD_PREFIX = "/fx/u"
 
 

--- a/tests/_file_exchange/test_upload_helpers.py
+++ b/tests/_file_exchange/test_upload_helpers.py
@@ -1,0 +1,82 @@
+"""Matrix rows F1, F2, F3, F4, D4, D5: pure-function helpers in _upload."""
+
+import base64
+import hashlib
+
+import pytest
+
+from fastmcp_pvl_core._file_exchange._upload import (
+    _content_digest_format,
+    _content_digest_parse,
+    _media_range_matches,
+)
+
+
+def test_content_digest_parse_sha256_well_formed():
+    payload = b"hello"
+    raw = hashlib.sha256(payload).digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    header = f"sha-256=:{b64}:"
+    algo, decoded = _content_digest_parse(header)
+    assert algo == "sha-256"
+    assert decoded == raw
+
+
+def test_content_digest_parse_sha512_well_formed():
+    raw = hashlib.sha512(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    algo, decoded = _content_digest_parse(f"sha-512=:{b64}:")
+    assert algo == "sha-512"
+    assert decoded == raw
+
+
+def test_content_digest_parse_tolerates_whitespace():
+    raw = hashlib.sha256(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    algo, decoded = _content_digest_parse(f"  sha-256 = :{b64}:  ")
+    assert algo == "sha-256"
+    assert decoded == raw
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "garbage",
+        "sha-256:abcd",  # missing structured-field colons
+        "md5=:YWJjZA==:",  # unsupported algo label
+        "sha-256=::",  # empty value
+        "sha-256=:not-base64!:",
+        "sha-256=:YWJjZA",  # missing trailing colon
+        "",
+    ],
+)
+def test_content_digest_parse_malformed_or_unknown_returns_none(header):
+    """D4 + D5: present-but-unparseable / unsupported-algo -> None."""
+    assert _content_digest_parse(header) is None
+
+
+def test_content_digest_format_round_trips():
+    raw = hashlib.sha256(b"hello").digest()
+    header = _content_digest_format("sha-256", raw)
+    parsed = _content_digest_parse(header)
+    assert parsed == ("sha-256", raw)
+
+
+@pytest.mark.parametrize(
+    "content_type,accept,expected",
+    [
+        ("application/json", ["application/json"], True),
+        ("application/json; charset=utf-8", ["application/json"], True),
+        ("image/png", ["image/*"], True),
+        ("text/plain", ["image/*"], False),
+        ("application/octet-stream", ["*/*"], True),
+        ("APPLICATION/JSON", ["application/json"], True),
+        ("application/json", ["text/plain", "application/json"], True),
+        ("application/json", ["text/plain", "text/html"], False),
+        ("", ["application/json"], False),
+        ("application/json", [], False),
+    ],
+)
+def test_media_range_matches_table(content_type, accept, expected):
+    """F3."""
+    assert _media_range_matches(content_type, accept) is expected

--- a/tests/_file_exchange/test_upload_helpers.py
+++ b/tests/_file_exchange/test_upload_helpers.py
@@ -63,6 +63,16 @@ def test_content_digest_parse_all_unsupported_returns_none():
     assert _content_digest_parse("md5=:YWJjZA==:, sha-3=:YWJjZA==:") is None
 
 
+def test_content_digest_parse_ignores_sf_parameters():
+    """RFC 8941 §3.2 / RFC 9530 §3: structured-field parameters appended to a
+    dictionary item (``sha-256=:<b64>:;foo=bar``) MUST be ignored, not cause
+    the entry to be rejected."""
+    raw = hashlib.sha256(b"hello").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    parsed = _content_digest_parse(f"sha-256=:{b64}:;foo=bar;baz")
+    assert parsed == ("sha-256", raw)
+
+
 def test_content_digest_parse_tolerates_whitespace():
     raw = hashlib.sha256(b"x").digest()
     b64 = base64.b64encode(raw).decode("ascii")
@@ -106,6 +116,9 @@ def test_content_digest_format_round_trips():
         ("APPLICATION/JSON", ["application/json"], True),
         ("application/json", ["text/plain", "application/json"], True),
         ("application/json", ["text/plain", "text/html"], False),
+        # */subtype is NOT a valid RFC 7231 media-range; reject it.
+        ("application/json", ["*/json"], False),
+        ("image/png", ["*/png"], False),
         ("application/json", ["bogus", "application/json"], True),
         ("", ["application/json"], False),
         ("application/json", [], False),

--- a/tests/_file_exchange/test_upload_helpers.py
+++ b/tests/_file_exchange/test_upload_helpers.py
@@ -30,6 +30,24 @@ def test_content_digest_parse_sha512_well_formed():
     assert decoded == raw
 
 
+def test_content_digest_parse_sha384_well_formed():
+    raw = hashlib.sha384(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    algo, decoded = _content_digest_parse(f"sha-384=:{b64}:")
+    assert algo == "sha-384"
+    assert decoded == raw
+
+
+def test_content_digest_parse_multi_algo_dict_takes_first_entry():
+    """Documented scoping: only the first dictionary entry is parsed."""
+    raw256 = hashlib.sha256(b"x").digest()
+    raw512 = hashlib.sha512(b"x").digest()
+    b256 = base64.b64encode(raw256).decode("ascii")
+    b512 = base64.b64encode(raw512).decode("ascii")
+    parsed = _content_digest_parse(f"sha-256=:{b256}:, sha-512=:{b512}:")
+    assert parsed == ("sha-256", raw256)
+
+
 def test_content_digest_parse_tolerates_whitespace():
     raw = hashlib.sha256(b"x").digest()
     b64 = base64.b64encode(raw).decode("ascii")
@@ -73,6 +91,7 @@ def test_content_digest_format_round_trips():
         ("APPLICATION/JSON", ["application/json"], True),
         ("application/json", ["text/plain", "application/json"], True),
         ("application/json", ["text/plain", "text/html"], False),
+        ("application/json", ["bogus", "application/json"], True),
         ("", ["application/json"], False),
         ("application/json", [], False),
     ],

--- a/tests/_file_exchange/test_upload_helpers.py
+++ b/tests/_file_exchange/test_upload_helpers.py
@@ -38,14 +38,29 @@ def test_content_digest_parse_sha384_well_formed():
     assert decoded == raw
 
 
-def test_content_digest_parse_multi_algo_dict_takes_first_entry():
-    """Documented scoping: only the first dictionary entry is parsed."""
+def test_content_digest_parse_multi_algo_dict_returns_first_supported():
+    """RFC 9530 §3: when a dictionary lists multiple algorithms, return the
+    first supported one in order. (sha-256 is supported; sha-3 is not.)"""
     raw256 = hashlib.sha256(b"x").digest()
     raw512 = hashlib.sha512(b"x").digest()
     b256 = base64.b64encode(raw256).decode("ascii")
     b512 = base64.b64encode(raw512).decode("ascii")
     parsed = _content_digest_parse(f"sha-256=:{b256}:, sha-512=:{b512}:")
     assert parsed == ("sha-256", raw256)
+
+
+def test_content_digest_parse_skips_unsupported_then_takes_supported():
+    """RFC 9530 §3 MUST-ignore: unsupported algorithm at first position is
+    skipped, the supported algorithm later in the dictionary is used."""
+    raw256 = hashlib.sha256(b"hello").digest()
+    b256 = base64.b64encode(raw256).decode("ascii")
+    parsed = _content_digest_parse(f"md5=:YWJjZA==:, sha-256=:{b256}:")
+    assert parsed == ("sha-256", raw256)
+
+
+def test_content_digest_parse_all_unsupported_returns_none():
+    """If every dictionary entry is in an unsupported algorithm, return None."""
+    assert _content_digest_parse("md5=:YWJjZA==:, sha-3=:YWJjZA==:") is None
 
 
 def test_content_digest_parse_tolerates_whitespace():

--- a/tests/_file_exchange/test_upload_mint.py
+++ b/tests/_file_exchange/test_upload_mint.py
@@ -38,16 +38,17 @@ async def test_mint_returns_intake_ticket_with_one_upload_sink():
     assert rec.single_use is True
 
 
-async def test_mint_method_post_threads_through():
+async def test_mint_method_is_always_put():
+    """Route method is a pvl-core shape decision (CLAUDE.md), not a kwarg.
+    Every minted UploadSink advertises PUT."""
     store = _store()
     ticket = await _upload.upload_receiver_mint(
         "art-2",
         token_store=store,
         base_url="https://b.example",
         ttl=120.0,
-        method="POST",
     )
-    assert ticket.sinks[0].method == "POST"
+    assert ticket.sinks[0].method == "PUT"
 
 
 async def test_mint_expected_round_trips_onto_ticket_and_metadata():

--- a/tests/_file_exchange/test_upload_mint.py
+++ b/tests/_file_exchange/test_upload_mint.py
@@ -1,0 +1,86 @@
+"""Matrix row E1, E4: upload_receiver_mint builds an IntakeTicket."""
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints, UploadSink
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+async def test_mint_returns_intake_ticket_with_one_upload_sink():
+    store = _store()
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://b.example",
+        ttl=120.0,
+    )
+    assert ticket.type == TICKET_TYPE
+    assert ticket.version == SPEC_VERSION
+    assert ticket.artifactId == "art-1"
+    assert ticket.expected is None
+    assert len(ticket.sinks) == 1
+    sink = ticket.sinks[0]
+    assert isinstance(sink, UploadSink)
+    assert sink.transport == "upload"
+    assert sink.url.startswith("https://b.example/fx/u/")
+    assert sink.method == "PUT"
+    token = sink.url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata == {"artifact_id": "art-1", "expected": None}
+    assert rec.single_use is True
+
+
+async def test_mint_method_post_threads_through():
+    store = _store()
+    ticket = await _upload.upload_receiver_mint(
+        "art-2",
+        token_store=store,
+        base_url="https://b.example",
+        ttl=120.0,
+        method="POST",
+    )
+    assert ticket.sinks[0].method == "POST"
+
+
+async def test_mint_expected_round_trips_onto_ticket_and_metadata():
+    store = _store()
+    expected = ArtifactConstraints(
+        maxSize=1024, acceptMimeTypes=["application/json"], requireDigest=["sha-256"]
+    )
+    ticket = await _upload.upload_receiver_mint(
+        "art-3",
+        token_store=store,
+        base_url="https://b.example",
+        ttl=120.0,
+        expected=expected,
+    )
+    assert ticket.expected == expected
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    rec = await store.lookup(token)
+    assert rec is not None
+    assert rec.metadata["artifact_id"] == "art-3"
+    assert rec.metadata["expected"] == expected.model_dump()
+
+
+async def test_mint_calls_do_not_collide_for_same_artifact_id():
+    """E1: minting twice yields two distinct tokens, both valid."""
+    store = _store()
+    t1 = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://b.example", ttl=120.0
+    )
+    t2 = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://b.example", ttl=120.0
+    )
+    tok1 = t1.sinks[0].url.rsplit("/", 1)[1]
+    tok2 = t2.sinks[0].url.rsplit("/", 1)[1]
+    assert tok1 != tok2
+    assert (await store.lookup(tok1)) is not None
+    assert (await store.lookup(tok2)) is not None

--- a/tests/_file_exchange/test_upload_mint.py
+++ b/tests/_file_exchange/test_upload_mint.py
@@ -68,7 +68,7 @@ async def test_mint_expected_round_trips_onto_ticket_and_metadata():
     rec = await store.lookup(token)
     assert rec is not None
     assert rec.metadata["artifact_id"] == "art-3"
-    assert rec.metadata["expected"] == expected.model_dump()
+    assert rec.metadata["expected"] == expected.model_dump(mode="json")
 
 
 async def test_repeated_mint_yields_distinct_tokens_with_same_artifact_id():

--- a/tests/_file_exchange/test_upload_mint.py
+++ b/tests/_file_exchange/test_upload_mint.py
@@ -70,8 +70,9 @@ async def test_mint_expected_round_trips_onto_ticket_and_metadata():
     assert rec.metadata["expected"] == expected.model_dump()
 
 
-async def test_mint_calls_do_not_collide_for_same_artifact_id():
-    """E1: minting twice yields two distinct tokens, both valid."""
+async def test_repeated_mint_yields_distinct_tokens_with_same_artifact_id():
+    """E1: minting twice for the same artifact_id yields two distinct
+    tokens; both lookups round-trip to the same artifact_id metadata."""
     store = _store()
     t1 = await _upload.upload_receiver_mint(
         "art-1", token_store=store, base_url="https://b.example", ttl=120.0
@@ -82,5 +83,8 @@ async def test_mint_calls_do_not_collide_for_same_artifact_id():
     tok1 = t1.sinks[0].url.rsplit("/", 1)[1]
     tok2 = t2.sinks[0].url.rsplit("/", 1)[1]
     assert tok1 != tok2
-    assert (await store.lookup(tok1)) is not None
-    assert (await store.lookup(tok2)) is not None
+    rec1 = await store.lookup(tok1)
+    rec2 = await store.lookup(tok2)
+    assert rec1 is not None and rec2 is not None
+    assert rec1.metadata["artifact_id"] == "art-1"
+    assert rec2.metadata["artifact_id"] == "art-1"


### PR DESCRIPTION
## Summary

Second of 5 stacked PRs for #146. Builds on #167 (\`_staging.py\` extraction). Adds:

- \`upload_receiver_mint\` — token mint + IntakeTicket build. No I/O, no hook calls.
- RFC 9530 \`Content-Digest\` parser + formatter (sha-256/384/512) — RFC 9530 §3 MUST-ignore semantics: unsupported algorithm labels within a dictionary are silently skipped and the first supported+well-formed entry is used.
- RFC 7231 §3.1.1.1 media-range matcher — \`type/*\`, \`*/*\`, parameters-ignored, case-insensitive.

All three helpers are pure functions, exhaustively covered with table-driven tests.

## Test plan

- [x] \`uv run pytest tests/_file_exchange\` — 588 passed (= 558 from slice 1 + 30 new mint+helpers tests)
- [x] \`uv run --python 3.10 pytest tests/_file_exchange\` — 588 passed
- [x] \`uv run --python 3.13 pytest tests/_file_exchange\` — 588 passed
- [x] \`uv run ruff format --check .\` clean
- [x] \`uv run ruff check src tests\` clean
- [x] \`uv run mypy src\` — no issues

**Base:** depends on #167; merge that first.

Part of #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)