### PR TITLE
feat(file-exchange): upload PUT/POST route + edge modes (slice 3/5 of #146)

### DIFF
--- a/src/fastmcp_pvl_core/_file_exchange/_staging.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_staging.py
@@ -58,3 +58,21 @@ def _write_chunk(tmp: IO[bytes], hasher: hashlib._Hash | None, chunk: bytes) -> 
     tmp.write(chunk)
     if hasher is not None:
         hasher.update(chunk)
+
+
+def _rehash_file(path: str, hashlib_name: str) -> bytes:
+    """Synchronously compute ``hashlib_name``'s digest of the file at ``path``.
+
+    Designed to be called via a single ``asyncio.to_thread`` dispatch
+    from the upload route's non-sha-256 verify branch — the entire
+    open + chunked-read + close runs in one worker thread rather than
+    spawning a thread per chunk.
+    """
+    h = hashlib.new(hashlib_name)
+    with open(path, "rb") as fh:
+        while True:
+            buf = fh.read(_CHUNK)
+            if not buf:
+                break
+            h.update(buf)
+    return h.digest()

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -36,8 +36,8 @@ from typing import TYPE_CHECKING, Literal, cast
 
 from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
 from fastmcp_pvl_core._file_exchange._staging import (
-    _CHUNK,
     _HASHLIB_BY_LABEL,
+    _rehash_file,
     _write_chunk,
 )
 from fastmcp_pvl_core._file_exchange._tokens import capability_url
@@ -214,24 +214,6 @@ def _media_range_matches(content_type: str, accept: list[str]) -> bool:
         ):
             return True
     return False
