### PR TITLE
fix(file-exchange): tighten _digest_verifier malformed-input edges

### DIFF
--- a/src/fastmcp_pvl_core/_file_exchange/_staging.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_staging.py
@@ -31,14 +31,20 @@ def _digest_verifier(
 ) -> tuple[hashlib._Hash | None, str | None, bool]:
     """Return ``(hasher | None, expected_hex | None, unverifiable)``.
 
-    ``unverifiable`` is True when a digest is declared with an unsupported
-    label — verification must then fail (cannot verify), never silently
-    skip (§15).
+    ``unverifiable`` is True when a digest is declared but cannot be verified
+    against — either the algorithm label is unsupported (e.g. ``md5``) or the
+    declaration is malformed (no colon, empty hex). Verification must then
+    fail (cannot verify), never silently skip (§15).
     """
     if declared is None:
         return None, None, False
-    label, _, expected_hex = declared.partition(":")
-    name = _HASHLIB_BY_LABEL.get(label.lower())
+    label, sep, expected_hex = declared.partition(":")
+    if sep != ":" or not expected_hex:
+        # No colon ("sha-256") or empty hex after the colon ("sha-256:") —
+        # there is nothing to verify against. Treat as unverifiable rather
+        # than letting the empty-string hex compare against a real hexdigest.
+        return None, expected_hex or None, True
+    name = _HASHLIB_BY_LABEL.get(label.strip().lower())
     if name is None:
         return None, expected_hex, True
     return hashlib.new(name), expected_hex.lower(), False

--- a/tests/_file_exchange/test_staging.py
+++ b/tests/_file_exchange/test_staging.py
@@ -37,6 +37,29 @@ def test_digest_verifier_none_declared_no_op():
     assert _staging._digest_verifier(None) == (None, None, False)
 
 
+def test_digest_verifier_no_colon_is_unverifiable():
+    """Pre-existing edge: "sha-256" without colon -> empty hex; treat as
+    unverifiable so the caller raises DIGEST_MISMATCH instead of comparing
+    a real hexdigest against the empty string."""
+    assert _staging._digest_verifier("sha-256") == (None, None, True)
+
+
+def test_digest_verifier_empty_hex_is_unverifiable():
+    """Pre-existing edge: "sha-256:" (trailing colon, empty hex) -> nothing
+    to verify against; unverifiable."""
+    assert _staging._digest_verifier("sha-256:") == (None, None, True)
+
+
+def test_digest_verifier_label_whitespace_is_stripped():
+    """Pre-existing edge: a leading-space label (" sha-256:...") must not
+    cause a valid declaration to be reported as an unsupported algorithm."""
+    declared = " sha-256:" + "0" * 64
+    hasher, expected_hex, unverifiable = _staging._digest_verifier(declared)
+    assert isinstance(hasher, type(hashlib.sha256()))
+    assert expected_hex == "0" * 64
+    assert unverifiable is False
+
+
 def test_write_chunk_writes_and_hashes(tmp_path):
     target = tmp_path / "buf.bin"
     with target.open("wb") as fh:


### PR DESCRIPTION
## Summary

Pre-existing bugs in \`_digest_verifier\` that claude-review surfaced on the post-merge pass of #167. They were carried over from \`_download.py\` into the canonical shared \`_staging.py\` and are about to be reused by the upload data plane (#168 + #169) — worth fixing **before** the upload path inherits them.

## What was broken

1. **No-colon / empty-hex declarations were not flagged as unverifiable.**
   - \`"sha-256"\` (no colon) or \`"sha-256:"\` (trailing colon, empty hex) returned \`(hasher, "", False)\`.
   - The caller compared a real hexdigest against the empty string, always raising \`DIGEST_MISMATCH\`. Observable behaviour was correct, but the semantic path was wrong: \`unverifiable\` should be \`True\` when there is nothing to verify against.
   - Fix: explicit \`if sep != ":" or not expected_hex: return None, expected_hex or None, True\` guard.

2. **Label not stripped before the algorithm-map lookup.**
   - A leading-space label like \`" sha-256:abc..."\` (possible from a lenient header parser or misbehaving peer) missed the supported-algorithm map, was reported as unverifiable, and raised \`DIGEST_MISMATCH\` on an otherwise valid declaration.
   - Fix: \`label.strip().lower()\` before the lookup.

## Tests

Three regression tests added in \`tests/_file_exchange/test_staging.py\`:

- \`test_digest_verifier_no_colon_is_unverifiable\`
- \`test_digest_verifier_empty_hex_is_unverifiable\`
- \`test_digest_verifier_label_whitespace_is_stripped\`

Existing \`test_digest_verifier_*\` tests still pass — the fix is additive at the contract level (the unverifiable=True branch grows, the unverifiable=False branch is unchanged for well-formed declarations).

## Test plan

- [x] \`uv run pytest tests/_file_exchange\` — 561 passed (= 558 from main + 3 new)
- [x] \`uv run --python 3.10 pytest tests/_file_exchange\` — 561 passed
- [x] \`uv run --python 3.13 pytest tests/_file_exchange\` — 561 passed
- [x] \`uv run ruff format --check .\` clean
- [x] \`uv run ruff check src tests\` clean
- [x] \`uv run mypy src\` — no issues

## Why a separate PR

This is a behaviour-tightening fix to a function the in-flight #146 chain (#168/#169/#170/#171) is about to start using. Bundling it into one of those slices would conflate concerns (the slices are about new functionality, not fixing pre-existing edges). Landing it before #168 means each downstream slice inherits the fix automatically on rebase.

Refs #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)