### PR TITLE
fix(file-exchange): reject empty-string elements in requireDigest

### DIFF
--- a/src/fastmcp_pvl_core/_file_exchange/_wire.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_wire.py
@@ -121,7 +121,15 @@ class ArtifactConstraints(_WireBase):
 
     maxSize: int | None = Field(default=None, ge=0)  # noqa: N815
     acceptMimeTypes: list[str] | None = None  # noqa: N815
-    requireDigest: list[str] | None = Field(default=None, min_length=1)  # noqa: N815
+    # ``min_length=1`` on the outer ``Field`` constrains the LIST length
+    # (≥1 algorithm), while the inner ``Annotated[str, Field(min_length=1)]``
+    # constrains each algorithm name to be a non-empty string. Without the
+    # inner constraint, ``requireDigest=[""]`` would pass validation and
+    # then permanently 400 every upload against that token (the route's
+    # ``preferred_set={""}`` matches no real algorithm).
+    requireDigest: list[Annotated[str, Field(min_length=1)]] | None = Field(  # noqa: N815
+        default=None, min_length=1
+    )
 
 
 class FilesystemSource(_DescriptorBase):

--- a/tests/_file_exchange/test_wire_metadata.py
+++ b/tests/_file_exchange/test_wire_metadata.py
@@ -59,6 +59,14 @@ def test_constraints_require_digest_must_be_non_empty():
         ArtifactConstraints(requireDigest=[])
 
 
+def test_constraints_require_digest_elements_must_be_non_empty():
+    """An empty-string algorithm name would create a token that 400s every
+    upload (the route's ``preferred_set={""}`` matches no real algorithm).
+    Reject at validation time."""
+    with pytest.raises(ValidationError):
+        ArtifactConstraints(requireDigest=[""])
+
+
 def test_constraints_max_size_non_negative():
     ArtifactConstraints(maxSize=0)
     with pytest.raises(ValidationError):


### PR DESCRIPTION
## Summary

PR #169 (slice 3) surfaced that \`ArtifactConstraints.requireDigest\`'s field-level constraint validates only the list length, not each algorithm name. A mint with \`requireDigest=[\"\"]\` passes validation and creates a token that returns 400 on every upload forever (the route's lowercased \`preferred_set={\"\"}\` matches no real algorithm label, and the fallback then fails the requireDigest membership check).

Fix: add an inner \`Annotated[str, Field(min_length=1)]\` so each element must be a non-empty string.

## Test plan

- [x] \`uv run pytest tests/_file_exchange\` — 595 passed (594 + 1 new)
- [x] \`uv run --python 3.10 pytest tests/_file_exchange\` — 595 passed
- [x] \`uv run --python 3.13 pytest tests/_file_exchange\` — 595 passed
- [x] \`uv run ruff format --check .\` clean
- [x] \`uv run ruff check src tests\` clean
- [x] \`uv run mypy src\` — no issues

## Why a separate PR

Same logic as #173: small fix to a wire-level function the in-flight #146 chain (#169 / #170 / #171) depends on. Landing it on its own keeps slice 3's review surface narrow; #169 will inherit on rebase.

Refs #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)