-
-
-def _rehash_file(path: str, hashlib_name: str) -> bytes:
-    """Synchronously compute ``hashlib_name``'s digest of the file at ``path``.
-
-    Called via a single ``asyncio.to_thread`` dispatch from the route's
-    rehash branch (the non-sha-256 ``Content-Digest`` verify path), so the
-    entire open + chunked-read + close runs in one worker thread rather
-    than spawning a thread per chunk.
-    """
-    h = hashlib.new(hashlib_name)
-    with open(path, "rb") as fh:
-        while True:
-            buf = fh.read(_CHUNK)
-            if not buf:
-                break
-            h.update(buf)
-    return h.digest()
 
 
 def register_upload_route(

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -214,6 +214,7 @@ def register_upload_route(
     body-size cap; per-mint ``expected.maxSize`` is the smaller of the two when
     set. See the failure-mode matrix for the full per-status-code contract.
     """
+    from starlette.requests import ClientDisconnect
     from starlette.responses import Response
 
     async def _handle(request: Request) -> Response:
@@ -273,6 +274,11 @@ def register_upload_route(
                             break
                         await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
                         received += len(chunk)
+                except ClientDisconnect:
+                    # Client dropped mid-upload — no response needed; outer
+                    # finally still unlinks the temp.
+                    logger.debug("file-exchange: upload client disconnected mid-stream")
+                    raise
                 except OSError:
                     logger.exception("file-exchange: upload temp write failed")
                     return Response(status_code=500)
@@ -281,7 +287,7 @@ def register_upload_route(
                     await asyncio.to_thread(tmp.close)
 
             if too_large:
-                return Response(status_code=413)
+                return Response(status_code=413, headers={"Connection": "close"})
 
             cd_header = request.headers.get("content-digest")
             required = expected.requireDigest if expected is not None else None
@@ -300,12 +306,16 @@ def register_upload_route(
                 else:
                     rehash = hashlib.new(_HASHLIB_BY_LABEL[cd_algo])
                     try:
-                        with open(tmp_path, "rb") as fh:
+                        fh = await asyncio.to_thread(open, tmp_path, "rb")
+                        try:
                             while True:
                                 buf = await asyncio.to_thread(fh.read, _CHUNK)
                                 if not buf:
                                     break
                                 rehash.update(buf)
+                        finally:
+                            with contextlib.suppress(OSError):
+                                await asyncio.to_thread(fh.close)
                     except OSError:
                         logger.exception("file-exchange: upload rehash read failed")
                         return Response(status_code=500)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -268,11 +268,22 @@ def register_upload_route(
             return Response(status_code=404)
         artifact_id = cast("str", rec.metadata["artifact_id"])
         expected_raw = rec.metadata.get("expected")
-        expected = (
-            ArtifactConstraints.model_validate(expected_raw)
-            if expected_raw is not None
-            else None
-        )
+        try:
+            expected = (
+                ArtifactConstraints.model_validate(expected_raw)
+                if expected_raw is not None
+                else None
+            )
+        except Exception:
+            # KV-stored metadata that fails Pydantic validation should
+            # never happen (the mint side validated before storing) but
+            # KV corruption / schema-version drift can produce it. Log
+            # and return a structured 500 rather than letting a
+            # ValidationError escape unwrapped to ASGI.
+            logger.exception(
+                "file-exchange: upload expected-constraints deserialise failed"
+            )
+            return Response(status_code=500)
 
         content_type = request.headers.get("content-type", "")
         if expected is not None and expected.acceptMimeTypes is not None:
@@ -391,7 +402,7 @@ def register_upload_route(
                     await asyncio.to_thread(f.close)
 
             try:
-                await token_store.consume(token)
+                consumed = await token_store.consume(token)
             except Exception:
                 # At-most-once *delivery*, not at-most-once *deposit*: the
                 # sink already stored these bytes, but the consume failure
@@ -404,6 +415,17 @@ def register_upload_route(
                     "token may remain usable to TTL and a sender retry would "
                     "deposit the same artifact a second time"
                 )
+            else:
+                if not consumed:
+                    # The store wrote, but the token was already gone
+                    # (concurrent PUT raced and consumed first, or a
+                    # revoke landed between lookup and consume). The
+                    # bytes are still in the sink — observability only,
+                    # not an error.
+                    logger.info(
+                        "file-exchange: upload token already consumed at deposit "
+                        "time (concurrent race or revoke); bytes are in the sink"
+                    )
             return Response(status_code=204)
         finally:
             with contextlib.suppress(OSError):

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -141,9 +141,11 @@ def _content_digest_parse(
     in preference to any other supported entry — used by the route to honour
     ``expected.requireDigest`` regardless of header entry ordering. When no
     ``preferred`` entry parses successfully, the parser falls back to the
-    first supported well-formed entry (so a client that sends a single
-    well-formed entry in a non-preferred algorithm still gets its digest
-    verified, just not against ``requireDigest``).
+    first supported well-formed entry. The caller decides what to do with
+    that fallback: the route rejects it with 400 when ``requireDigest`` is
+    set (the fallback algorithm is not in the required set, so the request
+    is non-conformant); when ``requireDigest`` is absent, the fallback
+    proceeds to digest verification against the bytes received.
     """
     if not header:
         return None
@@ -301,7 +303,9 @@ def register_upload_route(
                 raise
             try:
                 try:
-                    hasher = hashlib.new("sha256")
+                    # Use the canonical mapping so the streaming hasher
+                    # and the rehash branch can never drift apart.
+                    hasher = hashlib.new(_HASHLIB_BY_LABEL["sha-256"])
                 except Exception:
                     logger.exception("file-exchange: upload hasher init failed")
                     return Response(status_code=500)
@@ -338,10 +342,17 @@ def register_upload_route(
                 if parsed is None:
                     return Response(status_code=400)
                 cd_algo, cd_raw = parsed
-                if required is not None and cd_algo not in required:
-                    # ``preferred=required`` made the parser try ``required``
-                    # algorithms first; arriving here means the client's
-                    # header contained no entry in any ``required`` algo.
+                # ``cd_algo`` is always lowercase (the parser normalises);
+                # ``required`` comes from ``ArtifactConstraints.requireDigest``
+                # which is an unvalidated ``list[str]`` (no Pydantic-side
+                # normalisation), so lowercase the comparison set too.
+                if required is not None and cd_algo not in {
+                    r.strip().lower() for r in required
+                }:
+                    # The parser tried ``preferred=required`` first, so
+                    # arriving here means the client's header contained no
+                    # entry whose algorithm is in ``required`` — only a
+                    # fallback entry in a non-required algorithm.
                     return Response(status_code=400)
                 if cd_algo == "sha-256":
                     if hasher.digest() != cd_raw:

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -5,9 +5,9 @@ This module accrues the upload-transport helpers task by task:
 - ``upload_receiver_mint`` — receiver role: mint a single-use capability
   token and emit an :class:`IntakeTicket` carrying one
   :class:`UploadSink`.
-- ``_content_digest_parse`` / ``_content_digest_format`` / ``_media_range_matches``
-  — RFC 9530 Content-Digest dictionary-entry parse + format, and an RFC 7231
-  media-range matcher used by the route to enforce ``acceptMimeTypes``.
+- ``_media_range_matches`` — RFC 7231 §3.1.1.1 media-range matcher
+  used by the route to enforce ``acceptMimeTypes``. (The Content-Digest
+  parse + policy lives in :mod:`._content_digest`.)
 - ``register_upload_route`` — mount ``PUT <UPLOAD_PREFIX>/{token}``
   on a FastMCP server: streams the body to a temp file, verifies an optional
   ``Content-Digest`` before the sink sees the bytes, deposits to
@@ -25,8 +25,6 @@ for the implementation plan this module is built against.
 from __future__ import annotations
 
 import asyncio
-import base64 as _b64
-import binascii
 import contextlib
 import hashlib
 import logging
@@ -34,6 +32,7 @@ import os
 import tempfile
 from typing import TYPE_CHECKING, Literal, cast
 
+from fastmcp_pvl_core._file_exchange import _content_digest
 from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
 from fastmcp_pvl_core._file_exchange._staging import (
     _HASHLIB_BY_LABEL,
@@ -116,72 +115,6 @@ async def upload_receiver_mint(
             )
         ],
     )
-
-
-def _content_digest_parse(
-    header: str, *, preferred: list[str] | None = None
-) -> tuple[str, bytes] | None:
-    """Parse an RFC 9530 ``Content-Digest`` structured-field dictionary entry.
-
-    Returns ``(algo_label, raw_digest_bytes)`` on success, or ``None`` if no
-    supported, well-formed entry is present. Unsupported algorithms within a
-    dictionary are silently skipped (RFC 9530 §3: a recipient MUST ignore
-    digest values associated with algorithms that it does not support); the
-    function returns the first supported, well-formed entry it finds. ``None``
-    is treated by the caller as a verification failure (``digest-mismatch``),
-    never a silent skip of a header that did declare a known algorithm
-    (matrix rows D4, D5; spec §10.3).
-
-    Per RFC 8941 §3.2 a dictionary item may carry parameters
-    (``sha-256=:<b64>:;foo=bar``); RFC 9530 §3 requires unknown parameters
-    to be ignored, so they are stripped before the byte-sequence boundary
-    check.
-
-    ``preferred``, if given, lists algorithm labels the caller wants to use
-    in preference to any other supported entry — used by the route to honour
-    ``expected.requireDigest`` regardless of header entry ordering. When no
-    ``preferred`` entry parses successfully, the parser falls back to the
-    first supported well-formed entry. The caller decides what to do with
-    that fallback: the route rejects it with 400 when ``requireDigest`` is
-    set (the fallback algorithm is not in the required set, so the request
-    is non-conformant); when ``requireDigest`` is absent, the fallback
-    proceeds to digest verification against the bytes received.
-    """
-    if not header:
-        return None
-    preferred_set = {p.strip().lower() for p in preferred} if preferred else None
-    fallback: tuple[str, bytes] | None = None
-    for entry in header.split(","):
-        entry = entry.strip()
-        if not entry:
-            continue
-        label, sep, rest = entry.partition("=")
-        if sep != "=":
-            continue
-        label = label.strip().lower()
-        if label not in _HASHLIB_BY_LABEL:
-            continue
-        item, _, _ = rest.strip().partition(";")
-        item = item.strip()
-        if not item.startswith(":") or not item.endswith(":") or len(item) < 2:
-            continue
-        b64 = item[1:-1]
-        if not b64:
-            continue
-        try:
-            raw = _b64.b64decode(b64, validate=True)
-        except (binascii.Error, ValueError):
-            continue
-        if preferred_set is not None and label in preferred_set:
-            return label, raw
-        if fallback is None:
-            fallback = (label, raw)
-    return fallback
-
-
-def _content_digest_format(label: str, raw: bytes) -> str:
-    """Format ``(label, raw_digest_bytes)`` as ``algo=:base64:`` per RFC 9530."""
-    return f"{label}=:{_b64.b64encode(raw).decode('ascii')}:"
 
 
 def _media_range_matches(content_type: str, accept: list[str]) -> bool:
@@ -331,17 +264,11 @@ def register_upload_route(
             cd_header = request.headers.get("content-digest")
             required = expected.requireDigest if expected is not None else None
             if cd_header is not None:
-                parsed = _content_digest_parse(cd_header, preferred=required)
+                parsed = _content_digest.parse_header(cd_header, preferred=required)
                 if parsed is None:
                     return Response(status_code=400)
                 cd_algo, cd_raw = parsed
-                # ``cd_algo`` is always lowercase (the parser normalises);
-                # ``required`` comes from ``ArtifactConstraints.requireDigest``
-                # which is an unvalidated ``list[str]`` (no Pydantic-side
-                # normalisation), so lowercase the comparison set too.
-                if required is not None and cd_algo not in {
-                    r.strip().lower() for r in required
-                }:
+                if not _content_digest.satisfies_requirement(cd_algo, required):
                     # The parser tried ``preferred=required`` first, so
                     # arriving here means the client's header contained no
                     # entry whose algorithm is in ``required`` — only a

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -8,7 +8,7 @@ This module accrues the upload-transport helpers task by task:
 - ``_content_digest_parse`` / ``_content_digest_format`` / ``_media_range_matches``
   — RFC 9530 Content-Digest dictionary-entry parse + format, and an RFC 7231
   media-range matcher used by the route to enforce ``acceptMimeTypes``.
-- ``register_upload_route`` — mount ``PUT``/``POST <UPLOAD_PREFIX>/{token}``
+- ``register_upload_route`` — mount ``PUT <UPLOAD_PREFIX>/{token}``
   on a FastMCP server: streams the body to a temp file, verifies an optional
   ``Content-Digest`` before the sink sees the bytes, deposits to
   :class:`ArtifactSink`, and consumes the single-use token only after a
@@ -118,7 +118,9 @@ async def upload_receiver_mint(
     )
 
 
-def _content_digest_parse(header: str) -> tuple[str, bytes] | None:
+def _content_digest_parse(
+    header: str, *, preferred: list[str] | None = None
+) -> tuple[str, bytes] | None:
     """Parse an RFC 9530 ``Content-Digest`` structured-field dictionary entry.
 
     Returns ``(algo_label, raw_digest_bytes)`` on success, or ``None`` if no
@@ -134,9 +136,19 @@ def _content_digest_parse(header: str) -> tuple[str, bytes] | None:
     (``sha-256=:<b64>:;foo=bar``); RFC 9530 §3 requires unknown parameters
     to be ignored, so they are stripped before the byte-sequence boundary
     check.
+
+    ``preferred``, if given, lists algorithm labels the caller wants to use
+    in preference to any other supported entry — used by the route to honour
+    ``expected.requireDigest`` regardless of header entry ordering. When no
+    ``preferred`` entry parses successfully, the parser falls back to the
+    first supported well-formed entry (so a client that sends a single
+    well-formed entry in a non-preferred algorithm still gets its digest
+    verified, just not against ``requireDigest``).
     """
     if not header:
         return None
+    preferred_set = {p.strip().lower() for p in preferred} if preferred else None
+    fallback: tuple[str, bytes] | None = None
     for entry in header.split(","):
         entry = entry.strip()
         if not entry:
@@ -158,8 +170,11 @@ def _content_digest_parse(header: str) -> tuple[str, bytes] | None:
             raw = _b64.b64decode(b64, validate=True)
         except (binascii.Error, ValueError):
             continue
-        return label, raw
-    return None
+        if preferred_set is not None and label in preferred_set:
+            return label, raw
+        if fallback is None:
+            fallback = (label, raw)
+    return fallback
 
 
 def _content_digest_format(label: str, raw: bytes) -> str:
@@ -199,6 +214,24 @@ def _media_range_matches(content_type: str, accept: list[str]) -> bool:
     return False
 
 
+def _rehash_file(path: str, hashlib_name: str) -> bytes:
+    """Synchronously compute ``hashlib_name``'s digest of the file at ``path``.
+
+    Called via a single ``asyncio.to_thread`` dispatch from the route's
+    rehash branch (the non-sha-256 ``Content-Digest`` verify path), so the
+    entire open + chunked-read + close runs in one worker thread rather
+    than spawning a thread per chunk.
+    """
+    h = hashlib.new(hashlib_name)
+    with open(path, "rb") as fh:
+        while True:
+            buf = fh.read(_CHUNK)
+            if not buf:
+                break
+            h.update(buf)
+    return h.digest()
+
+
 def register_upload_route(
     mcp: FastMCP,
     *,
@@ -206,13 +239,22 @@ def register_upload_route(
     sink: ArtifactSink,
     config: ServerConfig,
 ) -> None:
-    """Mount ``PUT``/``POST <UPLOAD_PREFIX>/{token}`` on ``mcp``.
+    """Mount ``PUT <UPLOAD_PREFIX>/{token}`` on ``mcp``.
 
     The route serves §12 capability URLs minted by ``upload_receiver_mint``;
     ambient credentials are ignored — the in-URL token is the only
     authorization. ``config.file_exchange_max_artifact_size`` is the operator
     body-size cap; per-mint ``expected.maxSize`` is the smaller of the two when
     set. See the failure-mode matrix for the full per-status-code contract.
+
+    Kwargs (per CLAUDE.md classification):
+
+    - ``token_store`` (**shape**): the capability-token store. pvl-core owns
+      the token-store contract; downstream constructs but does not subclass.
+    - ``sink`` (**hook**): downstream's ``ArtifactSink`` implementation.
+      pvl-core cannot answer "where do these bytes go?" — domain hook.
+    - ``config`` (**config**): operator-side ``ServerConfig`` carrying
+      ``file_exchange_max_artifact_size`` (the body-size cap).
     """
     from starlette.requests import ClientDisconnect
     from starlette.responses import Response
@@ -292,34 +334,27 @@ def register_upload_route(
             cd_header = request.headers.get("content-digest")
             required = expected.requireDigest if expected is not None else None
             if cd_header is not None:
-                parsed = _content_digest_parse(cd_header)
+                parsed = _content_digest_parse(cd_header, preferred=required)
                 if parsed is None:
                     return Response(status_code=400)
                 cd_algo, cd_raw = parsed
                 if required is not None and cd_algo not in required:
-                    # requireDigest lists specific algorithms; a digest in a
-                    # different algorithm does not satisfy the requirement.
+                    # ``preferred=required`` made the parser try ``required``
+                    # algorithms first; arriving here means the client's
+                    # header contained no entry in any ``required`` algo.
                     return Response(status_code=400)
                 if cd_algo == "sha-256":
                     if hasher.digest() != cd_raw:
                         return Response(status_code=400)
                 else:
-                    rehash = hashlib.new(_HASHLIB_BY_LABEL[cd_algo])
                     try:
-                        fh = await asyncio.to_thread(open, tmp_path, "rb")
-                        try:
-                            while True:
-                                buf = await asyncio.to_thread(fh.read, _CHUNK)
-                                if not buf:
-                                    break
-                                rehash.update(buf)
-                        finally:
-                            with contextlib.suppress(OSError):
-                                await asyncio.to_thread(fh.close)
+                        rehash_digest = await asyncio.to_thread(
+                            _rehash_file, tmp_path, _HASHLIB_BY_LABEL[cd_algo]
+                        )
                     except OSError:
                         logger.exception("file-exchange: upload rehash read failed")
                         return Response(status_code=500)
-                    if rehash.digest() != cd_raw:
+                    if rehash_digest != cd_raw:
                         return Response(status_code=400)
             elif required is not None:
                 return Response(status_code=400)
@@ -347,13 +382,24 @@ def register_upload_route(
             try:
                 await token_store.consume(token)
             except Exception:
+                # At-most-once *delivery*, not at-most-once *deposit*: the
+                # sink already stored these bytes, but the consume failure
+                # left the token live, so a retry by the sender (e.g. on
+                # TCP timeout) will lookup-then-store again. Non-idempotent
+                # sinks need to be aware of this; pvl-core does not retry
+                # the consume internally.
                 logger.warning(
                     "file-exchange: upload token consume failed after store; "
-                    "token may remain usable to TTL"
+                    "token may remain usable to TTL and a sender retry would "
+                    "deposit the same artifact a second time"
                 )
             return Response(status_code=204)
         finally:
             with contextlib.suppress(OSError):
                 await asyncio.to_thread(os.unlink, tmp_path)
 
-    mcp.custom_route(f"{UPLOAD_PREFIX}/{{token}}", methods=["PUT", "POST"])(_handle)
+    # PUT only: ``upload_receiver_mint`` advertises ``method="PUT"`` (a
+    # pvl-core shape decision per ``_UPLOAD_METHOD``), so the route never
+    # needs to honour POST. Accepting it would let clients use a method
+    # pvl-core never minted, which is dead surface.
+    mcp.custom_route(f"{UPLOAD_PREFIX}/{{token}}", methods=["PUT"])(_handle)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -8,7 +8,12 @@ This module accrues the upload-transport helpers task by task:
 - ``_content_digest_parse`` / ``_content_digest_format`` / ``_media_range_matches``
   — RFC 9530 Content-Digest dictionary-entry parse + format, and an RFC 7231
   media-range matcher used by the route to enforce ``acceptMimeTypes``.
-- The serving route and the sender land in subsequent commits per
+- ``register_upload_route`` — mount ``PUT``/``POST <UPLOAD_PREFIX>/{token}``
+  on a FastMCP server: streams the body to a temp file, verifies an optional
+  ``Content-Digest`` before the sink sees the bytes, deposits to
+  :class:`ArtifactSink`, and consumes the single-use token only after a
+  successful store.
+- The sender (``upload_sender_consume``) lands in a subsequent commit per
   the implementation plan.
 
 See ``docs/superpowers/specs/2026-05-27-file-exchange-146-failure-modes.md``
@@ -19,18 +24,41 @@ for the implementation plan this module is built against.
 
 from __future__ import annotations
 
+import asyncio
 import base64 as _b64
 import binascii
-from typing import TYPE_CHECKING, Literal
+import contextlib
+import hashlib
+import logging
+import os
+import tempfile
+from typing import TYPE_CHECKING, Literal, cast
 
 from fastmcp_pvl_core._file_exchange._spec import SPEC_VERSION, TICKET_TYPE
-from fastmcp_pvl_core._file_exchange._staging import _HASHLIB_BY_LABEL
+from fastmcp_pvl_core._file_exchange._staging import (
+    _CHUNK,
+    _HASHLIB_BY_LABEL,
+    _write_chunk,
+)
 from fastmcp_pvl_core._file_exchange._tokens import capability_url
-from fastmcp_pvl_core._file_exchange._wire import IntakeTicket, UploadSink
+from fastmcp_pvl_core._file_exchange._wire import (
+    ArtifactConstraints,
+    ArtifactMetadata,
+    IntakeTicket,
+    UploadSink,
+)
 
 if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+    from fastmcp_pvl_core._config import ServerConfig
+    from fastmcp_pvl_core._file_exchange._hooks import ArtifactSink
     from fastmcp_pvl_core._file_exchange._tokens import CapabilityTokenStore
-    from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints
+
+
+logger = logging.getLogger(__name__)
 
 # pvl-core's upload route shape (§12 capability URL path). A constant, not a
 # kwarg — route structure is a pvl-core shape decision.
@@ -169,3 +197,139 @@ def _media_range_matches(content_type: str, accept: list[str]) -> bool:
         ):
             return True
     return False
+
+
+def register_upload_route(
+    mcp: FastMCP,
+    *,
+    token_store: CapabilityTokenStore,
+    sink: ArtifactSink,
+    config: ServerConfig,
+) -> None:
+    """Mount ``PUT``/``POST <UPLOAD_PREFIX>/{token}`` on ``mcp``.
+
+    The route serves §12 capability URLs minted by ``upload_receiver_mint``;
+    ambient credentials are ignored — the in-URL token is the only
+    authorization. ``config.file_exchange_max_artifact_size`` is the operator
+    body-size cap; per-mint ``expected.maxSize`` is the smaller of the two when
+    set. See the failure-mode matrix for the full per-status-code contract.
+    """
+    from starlette.responses import Response
+
+    async def _handle(request: Request) -> Response:
+        token = request.path_params["token"]
+        rec = await token_store.lookup(token)
+        if rec is None:
+            return Response(status_code=404)
+        artifact_id = cast("str", rec.metadata["artifact_id"])
+        expected_raw = rec.metadata.get("expected")
+        expected = (
+            ArtifactConstraints.model_validate(expected_raw)
+            if expected_raw is not None
+            else None
+        )
+
+        content_type = request.headers.get("content-type", "")
+        if expected is not None and expected.acceptMimeTypes is not None:
+            if not _media_range_matches(content_type, expected.acceptMimeTypes):
+                return Response(status_code=415)
+
+        cap_per_mint = expected.maxSize if expected is not None else None
+        cap_operator = config.file_exchange_max_artifact_size
+        cap: int | None
+        if cap_per_mint is None:
+            cap = cap_operator
+        elif cap_operator is None:
+            cap = cap_per_mint
+        else:
+            cap = min(cap_per_mint, cap_operator)
+
+        try:
+            fd, tmp_path = tempfile.mkstemp(prefix="fx-upload-")
+        except OSError:
+            logger.exception("file-exchange: upload mkstemp failed")
+            return Response(status_code=500)
+        try:
+            try:
+                tmp = os.fdopen(fd, "wb")
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                raise
+            try:
+                hasher = hashlib.new("sha256")
+                received = 0
+                too_large = False
+                try:
+                    async for chunk in request.stream():
+                        if not chunk:
+                            continue
+                        if cap is not None and received + len(chunk) > cap:
+                            too_large = True
+                            break
+                        await asyncio.to_thread(_write_chunk, tmp, hasher, chunk)
+                        received += len(chunk)
+                except OSError:
+                    logger.exception("file-exchange: upload temp write failed")
+                    return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(tmp.close)
+
+            if too_large:
+                return Response(status_code=413)
+
+            cd_header = request.headers.get("content-digest")
+            if cd_header is not None:
+                parsed = _content_digest_parse(cd_header)
+                if parsed is None:
+                    return Response(status_code=400)
+                cd_algo, cd_raw = parsed
+                if cd_algo == "sha-256":
+                    if hasher.digest() != cd_raw:
+                        return Response(status_code=400)
+                else:
+                    rehash = hashlib.new(_HASHLIB_BY_LABEL[cd_algo])
+                    try:
+                        with open(tmp_path, "rb") as fh:
+                            while True:
+                                buf = await asyncio.to_thread(fh.read, _CHUNK)
+                                if not buf:
+                                    break
+                                rehash.update(buf)
+                    except OSError:
+                        logger.exception("file-exchange: upload rehash read failed")
+                        return Response(status_code=500)
+                    if rehash.digest() != cd_raw:
+                        return Response(status_code=400)
+            elif expected is not None and expected.requireDigest is not None:
+                return Response(status_code=400)
+
+            meta = ArtifactMetadata(
+                mimeType=content_type or None,
+                size=received,
+                digest="sha-256:" + hasher.hexdigest(),
+            )
+            try:
+                f = await asyncio.to_thread(open, tmp_path, "rb")
+            except OSError:
+                logger.exception("file-exchange: upload temp re-open failed")
+                return Response(status_code=500)
+            try:
+                try:
+                    await sink.store_artifact(artifact_id, meta, f)
+                except Exception:
+                    logger.exception("file-exchange: upload sink store_artifact failed")
+                    return Response(status_code=500)
+            finally:
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(f.close)
+
+            with contextlib.suppress(Exception):
+                await token_store.consume(token)
+            return Response(status_code=204)
+        finally:
+            with contextlib.suppress(OSError):
+                await asyncio.to_thread(os.unlink, tmp_path)
+
+    mcp.custom_route(f"{UPLOAD_PREFIX}/{{token}}", methods=["PUT", "POST"])(_handle)

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -280,11 +280,16 @@ def register_upload_route(
                 return Response(status_code=413)
 
             cd_header = request.headers.get("content-digest")
+            required = expected.requireDigest if expected is not None else None
             if cd_header is not None:
                 parsed = _content_digest_parse(cd_header)
                 if parsed is None:
                     return Response(status_code=400)
                 cd_algo, cd_raw = parsed
+                if required is not None and cd_algo not in required:
+                    # requireDigest lists specific algorithms; a digest in a
+                    # different algorithm does not satisfy the requirement.
+                    return Response(status_code=400)
                 if cd_algo == "sha-256":
                     if hasher.digest() != cd_raw:
                         return Response(status_code=400)
@@ -302,7 +307,7 @@ def register_upload_route(
                         return Response(status_code=500)
                     if rehash.digest() != cd_raw:
                         return Response(status_code=400)
-            elif expected is not None and expected.requireDigest is not None:
+            elif required is not None:
                 return Response(status_code=400)
 
             meta = ArtifactMetadata(
@@ -325,8 +330,13 @@ def register_upload_route(
                 with contextlib.suppress(OSError):
                     await asyncio.to_thread(f.close)
 
-            with contextlib.suppress(Exception):
+            try:
                 await token_store.consume(token)
+            except Exception:
+                logger.warning(
+                    "file-exchange: upload token consume failed after store; "
+                    "token may remain usable to TTL"
+                )
             return Response(status_code=204)
         finally:
             with contextlib.suppress(OSError):

--- a/src/fastmcp_pvl_core/_file_exchange/_upload.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_upload.py
@@ -257,7 +257,11 @@ def register_upload_route(
                     os.close(fd)
                 raise
             try:
-                hasher = hashlib.new("sha256")
+                try:
+                    hasher = hashlib.new("sha256")
+                except Exception:
+                    logger.exception("file-exchange: upload hasher init failed")
+                    return Response(status_code=500)
                 received = 0
                 too_large = False
                 try:

--- a/tests/_file_exchange/test_content_digest.py
+++ b/tests/_file_exchange/test_content_digest.py
@@ -17,6 +17,20 @@ def test_supported_algorithms_set():
     )
 
 
+def test_supported_algorithms_match_staging_hashlib_map():
+    """``_content_digest.SUPPORTED_ALGORITHMS`` and
+    ``_staging._HASHLIB_BY_LABEL`` define the same algorithm set
+    independently — the route looks up ``_HASHLIB_BY_LABEL[cd_algo]`` after
+    ``parse_header`` has filtered against ``SUPPORTED_ALGORITHMS``, so the
+    two collections must keep their key sets in sync. Drift would surface
+    as a runtime ``KeyError`` in the rehash branch; this test pins the
+    invariant so a future algorithm addition cannot land on only one
+    side."""
+    from fastmcp_pvl_core._file_exchange import _staging
+
+    assert _content_digest.SUPPORTED_ALGORITHMS == frozenset(_staging._HASHLIB_BY_LABEL)
+
+
 def test_parse_header_single_sha256_entry():
     payload = b"hello"
     raw = hashlib.sha256(payload).digest()

--- a/tests/_file_exchange/test_staging.py
+++ b/tests/_file_exchange/test_staging.py
@@ -75,3 +75,19 @@ def test_write_chunk_no_hasher_writes_only(tmp_path):
     with target.open("wb") as fh:
         _staging._write_chunk(fh, None, b"abc")
     assert target.read_bytes() == b"abc"
+
+
+def test_rehash_file_sha384(tmp_path):
+    payload = b"the rehash helper now lives in _staging"
+    target = tmp_path / "blob"
+    target.write_bytes(payload)
+    expected = hashlib.sha384(payload).digest()
+    assert _staging._rehash_file(str(target), "sha384") == expected
+
+
+def test_rehash_file_sha512(tmp_path):
+    payload = b"x" * (3 * _staging._CHUNK + 7)  # multiple chunks + tail
+    target = tmp_path / "blob"
+    target.write_bytes(payload)
+    expected = hashlib.sha512(payload).digest()
+    assert _staging._rehash_file(str(target), "sha512") == expected

--- a/tests/_file_exchange/test_upload_helpers.py
+++ b/tests/_file_exchange/test_upload_helpers.py
@@ -1,108 +1,13 @@
-"""Matrix rows F1, F2, F3, F4, D4, D5: pure-function helpers in _upload."""
+"""Matrix rows F3, F4: ``_media_range_matches`` (RFC 7231 §3.1.1.1).
 
-import base64
-import hashlib
+Content-Digest helper tests moved to ``test_content_digest.py`` when
+the parse + policy was extracted from ``_upload.py`` into
+``_content_digest.py``.
+"""
 
 import pytest
 
-from fastmcp_pvl_core._file_exchange._upload import (
-    _content_digest_format,
-    _content_digest_parse,
-    _media_range_matches,
-)
-
-
-def test_content_digest_parse_sha256_well_formed():
-    payload = b"hello"
-    raw = hashlib.sha256(payload).digest()
-    b64 = base64.b64encode(raw).decode("ascii")
-    header = f"sha-256=:{b64}:"
-    algo, decoded = _content_digest_parse(header)
-    assert algo == "sha-256"
-    assert decoded == raw
-
-
-def test_content_digest_parse_sha512_well_formed():
-    raw = hashlib.sha512(b"x").digest()
-    b64 = base64.b64encode(raw).decode("ascii")
-    algo, decoded = _content_digest_parse(f"sha-512=:{b64}:")
-    assert algo == "sha-512"
-    assert decoded == raw
-
-
-def test_content_digest_parse_sha384_well_formed():
-    raw = hashlib.sha384(b"x").digest()
-    b64 = base64.b64encode(raw).decode("ascii")
-    algo, decoded = _content_digest_parse(f"sha-384=:{b64}:")
-    assert algo == "sha-384"
-    assert decoded == raw
-
-
-def test_content_digest_parse_multi_algo_dict_returns_first_supported():
-    """RFC 9530 §3: when a dictionary lists multiple algorithms, return the
-    first supported one in order. (sha-256 is supported; sha-3 is not.)"""
-    raw256 = hashlib.sha256(b"x").digest()
-    raw512 = hashlib.sha512(b"x").digest()
-    b256 = base64.b64encode(raw256).decode("ascii")
-    b512 = base64.b64encode(raw512).decode("ascii")
-    parsed = _content_digest_parse(f"sha-256=:{b256}:, sha-512=:{b512}:")
-    assert parsed == ("sha-256", raw256)
-
-
-def test_content_digest_parse_skips_unsupported_then_takes_supported():
-    """RFC 9530 §3 MUST-ignore: unsupported algorithm at first position is
-    skipped, the supported algorithm later in the dictionary is used."""
-    raw256 = hashlib.sha256(b"hello").digest()
-    b256 = base64.b64encode(raw256).decode("ascii")
-    parsed = _content_digest_parse(f"md5=:YWJjZA==:, sha-256=:{b256}:")
-    assert parsed == ("sha-256", raw256)
-
-
-def test_content_digest_parse_all_unsupported_returns_none():
-    """If every dictionary entry is in an unsupported algorithm, return None."""
-    assert _content_digest_parse("md5=:YWJjZA==:, sha-3=:YWJjZA==:") is None
-
-
-def test_content_digest_parse_ignores_sf_parameters():
-    """RFC 8941 §3.2 / RFC 9530 §3: structured-field parameters appended to a
-    dictionary item (``sha-256=:<b64>:;foo=bar``) MUST be ignored, not cause
-    the entry to be rejected."""
-    raw = hashlib.sha256(b"hello").digest()
-    b64 = base64.b64encode(raw).decode("ascii")
-    parsed = _content_digest_parse(f"sha-256=:{b64}:;foo=bar;baz")
-    assert parsed == ("sha-256", raw)
-
-
-def test_content_digest_parse_tolerates_whitespace():
-    raw = hashlib.sha256(b"x").digest()
-    b64 = base64.b64encode(raw).decode("ascii")
-    algo, decoded = _content_digest_parse(f"  sha-256 = :{b64}:  ")
-    assert algo == "sha-256"
-    assert decoded == raw
-
-
-@pytest.mark.parametrize(
-    "header",
-    [
-        "garbage",
-        "sha-256:abcd",  # missing structured-field colons
-        "md5=:YWJjZA==:",  # unsupported algo label
-        "sha-256=::",  # empty value
-        "sha-256=:not-base64!:",
-        "sha-256=:YWJjZA",  # missing trailing colon
-        "",
-    ],
-)
-def test_content_digest_parse_malformed_or_unknown_returns_none(header):
-    """D4 + D5: present-but-unparseable / unsupported-algo -> None."""
-    assert _content_digest_parse(header) is None
-
-
-def test_content_digest_format_round_trips():
-    raw = hashlib.sha256(b"hello").digest()
-    header = _content_digest_format("sha-256", raw)
-    parsed = _content_digest_parse(header)
-    assert parsed == ("sha-256", raw)
+from fastmcp_pvl_core._file_exchange._upload import _media_range_matches
 
 
 @pytest.mark.parametrize(

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -769,6 +769,29 @@ async def test_route_revoke_after_lookup_still_succeeds():
     assert await store.lookup(token) is None
 
 
+async def test_route_consume_raises_still_returns_204():
+    """If ``token_store.consume`` raises after a successful sink store
+    (transient KV failure), the route logs a warning and still returns 204
+    — the bytes are in the sink; pvl-core's at-most-once-delivery contract
+    explicitly tolerates a live token after store success."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+
+    async def raising_consume(token):
+        raise RuntimeError("simulated KV transient failure")
+
+    store.consume = raising_consume  # type: ignore[method-assign]
+
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+
+
 async def test_route_client_disconnect_propagates_without_500_response(monkeypatch):
     """starlette.requests.ClientDisconnect during request.stream() must
     propagate, not be caught as a generic OSError and turned into 500."""

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -223,6 +223,40 @@ async def test_route_non_sha256_digest_verified_via_rehash():
     assert meta.digest == "sha-256:" + hashlib.sha256(body).hexdigest()
 
 
+async def test_route_non_sha256_digest_mismatch_400():
+    """Rehash branch mismatch: sha-512 required, client sends a sha-512
+    Content-Digest that does NOT match the body bytes -> 400, no sink call.
+
+    Pinning this branch separately from the sha-256 mismatch test ensures a
+    regression in ``_rehash_file``'s algorithm selection or the ``!=``
+    comparison cannot pass silently."""
+    import base64
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+        expected=ArtifactConstraints(requireDigest=["sha-512"]),
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    body = b"correct body bytes"
+    # sha-512 of *different* bytes so the header parses cleanly but
+    # mismatches the body that gets sent.
+    wrong512 = hashlib.sha512(b"other bytes entirely").digest()
+    header = "sha-512=:" + base64.b64encode(wrong512).decode("ascii") + ":"
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=body,
+            headers={"Content-Type": "text/plain", "Content-Digest": header},
+        )
+    assert resp.status_code == 400
+    assert sink.calls == []
+
+
 async def test_route_second_put_after_success_returns_404():
     """A1 ordering: token consumed after first success; second PUT -> 404."""
     sink = _RecordingSink()

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -119,6 +119,42 @@ async def test_route_require_digest_algorithm_mismatch_400():
     assert sink.calls == []
 
 
+async def test_route_require_digest_picks_required_algo_regardless_of_order():
+    """requireDigest=[sha-256] must be honoured even when the client lists
+    sha-512 first in a multi-algorithm Content-Digest dictionary. Without
+    this, a parser that returned the first supported entry would falsely
+    reject a fully-valid request."""
+    import base64
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+        expected=ArtifactConstraints(requireDigest=["sha-256"]),
+    )
+    url = ticket.sinks[0].url
+    path = url[len("https://route.test") :]
+    body = b"hello world"
+    raw256 = hashlib.sha256(body).digest()
+    raw512 = hashlib.sha512(body).digest()
+    b256 = base64.b64encode(raw256).decode("ascii")
+    b512 = base64.b64encode(raw512).decode("ascii")
+    # sha-512 first, sha-256 second — the route must prefer sha-256
+    # because requireDigest lists it.
+    header = f"sha-512=:{b512}:, sha-256=:{b256}:"
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=body,
+            headers={"Content-Type": "text/plain", "Content-Digest": header},
+        )
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+
+
 async def test_route_second_put_after_success_returns_404():
     """A1 ordering: token consumed after first success; second PUT -> 404."""
     sink = _RecordingSink()
@@ -477,6 +513,12 @@ async def test_route_concurrent_puts_at_most_one_consumes():
         )
     statuses = sorted([r1.status_code, r2.status_code])
     assert statuses in ([204, 204], [204, 404])
+    # Sink may be called once (lookup-then-consume serialised) or twice
+    # (both pass lookup before either consumes), but never zero — at least
+    # one of the two PUTs must have stored. The spec design tolerates the
+    # duplicate-deposit case explicitly; pinning the upper bound at 2
+    # prevents a regression that would let unrelated PUTs sneak through.
+    assert 1 <= len(sink.calls) <= 2
     assert await store.lookup(token) is None
 
 

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -450,7 +450,18 @@ async def test_route_ambient_authorization_on_invalid_token_still_404():
 
 
 async def test_route_concurrent_puts_at_most_one_consumes():
-    """C1."""
+    """C1: two concurrent PUTs against one token do not crash, the token
+    is consumed exactly once, and the response set never contains two
+    404s.
+
+    Under ASGITransport's single-event-loop driver, the actual
+    interleaving window between ``token_store.lookup`` and
+    ``token_store.consume`` is not forced — the test pins the
+    observable contract (consume-exactly-once, response-set sanity)
+    rather than the specific race timing. A forced-interleaving test
+    that injects an awaitable barrier into the token store would be a
+    legitimate follow-up but is not required for the matrix row.
+    """
     sink = _RecordingSink()
     mcp, store = await _mount(sink)
     ticket = await _upload.upload_receiver_mint(

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -1,6 +1,8 @@
 """Matrix rows A1–A6, B1, B4, B6, C1–C2, D4–D8, F4, F5: upload route."""
 
+import asyncio as _asyncio
 import hashlib
+import os
 from typing import BinaryIO
 
 import httpx
@@ -114,3 +116,181 @@ async def test_route_require_digest_algorithm_mismatch_400():
         )
     assert resp.status_code == 400
     assert sink.calls == []
+
+
+async def test_route_second_put_after_success_returns_404():
+    """A1 ordering: token consumed after first success; second PUT -> 404."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        r1 = await c.put(path, content=b"a", headers={"Content-Type": "text/plain"})
+        r2 = await c.put(path, content=b"b", headers={"Content-Type": "text/plain"})
+    assert r1.status_code == 204
+    assert r2.status_code == 404
+    assert len(sink.calls) == 1
+
+
+class _RaisingSink:
+    def __init__(self) -> None:
+        self.attempts = 0
+
+    async def store_artifact(self, artifact_id, metadata, stream):
+        self.attempts += 1
+        stream.read()
+        if self.attempts == 1:
+            raise RuntimeError("boom")
+
+
+async def test_route_sink_raise_does_not_consume_token():
+    """A2: sink raises -> 500, token still valid, retry succeeds."""
+    sink = _RaisingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        r1 = await c.put(path, content=b"a", headers={"Content-Type": "text/plain"})
+        r2 = await c.put(path, content=b"b", headers={"Content-Type": "text/plain"})
+    assert r1.status_code == 500
+    assert r2.status_code == 204
+    assert sink.attempts == 2
+
+
+async def test_route_accept_mime_mismatch_415():
+    """A3."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+        expected=ArtifactConstraints(acceptMimeTypes=["application/json"]),
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"hi", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 415
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+
+async def test_route_too_large_per_mint_cap_413():
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+        expected=ArtifactConstraints(maxSize=4),
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path, content=b"too-many-bytes", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 413
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+
+async def test_route_too_large_operator_cap_413():
+    sink = _RecordingSink()
+    cfg = ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_token_ttl=3600.0,
+        file_exchange_max_artifact_size=4,
+    )
+    mcp, store = await _mount(sink, config=cfg)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path, content=b"too-many", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 413
+
+
+async def test_route_content_digest_mismatch_400():
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    bad = "sha-256=:" + "A" * 44 + ":"
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=b"hello",
+            headers={"Content-Type": "text/plain", "Content-Digest": bad},
+        )
+    assert resp.status_code == 400
+    assert sink.calls == []
+    assert await store.lookup(token) is not None
+
+
+async def test_route_require_digest_but_missing_header_400():
+    """A6."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+        expected=ArtifactConstraints(requireDigest=["sha-256"]),
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"hi", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 400
+    assert sink.calls == []
+
+
+async def test_route_content_digest_unparseable_400():
+    """D4."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=b"hi",
+            headers={"Content-Type": "text/plain", "Content-Digest": "garbage"},
+        )
+    assert resp.status_code == 400
+
+
+async def test_route_content_digest_unsupported_algo_400():
+    """D5."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=b"hi",
+            headers={
+                "Content-Type": "text/plain",
+                "Content-Digest": "md5=:YWJjZA==:",
+            },
+        )
+    assert resp.status_code == 400

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -6,6 +6,7 @@ import os
 from typing import BinaryIO
 
 import httpx
+import pytest
 from fastmcp import FastMCP
 
 from fastmcp_pvl_core._config import ServerConfig
@@ -497,3 +498,157 @@ async def test_route_content_digest_unsupported_algo_400():
             },
         )
     assert resp.status_code == 400
+
+
+async def test_route_tmp_close_failure_suppressed(monkeypatch):
+    """B2: tmp.close() raises on the success path -> suppressed, route still 204."""
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+
+    real_fdopen = up.os.fdopen
+    raised: list[bool] = []
+
+    def wrap(*a, **kw):
+        f = real_fdopen(*a, **kw)
+        real_close = f.close
+
+        def tracked_close():
+            raised.append(True)
+            real_close()
+            raise OSError("close failed")
+
+        f.close = tracked_close  # type: ignore[method-assign]
+        return f
+
+    monkeypatch.setattr(up.os, "fdopen", wrap)
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path, content=b"hello", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+    assert raised, "tmp.close should have been called"
+    assert await store.lookup(token) is None
+
+
+async def test_route_unlink_failure_suppressed_on_success(monkeypatch):
+    """B3: os.unlink raises during cleanup -> suppressed, response still 204."""
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+
+    real_unlink = up.os.unlink
+
+    def boom(p):
+        # Only fail for fx-upload temps; let other unlinks (if any) proceed.
+        if "fx-upload-" in str(p):
+            raise OSError("simulated unlink failure")
+        return real_unlink(p)
+
+    monkeypatch.setattr(up.os, "unlink", boom)
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+
+
+async def test_route_revoke_before_put_returns_404():
+    """C2 (a): revoke wins the race before lookup -> 404, no sink call."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    await store.revoke(token)
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 404
+    assert sink.calls == []
+
+
+async def test_route_revoke_after_lookup_still_succeeds():
+    """C2 (b): revoke fires between lookup and consume -> sink succeeded,
+    consume returns False, response still 204 (the bytes are in the sink;
+    spec is at-most-once-success, not at-most-once-with-rollback).
+    """
+    import asyncio as _aio
+
+    revoke_signal = _aio.Event()
+    consume_signal = _aio.Event()
+
+    class _SlowSink:
+        def __init__(self):
+            self.calls: list[bytes] = []
+
+        async def store_artifact(self, artifact_id, metadata, stream):
+            # Allow the test to revoke the token while the sink is mid-store.
+            revoke_signal.set()
+            await consume_signal.wait()
+            self.calls.append(stream.read())
+
+    sink = _SlowSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+
+    async def driver():
+        await revoke_signal.wait()
+        await store.revoke(token)
+        consume_signal.set()
+
+    async with await _client(mcp) as c:
+        results = await _asyncio.gather(
+            c.put(path, content=b"x", headers={"Content-Type": "text/plain"}),
+            driver(),
+        )
+    resp = results[0]
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+    # Token is gone (consume returned False, but revoke deleted it).
+    assert await store.lookup(token) is None
+
+
+async def test_route_client_disconnect_propagates_without_500_response(monkeypatch):
+    """starlette.requests.ClientDisconnect during request.stream() must
+    propagate, not be caught as a generic OSError and turned into 500."""
+    from starlette.requests import ClientDisconnect
+
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+
+    # Patch _write_chunk to raise ClientDisconnect when called (simulates
+    # the body iterator yielding then the connection dropping).
+    def disconnect(tmp, hasher, chunk):
+        raise ClientDisconnect()
+
+    monkeypatch.setattr(up, "_write_chunk", disconnect)
+    async with await _client(mcp) as c:
+        with pytest.raises(ClientDisconnect):
+            await c.put(path, content=b"hello", headers={"Content-Type": "text/plain"})
+    # Token not consumed (no response was produced)
+    assert await store.lookup(token) is not None
+    assert sink.calls == []

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -1,0 +1,87 @@
+"""Matrix rows A1–A6, B1, B4, B6, C1–C2, D4–D8, F4, F5: upload route."""
+
+import hashlib
+from typing import BinaryIO
+
+import httpx
+from fastmcp import FastMCP
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._file_exchange import _upload
+from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
+from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+
+
+def _store():
+    return build_capability_token_store(
+        ServerConfig(kv_store_url="memory://", file_exchange_token_ttl=3600.0)
+    )
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str | None, ArtifactMetadata, bytes]] = []
+
+    async def store_artifact(
+        self, artifact_id: str | None, metadata: ArtifactMetadata, stream: BinaryIO
+    ) -> None:
+        data = stream.read()
+        self.calls.append((artifact_id, metadata, data))
+
+
+async def _mount(sink, *, config=None):
+    cfg = config or ServerConfig(
+        kv_store_url="memory://",
+        file_exchange_token_ttl=3600.0,
+        file_exchange_max_artifact_size=10 * 1024 * 1024,
+    )
+    store = build_capability_token_store(cfg)
+    mcp = FastMCP("test")
+    _upload.register_upload_route(mcp, token_store=store, sink=sink, config=cfg)
+    return mcp, store
+
+
+async def _client(mcp):
+    transport = httpx.ASGITransport(app=mcp.http_app())
+    return httpx.AsyncClient(transport=transport, base_url="http://test")
+
+
+async def test_route_happy_put_deposits_and_consumes():
+    """A1 success: PUT 204 -> sink called once, token consumed."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+    )
+    url = ticket.sinks[0].url
+    token = url.rsplit("/", 1)[1]
+    path = "/" + url.split("/", 3)[3]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path, content=b"hello world", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+    aid, meta, body = sink.calls[0]
+    assert aid == "art-1"
+    assert body == b"hello world"
+    assert meta.mimeType == "text/plain"
+    assert meta.size == len(b"hello world")
+    assert meta.digest == "sha-256:" + hashlib.sha256(b"hello world").hexdigest()
+    # Token consumed
+    assert await store.lookup(token) is None
+
+
+async def test_route_unknown_token_404():
+    """A1 prelude: lookup miss -> 404."""
+    sink = _RecordingSink()
+    mcp, _ = await _mount(sink)
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            "/fx/u/does-not-exist", content=b"x", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 404
+    assert sink.calls == []

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -449,6 +449,25 @@ async def test_route_ambient_authorization_on_invalid_token_still_404():
     assert resp.status_code == 404
 
 
+async def test_route_concurrent_puts_at_most_one_consumes():
+    """C1."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    token = ticket.sinks[0].url.rsplit("/", 1)[1]
+    async with await _client(mcp) as c:
+        r1, r2 = await _asyncio.gather(
+            c.put(path, content=b"a", headers={"Content-Type": "text/plain"}),
+            c.put(path, content=b"b", headers={"Content-Type": "text/plain"}),
+        )
+    statuses = sorted([r1.status_code, r2.status_code])
+    assert statuses in ([204, 204], [204, 404])
+    assert await store.lookup(token) is None
+
+
 async def test_route_content_digest_unsupported_algo_400():
     """D5."""
     sink = _RecordingSink()

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -9,7 +9,7 @@ from fastmcp import FastMCP
 from fastmcp_pvl_core._config import ServerConfig
 from fastmcp_pvl_core._file_exchange import _upload
 from fastmcp_pvl_core._file_exchange._tokens import build_capability_token_store
