### PR TITLE
feat(auth): expose full OIDC claims via get_claims()

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -40,7 +40,7 @@ from fastmcp_pvl_core._server_info import (
     UpstreamResult,
     register_server_info_tool,
 )
-from fastmcp_pvl_core._subject import get_subject
+from fastmcp_pvl_core._subject import get_claims, get_subject
 
 __version__ = "3.0.0"  # PSR overrides at build time
 
@@ -67,6 +67,7 @@ __all__ = [
     "compute_app_domain",
     "configure_logging_from_env",
     "env",
+    "get_claims",
     "get_subject",
     "load_acl",
     "make_acl_authorizer",

--- a/src/fastmcp_pvl_core/_subject.py
+++ b/src/fastmcp_pvl_core/_subject.py
@@ -59,6 +59,11 @@ def set_current_auth_mode(mode: AuthMode | None) -> None:
     _current_auth_mode.set(mode)
 
 
+def _extract_claims(access_token: object) -> dict[str, Any]:
+    raw_claims = getattr(access_token, "claims", None)
+    return raw_claims if isinstance(raw_claims, dict) else {}
+
+
 def get_claims() -> dict[str, Any] | None:
     """Return the full claims dict for the current request, or ``None``.
 
@@ -74,8 +79,7 @@ def get_claims() -> dict[str, Any] | None:
     access_token = get_access_token()
     if access_token is None:
         return None
-    raw_claims = getattr(access_token, "claims", None)
-    return raw_claims if isinstance(raw_claims, dict) else {}
+    return _extract_claims(access_token)
 
 
 def get_subject() -> str | None:
@@ -97,7 +101,7 @@ def get_subject() -> str | None:
     access_token = get_access_token()
     if access_token is None:
         return "local" if _current_auth_mode.get() == "none" else None
-    claims = get_claims() or {}
+    claims = _extract_claims(access_token)
     sub = claims.get("sub")
     if isinstance(sub, str) and sub:
         return sub

--- a/src/fastmcp_pvl_core/_subject.py
+++ b/src/fastmcp_pvl_core/_subject.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING
 from fastmcp.server.dependencies import get_access_token
 
 if TYPE_CHECKING:
+    from typing import Any
+
     # Imported only for typing; runtime import would create a cycle
     # (``_auth`` imports ``set_current_auth_mode`` from this module).
     from fastmcp_pvl_core._auth import AuthMode
@@ -57,16 +59,35 @@ def set_current_auth_mode(mode: AuthMode | None) -> None:
     _current_auth_mode.set(mode)
 
 
+def get_claims() -> dict[str, Any] | None:
+    """Return the full claims dict for the current request, or ``None``.
+
+    Returns the raw claims from FastMCP's access token when one is
+    present for the current request. Returns ``{}`` when a token is
+    present but carries no claims. Returns ``None`` when no token is
+    present (regardless of auth mode).
+
+    Downstream callers read whichever standard OIDC claims they need
+    (``name``, ``email``, ``sub``, etc.) without pvl-core knowing which
+    ones matter to their domain.
+    """
+    access_token = get_access_token()
+    if access_token is None:
+        return None
+    raw_claims = getattr(access_token, "claims", None)
+    return raw_claims if isinstance(raw_claims, dict) else {}
+
+
 def get_subject() -> str | None:
     """Return the subject of the current request, or ``None``.
 
     Resolution order:
 
     1. If FastMCP's :func:`get_access_token` returns a token, prefer
-       ``token.claims["sub"]`` (OIDC's standard subject claim); fall
-       back to ``token.client_id`` when ``sub`` is absent or non-string.
-       The builders normalise ``client_id`` per bearer mode (mapped
-       subject for ``bearer-mapped``, ``bearer_default_subject`` for
+       ``claims["sub"]`` (OIDC's standard subject claim); fall back to
+       ``token.client_id`` when ``sub`` is absent or non-string. The
+       builders normalise ``client_id`` per bearer mode (mapped subject
+       for ``bearer-mapped``, ``bearer_default_subject`` for
        ``bearer-single``).
     2. If there is no access token and ``set_current_auth_mode`` was
        called with ``"none"``, return the literal ``"local"``.
@@ -76,8 +97,7 @@ def get_subject() -> str | None:
     access_token = get_access_token()
     if access_token is None:
         return "local" if _current_auth_mode.get() == "none" else None
-    raw_claims = getattr(access_token, "claims", None)
-    claims = raw_claims if isinstance(raw_claims, dict) else {}
+    claims = get_claims() or {}
     sub = claims.get("sub")
     if isinstance(sub, str) and sub:
         return sub

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -17,6 +17,8 @@ from fastmcp_pvl_core import (
     get_subject,
 )
 
+_UNSET = object()
+
 
 class _FakeAccessToken:
     """Minimal stand-in for fastmcp.server.auth.AccessToken."""
@@ -24,10 +26,10 @@ class _FakeAccessToken:
     def __init__(
         self,
         client_id: str | None = None,
-        claims: dict[str, Any] | None = None,
+        claims: object = _UNSET,
     ) -> None:
         self.client_id = client_id
-        self.claims = claims or {}
+        self.claims = {} if claims is _UNSET else claims
 
 
 @pytest.fixture
@@ -194,9 +196,13 @@ class TestGetClaims:
             assert get_claims() == {}
 
     def test_returns_empty_dict_when_claims_field_is_none(self, patch_get_access_token):
-        token = _FakeAccessToken()
-        token.claims = None  # type: ignore[assignment]
-        with patch_get_access_token(token):
+        with patch_get_access_token(_FakeAccessToken(claims=None)):
+            assert get_claims() == {}
+
+    def test_returns_empty_dict_when_claims_field_is_non_dict(
+        self, patch_get_access_token
+    ):
+        with patch_get_access_token(_FakeAccessToken(claims=["unexpected"])):
             assert get_claims() == {}
 
     def test_returns_none_when_no_token_in_auth_mode(self, patch_get_access_token):

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -13,6 +13,7 @@ import pytest
 from fastmcp_pvl_core import (
     ServerConfig,
     build_auth,
+    get_claims,
     get_subject,
 )
 
@@ -180,6 +181,42 @@ class TestExplicitContextIsolation:
 
         assert observed["a"] == "local"
         assert observed["b"] is None
+
+
+class TestGetClaims:
+    def test_returns_claims_dict_when_token_has_claims(self, patch_get_access_token):
+        claims = {"sub": "u1", "name": "Alice", "email": "alice@example.com"}
+        with patch_get_access_token(_FakeAccessToken(claims=claims)):
+            assert get_claims() == claims
+
+    def test_returns_empty_dict_when_token_has_no_claims(self, patch_get_access_token):
+        with patch_get_access_token(_FakeAccessToken(client_id="x", claims={})):
+            assert get_claims() == {}
+
+    def test_returns_empty_dict_when_claims_field_is_none(self, patch_get_access_token):
+        token = _FakeAccessToken()
+        token.claims = None  # type: ignore[assignment]
+        with patch_get_access_token(token):
+            assert get_claims() == {}
+
+    def test_returns_none_when_no_token_in_auth_mode(self, patch_get_access_token):
+        build_auth(ServerConfig(bearer_token="t"))
+        with patch_get_access_token(None):
+            assert get_claims() is None
+
+    def test_returns_none_when_no_token_in_no_auth_mode(self, patch_get_access_token):
+        # Unlike get_subject(), get_claims() always returns None when there is
+        # no token — there are no claims to return regardless of auth mode.
+        build_auth(ServerConfig())
+        with patch_get_access_token(None):
+            assert get_claims() is None
+
+    def test_returns_full_dict_including_non_string_values(
+        self, patch_get_access_token
+    ):
+        claims = {"sub": "u1", "groups": ["admin", "editor"], "exp": 9999999999}
+        with patch_get_access_token(_FakeAccessToken(claims=claims)):
+            assert get_claims() == claims
 
 
 # Note: ``multi`` mode is not exercised here. When a token is present,


### PR DESCRIPTION
## Summary

- Adds `get_claims() -> dict[str, Any] | None` to `_subject.py`, exported from the package root alongside `get_subject()`
- Returns the raw claims dict from the current request's access token; `{}` when the token carries no claims; `None` when no token is present (regardless of auth mode)
- Refactors `get_subject()` to delegate claims extraction to `get_claims()`, removing duplicated `getattr` logic

## Motivation

Downstream servers that want to use standard OIDC claims (`name`, `email`, `given_name`, etc.) had no public surface to read them from — they would have had to reach into fastmcp's `AccessToken` directly. `get_claims()` exposes the full claims dict without pvl-core knowing which ones matter to a given downstream's domain.

Immediate driver: `markdown-vault-mcp` wants to attribute git commits to the real human author (from `claims["name"]` / `claims["email"]`) when multiple users share a vault under OIDC auth — no side-file mapping needed.

## Test plan

- [ ] 6 new `TestGetClaims` cases covering: claims dict returned, empty dict on no claims, empty dict on `None` claims field, `None` on no token (auth mode and no-auth mode), full dict with non-string values
- [ ] All 10 existing `get_subject()` tests continue to pass (refactor regression guard)
- [ ] `uv run pytest` — 389 passed
- [ ] `uv run mypy src` — clean
- [ ] `uv run ruff check . && uv run ruff format --check .` — clean

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)