### PR TITLE
feat(file-exchange): _content_digest.py + http-sf dependency (#146)

### DIFF
--- a/docs/superpowers/plans/2026-05-28-content-digest-restructure.md
+++ b/docs/superpowers/plans/2026-05-28-content-digest-restructure.md
@@ -1,0 +1,1121 @@
+# Content-Digest pipeline restructure — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hand-rolled RFC 8941/9530 parser inside `_upload.py` with the `http-sf` library wrapped by a new `_content_digest.py` module that splits Layer-2 (algorithm selection), Layer-3 (`requireDigest` membership), and Layer-4 (bytes verification) into named, separately-testable concerns.
+
+**Architecture:** Two PRs in sequence: **PR-A** lands the new library dependency and the new pure-function module against `main` (route untouched, narrow review surface). **PR-B** rebases the in-flight slice 3 (#169) on PR-A, deletes the hand-rolled parser, and migrates the route to call into the new module. Slices 4 (#170) and 5 (#171) then rebase mechanically.
+
+**Tech Stack:** Python 3.10–3.13, [`http-sf`](https://pypi.org/project/http-sf/) v1.3+ (Mark Nottingham's RFC 8941 reference implementation; pure-Python, no transitive deps), pytest with `asyncio_mode = "auto"`, ruff, mypy.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-content-digest-restructure.md` (commit `f2f81e2`).
+
+**Branch hygiene at every Task boundary:**
+
+```bash
+uv run pytest tests/_file_exchange -q
+uv run --python 3.10 pytest tests/_file_exchange -q
+uv run --python 3.13 pytest tests/_file_exchange -q
+uv run ruff format --check .
+uv run ruff check src tests
+uv run mypy src
+```
+
+All six must pass before the commit lands.
+
+---
+
+## PR-A — `_content_digest.py` (new module against `main`)
+
+Branch: `feat/146-content-digest-module` off `main`. No route changes. Self-contained, reviewable in one bot round.
+
+### Task A1 — Add `http-sf` runtime dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `uv.lock` (regenerated)
+
+- [ ] **Step A1.1: Add the dependency.**
+
+Find the `dependencies = [...]` array in `pyproject.toml`'s `[project]` table and add `"http-sf>=1.3"` in alphabetical position. After the edit, the relevant section should contain a line like:
+
+```toml
+    "http-sf>=1.3",
+```
+
+(Match the surrounding quoting style and comma placement of the existing entries; if entries are sorted alphabetically, place this between `httpx` and `jsonschema` or wherever `h*` lands.)
+
+- [ ] **Step A1.2: Regenerate the lock + sync the env.**
+
+```bash
+uv sync --all-extras
+```
+
+Expected: `http-sf` resolves to a 1.3.x version with zero transitive runtime deps.
+
+- [ ] **Step A1.3: Smoke-import.**
+
+```bash
+uv run python -c "from http_sf import parse, ser_dictionary; print('ok')"
+```
+Expected output: `ok`.
+
+- [ ] **Step A1.4: Commit.**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "$(cat <<'EOF'
+build(deps): add http-sf for RFC 8941 Structured Fields parsing (#146)
+
+http-sf is Mark Nottingham's RFC 8941 reference implementation
+(pure-Python, no transitive runtime deps). Used by the upcoming
+_content_digest.py module to replace the hand-rolled Content-Digest
+parser whose finding cluster on PR #169 motivated the restructure.
+
+Refs #146.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task A2 — `_content_digest.py` skeleton + first contract test
+
+**Files:**
+- Create: `src/fastmcp_pvl_core/_file_exchange/_content_digest.py`
+- Create: `tests/_file_exchange/test_content_digest.py`
+
+- [ ] **Step A2.1: Write the first failing test.**
+
+```python
+# tests/_file_exchange/test_content_digest.py
+"""Contract tests for the Content-Digest parse + policy module.
+
+Every spec edge previously surfaced as a route-level bug on PR #169
+gets its own test here so the route layer can rely on the contract
+without re-deriving it.
+"""
+
+import base64
+import hashlib
+
+import pytest
+
+from fastmcp_pvl_core._file_exchange import _content_digest
+
+
+def test_supported_algorithms_set():
+    assert _content_digest.SUPPORTED_ALGORITHMS == frozenset(
+        {"sha-256", "sha-384", "sha-512"}
+    )
+```
+
+- [ ] **Step A2.2: Run — expect ModuleNotFoundError.**
+
+```bash
+uv run pytest tests/_file_exchange/test_content_digest.py -v
+```
+Expected: `ModuleNotFoundError: No module named 'fastmcp_pvl_core._file_exchange._content_digest'`.
+
+- [ ] **Step A2.3: Create the module skeleton.**
+
+```python
+# src/fastmcp_pvl_core/_file_exchange/_content_digest.py
+"""RFC 9530 Content-Digest header parser + policy helpers.
+
+Parsing delegates to the ``http_sf`` library (RFC 8941 Structured
+Fields); this module adds the spec-9530 policy layered on top:
+which algorithms pvl-core supports, how a multi-algorithm dictionary
+is reduced to a single selected entry, and whether a selected entry
+satisfies a receiver's ``requireDigest`` constraint.
+
+Bytes verification (computing or rehashing the body's digest) is NOT
+in this module — that's the route's concern because it owns the
+staging temp-file lifecycle.
+"""
+
+from __future__ import annotations
+
+SUPPORTED_ALGORITHMS = frozenset({"sha-256", "sha-384", "sha-512"})
+```
+
+- [ ] **Step A2.4: Run — expect PASS.**
+
+```bash
+uv run pytest tests/_file_exchange/test_content_digest.py -v
+```
+
+- [ ] **Step A2.5: Lint + commit.**
+
+```bash
+uv run ruff format .
+uv run ruff check src tests
+uv run mypy src
+git add src/fastmcp_pvl_core/_file_exchange/_content_digest.py \
+        tests/_file_exchange/test_content_digest.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): _content_digest.py skeleton + SUPPORTED_ALGORITHMS (#146)
+
+Container module for the upload route's Content-Digest parse + policy
+layers. This commit lands the docstring + the supported-algorithm
+frozenset; parse_header, satisfies_requirement, and format_header
+land in subsequent commits per the TDD micro-cycle.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task A3 — `parse_header` happy path (single supported entry)
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_content_digest.py`
+- Modify: `tests/_file_exchange/test_content_digest.py`
+
+- [ ] **Step A3.1: Write the failing test.**
+
+Append to `tests/_file_exchange/test_content_digest.py`:
+
+```python
+def test_parse_header_single_sha256_entry():
+    payload = b"hello"
+    raw = hashlib.sha256(payload).digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    parsed = _content_digest.parse_header(f"sha-256=:{b64}:")
+    assert parsed == ("sha-256", raw)
+```
+
+- [ ] **Step A3.2: Run — expect AttributeError.**
+
+```bash
+uv run pytest tests/_file_exchange/test_content_digest.py::test_parse_header_single_sha256_entry -v
+```
+
+- [ ] **Step A3.3: Implement the minimal happy path.**
+
+Append to `src/fastmcp_pvl_core/_file_exchange/_content_digest.py`:
+
+```python
+from collections.abc import Iterable
+
+import http_sf
+
+
+def parse_header(
+    header: str, *, preferred: Iterable[str] | None = None
+) -> tuple[str, bytes] | None:
+    """Parse a Content-Digest header into ``(algo, raw_digest_bytes)``.
+
+    Returns ``None`` if the header is empty, malformed at the RFC 8941
+    layer, or contains no supported algorithm. Otherwise returns the
+    first supported entry, preferring ``preferred`` algorithms (if any
+    are present and parse) and falling back to the first supported
+    entry the dictionary lists.
+
+    Unsupported algorithms within a multi-algorithm dictionary are
+    silently skipped (RFC 9530 §3 MUST-ignore). Parameter dictionaries
+    on entries (``algo=:bytes:;p=v``) are accepted and ignored.
+    """
+    if not header:
+        return None
+    try:
+        parsed = http_sf.parse(header.encode("ascii"), tltype="dictionary")
+    except Exception:
+        return None
+    preferred_set = (
+        {p.strip().lower() for p in preferred} if preferred else None
+    )
+    fallback: tuple[str, bytes] | None = None
+    for raw_label, (value, _params) in parsed.items():
+        label = raw_label.lower()
+        if label not in SUPPORTED_ALGORITHMS:
+            continue
+        if not isinstance(value, bytes):
+            continue
+        if preferred_set is not None and label in preferred_set:
+            return label, value
+        if fallback is None:
+            fallback = (label, value)
+    return fallback
+```
+
+- [ ] **Step A3.4: Run — expect PASS.**
+
+```bash
+uv run pytest tests/_file_exchange/test_content_digest.py -v
+```
+Expected: both tests pass.
+
+- [ ] **Step A3.5: Commit.**
+
+```bash
+uv run ruff format .
+uv run ruff check src tests
+uv run mypy src
+git add src/fastmcp_pvl_core/_file_exchange/_content_digest.py \
+        tests/_file_exchange/test_content_digest.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): _content_digest.parse_header — single-entry happy path (#146)
+
+Delegates RFC 8941 parsing to http_sf; layered policy (supported-algo
+filter, preferred-algo preference, fallback to first supported)
+implemented as a thin loop. The function's full edge surface lands in
+subsequent commits one matrix row at a time.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task A4 — `parse_header` edge surface (every prior route-level finding)
+
+For each sub-step below: add the test, run it (expect PASS since the implementation from Task A3 already covers each edge structurally), and commit. The discipline is to **prove** each historical finding is covered, not to add code that no test exercises.
+
+**Files:** `tests/_file_exchange/test_content_digest.py` only.
+
+- [ ] **Step A4.1: Empty header → None.**
+
+```python
+def test_parse_header_empty_returns_none():
+    assert _content_digest.parse_header("") is None
+```
+
+- [ ] **Step A4.2: Malformed (StructuredFieldError) → None.**
+
+```python
+def test_parse_header_malformed_returns_none():
+    assert _content_digest.parse_header("not a structured field!!!") is None
+```
+
+- [ ] **Step A4.3: All-unsupported dictionary → None.**
+
+```python
+def test_parse_header_all_unsupported_returns_none():
+    assert (
+        _content_digest.parse_header("md5=:YWJjZA==:, sha-3=:YWJjZA==:")
+        is None
+    )
+```
+
+- [ ] **Step A4.4: Skip unsupported, return supported (RFC 9530 §3 MUST-ignore).**
+
+```python
+def test_parse_header_skips_unsupported_takes_supported():
+    raw = hashlib.sha256(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    parsed = _content_digest.parse_header(f"md5=:YWJjZA==:, sha-256=:{b64}:")
+    assert parsed == ("sha-256", raw)
+```
+
+- [ ] **Step A4.5: SF parameters on entry are ignored.**
+
+```python
+def test_parse_header_ignores_sf_parameters():
+    raw = hashlib.sha256(b"hello").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    parsed = _content_digest.parse_header(f"sha-256=:{b64}:;foo=bar;baz=42")
+    assert parsed == ("sha-256", raw)
+```
+
+- [ ] **Step A4.6: Case folding on the algorithm label.**
+
+```python
+def test_parse_header_lowercases_algorithm_label():
+    raw = hashlib.sha256(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    parsed = _content_digest.parse_header(f"SHA-256=:{b64}:")
+    # Note: http_sf normalizes keys per RFC 8941 (lowercase); we still
+    # apply .lower() defensively so the post-condition is pinned here.
+    assert parsed == ("sha-256", raw)
+```
+
+**Verify expected outcome first:** RFC 8941 §3.2 says dictionary keys are lcalpha — `http_sf.parse` will raise `StructuredFieldError` on `SHA-256` (uppercase). If the test reports `None` rather than `("sha-256", raw)`, that is acceptable behaviour (the wire format rejects uppercase keys; the route then returns 400). In that case, rewrite the assertion to:
+
+```python
+    # Per RFC 8941 dictionary keys are lcalpha; uppercase is rejected at
+    # the wire layer (http_sf raises StructuredFieldError -> None). Pin
+    # the rejection rather than the case-folding behaviour.
+    assert parsed is None
+```
+
+Run the test against the implementation; choose whichever assertion matches the library's actual behaviour and commit that one.
+
+- [ ] **Step A4.7: Whitespace tolerance.**
+
+```python
+def test_parse_header_tolerates_optional_whitespace():
+    raw = hashlib.sha256(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    # OWS around the equals sign and the colon framing.
+    parsed = _content_digest.parse_header(f"sha-256= :{b64}:")
+    assert parsed == ("sha-256", raw)
+```
+
+(If this also reports `None`, then OWS around `=` is rejected by the library; rewrite the test docstring to pin the rejection, same as A4.6.)
+
+- [ ] **Step A4.8: Multi-supported dictionary, no `preferred` → first entry.**
+
+```python
+def test_parse_header_multi_supported_no_preferred_returns_first():
+    raw256 = hashlib.sha256(b"x").digest()
+    raw512 = hashlib.sha512(b"x").digest()
+    b256 = base64.b64encode(raw256).decode("ascii")
+    b512 = base64.b64encode(raw512).decode("ascii")
+    parsed = _content_digest.parse_header(f"sha-256=:{b256}:, sha-512=:{b512}:")
+    assert parsed == ("sha-256", raw256)
+```
+
+- [ ] **Step A4.9: Multi-supported, `preferred=["sha-256"]` with sha-512 listed first → sha-256 selected.**
+
+```python
+def test_parse_header_preferred_overrides_order():
+    raw256 = hashlib.sha256(b"x").digest()
+    raw512 = hashlib.sha512(b"x").digest()
+    b256 = base64.b64encode(raw256).decode("ascii")
+    b512 = base64.b64encode(raw512).decode("ascii")
+    parsed = _content_digest.parse_header(
+        f"sha-512=:{b512}:, sha-256=:{b256}:", preferred=["sha-256"]
+    )
+    assert parsed == ("sha-256", raw256)
+```
+
+- [ ] **Step A4.10: Fallback when no `preferred` entry is present.**
+
+```python
+def test_parse_header_preferred_absent_falls_back_to_first_supported():
+    raw512 = hashlib.sha512(b"x").digest()
+    b512 = base64.b64encode(raw512).decode("ascii")
+    parsed = _content_digest.parse_header(
+        f"sha-512=:{b512}:", preferred=["sha-256"]
+    )
+    assert parsed == ("sha-512", raw512)
+```
+
+- [ ] **Step A4.11: `preferred` case-insensitive.**
+
+```python
+def test_parse_header_preferred_is_case_insensitive():
+    raw = hashlib.sha256(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    parsed = _content_digest.parse_header(
+        f"sha-512=:{base64.b64encode(hashlib.sha512(b'x').digest()).decode('ascii')}:, "
+        f"sha-256=:{b64}:",
+        preferred=["SHA-256"],
+    )
+    assert parsed == ("sha-256", raw)
+```
+
+- [ ] **Step A4.12: Commit (one commit for the whole edge sweep).**
+
+```bash
+uv run pytest tests/_file_exchange/test_content_digest.py -v
+uv run ruff format .
+uv run ruff check src tests
+uv run mypy src
+git add tests/_file_exchange/test_content_digest.py
+git commit -m "$(cat <<'EOF'
+test(file-exchange): pin parse_header edges against historical findings (#146)
+
+Add contract tests for every edge that previously surfaced as a
+route-level bug on PR #169:
+
+- empty header / malformed input -> None
+- all-unsupported algorithms -> None
+- skip-unsupported-take-supported (RFC 9530 §3 MUST-ignore)
+- SF parameters on entries are ignored (RFC 8941 §3.2)
+- algorithm-label case behaviour (library rejects uppercase per
+  RFC 8941 lcalpha; pinned with whichever observable behaviour
+  http_sf actually produces)
+- whitespace handling (same library-defers note)
+- multi-supported dictionary fallback when no preferred is given
+- preferred=[algo] overrides dictionary entry order
+- preferred case-insensitive matching
+- fallback to first supported when preferred not present
+
+These tests are the contract slice 3's route can rely on without
+re-deriving the parsing rules.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task A5 — `satisfies_requirement`
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_content_digest.py`
+- Modify: `tests/_file_exchange/test_content_digest.py`
+
+- [ ] **Step A5.1: Write failing tests.**
+
+```python
+def test_satisfies_requirement_none_is_always_true():
+    assert _content_digest.satisfies_requirement("sha-256", None) is True
+    assert _content_digest.satisfies_requirement("anything", None) is True
+
+
+def test_satisfies_requirement_empty_is_always_true():
+    assert _content_digest.satisfies_requirement("sha-256", []) is True
+
+
+def test_satisfies_requirement_exact_match():
+    assert (
+        _content_digest.satisfies_requirement("sha-256", ["sha-256"]) is True
+    )
+
+
+def test_satisfies_requirement_case_insensitive():
+    assert (
+        _content_digest.satisfies_requirement("sha-256", ["SHA-256"]) is True
+    )
+    assert (
+        _content_digest.satisfies_requirement("SHA-256", ["sha-256"]) is True
+    )
+
+
+def test_satisfies_requirement_not_in_list():
+    assert (
+        _content_digest.satisfies_requirement("sha-512", ["sha-256"]) is False
+    )
+
+
+def test_satisfies_requirement_normalises_whitespace_in_required():
+    assert (
+        _content_digest.satisfies_requirement("sha-256", [" sha-256 "])
+        is True
+    )
+```
+
+- [ ] **Step A5.2: Run — expect failure.**
+
+- [ ] **Step A5.3: Implement.**
+
+Append to `_content_digest.py`:
+
+```python
+def satisfies_requirement(
+    algo: str, required: Iterable[str] | None
+) -> bool:
+    """Case-insensitive: does ``algo`` appear in ``required``?
+
+    ``required=None`` or empty means no constraint — always True.
+    ``algo`` and the ``required`` entries are compared after
+    ``str.strip().lower()`` normalisation, so callers can pass an
+    unvalidated wire-derived list without pre-normalising.
+    """
+    if not required:
+        return True
+    needle = algo.strip().lower()
+    return needle in {r.strip().lower() for r in required}
+```
+
+- [ ] **Step A5.4: Run — expect PASS.**
+
+- [ ] **Step A5.5: Commit.**
+
+```bash
+uv run ruff format .
+uv run ruff check src tests
+uv run mypy src
+git add src/fastmcp_pvl_core/_file_exchange/_content_digest.py \
+        tests/_file_exchange/test_content_digest.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): _content_digest.satisfies_requirement (#146)
+
+Pure case-insensitive set-membership check for ArtifactConstraints.
+requireDigest. Both algorithm name and required entries are normalised
+via str.strip().lower() so the route can pass unvalidated wire-derived
+input without pre-normalisation. None / empty list means "no
+constraint, always True".
+
+Replaces the inline lowercased-set-comprehension previously living in
+the route handler.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task A6 — `format_header`
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_content_digest.py`
+- Modify: `tests/_file_exchange/test_content_digest.py`
+
+- [ ] **Step A6.1: Write failing test.**
+
+```python
+def test_format_header_round_trips_via_parse():
+    raw = hashlib.sha256(b"hello world").digest()
+    header = _content_digest.format_header("sha-256", raw)
+    parsed = _content_digest.parse_header(header)
+    assert parsed == ("sha-256", raw)
+
+
+def test_format_header_shape_matches_rfc_9530():
+    raw = hashlib.sha256(b"x").digest()
+    header = _content_digest.format_header("sha-256", raw)
+    expected = "sha-256=:" + base64.b64encode(raw).decode("ascii") + ":"
+    assert header == expected
+```
+
+- [ ] **Step A6.2: Run — expect failure.**
+
+- [ ] **Step A6.3: Implement.**
+
+Append to `_content_digest.py`:
+
+```python
+def format_header(algo: str, raw: bytes) -> str:
+    """Serialise ``(algo, raw)`` as an RFC 9530 Content-Digest value.
+
+    Delegates to http_sf.ser_dictionary for the canonical RFC 8941
+    form. ``algo`` is the lowercase algorithm label
+    (``sha-256``/``sha-384``/``sha-512``); ``raw`` is the digest bytes.
+    """
+    return http_sf.ser_dictionary({algo: (raw, {})})
+```
+
+- [ ] **Step A6.4: Run — expect PASS.**
+
+If `test_format_header_shape_matches_rfc_9530` fails because `http_sf.ser_dictionary` adds optional whitespace (it shouldn't, but check the library output empirically), adjust the test to a `parse_header` round-trip plus an `assert "=" in header and ":" in header` shape check rather than an exact-string equality. Prefer keeping the exact-string assertion because it pins the canonical form.
+
+- [ ] **Step A6.5: Commit.**
+
+```bash
+uv run ruff format .
+uv run ruff check src tests
+uv run mypy src
+git add src/fastmcp_pvl_core/_file_exchange/_content_digest.py \
+        tests/_file_exchange/test_content_digest.py
+git commit -m "$(cat <<'EOF'
+feat(file-exchange): _content_digest.format_header (#146)
+
+RFC 9530 Content-Digest serialiser via http_sf.ser_dictionary.
+Round-trips with parse_header. Used by the upload sender (slice 5) to
+attach Content-Digest to outgoing PUTs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task A7 — Multi-Python sanity + push + open PR-A
+
+- [ ] **Step A7.1: Run all checks on min + max Python.**
+
+```bash
+uv run pytest tests/_file_exchange -q
+uv run --python 3.10 pytest tests/_file_exchange -q
+uv run --python 3.13 pytest tests/_file_exchange -q
+uv run ruff format --check .
+uv run ruff check src tests
+uv run mypy src
+```
+
+Every command must succeed. Expected file-exchange suite count: previous baseline (~558) + the new `test_content_digest.py` count.
+
+- [ ] **Step A7.2: Push the branch.**
+
+```bash
+git push -u origin feat/146-content-digest-module
+```
+
+- [ ] **Step A7.3: Open PR-A.**
+
+```bash
+gh pr create --title "feat(file-exchange): _content_digest.py + http-sf dependency (#146)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Root-cause response to the ≥12-finding cluster on PR #169 / #173 / #174 (closed). Introduces a new pure-function module \`_content_digest.py\` wrapping the [\`http-sf\`](https://pypi.org/project/http-sf/) library (Mark Nottingham's RFC 8941 reference implementation, pure-Python, zero transitive deps) plus a comprehensive contract-test suite covering every Content-Digest edge previously surfaced as a route-level bug.
+
+The route itself is untouched — the new module sits unused after this PR. **PR-B** (rebased slice 3 / #169) deletes the hand-rolled parser and migrates the route to call into this module.
+
+## Design
+
+\`docs/superpowers/specs/2026-05-28-content-digest-restructure.md\` — 4-layer architecture (library handles RFC 8941 grammar; \`_content_digest.py\` owns algorithm selection + requireDigest membership; the route still owns bytes verification because that's tied to the staging temp-file lifecycle).
+
+## Surface added
+
+- \`_content_digest.SUPPORTED_ALGORITHMS\` — frozenset of algorithm labels pvl-core supports
+- \`_content_digest.parse_header(header, *, preferred=None) -> (algo, bytes) | None\` — RFC 9530 §3 MUST-ignore semantics; honours \`preferred=\`; falls back to first supported entry
+- \`_content_digest.satisfies_requirement(algo, required) -> bool\` — case-insensitive membership against \`ArtifactConstraints.requireDigest\`
+- \`_content_digest.format_header(algo, raw) -> str\` — RFC 9530 serialiser via \`http_sf.ser_dictionary\`
+
+## Test plan
+
+- [x] \`uv run pytest tests/_file_exchange\` — 558 baseline + N new \`test_content_digest.py\` tests, all green
+- [x] \`uv run --python 3.10 pytest tests/_file_exchange\` — green
+- [x] \`uv run --python 3.13 pytest tests/_file_exchange\` — green
+- [x] \`uv run ruff format --check .\` clean
+- [x] \`uv run ruff check src tests\` clean
+- [x] \`uv run mypy src\` — no issues
+
+Refs #146, PR #169 (paused pending this).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## PR-B — Slice 3 (#169) rebase + route migration onto PR-A
+
+Branch: existing `feat/146-upload-route` (PR #169), rebased onto PR-A's branch. Per the spec, this PR replaces #169's current hand-rolled parser with calls into `_content_digest.py` and moves `_rehash_file` to `_staging.py`.
+
+This whole PR is one logical change ("migrate the route to the new module") and a single commit is acceptable, since the existing PR #169 commits already provide the route's matrix-row coverage — the migration is mechanical.
+
+### Task B1 — Rebase the branch onto PR-A's tip
+
+- [ ] **Step B1.1: Sync local main.**
+
+```bash
+git checkout main
+git pull --ff-only
+```
+
+- [ ] **Step B1.2: Fetch PR-A's branch tip.**
+
+If PR-A is not yet merged: rebase onto its branch tip.
+
+```bash
+git fetch origin feat/146-content-digest-module
+git checkout feat/146-upload-route
+```
+
+If PR-A is already merged: rebase onto main.
+
+- [ ] **Step B1.3: Rebase.**
+
+Identify the last commit on `feat/146-upload-route` that was a slice-3 commit (not a slice-2-duplicate). Use the same `git rebase --onto` pattern we used in prior slice rebases:
+
+```bash
+# If PR-A is unmerged: target is origin/feat/146-content-digest-module
+git rebase --onto origin/feat/146-content-digest-module \
+    <last-slice-2-commit-on-branch> feat/146-upload-route
+# Or if PR-A is merged into main:
+git rebase --onto origin/main <last-slice-2-commit-on-branch> feat/146-upload-route
+```
+
+Resolve any conflicts in `_upload.py` / `_content_digest.py` (none expected since PR-A added only new files).
+
+- [ ] **Step B1.4: Verify the rebase is clean.**
+
+```bash
+git log --oneline main..HEAD | head -20
+uv run pytest tests/_file_exchange -q
+```
+
+All existing route tests must still pass before the migration commit lands.
+
+### Task B2 — Move `_rehash_file` to `_staging.py`
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_staging.py`
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+
+- [ ] **Step B2.1: Cut + paste the function.**
+
+In `src/fastmcp_pvl_core/_file_exchange/_upload.py`, find the `_rehash_file` definition (currently above `register_upload_route`) and copy its full body. Delete it from `_upload.py`.
+
+Append the body to `src/fastmcp_pvl_core/_file_exchange/_staging.py` after `_write_chunk`:
+
+```python
+def _rehash_file(path: str, hashlib_name: str) -> bytes:
+    """Synchronously compute ``hashlib_name``'s digest of the file at ``path``.
+
+    Designed to be called via a single ``asyncio.to_thread`` dispatch
+    from the upload route's non-sha-256 verify branch — the entire
+    open + chunked-read + close runs in one worker thread rather than
+    spawning a thread per chunk.
+    """
+    h = hashlib.new(hashlib_name)
+    with open(path, "rb") as fh:
+        while True:
+            buf = fh.read(_CHUNK)
+            if not buf:
+                break
+            h.update(buf)
+    return h.digest()
+```
+
+- [ ] **Step B2.2: Update the route's call site to import from `_staging`.**
+
+In `src/fastmcp_pvl_core/_file_exchange/_upload.py`, update the `_staging` import block (already imports `_CHUNK`, `_HASHLIB_BY_LABEL`, `_write_chunk`) to also include `_rehash_file`:
+
+```python
+from fastmcp_pvl_core._file_exchange._staging import (
+    _CHUNK,
+    _HASHLIB_BY_LABEL,
+    _rehash_file,
+    _write_chunk,
+)
+```
+
+- [ ] **Step B2.3: Run tests — expect PASS (no behaviour change).**
+
+```bash
+uv run pytest tests/_file_exchange/test_upload_route.py tests/_file_exchange/test_staging.py -v
+```
+
+- [ ] **Step B2.4: Add a `_staging.py` unit test for `_rehash_file`.**
+
+The function previously had no direct test (route-level tests covered it transitively). Move that coverage onto the module itself:
+
+```python
+# Append to tests/_file_exchange/test_staging.py
+def test_rehash_file_sha384(tmp_path):
+    payload = b"the rehash helper now lives in _staging"
+    target = tmp_path / "blob"
+    target.write_bytes(payload)
+    import hashlib
+    expected = hashlib.sha384(payload).digest()
+    assert _staging._rehash_file(str(target), "sha384") == expected
+
+
+def test_rehash_file_sha512(tmp_path):
+    payload = b"x" * (3 * _staging._CHUNK + 7)  # multiple chunks + tail
+    target = tmp_path / "blob"
+    target.write_bytes(payload)
+    import hashlib
+    expected = hashlib.sha512(payload).digest()
+    assert _staging._rehash_file(str(target), "sha512") == expected
+```
+
+(Adjust `import hashlib` if `test_staging.py` already imports it; deduplicate.)
+
+- [ ] **Step B2.5: Run, lint, type-check, commit.**
+
+```bash
+uv run pytest tests/_file_exchange -q
+uv run ruff format .
+uv run ruff check src tests
+uv run mypy src
+git add src/fastmcp_pvl_core/_file_exchange/_staging.py \
+        src/fastmcp_pvl_core/_file_exchange/_upload.py \
+        tests/_file_exchange/test_staging.py
+git commit -m "$(cat <<'EOF'
+refactor(file-exchange): move _rehash_file to _staging.py (#146)
+
+The rehash helper is a chunk-read primitive that fits naturally
+alongside _write_chunk in _staging.py. The route imports it from
+there; no behaviour change. Two direct unit tests (sha-384,
+sha-512 across multiple chunks + tail) move the coverage onto
+the module itself rather than relying on the route's transitive
+exercise.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task B3 — Migrate the route to use `_content_digest`
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+
+- [ ] **Step B3.1: Delete the hand-rolled helpers.**
+
+In `src/fastmcp_pvl_core/_file_exchange/_upload.py`:
+
+1. Delete the `_content_digest_parse` function (the one with the `preferred=` kwarg).
+2. Delete the `_content_digest_format` function.
+3. Delete the unused imports they pulled in:
+   - `import base64 as _b64`
+   - `import binascii`
+   
+   (Keep `import hashlib` — the streaming hasher still uses it.)
+4. Delete the module-docstring inventory bullets for those two helpers.
+
+- [ ] **Step B3.2: Add the new module import.**
+
+Add to `_upload.py`'s import block:
+
+```python
+from fastmcp_pvl_core._file_exchange import _content_digest
+```
+
+(Place it alphabetically among the other `from fastmcp_pvl_core._file_exchange._foo import ...` lines — likely between `_codes` and `_errors`.)
+
+- [ ] **Step B3.3: Migrate the route's parse + selection + requirement-check branch.**
+
+Find the route handler's Content-Digest verification block (currently uses `_content_digest_parse(cd_header, preferred=required)` and the inline lowercase-set comprehension). Replace with:
+
+```python
+            cd_header = request.headers.get("content-digest")
+            required = expected.requireDigest if expected is not None else None
+            if cd_header is not None:
+                parsed = _content_digest.parse_header(
+                    cd_header, preferred=required
+                )
+                if parsed is None:
+                    return Response(status_code=400)
+                cd_algo, cd_raw = parsed
+                if not _content_digest.satisfies_requirement(cd_algo, required):
+                    # The parser tried ``preferred=required`` first, so
+                    # arriving here means the client's header contained no
+                    # entry whose algorithm is in ``required`` — only a
+                    # fallback entry in a non-required algorithm.
+                    return Response(status_code=400)
+                if cd_algo == "sha-256":
+                    if hasher.digest() != cd_raw:
+                        return Response(status_code=400)
+                else:
+                    try:
+                        rehash_digest = await asyncio.to_thread(
+                            _rehash_file, tmp_path, _HASHLIB_BY_LABEL[cd_algo]
+                        )
+                    except OSError:
+                        logger.exception(
+                            "file-exchange: upload rehash read failed"
+                        )
+                        return Response(status_code=500)
+                    if rehash_digest != cd_raw:
+                        return Response(status_code=400)
+            elif required is not None:
+                return Response(status_code=400)
+```
+
+The verify-against-bytes branch (sha-256 streaming compare; sha-384/512 rehash) stays inline because it's tied to the staging temp-file lifecycle.
+
+- [ ] **Step B3.4: Update the module docstring inventory.**
+
+Replace the previous \``_content_digest_parse` / `_content_digest_format` / `_media_range_matches`\` bullet with:
+
+```
+- ``_media_range_matches`` — RFC 7231 §3.1.1.1 media-range matcher
+  used by the route to enforce ``acceptMimeTypes``. (The Content-Digest
+  parse + policy lives in :mod:`._content_digest`.)
+```
+
+- [ ] **Step B3.5: Run tests — expect PASS.**
+
+```bash
+uv run pytest tests/_file_exchange/test_upload_route.py -v
+```
+
+Every existing route-level test must still pass — the migration is behaviour-preserving by design (`_content_digest.parse_header` + `satisfies_requirement` together produce the same observable contract as the prior hand-rolled `_content_digest_parse` + inline set check).
+
+If any test fails, the most likely cause is a behaviour drift at the parser boundary (whitespace handling, malformed-input semantics). Fix by reading the test's docstring (every route test names its matrix row) and adjusting the call site, not by re-introducing hand-rolled parsing.
+
+- [ ] **Step B3.6: Lint, type-check, commit.**
+
+```bash
+uv run ruff format .
+uv run ruff check src tests
+uv run mypy src
+git add src/fastmcp_pvl_core/_file_exchange/_upload.py
+git commit -m "$(cat <<'EOF'
+refactor(file-exchange): route uses _content_digest module (#146)
+
+Replace the hand-rolled RFC 8941 parser + inline requirement-set
+comprehension in the upload route handler with calls to
+_content_digest.parse_header and _content_digest.satisfies_requirement.
+
+Deletes _content_digest_parse and _content_digest_format from
+_upload.py (and their now-unused base64/binascii imports) — those
+edges are now contract-tested in tests/_file_exchange/test_content_digest.py
+rather than scattered across the route's tests.
+
+Bytes verification (sha-256 streaming compare; non-sha-256 rehash via
+_rehash_file) stays inline in the route — it's tied to the staging
+temp-file lifecycle.
+
+Closes the root-cause restructure tracked in
+docs/superpowers/specs/2026-05-28-content-digest-restructure.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task B4 — Trim the now-redundant tests + verify on 3.10/3.13
+
+**Files:**
+- Modify: `tests/_file_exchange/test_upload_helpers.py`
+
+The previous Content-Digest tests in `test_upload_helpers.py` exercised the deleted hand-rolled parser. The equivalent contract is now in `test_content_digest.py` (Task A4). Trim `test_upload_helpers.py` so it covers only its remaining concern (`_media_range_matches`).
+
+- [ ] **Step B4.1: Delete the Content-Digest test block.**
+
+In `tests/_file_exchange/test_upload_helpers.py`, delete every test whose name starts with `test_content_digest_*` and `test_content_digest_format_round_trips`. Keep:
+
+- `test_media_range_matches_table` (parametrised)
+
+Update the module docstring to reflect the narrower scope:
+
+```python
+"""Matrix rows F3, F4: ``_media_range_matches`` (RFC 7231 §3.1.1.1).
+
+Content-Digest helper tests moved to ``test_content_digest.py`` when
+the parse + policy was extracted from ``_upload.py`` into
+``_content_digest.py``.
+"""
+```
+
+Drop unused imports (`base64`, `hashlib`, etc.) that the Content-Digest tests used; keep `pytest`.
+
+Also remove the `_content_digest_parse` / `_content_digest_format` names from the import block at the top of the file.
+
+- [ ] **Step B4.2: Verify nothing else imports the deleted names.**
+
+```bash
+grep -rn "_content_digest_parse\|_content_digest_format" src tests
+```
+
+Expected: zero matches (every consumer now goes through `_content_digest.parse_header` / `_content_digest.format_header`).
+
+- [ ] **Step B4.3: Run all checks on min + max Python.**
+
+```bash
+uv run pytest tests/_file_exchange -q
+uv run --python 3.10 pytest tests/_file_exchange -q
+uv run --python 3.13 pytest tests/_file_exchange -q
+uv run ruff format --check .
+uv run ruff check src tests
+uv run mypy src
+```
+
+- [ ] **Step B4.4: Commit.**
+
+```bash
+git add tests/_file_exchange/test_upload_helpers.py
+git commit -m "$(cat <<'EOF'
+test(file-exchange): trim test_upload_helpers.py to media-range only (#146)
+
+The Content-Digest tests in this file exercised the hand-rolled parser
+that was just removed. The equivalent contract is now in
+test_content_digest.py. _media_range_matches (RFC 7231) is unrelated
+and stays.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task B5 — Force-push slice 3 and flip back to ready
+
+- [ ] **Step B5.1: Force-push.**
+
+```bash
+git push --force-with-lease origin feat/146-upload-route
+```
+
+- [ ] **Step B5.2: Flip PR #169 back to ready and post the diagnosis-resolved comment.**
+
+```bash
+gh pr ready 169
+gh pr comment 169 --body "$(cat <<'EOF'
+## Restructure complete; flipping back to ready
+
+The digest-pipeline restructure landed across two PRs as planned:
+
+- **PR-A** (\`feat/146-content-digest-module\` / #<NUMBER>) added the new \`_content_digest.py\` module wrapping http-sf, plus a contract-test suite covering every prior route-level edge.
+- **PR-B** (this branch, rebased): deleted the hand-rolled \`_content_digest_parse\` / \`_content_digest_format\`; moved \`_rehash_file\` to \`_staging.py\`; route now orchestrates \`parse_header\` + \`satisfies_requirement\` + the existing verify-against-bytes branch.
+
+Every prior route test still passes. The matrix's row count for slice 3 is unchanged. The Content-Digest edge surface that produced ≥12 findings over three review rounds is now contract-tested at the module level, with the route's role narrowed to orchestration.
+
+The wire-spec gap that surfaced as PR #174 (\`requireDigest=[""]\`) is tracked separately at [\`pvliesdonk/mcp-file-exchange-ext#16\`](https://github.com/pvliesdonk/mcp-file-exchange-ext/issues/16); pvl-core does not fork the vendored spec.
+EOF
+)"
+```
+
+Replace `<NUMBER>` with PR-A's actual number once it's opened.
+
+---
+
+## PR-C / PR-D — Rebase slices 4 + 5 mechanically
+
+After PR-B is up to date with the rewritten slice 3:
+
+- [ ] **Step C1: Rebase #170 onto the new slice 3.**
+
+```bash
+git checkout feat/146-cross-transport-registrar
+git fetch origin feat/146-upload-route
+git rebase --onto feat/146-upload-route <last-slice-3-commit> \
+    feat/146-cross-transport-registrar
+uv run pytest tests/_file_exchange -q
+git push --force-with-lease
+```
+
+`<last-slice-3-commit>` is the slice-3 head on the slice-4 branch *before* the rebase (use `git log --oneline feat/146-cross-transport-registrar ^feat/146-upload-route | tail -1`'s parent).
+
+- [ ] **Step D1: Rebase #171 onto the new slice 4.**
+
+```bash
+git checkout feat/146-sender-e2e
+git rebase --onto feat/146-cross-transport-registrar <last-slice-4-commit> \
+    feat/146-sender-e2e
+uv run pytest tests/_file_exchange -q
+uv run --python 3.13 pytest tests/_file_exchange -q
+uv run mypy src
+git push --force-with-lease
+```
+
+No code changes expected — the sender (slice 5) imports `_content_digest.format_header` from the new module; it was always going to use that name once the module landed, so this is a mechanical update of the import and the call site.
+
+Actually, the sender on slice 5 currently calls `_content_digest_format` (the deleted hand-rolled helper). The rebase will conflict on the sender's body. Resolve by updating the call:
+
+```python
+cd_header = _content_digest.format_header("sha-256", hasher.digest())
+```
+
+(Add the `from fastmcp_pvl_core._file_exchange import _content_digest` import to `_upload.py` if not already present from PR-B's rebase.)
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| Architecture: 4 layers | Task A2–A6 (layers 1–3); Task B3 (layer 4 orchestration) |
+| `_content_digest.py` module creation | Task A2 (skeleton), A3–A4 (`parse_header`), A5 (`satisfies_requirement`), A6 (`format_header`) |
+| `_staging.py` extension (`_rehash_file`) | Task B2 |
+| `_upload.py` simplification | Task B3 (delete hand-rolled helpers + migrate route), Task B4 (trim helper tests) |
+| `test_content_digest.py` contract tests | Task A4 (every prior route-level finding has a row) |
+| `test_upload_helpers.py` shrunk | Task B4 |
+| `http-sf` dependency | Task A1 |
+| Two-PR shape | PR-A: A1–A7; PR-B: B1–B5 |
+| Slices 4 + 5 mechanical rebase | PR-C / PR-D |
+| Wire-format discipline (no schema edits) | No task touches `_schema/file-exchange.json` — explicit by omission. |
+
+**Placeholder scan:** One conditional in Task A4.6/A4.7 ("if the test reports None, rewrite the assertion to..."). This is intentional — the http_sf library's exact case-folding and OWS behaviour at the dictionary-key layer needs empirical verification at implementation time, and the test should pin whichever behaviour actually fires. The plan provides both forms of the assertion concretely. Not a TBD; a conditional with both branches spelled out.
+
+**Type consistency:** `parse_header` returns `tuple[str, bytes] | None` everywhere it's used (A3, A4, B3). `satisfies_requirement` returns `bool` everywhere (A5, B3). `format_header` returns `str` everywhere (A6, slice 5 rebase). `_rehash_file` returns `bytes` everywhere (B2, B3).
+
+`SUPPORTED_ALGORITHMS` is a `frozenset[str]` containing lowercase labels (`"sha-256"`, `"sha-384"`, `"sha-512"`) — every test and call site matches.
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-28-content-digest-restructure.md`.**
+
+Two execution options:
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — execute tasks in this session with `superpowers:executing-plans`, batch with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-28-content-digest-restructure.md
+++ b/docs/superpowers/specs/2026-05-28-content-digest-restructure.md
@@ -186,7 +186,8 @@ Two PRs in sequence, then the existing slice chain rebases:
   - OWS around `=` within a dictionary entry → **rejected** by `http_sf` per
     strict RFC 8941 grammar (pinned in `test_parse_header_ows_around_equals_rejected`).
   - Malformed base64 → `None`.
-  - Case folding: `SHA-256=:...:` → lowercase label returned.
+  - Uppercase algorithm label (`SHA-256=:...:`) → **rejected** by `http_sf`
+    per RFC 8941 lcalpha (pinned in `test_parse_header_uppercase_label_rejected`).
   - `satisfies_requirement` with `required=None`, empty list, uppercase, mixed case.
   - `format_header` round-trips through `parse_header`.
 - Does NOT touch `_upload.py` yet — keeps the diff narrow and reviewable.

--- a/docs/superpowers/specs/2026-05-28-content-digest-restructure.md
+++ b/docs/superpowers/specs/2026-05-28-content-digest-restructure.md
@@ -182,7 +182,9 @@ Two PRs in sequence, then the existing slice chain rebases:
   - Unsupported algorithm + supported algorithm → supported returned.
   - All unsupported → `None`.
   - SF parameters on the entry (`sha-256=:b64:;foo=bar`) → ignored, entry still parses.
-  - Whitespace around `=` and `,` → tolerated.
+  - OWS around `,` between dictionary entries → tolerated (RFC 8941 grammar).
+  - OWS around `=` within a dictionary entry → **rejected** by `http_sf` per
+    strict RFC 8941 grammar (pinned in `test_parse_header_ows_around_equals_rejected`).
   - Malformed base64 → `None`.
   - Case folding: `SHA-256=:...:` → lowercase label returned.
   - `satisfies_requirement` with `required=None`, empty list, uppercase, mixed case.

--- a/docs/superpowers/specs/2026-05-28-content-digest-restructure.md
+++ b/docs/superpowers/specs/2026-05-28-content-digest-restructure.md
@@ -1,0 +1,264 @@
+# Content-Digest pipeline restructure (root-cause response to #169 finding cluster)
+
+> **Status:** Design record. Process artifact for the in-flight #146
+> chain (slice 3 / PR #169 was paused to address this).
+
+## Why this design exists
+
+Across rounds 1–3 of bot review on PR #169 plus the post-merge passes on
+#167 / #168 / #173 / the closed #174, the same area produced ≥12 findings:
+
+| Cluster | Findings |
+|---|---|
+| **Hand-rolled SF parser edges** | RFC 8941 SF-parameter handling; multi-algorithm entry ordering; case-insensitivity of algorithm labels; whitespace tolerance; base64 validation |
+| **Policy layered on parser** | `requireDigest` case sensitivity; `requireDigest=[""]` Pydantic/route drift; parser fallback semantics; caller-site rejection logic split between parser and route |
+| **Coverage gaps in the verify branch** | `_rehash_file` happy path; non-sha-256 mismatch; consume-after-store observability |
+| **Cross-source drift** | Schema vs. Pydantic vs. route logic disagreements ("triple source of truth"); the closed #174 attempt to tighten Pydantic beyond the vendored spec |
+
+That cluster size is exactly the signal `CLAUDE.md`'s Test-driven discipline
+section names: *"the moment you notice multiple defects pointing at the
+same underlying design hole, that is the signal."* Continuing to apply
+findings one-by-one is the whack-a-mole the discipline exists to prevent.
+
+The root cause is **a hand-rolled RFC 8941 / 9530 parser interleaved with
+`requireDigest`-policy and bytes-verification concerns in a single
+function**. The library handles the parsing grammar perfectly; the policy
+is small but currently shares its module and its tests with the parser.
+Each spec edge has been discovered as a route-level bug rather than a
+parser-level contract.
+
+## Architecture: four layers, library handles layer 1
+
+| Layer | Concern | Where it lives |
+|---|---|---|
+| 1. SF parsing | RFC 8941 grammar — dictionary, item parameters, byte-sequence framing, whitespace, case | [`http-sf`](https://pypi.org/project/http-sf/) library (`http_sf.parse(header, tltype="dictionary")`) |
+| 2. Algorithm selection | Filter parsed dictionary to supported algorithms; honour caller's `preferred=` list; fall back to first supported when no preferred is present | `_content_digest.py` — `parse_header` |
+| 3. Requirement membership | Case-insensitive set check: is the selected algorithm in `requireDigest`? | `_content_digest.py` — `satisfies_requirement` |
+| 4. Bytes verification | sha-256: compare against the streaming-hash captured during body read. sha-384/512: rehash from the staged temp file via `_rehash_file`. | Inline in `_upload.py` route handler + `_rehash_file` in `_staging.py` |
+
+Each layer has a single responsibility and a well-defined input/output
+contract. The route handler is then a thin orchestrator:
+
+```
+cd_entry = parse_header(cd_header, preferred=required)   # layer 1+2
+if cd_entry is None:
+    return 400
+algo, raw = cd_entry
+if not satisfies_requirement(algo, required):            # layer 3
+    return 400
+if not verify_against_bytes(algo, raw, hasher, tmp_path):  # layer 4
+    return 400
+```
+
+## Module layout
+
+### New: `src/fastmcp_pvl_core/_file_exchange/_content_digest.py`
+
+```python
+"""RFC 9530 Content-Digest header parser + policy helpers.
+
+Parsing delegates to the http_sf library (RFC 8941 Structured Fields);
+this module adds the spec-9530 policy layered on top: which algorithms
+pvl-core supports, how a multi-algorithm dictionary is reduced to a
+single selected entry, and whether a selected entry satisfies a
+receiver's ``requireDigest`` constraint.
+
+Bytes verification (computing or rehashing the body's digest) is NOT
+in this module — that's the route's concern because it owns the
+staging temp-file lifecycle.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import http_sf
+
+SUPPORTED_ALGORITHMS = frozenset({"sha-256", "sha-384", "sha-512"})
+
+
+def parse_header(
+    header: str, *, preferred: Iterable[str] | None = None
+) -> tuple[str, bytes] | None:
+    """Parse a Content-Digest header into ``(algo, raw_digest_bytes)``.
+
+    RFC 9530 §3 MUST-ignore: unsupported algorithms are skipped, not
+    rejected. ``preferred`` (if given) is the caller's algorithm
+    preference list — a matching entry is returned in preference to any
+    other supported entry. When no preferred entry is present (or no
+    ``preferred`` was given), the first supported well-formed entry is
+    returned. ``None`` only when the dictionary parses but contains no
+    supported entry, or when the header value is malformed at the
+    RFC 8941 layer.
+
+    Parameter dictionaries on entries (``algo=:bytes:;p=v``) are accepted
+    and ignored per RFC 9530 §3.
+    """
+    ...
+
+
+def satisfies_requirement(algo: str, required: Iterable[str] | None) -> bool:
+    """Case-insensitive membership: does ``algo`` appear in ``required``?
+
+    ``required=None`` or empty means no constraint — always True.
+    ``algo`` and the ``required`` entries are compared after
+    ``str.strip().lower()`` normalisation (RFC-aligned: algorithm labels
+    are case-insensitive in the structured-fields grammar).
+    """
+    ...
+
+
+def format_header(algo: str, raw: bytes) -> str:
+    """Serialise ``(algo, raw)`` to a Content-Digest header value.
+
+    Delegates to http_sf to produce the canonical RFC 8941 form.
+    """
+    ...
+```
+
+### Extended: `src/fastmcp_pvl_core/_file_exchange/_staging.py`
+
+Add `_rehash_file` (currently in `_upload.py`):
+
+```python
+def _rehash_file(path: str, hashlib_name: str) -> bytes:
+    """Synchronously compute ``hashlib_name``'s digest of the file at ``path``.
+
+    Designed to be called via a single ``asyncio.to_thread`` dispatch
+    from the route's non-sha-256 verify branch (the entire open + chunked
+    read + close runs in one worker thread).
+    """
+    ...
+```
+
+### Simplified: `src/fastmcp_pvl_core/_file_exchange/_upload.py`
+
+Delete:
+- `_content_digest_parse` (replaced by `_content_digest.parse_header`)
+- `_content_digest_format` (replaced by `_content_digest.format_header`)
+- The inline `_rehash_file` (moved to `_staging.py`)
+- The route's lowercase-`required`-set comprehension (moved to `satisfies_requirement`)
+
+Keep:
+- `UPLOAD_PREFIX`, `_UPLOAD_METHOD` constants
+- `upload_receiver_mint`
+- `_media_range_matches` (RFC 7231, separate concern)
+- The route handler, simplified to orchestrate the four layers
+- `upload_sender_consume` (slice 5 — uses `_content_digest.format_header`)
+
+### Tests
+
+- **New:** `tests/_file_exchange/test_content_digest.py` — exhaustive contract tests for `parse_header`, `satisfies_requirement`, `format_header`. Tests include every spec edge previously found as a route-level bug.
+- **Shrunk:** `tests/_file_exchange/test_upload_helpers.py` — keeps only the `_media_range_matches` table.
+- **Unchanged behaviour:** `tests/_file_exchange/test_upload_route.py` — every existing route-level test continues to pass; only the function names invoked inside the route change.
+
+## Dependency: `http-sf`
+
+- Package: [`http-sf`](https://pypi.org/project/http-sf/) on PyPI.
+- Upstream: github.com/mnot/http-sf (Mark Nottingham, IETF HTTPbis editor).
+- Pure-Python; no transitive deps.
+- Python ≥ 3.8 supported (pvl-core targets 3.10+, well above).
+- Minimum version: pin to whatever currently exposes the `tltype="dictionary"` form. Resolve concretely during PR-A.
+
+The lock-in risk is low: the library wraps an IETF Proposed Standard that
+is itself frozen, and the surface we touch (`parse(bytes, tltype="dictionary")`
++ `serialize(dict, tltype="dictionary")`) is the textbook RFC 8941 entry point.
+If the library is ever removed from PyPI, swapping back to a hand-rolled
+parser is a one-module change because the policy layers stay put.
+
+## PR shape
+
+Two PRs in sequence, then the existing slice chain rebases:
+
+### PR-A — new, against `main`
+
+- Add `http-sf>=<min>` to `pyproject.toml`'s runtime deps.
+- Create `_content_digest.py` with the three functions above.
+- Create `tests/_file_exchange/test_content_digest.py` with comprehensive contract tests including every prior route-level edge:
+  - Empty header → `None`.
+  - Single supported algorithm, well-formed → returns it.
+  - Multiple supported algorithms, no `preferred` → first one.
+  - Multiple supported, `preferred=["sha-256"]` with sha-256 second → sha-256 returned.
+  - Unsupported algorithm + supported algorithm → supported returned.
+  - All unsupported → `None`.
+  - SF parameters on the entry (`sha-256=:b64:;foo=bar`) → ignored, entry still parses.
+  - Whitespace around `=` and `,` → tolerated.
+  - Malformed base64 → `None`.
+  - Case folding: `SHA-256=:...:` → lowercase label returned.
+  - `satisfies_requirement` with `required=None`, empty list, uppercase, mixed case.
+  - `format_header` round-trips through `parse_header`.
+- Does NOT touch `_upload.py` yet — keeps the diff narrow and reviewable.
+- After merge: pvl-core has the new module sitting unused, with full test
+  coverage. PR-B then wires it in.
+
+### PR-B — rebase of slice 3 (#169) on top of PR-A
+
+- Delete `_content_digest_parse`, `_content_digest_format` from `_upload.py`.
+- Move `_rehash_file` from `_upload.py` to `_staging.py`; update the route's call site.
+- Route handler: replace the hand-rolled parse with
+  `parse_header(cd_header, preferred=required)`; replace the inline
+  set-comprehension with `satisfies_requirement(cd_algo, required)`.
+- Delete tests that lived on the hand-rolled parser
+  (`test_upload_helpers.py`'s Content-Digest section); the same edges
+  are now covered in `test_content_digest.py` (PR-A).
+- `test_upload_route.py` tests stay — they're route-level and orchestration-level, exactly what should still be route-tested.
+
+### PR-C / PR-D — rebase of #170 and #171
+
+Mechanical rebases on the new slice 3. They don't touch the digest path
+directly (slice 4 is the cross-transport registrar; slice 5 is the sender,
+which uses `format_header`).
+
+## Error handling
+
+- `_content_digest.parse_header` catches every exception `http_sf.parse`
+  can raise (the library raises `ValueError` for malformed input;
+  catching broadly so a library version bump's new exception type
+  doesn't change pvl-core's observable behaviour) and returns `None`.
+  The route treats `None` as `400 digest-mismatch`, matching today.
+- `satisfies_requirement` is pure; cannot fail.
+- `format_header` round-trips known-supported input; we never feed it
+  arbitrary algorithm names, so it cannot fail in practice.
+- The route's existing `ArtifactConstraints.model_validate` try/except
+  (slice 3's existing fix) is unchanged.
+
+## Spec / vendoring discipline
+
+This restructure does NOT change any wire format. The vendored
+`_schema/file-exchange.json` is untouched. The `requireDigest=[""]`
+finding from PR #174 was correctly identified as a wire-spec gap rather
+than a pvl-core bug — tracked separately as
+[`pvliesdonk/mcp-file-exchange-ext#16`](https://github.com/pvliesdonk/mcp-file-exchange-ext/issues/16)
+proposing `minLength: 1` on `requireDigest` items for v0.2 of the spec.
+When that lands, pvl-core re-pins and the constraint comes through the
+schema correctly. Until then, the route's policy layer naturally rejects
+`[""]` because `""` is not in `SUPPORTED_ALGORITHMS`.
+
+## What this restructure does NOT address
+
+Two outstanding cross-transport questions remain open and are
+intentionally out of scope here:
+
+1. **Per-chunk `asyncio.to_thread` vs. accumulated-buffer writes.** Both
+   download and upload do per-chunk `to_thread` dispatch — the symmetry is
+   intentional but the buffering trade-off was discussed during spec
+   brainstorm and may want revisiting. Track as a separate issue against
+   both data planes.
+2. **Schema vs. Pydantic vs. route triple-source drift.** Beyond
+   `requireDigest`, other wire fields may have similar drift. A separate
+   audit pass against the merged data planes (download + upload) is
+   warranted once #146 is fully landed.
+
+Both are listed in the EPIC #138 issue map's "out of scope" tracker.
+
+## References
+
+- Bot finding patterns: PR #169 comments rounds 1–3; PR #173 (merged);
+  PR #174 (closed for forking vendored spec).
+- Memory `feedback_three_abandons_means_scope.md` — informs the
+  "stop and design" choice over another iteration round.
+- CLAUDE.md — "Test-driven discipline" section's design-revision rule;
+  "Spec docs are protocol extensions, not design docs" section's
+  vendoring discipline.
+- RFC 8941 (Structured Fields), RFC 9530 (Digest Fields, in particular
+  §3 MUST-ignore semantics), RFC 7231 §3.1.1.1 (media-range — unaffected).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ authors = [{name = "Peter van Liesdonk", email = "peter@liesdonk.nl"}]
 requires-python = ">=3.10"
 dependencies = [
   "fastmcp>=3.3.1,<4",
+  # http-sf is Mark Nottingham's RFC 8941 Structured Fields reference
+  # implementation (pure-Python, no transitive runtime deps). Used by
+  # the content-digest module to parse/serialise Content-Digest headers.
+  "http-sf>=1.3",
   # httpx is used by the remote-auth provider (`_auth.py`) to fetch the
   # OIDC discovery document at startup. Kept as a hard dependency; the
   # `remote-auth` extra is retained as a backwards-compat no-op.

--- a/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 import http_sf
+from http_sf.dictionary import ser_dictionary as _ser_dictionary
 
 SUPPORTED_ALGORITHMS = frozenset({"sha-256", "sha-384", "sha-512"})
 
@@ -73,3 +74,13 @@ def satisfies_requirement(algo: str, required: Iterable[str] | None) -> bool:
         return True
     needle = algo.strip().lower()
     return needle in {r.strip().lower() for r in required}
+
+
+def format_header(algo: str, raw: bytes) -> str:
+    """Serialise ``(algo, raw)`` as an RFC 9530 Content-Digest value.
+
+    Delegates to http_sf.ser_dictionary for the canonical RFC 8941
+    form. ``algo`` is the lowercase algorithm label
+    (``sha-256``/``sha-384``/``sha-512``); ``raw`` is the digest bytes.
+    """
+    return _ser_dictionary({algo: (raw, {})})

--- a/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
@@ -16,6 +16,11 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 import http_sf
+
+# http_sf re-exports ``ser_dictionary`` into its package namespace but does
+# not list it in ``__all__``, so mypy refuses ``http_sf.ser_dictionary(...)``.
+# The submodule path is the cleanest mypy-clean alternative; revisit on any
+# http-sf upgrade in case a public serialiser surfaces upstream.
 from http_sf.dictionary import ser_dictionary as _ser_dictionary
 
 SUPPORTED_ALGORITHMS = frozenset({"sha-256", "sha-384", "sha-512"})
@@ -46,11 +51,15 @@ def parse_header(
         return None
     preferred_set = {p.strip().lower() for p in preferred} if preferred else None
     fallback: tuple[str, bytes] | None = None
-    for raw_label, entry in parsed.items():
+    for label, entry in parsed.items():
+        # http_sf enforces RFC 8941 lcalpha at parse time, so ``label`` is
+        # already lowercase; SUPPORTED_ALGORITHMS membership is the only check
+        # we need. The runtime narrowing on ``entry`` guards against
+        # pathological return shapes from a future library version, not
+        # against well-formed RFC 8941 input.
         if not (isinstance(entry, tuple) and len(entry) == 2):
             continue
         value, _params = entry
-        label = raw_label.lower()
         if label not in SUPPORTED_ALGORITHMS:
             continue
         if not isinstance(value, bytes):

--- a/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
@@ -1,0 +1,16 @@
+"""RFC 9530 Content-Digest header parser + policy helpers.
+
+Parsing delegates to the ``http_sf`` library (RFC 8941 Structured
+Fields); this module adds the spec-9530 policy layered on top:
+which algorithms pvl-core supports, how a multi-algorithm dictionary
+is reduced to a single selected entry, and whether a selected entry
+satisfies a receiver's ``requireDigest`` constraint.
+
+Bytes verification (computing or rehashing the body's digest) is NOT
+in this module — that's the route's concern because it owns the
+staging temp-file lifecycle.
+"""
+
+from __future__ import annotations
+
+SUPPORTED_ALGORITHMS = frozenset({"sha-256", "sha-384", "sha-512"})

--- a/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
@@ -59,3 +59,17 @@ def parse_header(
         if fallback is None:
             fallback = (label, value)
     return fallback
+
+
+def satisfies_requirement(algo: str, required: Iterable[str] | None) -> bool:
+    """Case-insensitive: does ``algo`` appear in ``required``?
+
+    ``required=None`` or empty means no constraint — always True.
+    ``algo`` and the ``required`` entries are compared after
+    ``str.strip().lower()`` normalisation, so callers can pass an
+    unvalidated wire-derived list without pre-normalising.
+    """
+    if not required:
+        return True
+    needle = algo.strip().lower()
+    return needle in {r.strip().lower() for r in required}

--- a/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
@@ -18,11 +18,11 @@ from typing import Literal
 
 import http_sf
 
-# http_sf re-exports ``ser_dictionary`` into its package namespace but does
-# not list it in ``__all__``, so mypy refuses ``http_sf.ser_dictionary(...)``.
-# The submodule path is the cleanest mypy-clean alternative; revisit on any
-# http-sf upgrade in case a public serialiser surfaces upstream.
-from http_sf.dictionary import ser_dictionary as _ser_dictionary
+# ``ser_dictionary`` is re-exported into the ``http_sf`` package namespace
+# but omitted from ``__all__``, so mypy refuses the bare attribute access.
+# The ``type: ignore`` is the conventional fix; revisit on any http-sf
+# upgrade in case a public serialiser surfaces upstream.
+from http_sf import ser_dictionary as _ser_dictionary  # type: ignore[attr-defined]
 
 SUPPORTED_ALGORITHMS = frozenset({"sha-256", "sha-384", "sha-512"})
 

--- a/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
@@ -13,4 +13,49 @@ staging temp-file lifecycle.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
+import http_sf
+
 SUPPORTED_ALGORITHMS = frozenset({"sha-256", "sha-384", "sha-512"})
+
+
+def parse_header(
+    header: str, *, preferred: Iterable[str] | None = None
+) -> tuple[str, bytes] | None:
+    """Parse a Content-Digest header into ``(algo, raw_digest_bytes)``.
+
+    Returns ``None`` if the header is empty, malformed at the RFC 8941
+    layer, or contains no supported algorithm. Otherwise returns the
+    first supported entry, preferring ``preferred`` algorithms (if any
+    are present and parse) and falling back to the first supported
+    entry the dictionary lists.
+
+    Unsupported algorithms within a multi-algorithm dictionary are
+    silently skipped (RFC 9530 §3 MUST-ignore). Parameter dictionaries
+    on entries (``algo=:bytes:;p=v``) are accepted and ignored.
+    """
+    if not header:
+        return None
+    try:
+        parsed = http_sf.parse(header.encode("ascii"), tltype="dictionary")
+    except Exception:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    preferred_set = {p.strip().lower() for p in preferred} if preferred else None
+    fallback: tuple[str, bytes] | None = None
+    for raw_label, entry in parsed.items():
+        if not (isinstance(entry, tuple) and len(entry) == 2):
+            continue
+        value, _params = entry
+        label = raw_label.lower()
+        if label not in SUPPORTED_ALGORITHMS:
+            continue
+        if not isinstance(value, bytes):
+            continue
+        if preferred_set is not None and label in preferred_set:
+            return label, value
+        if fallback is None:
+            fallback = (label, value)
+    return fallback

--- a/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
+++ b/src/fastmcp_pvl_core/_file_exchange/_content_digest.py
@@ -14,6 +14,7 @@ staging temp-file lifecycle.
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Literal
 
 import http_sf
 
@@ -36,6 +37,14 @@ def parse_header(
     first supported entry, preferring ``preferred`` algorithms (if any
     are present and parse) and falling back to the first supported
     entry the dictionary lists.
+
+    ``preferred`` is treated as an **unordered set** ("any preferred
+    algorithm beats any non-preferred one"); when more than one
+    preferred algorithm is present in the header, the tie-break follows
+    header dictionary order. This matches the wire-spec semantic of
+    ``ArtifactConstraints.requireDigest`` (§7.4), which lists accepted
+    algorithms without implying priority. A future caller that wants
+    true priority-order selection would need a separate parameter.
 
     Unsupported algorithms within a multi-algorithm dictionary are
     silently skipped (RFC 9530 §3 MUST-ignore). Parameter dictionaries
@@ -85,11 +94,16 @@ def satisfies_requirement(algo: str, required: Iterable[str] | None) -> bool:
     return needle in {r.strip().lower() for r in required}
 
 
-def format_header(algo: str, raw: bytes) -> str:
+def format_header(algo: Literal["sha-256", "sha-384", "sha-512"], raw: bytes) -> str:
     """Serialise ``(algo, raw)`` as an RFC 9530 Content-Digest value.
 
-    Delegates to http_sf.ser_dictionary for the canonical RFC 8941
-    form. ``algo`` is the lowercase algorithm label
-    (``sha-256``/``sha-384``/``sha-512``); ``raw`` is the digest bytes.
+    Delegates to ``http_sf.ser_dictionary`` for the canonical RFC 8941
+    form. ``algo`` is constrained at type-check time to the lowercase
+    labels in :data:`SUPPORTED_ALGORITHMS`; ``raw`` is the digest bytes.
+
+    The ``Literal`` type annotation is load-bearing: ``ser_dictionary``
+    enforces RFC 8941 lcalpha at serialisation time and raises on any
+    other key. Callers must pass a literal from the supported set;
+    pvl-core never reaches this function with a non-literal algo.
     """
     return _ser_dictionary({algo: (raw, {})})

--- a/tests/_file_exchange/test_content_digest.py
+++ b/tests/_file_exchange/test_content_digest.py
@@ -5,6 +5,9 @@ gets its own test here so the route layer can rely on the contract
 without re-deriving it.
 """
 
+import base64
+import hashlib
+
 from fastmcp_pvl_core._file_exchange import _content_digest
 
 
@@ -12,3 +15,11 @@ def test_supported_algorithms_set():
     assert _content_digest.SUPPORTED_ALGORITHMS == frozenset(
         {"sha-256", "sha-384", "sha-512"}
     )
+
+
+def test_parse_header_single_sha256_entry():
+    payload = b"hello"
+    raw = hashlib.sha256(payload).digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    parsed = _content_digest.parse_header(f"sha-256=:{b64}:")
+    assert parsed == ("sha-256", raw)

--- a/tests/_file_exchange/test_content_digest.py
+++ b/tests/_file_exchange/test_content_digest.py
@@ -23,3 +23,84 @@ def test_parse_header_single_sha256_entry():
     b64 = base64.b64encode(raw).decode("ascii")
     parsed = _content_digest.parse_header(f"sha-256=:{b64}:")
     assert parsed == ("sha-256", raw)
+
+
+def test_parse_header_empty_returns_none():
+    assert _content_digest.parse_header("") is None
+
+
+def test_parse_header_malformed_returns_none():
+    assert _content_digest.parse_header("not a structured field!!!") is None
+
+
+def test_parse_header_all_unsupported_returns_none():
+    assert _content_digest.parse_header("md5=:YWJjZA==:, sha-3=:YWJjZA==:") is None
+
+
+def test_parse_header_skips_unsupported_takes_supported():
+    raw = hashlib.sha256(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    parsed = _content_digest.parse_header(f"md5=:YWJjZA==:, sha-256=:{b64}:")
+    assert parsed == ("sha-256", raw)
+
+
+def test_parse_header_ignores_sf_parameters():
+    raw = hashlib.sha256(b"hello").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    parsed = _content_digest.parse_header(f"sha-256=:{b64}:;foo=bar;baz=42")
+    assert parsed == ("sha-256", raw)
+
+
+def test_parse_header_uppercase_label_rejected():
+    raw = hashlib.sha256(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    # Per RFC 8941 dictionary keys are lcalpha; uppercase is rejected at
+    # the wire layer (http_sf raises StructuredFieldError -> None). Pin
+    # the rejection rather than the case-folding behaviour.
+    assert _content_digest.parse_header(f"SHA-256=:{b64}:") is None
+
+
+def test_parse_header_ows_around_equals_rejected():
+    raw = hashlib.sha256(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    # http_sf rejects OWS around the `=` per strict RFC 8941 grammar
+    # -> parser returns None.
+    assert _content_digest.parse_header(f"sha-256= :{b64}:") is None
+
+
+def test_parse_header_multi_supported_no_preferred_returns_first():
+    raw256 = hashlib.sha256(b"x").digest()
+    raw512 = hashlib.sha512(b"x").digest()
+    b256 = base64.b64encode(raw256).decode("ascii")
+    b512 = base64.b64encode(raw512).decode("ascii")
+    parsed = _content_digest.parse_header(f"sha-256=:{b256}:, sha-512=:{b512}:")
+    assert parsed == ("sha-256", raw256)
+
+
+def test_parse_header_preferred_overrides_order():
+    raw256 = hashlib.sha256(b"x").digest()
+    raw512 = hashlib.sha512(b"x").digest()
+    b256 = base64.b64encode(raw256).decode("ascii")
+    b512 = base64.b64encode(raw512).decode("ascii")
+    parsed = _content_digest.parse_header(
+        f"sha-512=:{b512}:, sha-256=:{b256}:", preferred=["sha-256"]
+    )
+    assert parsed == ("sha-256", raw256)
+
+
+def test_parse_header_preferred_absent_falls_back_to_first_supported():
+    raw512 = hashlib.sha512(b"x").digest()
+    b512 = base64.b64encode(raw512).decode("ascii")
+    parsed = _content_digest.parse_header(f"sha-512=:{b512}:", preferred=["sha-256"])
+    assert parsed == ("sha-512", raw512)
+
+
+def test_parse_header_preferred_is_case_insensitive():
+    raw = hashlib.sha256(b"x").digest()
+    b64 = base64.b64encode(raw).decode("ascii")
+    parsed = _content_digest.parse_header(
+        f"sha-512=:{base64.b64encode(hashlib.sha512(b'x').digest()).decode('ascii')}:, "
+        f"sha-256=:{b64}:",
+        preferred=["SHA-256"],
+    )
+    assert parsed == ("sha-256", raw)

--- a/tests/_file_exchange/test_content_digest.py
+++ b/tests/_file_exchange/test_content_digest.py
@@ -130,3 +130,17 @@ def test_satisfies_requirement_not_in_list():
 
 def test_satisfies_requirement_normalises_whitespace_in_required():
     assert _content_digest.satisfies_requirement("sha-256", [" sha-256 "]) is True
+
+
+def test_format_header_round_trips_via_parse():
+    raw = hashlib.sha256(b"hello world").digest()
+    header = _content_digest.format_header("sha-256", raw)
+    parsed = _content_digest.parse_header(header)
+    assert parsed == ("sha-256", raw)
+
+
+def test_format_header_shape_matches_rfc_9530():
+    raw = hashlib.sha256(b"x").digest()
+    header = _content_digest.format_header("sha-256", raw)
+    expected = "sha-256=:" + base64.b64encode(raw).decode("ascii") + ":"
+    assert header == expected

--- a/tests/_file_exchange/test_content_digest.py
+++ b/tests/_file_exchange/test_content_digest.py
@@ -33,6 +33,16 @@ def test_parse_header_malformed_returns_none():
     assert _content_digest.parse_header("not a structured field!!!") is None
 
 
+def test_parse_header_malformed_base64_value_returns_none():
+    """A structurally-valid SF dictionary key (sha-256) paired with an
+    invalid byte-sequence payload should produce None — http_sf parses
+    byte-sequences eagerly, so non-base64 inside the `:…:` framing raises
+    at parse time. This is a different failure mode from
+    ``test_parse_header_malformed_returns_none`` (which trips the
+    structured-field grammar itself)."""
+    assert _content_digest.parse_header("sha-256=:not!base64!:") is None
+
+
 def test_parse_header_all_unsupported_returns_none():
     assert _content_digest.parse_header("md5=:YWJjZA==:, sha-3=:YWJjZA==:") is None
 

--- a/tests/_file_exchange/test_content_digest.py
+++ b/tests/_file_exchange/test_content_digest.py
@@ -106,6 +106,31 @@ def test_parse_header_preferred_is_case_insensitive():
     assert parsed == ("sha-256", raw)
 
 
+def test_parse_header_preferred_is_unordered_tie_break_by_header():
+    """When ``preferred`` lists multiple algorithms that the header all
+    advertises, ``preferred`` is treated as an unordered set — the tie-break
+    follows the header's dictionary order, NOT ``preferred``'s argument order.
+    This matches the wire semantic of ``requireDigest`` (a set of accepted
+    algorithms, no priority implied)."""
+    raw256 = hashlib.sha256(b"x").digest()
+    raw512 = hashlib.sha512(b"x").digest()
+    b256 = base64.b64encode(raw256).decode("ascii")
+    b512 = base64.b64encode(raw512).decode("ascii")
+    # ``preferred`` argument lists sha-512 first, but the header lists
+    # sha-256 first; tie-break wins for sha-256.
+    parsed = _content_digest.parse_header(
+        f"sha-256=:{b256}:, sha-512=:{b512}:",
+        preferred=["sha-512", "sha-256"],
+    )
+    assert parsed == ("sha-256", raw256)
+    # Reverse the header order to confirm the tie-break really follows it.
+    parsed = _content_digest.parse_header(
+        f"sha-512=:{b512}:, sha-256=:{b256}:",
+        preferred=["sha-512", "sha-256"],
+    )
+    assert parsed == ("sha-512", raw512)
+
+
 def test_satisfies_requirement_none_is_always_true():
     assert _content_digest.satisfies_requirement("sha-256", None) is True
     assert _content_digest.satisfies_requirement("anything", None) is True
@@ -130,6 +155,19 @@ def test_satisfies_requirement_not_in_list():
 
 def test_satisfies_requirement_normalises_whitespace_in_required():
     assert _content_digest.satisfies_requirement("sha-256", [" sha-256 "]) is True
+
+
+def test_satisfies_requirement_empty_string_entry_returns_false():
+    """An ``ArtifactConstraints.requireDigest=[""]`` wire value is currently
+    accepted by the Pydantic model (``min_length=1`` on the list constrains
+    its length, not its elements) — see ``mcp-file-exchange-ext#16`` for the
+    deferred spec evolution. Until that lands, an empty-string entry is
+    syntactically valid input that no real algorithm can satisfy: the
+    function returns False, and the route's response then becomes 400.
+    Pinned here so a future "treat [\"\"] as no-constraint" change doesn't
+    happen accidentally."""
+    assert _content_digest.satisfies_requirement("sha-256", [""]) is False
+    assert _content_digest.satisfies_requirement("sha-512", [""]) is False
 
 
 def test_format_header_round_trips_via_parse():

--- a/tests/_file_exchange/test_content_digest.py
+++ b/tests/_file_exchange/test_content_digest.py
@@ -1,0 +1,14 @@
+"""Contract tests for the Content-Digest parse + policy module.
+
+Every spec edge previously surfaced as a route-level bug on PR #169
+gets its own test here so the route layer can rely on the contract
+without re-deriving it.
+"""
+
+from fastmcp_pvl_core._file_exchange import _content_digest
+
+
+def test_supported_algorithms_set():
+    assert _content_digest.SUPPORTED_ALGORITHMS == frozenset(
+        {"sha-256", "sha-384", "sha-512"}
+    )

--- a/tests/_file_exchange/test_content_digest.py
+++ b/tests/_file_exchange/test_content_digest.py
@@ -104,3 +104,29 @@ def test_parse_header_preferred_is_case_insensitive():
         preferred=["SHA-256"],
     )
     assert parsed == ("sha-256", raw)
+
+
+def test_satisfies_requirement_none_is_always_true():
+    assert _content_digest.satisfies_requirement("sha-256", None) is True
+    assert _content_digest.satisfies_requirement("anything", None) is True
+
+
+def test_satisfies_requirement_empty_is_always_true():
+    assert _content_digest.satisfies_requirement("sha-256", []) is True
+
+
+def test_satisfies_requirement_exact_match():
+    assert _content_digest.satisfies_requirement("sha-256", ["sha-256"]) is True
+
+
+def test_satisfies_requirement_case_insensitive():
+    assert _content_digest.satisfies_requirement("sha-256", ["SHA-256"]) is True
+    assert _content_digest.satisfies_requirement("SHA-256", ["sha-256"]) is True
+
+
+def test_satisfies_requirement_not_in_list():
+    assert _content_digest.satisfies_requirement("sha-512", ["sha-256"]) is False
+
+
+def test_satisfies_requirement_normalises_whitespace_in_required():
+    assert _content_digest.satisfies_requirement("sha-256", [" sha-256 "]) is True

--- a/uv.lock
+++ b/uv.lock
@@ -834,6 +834,7 @@ version = "3.0.1rc3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "http-sf" },
     { name = "httpx" },
     { name = "jsonschema", extra = ["format-nongpl"] },
     { name = "pydantic" },
@@ -871,6 +872,7 @@ dev = [
 requires-dist = [
     { name = "debugpy", marker = "extra == 'debug'", specifier = ">=1.8" },
     { name = "fastmcp", specifier = ">=3.3.1,<4" },
+    { name = "http-sf", specifier = ">=1.3" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jsonschema", extras = ["format-nongpl"], specifier = ">=4.18" },
     { name = "py-key-value-aio", extras = ["dynamodb"], marker = "extra == 'dynamodb'" },
@@ -1088,6 +1090,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "http-sf"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/aa/2db087c98e3dd52474be6c42fc42d317944a95c9b515d3753442a88358cb/http_sf-1.3.0.tar.gz", hash = "sha256:95c2d0bdc756a61d46ca0993d7225ed6871a9329331b2fbc7a751fa82c62a1b3", size = 23107, upload-time = "2026-05-25T04:20:45.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8f/08d1dd69e8f8115fa95b96ca82ef02c7c6baa1dcd798e896e4926bf6808d/http_sf-1.3.0-py3-none-any.whl", hash = "sha256:2b3e3130bb1b8ec2a2262a4651addff36cc06c05d514564e5fa3a9e500b4cc71", size = 22305, upload-time = "2026-05-25T04:20:43.822Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Root-cause response to the ≥12-finding cluster on PRs #167 / #168 / #169 / #173 / #174 (closed). Introduces a new pure-function module \`_content_digest.py\` wrapping the [\`http-sf\`](https://pypi.org/project/http-sf/) library (Mark Nottingham's RFC 8941 reference implementation, pure-Python) plus a comprehensive contract-test suite covering every Content-Digest edge previously surfaced as a route-level bug.

The route itself is untouched. **PR-B** (rebased slice 3 / #169) will delete the hand-rolled parser and migrate the route to call into this module.

## Design

\`docs/superpowers/specs/2026-05-28-content-digest-restructure.md\` — 4-layer architecture (library handles RFC 8941 grammar; \`_content_digest.py\` owns algorithm selection + requireDigest membership; the route still owns bytes verification because that's tied to the staging temp-file lifecycle).

\`docs/superpowers/plans/2026-05-28-content-digest-restructure.md\` — implementation plan (PR-A as 7 tasks; PR-B as 5).

## Surface added

- \`_content_digest.SUPPORTED_ALGORITHMS\` — frozenset of algorithm labels pvl-core supports (\`sha-256\`, \`sha-384\`, \`sha-512\`).
- \`_content_digest.parse_header(header, *, preferred=None) -> (algo, bytes) | None\` — RFC 9530 §3 MUST-ignore semantics; honours \`preferred=\`; falls back to first supported entry.
- \`_content_digest.satisfies_requirement(algo, required) -> bool\` — case-insensitive membership against \`ArtifactConstraints.requireDigest\`.
- \`_content_digest.format_header(algo, raw) -> str\` — RFC 9530 serialiser via \`http_sf.ser_dictionary\`.

## Edge surface pinned by tests

Every prior route-level finding now has a contract test at the module level:

| Edge | Test |
|---|---|
| Empty / malformed header | \`test_parse_header_empty_returns_none\`, \`..._malformed_returns_none\` |
| All-unsupported algos | \`..._all_unsupported_returns_none\` |
| RFC 9530 §3 MUST-ignore | \`..._skips_unsupported_takes_supported\` |
| RFC 8941 §3.2 params on entries | \`..._ignores_sf_parameters\` |
| Uppercase algorithm label | \`..._uppercase_label_rejected\` (http_sf rejects per lcalpha grammar) |
| OWS around \`=\` | \`..._ows_around_equals_rejected\` (http_sf rejects per strict grammar) |
| Multi-supported, no preferred | \`..._multi_supported_no_preferred_returns_first\` |
| \`preferred=\` overrides order | \`..._preferred_overrides_order\` |
| \`preferred=\` case-insensitive | \`..._preferred_is_case_insensitive\` |
| \`preferred=\` absent → fallback | \`..._preferred_absent_falls_back_to_first_supported\` |
| requireDigest None / empty | \`test_satisfies_requirement_none_is_always_true\`, \`..._empty_..\` |
| requireDigest case-insensitive | \`..._case_insensitive\` |
| requireDigest whitespace | \`..._normalises_whitespace_in_required\` |
| format_header round-trip + RFC 9530 shape | \`test_format_header_round_trips_via_parse\`, \`..._shape_matches_rfc_9530\` |

## Test plan

- [x] \`uv run pytest tests/_file_exchange\` — 615 passed
- [x] \`uv run --python 3.10 pytest tests/_file_exchange\` — 615 passed
- [x] \`uv run --python 3.13 pytest tests/_file_exchange\` — 615 passed
- [x] \`uv run ruff format --check .\` clean
- [x] \`uv run ruff check src tests\` clean
- [x] \`uv run mypy src\` — no issues

Refs #146, PR #169 (paused pending this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)