-from fastmcp_pvl_core._file_exchange._wire import ArtifactMetadata
+from fastmcp_pvl_core._file_exchange._wire import ArtifactConstraints, ArtifactMetadata
 
 
 def _store():
@@ -84,4 +84,33 @@ async def test_route_unknown_token_404():
             "/fx/u/does-not-exist", content=b"x", headers={"Content-Type": "text/plain"}
         )
     assert resp.status_code == 404
+    assert sink.calls == []
+
+
+async def test_route_require_digest_algorithm_mismatch_400():
+    """A6 tightening: requireDigest=[sha-256] but client sends sha-512 -> 400."""
+    import base64
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+        expected=ArtifactConstraints(requireDigest=["sha-256"]),
+    )
+    url = ticket.sinks[0].url
+    path = url[len("https://route.test") :]
+    # Compute a correct sha-512 digest of the body so the header parses cleanly.
+    body = b"hello"
+    raw512 = hashlib.sha512(body).digest()
+    header = "sha-512=:" + base64.b64encode(raw512).decode("ascii") + ":"
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=body,
+            headers={"Content-Type": "text/plain", "Content-Digest": header},
+        )
+    assert resp.status_code == 400
     assert sink.calls == []

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -155,6 +155,74 @@ async def test_route_require_digest_picks_required_algo_regardless_of_order():
     assert len(sink.calls) == 1
 
 
+async def test_route_require_digest_is_case_insensitive():
+    """``ArtifactConstraints.requireDigest`` is an unvalidated ``list[str]``;
+    a downstream that mints with ``["SHA-256"]`` (uppercase, non-standard
+    but syntactically valid) must not have its tokens permanently rejected.
+    The route lowercases the comparison set so ``cd_algo=="sha-256"`` still
+    satisfies the requirement."""
+    import base64
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+        expected=ArtifactConstraints(requireDigest=["SHA-256"]),
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    body = b"case sanity"
+    raw = hashlib.sha256(body).digest()
+    header = "sha-256=:" + base64.b64encode(raw).decode("ascii") + ":"
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=body,
+            headers={"Content-Type": "text/plain", "Content-Digest": header},
+        )
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+
+
+async def test_route_non_sha256_digest_verified_via_rehash():
+    """Exercises the ``_rehash_file`` branch: when ``Content-Digest`` is in a
+    non-sha-256 algorithm (and that algorithm is required), the route re-reads
+    the staged temp through ``_rehash_file`` to compute the declared
+    algorithm's digest, compares it to the header, and on match deposits to
+    the sink with a 204."""
+    import base64
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1",
+        token_store=store,
+        base_url="https://route.test",
+        ttl=120.0,
+        expected=ArtifactConstraints(requireDigest=["sha-512"]),
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    body = b"the rehash branch needs its own test"
+    raw512 = hashlib.sha512(body).digest()
+    header = "sha-512=:" + base64.b64encode(raw512).decode("ascii") + ":"
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=body,
+            headers={"Content-Type": "text/plain", "Content-Digest": header},
+        )
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+    aid, meta, deposited = sink.calls[0]
+    assert deposited == body
+    # ``meta.digest`` is recorded in pvl-core's canonical sha-256 form
+    # regardless of which algorithm the client attested — the rehash only
+    # verifies the client's attestation, it does not change the record.
+    assert meta.digest == "sha-256:" + hashlib.sha256(body).hexdigest()
+
+
 async def test_route_second_put_after_success_returns_404():
     """A1 ordering: token consumed after first success; second PUT -> 404."""
     sink = _RecordingSink()

--- a/tests/_file_exchange/test_upload_route.py
+++ b/tests/_file_exchange/test_upload_route.py
@@ -276,6 +276,179 @@ async def test_route_content_digest_unparseable_400():
     assert resp.status_code == 400
 
 
+async def test_route_hashlib_failure_does_not_leak_fd(monkeypatch):
+    """B1: simulated post-fdopen pre-staging failure -> fd closed, temp unlinked."""
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+
+    created: list[str] = []
+    real_mkstemp = up.tempfile.mkstemp
+
+    def spy_mkstemp(**kw):
+        fd, path_ = real_mkstemp(**kw)
+        created.append(path_)
+        return fd, path_
+
+    monkeypatch.setattr(up.tempfile, "mkstemp", spy_mkstemp)
+
+    real_hashlib_new = up.hashlib.new
+
+    def boom(name):
+        if name == "sha256":
+            raise RuntimeError("FIPS")
+        return real_hashlib_new(name)
+
+    monkeypatch.setattr(up.hashlib, "new", boom)
+
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"hi", headers={"Content-Type": "text/plain"})
+    # 500 is the expected mapping for an unexpected RuntimeError inside the handler.
+    assert resp.status_code == 500
+    for p in created:
+        assert not os.path.exists(p), f"temp leaked: {p}"
+
+
+async def test_route_sink_does_not_close_fd_route_closes_it():
+    """B4: route owns the fd handed to the sink and closes it."""
+    closes: list[bool] = []
+
+    class _SpySink:
+        async def store_artifact(self, artifact_id, metadata, stream):
+            stream.read()
+            original_close = stream.close
+
+            def tracked():
+                closes.append(True)
+                original_close()
+
+            stream.close = tracked  # type: ignore[method-assign]
+
+    mcp, store = await _mount(_SpySink())
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 204
+    assert closes == [True]
+
+
+async def test_route_temp_reopen_failure_500(monkeypatch):
+    """B6: open(tmp_path, 'rb') raises -> 500, sink not called."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+
+    import builtins
+
+    real_open = builtins.open
+
+    def fake_open(p, mode="r", *a, **kw):
+        if isinstance(p, str) and "fx-upload-" in p and "rb" in mode:
+            raise OSError("simulated")
+        return real_open(p, mode, *a, **kw)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 500
+    assert sink.calls == []
+
+
+class _FxFailSink:
+    async def store_artifact(self, artifact_id, metadata, stream):
+        from fastmcp_pvl_core._file_exchange._codes import TransferErrorCode
+        from fastmcp_pvl_core._file_exchange._errors import FileExchangeTransferError
+
+        stream.read()
+        raise FileExchangeTransferError(
+            TransferErrorCode.TRANSFER_FAILED, transport="upload", detail="x"
+        )
+
+
+async def test_route_sink_raises_file_exchange_error_500():
+    """D6."""
+    mcp, store = await _mount(_FxFailSink())
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(path, content=b"x", headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 500
+    assert resp.content == b""
+
+
+async def test_route_temp_write_oserror_500(monkeypatch):
+    """D8."""
+    import fastmcp_pvl_core._file_exchange._upload as up
+
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+
+    def boom(tmp, hasher, chunk):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(up, "_write_chunk", boom)
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path, content=b"hello", headers={"Content-Type": "text/plain"}
+        )
+    assert resp.status_code == 500
+    assert sink.calls == []
+
+
+async def test_route_ambient_authorization_ignored():
+    """F5."""
+    sink = _RecordingSink()
+    mcp, store = await _mount(sink)
+    ticket = await _upload.upload_receiver_mint(
+        "art-1", token_store=store, base_url="https://route.test", ttl=120.0
+    )
+    path = ticket.sinks[0].url[len("https://route.test") :]
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            path,
+            content=b"x",
+            headers={
+                "Content-Type": "text/plain",
+                "Authorization": "Bearer fake",
+                "Cookie": "session=abc",
+            },
+        )
+    assert resp.status_code == 204
+    assert len(sink.calls) == 1
+
+
+async def test_route_ambient_authorization_on_invalid_token_still_404():
+    sink = _RecordingSink()
+    mcp, _ = await _mount(sink)
+    async with await _client(mcp) as c:
+        resp = await c.put(
+            "/fx/u/nope",
+            content=b"x",
+            headers={
+                "Content-Type": "text/plain",
+                "Authorization": "Bearer admin",
+            },
+        )
+    assert resp.status_code == 404
+
+
 async def test_route_content_digest_unsupported_algo_400():
     """D5."""
     sink = _RecordingSink()


### PR DESCRIPTION
## Summary

Third of 5 stacked PRs for #146. Builds on #168 (mint + helpers). Adds \`register_upload_route\` — the upload data plane's serving route — plus a comprehensive edge-mode test sweep covering matrix rows A1–A6, B1/B4/B6, C1/C2, D4–D8, F4–F5.

## Route behaviour

\`PUT\`/\`POST /fx/u/{token}\`:

- Token lookup miss → 404 (uniform for unknown / expired / consumed; no token state leakage)
- \`acceptMimeTypes\` mismatch → 415 (no consume, no sink call)
- Effective body cap = \`min(expected.maxSize, config.file_exchange_max_artifact_size)\` → over cap → 413 with \`Connection: close\` (prevents next-request misframing on HTTP/1.1 keep-alive)
- \`Content-Digest\` verification BEFORE the sink sees the bytes:
  - missing-when-\`requireDigest\` → 400
  - present-but-unparseable → 400
  - present-but-unsupported algorithm → 400
  - mismatch → 400
  - \`requireDigest\` enforces algorithm-list membership, not just presence
- Sink raise → 500 (token NOT consumed; subsequent PUT can retry)
- \`token_store.consume\` runs only AFTER successful sink return (matrix row A1+A2 contract)
- \`starlette.requests.ClientDisconnect\` caught and re-raised (it inherits from \`Exception\`, not \`OSError\`)
- Temp file unlinked on every path

## Test plan

- [x] \`uv run pytest tests/_file_exchange\` — 613 passed (= 588 from slice 2 + 25 new route tests)
- [x] \`uv run --python 3.10 pytest tests/_file_exchange\` — 613 passed
- [x] \`uv run --python 3.13 pytest tests/_file_exchange\` — 613 passed
- [x] \`uv run ruff format --check .\` clean
- [x] \`uv run ruff check src tests\` clean
- [x] \`uv run mypy src\` — no issues

**Base:** depends on #168 → #167. Merge those first.

Part of #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)