### PR TITLE
feat(env): public dual-mode numeric env helpers (env_int/env_float)

### DIFF
--- a/docs/superpowers/specs/2026-06-03-env-numeric-helper-design.md
+++ b/docs/superpowers/specs/2026-06-03-env-numeric-helper-design.md
@@ -115,6 +115,26 @@ This is a deliberate **behavior change** — the live scope of #159:
 `port == 0` is rejected: a server *listen* port of 0 (OS-ephemeral) is a
 misconfiguration for an addressable MCP server.
 
+### Versioning (deliberate `feat:`/minor, not breaking)
+
+Although this tightens `from_env`'s PORT handling — malformed input now raises
+`ConfigurationError` (not a bare `ValueError`; note `ConfigurationError` is **not**
+a `ValueError` subclass) and `0`/negative/`>65535` now raise instead of being
+accepted — it ships as a non-breaking **minor** (`feat:`), not a major. Rationale,
+recorded so the choice is visible to review and not a missing-`BREAKING CHANGE`
+oversight:
+
+- The old behaviour was never a documented contract: the bare `int(port_str)`
+  `ValueError` was incidental, and out-of-range acceptance was the latent bug
+  #159 was filed to fix. Tightening validation of *invalid* input is the
+  hardening #159 explicitly asked for, not a redesign of a promised API.
+- The consumers are the coordinated `pvliesdonk/*-mcp` family; none binds a
+  non-`1..65535` PORT. No external contract relies on the old exception type.
+
+This is the maintainer's semver decision. A reviewer (or `python-semantic-release`)
+expecting a `BREAKING CHANGE` marker for an exception-type change should read this
+note as the deliberate, accepted answer rather than an omission.
+
 ### Exports
 
 `env_float`, `env_int` added to `__init__.py` import and `__all__` in alphabetical

--- a/docs/superpowers/specs/2026-06-03-env-numeric-helper-design.md
+++ b/docs/superpowers/specs/2026-06-03-env-numeric-helper-design.md
@@ -70,6 +70,20 @@ silently changing an operator's configured value is a footgun.
 - Soft mode logs the **same message text** at `WARNING` via a module logger
   (`logging.getLogger("fastmcp_pvl_core._env")`), suffixed `— using default <default>`.
 
+### Accept-set (shape decision, recorded during review)
+
+The helpers **delegate to Python's `int()` / `float()`** and accept whatever those
+accept — including PEP 515 underscore separators (`"1_000"` → `1000`), a leading
+sign, and (for `float` only) scientific notation (`"1e3"` → `1000.0`). This is a
+deliberate shape decision: rejecting underscores alone would be incoherent while
+still accepting `1e3`/`+5`/non-ASCII digits, and a true "plain decimal only"
+contract would need a regex for no real benefit (readable large numbers like
+`10_000_000` are a plus for downstream byte/size limits). The accept-set is
+**documented in both docstrings and pinned by characterization tests** so it is an
+explicit, regression-protected contract rather than an implicit consequence of the
+stdlib. `int()`/`float()` reject leading/trailing/doubled underscores themselves,
+so `"_1"` / `"1__0"` are still invalid.
+
 ### Small refactor
 
 Extract `_resolve_key(prefix, name) -> str` (`f"{prefix.rstrip('_')}_{name}"`) and use

--- a/docs/superpowers/specs/2026-06-03-env-numeric-helper-design.md
+++ b/docs/superpowers/specs/2026-06-03-env-numeric-helper-design.md
@@ -56,7 +56,10 @@ raise/warn only fires on malformed-when-set, never on a simply-absent var).
 
 `minimum` / `maximum` are inclusive and **reject** out-of-range values (treated
 identically to malformed: soft warns + default, strict raises). No clamping/coercion —
-silently changing an operator's configured value is a footgun.
+silently changing an operator's configured value is a footgun. The bounds validate the
+**operator's env value only**; the developer-supplied `default` is the trusted fallback
+and is returned as-is (never re-validated against the bounds), consistent with the
+unset path.
 
 ### Errors and messages
 
@@ -76,7 +79,8 @@ The helpers **delegate to Python's `int()` / `float()`** and accept whatever tho
 accept — including PEP 515 underscore separators (`"1_000"` → `1000`), a leading
 sign, and (for `float` only) scientific notation (`"1e3"` → `1000.0`). This is a
 deliberate shape decision: rejecting underscores alone would be incoherent while
-still accepting `1e3`/`+5`/non-ASCII digits, and a true "plain decimal only"
+still accepting `+5`/non-ASCII digits (and, for `float`, `1e3`), and a true "plain
+decimal only"
 contract would need a regex for no real benefit (readable large numbers like
 `10_000_000` are a plus for downstream byte/size limits). The accept-set is
 **documented in both docstrings and pinned by characterization tests** so it is an

--- a/docs/superpowers/specs/2026-06-03-env-numeric-helper-design.md
+++ b/docs/superpowers/specs/2026-06-03-env-numeric-helper-design.md
@@ -1,0 +1,157 @@
+# Design: numeric env helpers (`env_int` / `env_float`)
+
+**Date:** 2026-06-03  
+**Issues:** pvliesdonk/fastmcp-pvl-core#180, #159 (Closes both — see closure note)  
+**Follow-up:** pvliesdonk/fastmcp-pvl-core#181 (`_debug.py` convergence — out of scope here)  
+**Related downstream:** pvliesdonk/markdown-vault-mcp#579 (blocked on this landing + a pvl-core release)
+
+---
+
+## Problem
+
+`fastmcp_pvl_core._env` exposes `env` (read) and `parse_bool` / `parse_list` /
+`parse_scopes` (convert) — but **no numeric parser**. Downstream servers therefore
+hand-roll int/float env parsing per field. `markdown-vault-mcp` does it **nine times
+in two shapes**: *warn-and-fall-back-to-default* (×5) and *parse-or-raise* (×4), most
+with a post-parse bound. pvl-core is the right place to absorb this once, alongside
+the existing `parse_*` family.
+
+## Design
+
+### Shape
+
+Read-and-parse helpers mirroring `env` (not parse-only), because every observed
+consumer reads *and* parses — one call replaces the whole read + `try/except` +
+fallback stanza. No standalone `parse_int` / `parse_float` (YAGNI: no consumer needs
+parse-only today).
+
+```python
+def env_int(prefix, name, default=None, *, strict=False, minimum=None, maximum=None) -> int | None
+def env_float(prefix, name, default=None, *, strict=False, minimum=None, maximum=None) -> float | None
+```
+
+Overloads mirror `env`: `default: int` → returns `int`; `default: None` / omitted →
+returns `int | None` (and likewise `float`).
+
+### Dual mode — one function, `strict=` flag
+
+A single function per type expresses both observed shapes via `strict`. `strict` is a
+per-field **behavioral selector the caller chooses** (like `default`), not a shape
+override and not operator config:
+
+| Input | `strict=False` (soft) | `strict=True` |
+|---|---|---|
+| unset / blank-after-strip | return `default` (silent) | return `default` (silent) |
+| valid & in-bounds | return parsed value | return parsed value |
+| set but non-numeric | `WARNING` + return `default` | raise `ConfigurationError` |
+| out of `[minimum, maximum]` (inclusive) | `WARNING` + return `default` | raise `ConfigurationError` |
+| `env_float` only: `nan` / `±inf` | `WARNING` + return `default` | raise `ConfigurationError` |
+
+The unset/blank case delegates to `env(prefix, name)` (which already strips and treats
+blank as unset), so the numeric helpers never re-implement read/strip semantics. Only a
+**set, non-blank** value is ever parsed; "unset" and "malformed" stay distinct (the
+raise/warn only fires on malformed-when-set, never on a simply-absent var).
+
+### Bounds = reject, never clamp
+
+`minimum` / `maximum` are inclusive and **reject** out-of-range values (treated
+identically to malformed: soft warns + default, strict raises). No clamping/coercion —
+silently changing an operator's configured value is a footgun.
+
+### Errors and messages
+
+- Raise-mode uses **`ConfigurationError`** (the existing operator-visible-misconfig
+  type), consistent with #159 / #161. This is also what lets `from_env` reuse the
+  helper and inherit the better message.
+- Message names the full key and the offending value:
+  - non-numeric: `MYAPP_PORT must be an integer; got 'abc'` (`env_float`: `must be a number`)
+  - non-finite float: `MYAPP_X must be a finite number; got 'inf'`
+  - bound: `MYAPP_PORT must be >= 1; got 0` / `must be <= 65535; got 70000`
+- Soft mode logs the **same message text** at `WARNING` via a module logger
+  (`logging.getLogger("fastmcp_pvl_core._env")`), suffixed `— using default <default>`.
+
+### Small refactor
+
+Extract `_resolve_key(prefix, name) -> str` (`f"{prefix.rstrip('_')}_{name}"`) and use
+it in `env` and the new helpers, so reads and error messages share one
+key-construction rule (no drift, no `MYAPP__PORT` double-underscore).
+
+### `from_env` adoption (in this PR)
+
+`ServerConfig.from_env` has exactly one numeric cast left on `main`
+(`port=int(port_str)`; #159's two file-exchange casts were parked off `main`). Convert it:
+
+```python
+port=env_int(env_prefix, "PORT", 8000, strict=True, minimum=1, maximum=65535),
+```
+
+(The separate `port_str = env(env_prefix, "PORT", "8000")` line is removed.)
+
+This is a deliberate **behavior change** — the live scope of #159:
+
+- malformed `PORT` (e.g. `abc`) → `ConfigurationError` naming the var (was bare
+  `ValueError` from `_config.py`)
+- `PORT` of `0`, `-5`, or `70000` → `ConfigurationError` (were **silently accepted**)
+- `PORT` unset → `8000`; `1` and `65535` accepted (inclusive bounds)
+
+`port == 0` is rejected: a server *listen* port of 0 (OS-ephemeral) is a
+misconfiguration for an addressable MCP server.
+
+### Exports
+
+`env_float`, `env_int` added to `__init__.py` import and `__all__` in alphabetical
+order (between `env` and the `parse_*` block).
+
+### Issue closure note
+
+`Closes #180` **and `Closes #159`**. This **supersedes #159's proposed *private*
+`_parse_int_env` / `_parse_float_env`** with a public, dual-mode helper used internally
+for `port` — #159's only live deliverable (the `port` cast) is satisfied here, and its
+two other casts (file-exchange `token_ttl` / `max_artifact_size`) no longer exist on
+`main` (parked). The PR body notes this supersession so #159's text-vs-reality gap is
+recorded at close time. #161 stays open (its item 2 is an unrelated test tightening).
+
+## Tests (`tests/test_env.py`)
+
+Test-first, one behavior each. `env_int` and `env_float` mirror this list.
+
+| Test | Assertion |
+|---|---|
+| unset → default | var absent → returns `default` (both `strict` values), **no warning logged** |
+| blank → default | `"   "` → returns `default`, no warning (delegates to `env` strip) |
+| valid in-bounds | `"42"` → `42` (`env_float`: `"3.14"` → `3.14`; `"5"` → `5.0`) |
+| whitespace around value | `"  42  "` → `42` |
+| default omitted → None | unset, no `default` arg → `None` |
+| malformed, soft | `"abc"` → returns `default` **and** a `WARNING` is logged naming the key |
+| malformed, strict | `"abc"`, `strict=True` → raises `ConfigurationError`; message contains key + `'abc'` |
+| `env_int` rejects float text | `"42.5"` → invalid (soft default+warn; strict raises) |
+| below minimum, soft | `"0"`, `minimum=1` → `default` + WARNING |
+| below minimum, strict | `"0"`, `minimum=1`, `strict=True` → `ConfigurationError` containing `>= 1` |
+| above maximum, strict | `"70000"`, `maximum=65535`, `strict=True` → `ConfigurationError` containing `<= 65535` |
+| boundary inclusive | `minimum`/`maximum` exactly equal to value → accepted |
+| no bounds set | `minimum=maximum=None` → any parseable value accepted |
+| trailing-underscore prefix | `env_int("MYAPP_", "PORT")` == `env_int("MYAPP", "PORT")`; error key has no `__` |
+| `env_float` non-finite | `"nan"` / `"inf"` / `"-inf"` → invalid (soft default+warn; strict raises `finite`) |
+
+### `from_env` port (config tests)
+
+| Test | Assertion |
+|---|---|
+| unset → 8000 | no `PORT` env → `from_env(...).port == 8000` |
+| valid → parsed | `PORT=9000` → `port == 9000` |
+| malformed → ConfigurationError | `PORT=abc` → raises `ConfigurationError` naming `<PREFIX>_PORT` (not bare `ValueError`) |
+| out of range → ConfigurationError | `PORT=0`, `PORT=70000`, `PORT=-1` each raise `ConfigurationError` |
+| boundary accepted | `PORT=1`, `PORT=65535` → accepted |
+
+Existing `from_env` tests that asserted the old bare-`int()` behavior are updated to the
+new strict contract (not deleted).
+
+## Out of scope
+
+- **`_debug.py` DEBUG_PORT convergence** — second internal soft-mode consumer, but
+  carries a `port == 0`-as-disable sentinel `env_int` doesn't model and would churn the
+  `test_debug.py` hotspot. Tracked as #181.
+- **`parse_int` / `parse_float`** (parse-only) — no consumer needs them; add when one does.
+- **Clamping bounds** — rejected by design (silent value change).
+- **Downstream adoption** (MV's nine stanzas, image-gen's one) — happens per-repo after a
+  pvl-core release.

--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -25,7 +25,14 @@ from fastmcp_pvl_core._authorization import (
 from fastmcp_pvl_core._cli import make_serve_parser, normalise_http_path
 from fastmcp_pvl_core._config import ServerConfig, Transport
 from fastmcp_pvl_core._debug import maybe_start_debugpy
-from fastmcp_pvl_core._env import env, parse_bool, parse_list, parse_scopes
+from fastmcp_pvl_core._env import (
+    env,
+    env_float,
+    env_int,
+    parse_bool,
+    parse_list,
+    parse_scopes,
+)
 from fastmcp_pvl_core._errors import ConfigurationError
 from fastmcp_pvl_core._factory import (
     build_event_store,
@@ -71,6 +78,8 @@ __all__ = [
     "compute_app_domain",
     "configure_logging_from_env",
     "env",
+    "env_float",
+    "env_int",
     "get_claims",
     "get_subject",
     "load_acl",

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from fastmcp_pvl_core._env import env, parse_bool, parse_scopes
+from fastmcp_pvl_core._env import env, env_int, parse_bool, parse_scopes
 
 Transport = Literal["stdio", "http", "sse"]
 
@@ -91,14 +91,21 @@ class ServerConfig:
         """Load all fields from ``{env_prefix}_*`` environment variables.
 
         Unknown values for ``TRANSPORT`` silently fall back to ``"stdio"``
-        rather than raising.  This matches the rest of the env-reading
-        helpers, which prefer permissive defaults over hard failures.
+        rather than raising — string fields prefer permissive defaults.
+        ``PORT``, by contrast, is parsed strictly via :func:`env_int`: a
+        non-integer or out-of-``1..65535`` value raises
+        :class:`ConfigurationError` naming the var, so an operator typo
+        fails fast at load instead of binding an invalid port later.
 
         Args:
             env_prefix: Env var prefix, no trailing underscore needed.
 
         Returns:
             A populated :class:`ServerConfig` instance.
+
+        Raises:
+            ConfigurationError: If ``{env_prefix}_PORT`` is set to a
+                non-integer or out-of-``1..65535`` value.
         """
         transport_raw = env(env_prefix, "TRANSPORT", "stdio")
         transport: Transport
@@ -110,7 +117,6 @@ class ServerConfig:
             transport = "stdio"
 
         host = env(env_prefix, "HOST", "127.0.0.1")
-        port_str = env(env_prefix, "PORT", "8000")
 
         scopes_raw = env(env_prefix, "OIDC_REQUIRED_SCOPES")
         scopes = tuple(parse_scopes(scopes_raw) or ())
@@ -134,7 +140,9 @@ class ServerConfig:
         return cls(
             transport=transport,
             host=host,
-            port=int(port_str),
+            port=env_int(
+                env_prefix, "PORT", 8000, strict=True, minimum=1, maximum=65535
+            ),
             base_url=env(env_prefix, "BASE_URL"),
             bearer_token=env(env_prefix, "BEARER_TOKEN"),
             oidc_config_url=env(env_prefix, "OIDC_CONFIG_URL"),

--- a/src/fastmcp_pvl_core/_env.py
+++ b/src/fastmcp_pvl_core/_env.py
@@ -6,8 +6,21 @@ through :func:`env` to keep naming consistent.
 
 from __future__ import annotations
 
+import logging
+import math
 import os
-from typing import overload
+from typing import TypeVar, overload
+
+from fastmcp_pvl_core._errors import ConfigurationError
+
+logger = logging.getLogger(__name__)
+
+_Number = TypeVar("_Number", int, float)
+
+
+def _resolve_key(prefix: str, name: str) -> str:
+    """Build the ``{PREFIX}_{NAME}`` env var key (trailing ``_`` on prefix optional)."""
+    return f"{prefix.rstrip('_')}_{name}"
 
 
 @overload
@@ -27,12 +40,192 @@ def env(prefix: str, name: str, default: str | None = None) -> str | None:
     Returns:
         The env var value stripped of whitespace, or ``default``.
     """
-    key = f"{prefix.rstrip('_')}_{name}"
+    key = _resolve_key(prefix, name)
     raw = os.environ.get(key)
     if raw is None:
         return default
     value = raw.strip()
     return value or default
+
+
+def _reject(
+    key: str,
+    requirement: str,
+    got: object,
+    *,
+    default: _Number | None,
+    strict: bool,
+) -> _Number | None:
+    """Reject a malformed or out-of-range value.
+
+    In ``strict`` mode raises :class:`ConfigurationError`; otherwise logs a
+    ``WARNING`` and returns *default*.  *requirement* is the human phrase
+    completing ``{KEY} must ...`` (e.g. ``"be an integer"``, ``"be >= 1"``).
+    """
+    message = f"{key} must {requirement}; got {got!r}"
+    if strict:
+        raise ConfigurationError(message)
+    logger.warning("%s — using default %r", message, default)
+    return default
+
+
+def _check_bounds(
+    key: str,
+    value: _Number,
+    *,
+    default: _Number | None,
+    strict: bool,
+    minimum: _Number | None,
+    maximum: _Number | None,
+) -> _Number | None:
+    """Return *value* if within the inclusive bounds, else reject it."""
+    if minimum is not None and value < minimum:
+        return _reject(key, f"be >= {minimum}", value, default=default, strict=strict)
+    if maximum is not None and value > maximum:
+        return _reject(key, f"be <= {maximum}", value, default=default, strict=strict)
+    return value
+
+
+@overload
+def env_int(
+    prefix: str,
+    name: str,
+    *,
+    strict: bool = ...,
+    minimum: int | None = ...,
+    maximum: int | None = ...,
+) -> int | None: ...
+@overload
+def env_int(
+    prefix: str,
+    name: str,
+    default: int,
+    *,
+    strict: bool = ...,
+    minimum: int | None = ...,
+    maximum: int | None = ...,
+) -> int: ...
+@overload
+def env_int(
+    prefix: str,
+    name: str,
+    default: None,
+    *,
+    strict: bool = ...,
+    minimum: int | None = ...,
+    maximum: int | None = ...,
+) -> int | None: ...
+def env_int(
+    prefix: str,
+    name: str,
+    default: int | None = None,
+    *,
+    strict: bool = False,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int | None:
+    """Read ``{PREFIX}_{NAME}`` as an integer, with a default and optional bounds.
+
+    Args:
+        prefix: Env var prefix (trailing underscore optional).
+        name: Variable name (without prefix).
+        default: Returned when the var is unset/blank, and (in soft mode) when
+            the value is invalid.
+        strict: When ``True``, an invalid or out-of-range value raises
+            :class:`ConfigurationError` naming the var.  When ``False`` (the
+            default), it logs a ``WARNING`` and returns *default*.
+        minimum: Inclusive lower bound; values below it are rejected.
+        maximum: Inclusive upper bound; values above it are rejected.
+
+    Returns:
+        The parsed integer, or *default* when unset/blank (or invalid in soft
+        mode).  An unset var never warns or raises.
+    """
+    raw = env(prefix, name)
+    if raw is None:
+        return default
+    key = _resolve_key(prefix, name)
+    try:
+        value = int(raw)
+    except ValueError:
+        return _reject(key, "be an integer", raw, default=default, strict=strict)
+    return _check_bounds(
+        key, value, default=default, strict=strict, minimum=minimum, maximum=maximum
+    )
+
+
+@overload
+def env_float(
+    prefix: str,
+    name: str,
+    *,
+    strict: bool = ...,
+    minimum: float | None = ...,
+    maximum: float | None = ...,
+) -> float | None: ...
+@overload
+def env_float(
+    prefix: str,
+    name: str,
+    default: float,
+    *,
+    strict: bool = ...,
+    minimum: float | None = ...,
+    maximum: float | None = ...,
+) -> float: ...
+@overload
+def env_float(
+    prefix: str,
+    name: str,
+    default: None,
+    *,
+    strict: bool = ...,
+    minimum: float | None = ...,
+    maximum: float | None = ...,
+) -> float | None: ...
+def env_float(
+    prefix: str,
+    name: str,
+    default: float | None = None,
+    *,
+    strict: bool = False,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float | None:
+    """Read ``{PREFIX}_{NAME}`` as a float, with a default and optional bounds.
+
+    Behaves like :func:`env_int` but parses a floating-point value.  Non-finite
+    values (``nan``, ``inf``, ``-inf``) are rejected as invalid, since a config
+    value is expected to be finite.
+
+    Args:
+        prefix: Env var prefix (trailing underscore optional).
+        name: Variable name (without prefix).
+        default: Returned when the var is unset/blank, and (in soft mode) when
+            the value is invalid.
+        strict: When ``True``, an invalid or out-of-range value raises
+            :class:`ConfigurationError` naming the var.  When ``False`` (the
+            default), it logs a ``WARNING`` and returns *default*.
+        minimum: Inclusive lower bound; values below it are rejected.
+        maximum: Inclusive upper bound; values above it are rejected.
+
+    Returns:
+        The parsed float, or *default* when unset/blank (or invalid in soft
+        mode).  An unset var never warns or raises.
+    """
+    raw = env(prefix, name)
+    if raw is None:
+        return default
+    key = _resolve_key(prefix, name)
+    try:
+        value = float(raw)
+    except ValueError:
+        return _reject(key, "be a number", raw, default=default, strict=strict)
+    if not math.isfinite(value):
+        return _reject(key, "be a finite number", raw, default=default, strict=strict)
+    return _check_bounds(
+        key, value, default=default, strict=strict, minimum=minimum, maximum=maximum
+    )
 
 
 def parse_bool(value: str) -> bool:

--- a/src/fastmcp_pvl_core/_env.py
+++ b/src/fastmcp_pvl_core/_env.py
@@ -55,16 +55,20 @@ def _reject(
     *,
     default: _Number | None,
     strict: bool,
+    cause: Exception | None = None,
 ) -> _Number | None:
     """Reject a malformed or out-of-range value.
 
     In ``strict`` mode raises :class:`ConfigurationError`; otherwise logs a
     ``WARNING`` and returns *default*.  *requirement* is the human phrase
     completing ``{KEY} must ...`` (e.g. ``"be an integer"``, ``"be >= 1"``).
+    *cause* is the originating ``ValueError`` on the parse path; it is chained
+    into the raised error (``raise ... from cause``) so the low-level reason
+    stays attached, and is ``None`` on the bounds / non-finite paths.
     """
     message = f"{key} must {requirement}; got {got!r}"
     if strict:
-        raise ConfigurationError(message)
+        raise ConfigurationError(message) from cause
     logger.warning("%s — using default %r", message, default)
     return default
 
@@ -160,8 +164,10 @@ def env_int(
     key = _resolve_key(prefix, name)
     try:
         value = int(raw)
-    except ValueError:
-        return _reject(key, "be an integer", raw, default=default, strict=strict)
+    except ValueError as exc:
+        return _reject(
+            key, "be an integer", raw, default=default, strict=strict, cause=exc
+        )
     return _check_bounds(
         key, value, default=default, strict=strict, minimum=minimum, maximum=maximum
     )
@@ -241,8 +247,10 @@ def env_float(
     key = _resolve_key(prefix, name)
     try:
         value = float(raw)
-    except ValueError:
-        return _reject(key, "be a number", raw, default=default, strict=strict)
+    except ValueError as exc:
+        return _reject(
+            key, "be a number", raw, default=default, strict=strict, cause=exc
+        )
     if not math.isfinite(value):
         return _reject(key, "be a finite number", raw, default=default, strict=strict)
     return _check_bounds(

--- a/src/fastmcp_pvl_core/_env.py
+++ b/src/fastmcp_pvl_core/_env.py
@@ -142,7 +142,10 @@ def env_int(
             default.
         strict: When ``True``, an invalid or out-of-range value raises
             :class:`ConfigurationError` naming the var.  When ``False`` (the
-            default), it logs a ``WARNING`` and returns *default*.
+            default), it logs a ``WARNING`` and returns *default* — which is
+            ``None`` when no default was supplied, so in soft mode an invalid
+            value yields ``None`` (still warned).  Use ``strict=True`` when an
+            invalid value must fail hard rather than degrade to ``None``.
         minimum: Inclusive lower bound; values below it are rejected.
         maximum: Inclusive upper bound; values above it are rejected.
 
@@ -220,7 +223,10 @@ def env_float(
             default.
         strict: When ``True``, an invalid or out-of-range value raises
             :class:`ConfigurationError` naming the var.  When ``False`` (the
-            default), it logs a ``WARNING`` and returns *default*.
+            default), it logs a ``WARNING`` and returns *default* — which is
+            ``None`` when no default was supplied, so in soft mode an invalid
+            value yields ``None`` (still warned).  Use ``strict=True`` when an
+            invalid value must fail hard rather than degrade to ``None``.
         minimum: Inclusive lower bound; values below it are rejected.
         maximum: Inclusive upper bound; values above it are rejected.
 

--- a/src/fastmcp_pvl_core/_env.py
+++ b/src/fastmcp_pvl_core/_env.py
@@ -126,6 +126,12 @@ def env_int(
 ) -> int | None:
     """Read ``{PREFIX}_{NAME}`` as an integer, with a default and optional bounds.
 
+    The value is parsed with Python's :func:`int`, so it accepts the same
+    forms — a leading sign and PEP 515 underscore separators (``"1_000"`` →
+    ``1000``).  A non-integer string is invalid, including a float literal
+    (``"42.5"``) or scientific notation (``"1e3"``); use :func:`env_float`
+    for those.
+
     Args:
         prefix: Env var prefix (trailing underscore optional).
         name: Variable name (without prefix).
@@ -194,9 +200,11 @@ def env_float(
 ) -> float | None:
     """Read ``{PREFIX}_{NAME}`` as a float, with a default and optional bounds.
 
-    Behaves like :func:`env_int` but parses a floating-point value.  Non-finite
-    values (``nan``, ``inf``, ``-inf``) are rejected as invalid, since a config
-    value is expected to be finite.
+    Behaves like :func:`env_int` but parses with Python's :func:`float`, so it
+    accepts the same forms — a leading sign, PEP 515 underscore separators
+    (``"1_000.5"``), and scientific notation (``"1e3"`` → ``1000.0``).
+    Non-finite values (``nan``, ``inf``, ``-inf``) are rejected as invalid,
+    since a config value is expected to be finite.
 
     Args:
         prefix: Env var prefix (trailing underscore optional).

--- a/src/fastmcp_pvl_core/_env.py
+++ b/src/fastmcp_pvl_core/_env.py
@@ -135,8 +135,11 @@ def env_int(
     Args:
         prefix: Env var prefix (trailing underscore optional).
         name: Variable name (without prefix).
-        default: Returned when the var is unset/blank, and (in soft mode) when
-            the value is invalid.
+        default: The trusted fallback, returned **as-is and never itself
+            bounds-checked**, when the var is unset/blank and — in soft mode —
+            when the value is invalid or out of range.  ``minimum``/``maximum``
+            validate the operator's env value, not this developer-supplied
+            default.
         strict: When ``True``, an invalid or out-of-range value raises
             :class:`ConfigurationError` naming the var.  When ``False`` (the
             default), it logs a ``WARNING`` and returns *default*.
@@ -144,8 +147,9 @@ def env_int(
         maximum: Inclusive upper bound; values above it are rejected.
 
     Returns:
-        The parsed integer, or *default* when unset/blank (or invalid in soft
-        mode).  An unset var never warns or raises.
+        The parsed integer, or *default* when unset/blank (or, in soft mode,
+        when the value is invalid or out of range).  An unset var never warns
+        or raises.
     """
     raw = env(prefix, name)
     if raw is None:
@@ -209,8 +213,11 @@ def env_float(
     Args:
         prefix: Env var prefix (trailing underscore optional).
         name: Variable name (without prefix).
-        default: Returned when the var is unset/blank, and (in soft mode) when
-            the value is invalid.
+        default: The trusted fallback, returned **as-is and never itself
+            bounds-checked**, when the var is unset/blank and — in soft mode —
+            when the value is invalid or out of range.  ``minimum``/``maximum``
+            validate the operator's env value, not this developer-supplied
+            default.
         strict: When ``True``, an invalid or out-of-range value raises
             :class:`ConfigurationError` naming the var.  When ``False`` (the
             default), it logs a ``WARNING`` and returns *default*.
@@ -218,8 +225,9 @@ def env_float(
         maximum: Inclusive upper bound; values above it are rejected.
 
     Returns:
-        The parsed float, or *default* when unset/blank (or invalid in soft
-        mode).  An unset var never warns or raises.
+        The parsed float, or *default* when unset/blank (or, in soft mode,
+        when the value is invalid or out of range).  An unset var never warns
+        or raises.
     """
     raw = env(prefix, name)
     if raw is None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from fastmcp_pvl_core import ServerConfig, build_bearer_auth
+from fastmcp_pvl_core import ConfigurationError, ServerConfig, build_bearer_auth
 
 
 class TestServerConfigDefaults:
@@ -59,6 +59,32 @@ class TestServerConfigFromEnv:
         config = ServerConfig.from_env("MYAPP")
         assert config.host == "0.0.0.0"
         assert config.port == 9000
+
+    def test_port_unset_defaults_to_8000(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("MYAPP_PORT", raising=False)
+        assert ServerConfig.from_env("MYAPP").port == 8000
+
+    def test_malformed_port_raises_configuration_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("MYAPP_PORT", "abc")
+        with pytest.raises(ConfigurationError) as exc:
+            ServerConfig.from_env("MYAPP")
+        assert "MYAPP_PORT" in str(exc.value)
+
+    @pytest.mark.parametrize("raw", ["0", "-1", "70000"])
+    def test_out_of_range_port_raises_configuration_error(
+        self, raw: str, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("MYAPP_PORT", raw)
+        with pytest.raises(ConfigurationError) as exc:
+            ServerConfig.from_env("MYAPP")
+        assert "MYAPP_PORT" in str(exc.value)
+
+    @pytest.mark.parametrize("raw", ["1", "65535"])
+    def test_boundary_ports_accepted(self, raw: str, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_PORT", raw)
+        assert ServerConfig.from_env("MYAPP").port == int(raw)
 
     def test_reads_bearer_token(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("MYAPP_BEARER_TOKEN", "secret")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
-from fastmcp_pvl_core import env, parse_bool, parse_list, parse_scopes
+from fastmcp_pvl_core import (
+    ConfigurationError,
+    env,
+    env_float,
+    env_int,
+    parse_bool,
+    parse_list,
+    parse_scopes,
+)
 
 
 class TestEnv:
@@ -28,6 +38,196 @@ class TestEnv:
         monkeypatch.setenv("MYAPP_FOO", "x")
         assert env("MYAPP_", "FOO") == "x"
         assert env("MYAPP", "FOO") == "x"
+
+
+def _warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+class TestEnvInt:
+    def test_unset_returns_default(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("MYAPP_N", raising=False)
+        assert env_int("MYAPP", "N", 8000) == 8000
+
+    def test_unset_without_default_returns_none(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("MYAPP_N", raising=False)
+        assert env_int("MYAPP", "N") is None
+
+    def test_unset_does_not_warn(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.delenv("MYAPP_N", raising=False)
+        with caplog.at_level(logging.WARNING):
+            env_int("MYAPP", "N", 5)
+        assert _warnings(caplog) == []
+
+    def test_blank_returns_default_silently(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv("MYAPP_N", "   ")
+        with caplog.at_level(logging.WARNING):
+            assert env_int("MYAPP", "N", 7) == 7
+        assert _warnings(caplog) == []
+
+    def test_valid_value(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_N", "42")
+        assert env_int("MYAPP", "N", 0) == 42
+
+    def test_strips_surrounding_whitespace(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_N", "  42  ")
+        assert env_int("MYAPP", "N") == 42
+
+    def test_float_text_is_invalid(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv("MYAPP_N", "42.5")
+        with caplog.at_level(logging.WARNING):
+            assert env_int("MYAPP", "N", 3) == 3
+        assert "MYAPP_N" in caplog.text
+
+    def test_malformed_soft_warns_and_defaults(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv("MYAPP_N", "abc")
+        with caplog.at_level(logging.WARNING):
+            assert env_int("MYAPP", "N", 9) == 9
+        warnings = _warnings(caplog)
+        assert len(warnings) == 1
+        assert "MYAPP_N" in warnings[0].getMessage()
+        assert "abc" in warnings[0].getMessage()
+
+    def test_malformed_strict_raises(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_N", "abc")
+        with pytest.raises(ConfigurationError) as exc:
+            env_int("MYAPP", "N", 9, strict=True)
+        assert "MYAPP_N" in str(exc.value)
+        assert "abc" in str(exc.value)
+
+    def test_below_minimum_soft_warns_and_defaults(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv("MYAPP_N", "0")
+        with caplog.at_level(logging.WARNING):
+            assert env_int("MYAPP", "N", 8000, minimum=1) == 8000
+        assert _warnings(caplog)
+
+    def test_below_minimum_strict_raises(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_N", "0")
+        with pytest.raises(ConfigurationError) as exc:
+            env_int("MYAPP", "N", 8000, minimum=1, strict=True)
+        assert ">= 1" in str(exc.value)
+
+    def test_above_maximum_strict_raises(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_N", "70000")
+        with pytest.raises(ConfigurationError) as exc:
+            env_int("MYAPP", "N", 8000, maximum=65535, strict=True)
+        assert "<= 65535" in str(exc.value)
+
+    def test_boundaries_are_inclusive(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_N", "1")
+        assert env_int("MYAPP", "N", minimum=1, maximum=65535) == 1
+        monkeypatch.setenv("MYAPP_N", "65535")
+        assert env_int("MYAPP", "N", minimum=1, maximum=65535) == 65535
+
+    def test_no_bounds_accepts_any_integer(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_N", "-1000000")
+        assert env_int("MYAPP", "N") == -1000000
+
+    def test_trailing_underscore_prefix(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_N", "5")
+        assert env_int("MYAPP_", "N") == env_int("MYAPP", "N") == 5
+
+    def test_error_key_has_no_double_underscore(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_N", "abc")
+        with pytest.raises(ConfigurationError) as exc:
+            env_int("MYAPP_", "N", strict=True)
+        assert "MYAPP_N" in str(exc.value)
+        assert "MYAPP__N" not in str(exc.value)
+
+
+class TestEnvFloat:
+    def test_unset_returns_default(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("MYAPP_X", raising=False)
+        assert env_float("MYAPP", "X", 2.5) == 2.5
+
+    def test_unset_without_default_returns_none(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("MYAPP_X", raising=False)
+        assert env_float("MYAPP", "X") is None
+
+    def test_blank_returns_default_silently(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv("MYAPP_X", "   ")
+        with caplog.at_level(logging.WARNING):
+            assert env_float("MYAPP", "X", 1.5) == 1.5
+        assert _warnings(caplog) == []
+
+    def test_decimal_value(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_X", "3.14")
+        assert env_float("MYAPP", "X") == 3.14
+
+    def test_integer_text_becomes_float(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_X", "5")
+        result = env_float("MYAPP", "X")
+        assert result == 5.0
+        assert isinstance(result, float)
+
+    def test_malformed_soft_warns_and_defaults(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv("MYAPP_X", "abc")
+        with caplog.at_level(logging.WARNING):
+            assert env_float("MYAPP", "X", 1.0) == 1.0
+        warnings = _warnings(caplog)
+        assert len(warnings) == 1
+        assert "MYAPP_X" in warnings[0].getMessage()
+
+    def test_malformed_strict_raises(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_X", "abc")
+        with pytest.raises(ConfigurationError) as exc:
+            env_float("MYAPP", "X", strict=True)
+        assert "MYAPP_X" in str(exc.value)
+
+    @pytest.mark.parametrize("value", ["nan", "inf", "-inf", "Infinity"])
+    def test_non_finite_soft_warns_and_defaults(
+        self,
+        value: str,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        monkeypatch.setenv("MYAPP_X", value)
+        with caplog.at_level(logging.WARNING):
+            assert env_float("MYAPP", "X", 1.0) == 1.0
+        assert _warnings(caplog)
+
+    @pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+    def test_non_finite_strict_raises(
+        self, value: str, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("MYAPP_X", value)
+        with pytest.raises(ConfigurationError) as exc:
+            env_float("MYAPP", "X", strict=True)
+        assert "finite" in str(exc.value)
+
+    def test_below_minimum_strict_raises(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_X", "-0.5")
+        with pytest.raises(ConfigurationError) as exc:
+            env_float("MYAPP", "X", 1.0, minimum=0.0, strict=True)
+        assert ">= 0" in str(exc.value)
+
+    def test_above_maximum_soft_warns_and_defaults(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv("MYAPP_X", "9.9")
+        with caplog.at_level(logging.WARNING):
+            assert env_float("MYAPP", "X", 1.0, maximum=5.0) == 1.0
+        assert _warnings(caplog)
+
+    def test_boundaries_are_inclusive(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_X", "0.0")
+        assert env_float("MYAPP", "X", minimum=0.0, maximum=1.0) == 0.0
+        monkeypatch.setenv("MYAPP_X", "1.0")
+        assert env_float("MYAPP", "X", minimum=0.0, maximum=1.0) == 1.0
 
 
 class TestParseBool:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -123,6 +123,14 @@ class TestEnvInt:
             env_int("MYAPP", "N", 8000, maximum=65535, strict=True)
         assert "<= 65535" in str(exc.value)
 
+    def test_above_maximum_soft_warns_and_defaults(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv("MYAPP_N", "70000")
+        with caplog.at_level(logging.WARNING):
+            assert env_int("MYAPP", "N", 8000, maximum=65535) == 8000
+        assert _warnings(caplog)
+
     def test_boundaries_are_inclusive(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("MYAPP_N", "1")
         assert env_int("MYAPP", "N", minimum=1, maximum=65535) == 1
@@ -132,6 +140,12 @@ class TestEnvInt:
     def test_no_bounds_accepts_any_integer(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("MYAPP_N", "-1000000")
         assert env_int("MYAPP", "N") == -1000000
+
+    def test_accepts_pep515_underscores(self, monkeypatch: pytest.MonkeyPatch):
+        # Documented accept-set: env_int delegates to int(), which accepts
+        # PEP 515 underscore separators. Pinned so the contract is explicit.
+        monkeypatch.setenv("MYAPP_N", "1_000")
+        assert env_int("MYAPP", "N") == 1000
 
     def test_trailing_underscore_prefix(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("MYAPP_N", "5")
@@ -228,6 +242,18 @@ class TestEnvFloat:
         assert env_float("MYAPP", "X", minimum=0.0, maximum=1.0) == 0.0
         monkeypatch.setenv("MYAPP_X", "1.0")
         assert env_float("MYAPP", "X", minimum=0.0, maximum=1.0) == 1.0
+
+    def test_accepts_pep515_underscores(self, monkeypatch: pytest.MonkeyPatch):
+        # Documented accept-set: env_float delegates to float(), which accepts
+        # PEP 515 underscore separators. Pinned so the contract is explicit.
+        monkeypatch.setenv("MYAPP_X", "1_000.5")
+        assert env_float("MYAPP", "X") == 1000.5
+
+    def test_accepts_scientific_notation(self, monkeypatch: pytest.MonkeyPatch):
+        # Documented accept-set: float() accepts scientific notation, unlike
+        # int() (env_int rejects "1e3"). Pinned to lock the int/float asymmetry.
+        monkeypatch.setenv("MYAPP_X", "1e3")
+        assert env_float("MYAPP", "X") == 1000.0
 
 
 class TestParseBool:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -103,6 +103,18 @@ class TestEnvInt:
         assert "MYAPP_N" in str(exc.value)
         assert "abc" in str(exc.value)
 
+    def test_soft_reject_without_default_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        # Soft mode + no default: an invalid value yields None (still warns).
+        # The int|None overload makes None a first-class "no usable value"
+        # outcome — the numeric analog of env() -> None. A caller wanting an
+        # invalid value to fail hard uses strict=True instead.
+        monkeypatch.setenv("MYAPP_N", "abc")
+        with caplog.at_level(logging.WARNING):
+            assert env_int("MYAPP", "N") is None
+        assert _warnings(caplog)
+
     def test_below_minimum_soft_warns_and_defaults(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ):
@@ -213,6 +225,15 @@ class TestEnvFloat:
         with pytest.raises(ConfigurationError) as exc:
             env_float("MYAPP", "X", strict=True)
         assert "MYAPP_X" in str(exc.value)
+
+    def test_soft_reject_without_default_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        # See TestEnvInt: soft + no default + invalid -> None (warns), not a raise.
+        monkeypatch.setenv("MYAPP_X", "abc")
+        with caplog.at_level(logging.WARNING):
+            assert env_float("MYAPP", "X") is None
+        assert _warnings(caplog)
 
     @pytest.mark.parametrize("value", ["nan", "inf", "-inf", "Infinity"])
     def test_non_finite_soft_warns_and_defaults(

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -131,6 +131,18 @@ class TestEnvInt:
             assert env_int("MYAPP", "N", 8000, maximum=65535) == 8000
         assert _warnings(caplog)
 
+    def test_soft_default_is_not_bounds_checked(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        # Contract: the default is the trusted developer fallback, returned
+        # as-is on the soft reject path. minimum/maximum validate the operator's
+        # env value, NOT the default — so a default that itself violates the
+        # bounds is still returned (with the warning for the rejected value).
+        monkeypatch.setenv("MYAPP_N", "70000")
+        with caplog.at_level(logging.WARNING):
+            assert env_int("MYAPP", "N", 0, minimum=1, maximum=65535) == 0
+        assert _warnings(caplog)
+
     def test_boundaries_are_inclusive(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("MYAPP_N", "1")
         assert env_int("MYAPP", "N", minimum=1, maximum=65535) == 1

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -200,7 +200,7 @@ class TestEnvFloat:
             assert env_float("MYAPP", "X", 1.0) == 1.0
         assert _warnings(caplog)
 
-    @pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+    @pytest.mark.parametrize("value", ["nan", "inf", "-inf", "Infinity"])
     def test_non_finite_strict_raises(
         self, value: str, monkeypatch: pytest.MonkeyPatch
     ):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -103,6 +103,16 @@ class TestEnvInt:
         assert "MYAPP_N" in str(exc.value)
         assert "abc" in str(exc.value)
 
+    def test_strict_parse_error_chains_value_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The ConfigurationError chains the underlying int() ValueError
+        # (raise ... from cause), so the low-level reason stays attached.
+        monkeypatch.setenv("MYAPP_N", "abc")
+        with pytest.raises(ConfigurationError) as exc:
+            env_int("MYAPP", "N", strict=True)
+        assert isinstance(exc.value.__cause__, ValueError)
+
     def test_soft_reject_without_default_returns_none(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ):
@@ -254,6 +264,17 @@ class TestEnvFloat:
         monkeypatch.setenv("MYAPP_X", value)
         with pytest.raises(ConfigurationError) as exc:
             env_float("MYAPP", "X", strict=True)
+        assert "finite" in str(exc.value)
+
+    def test_non_finite_rejected_before_bounds(self, monkeypatch: pytest.MonkeyPatch):
+        # Ordering invariant: the finite check runs *before* _check_bounds.
+        # nan compares False to every bound (nan < 0.0 and nan > 5.0 are both
+        # False), so were the order reversed it would slip through the bounds
+        # and be returned as a config value. Pinned so a reorder fails here:
+        # with bounds set, a non-finite value is still rejected as "finite".
+        monkeypatch.setenv("MYAPP_X", "nan")
+        with pytest.raises(ConfigurationError) as exc:
+            env_float("MYAPP", "X", 1.0, minimum=0.0, maximum=5.0, strict=True)
         assert "finite" in str(exc.value)
 
     def test_below_minimum_soft_warns_and_defaults(

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -235,6 +235,14 @@ class TestEnvFloat:
             env_float("MYAPP", "X", strict=True)
         assert "finite" in str(exc.value)
 
+    def test_below_minimum_soft_warns_and_defaults(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv("MYAPP_X", "-0.5")
+        with caplog.at_level(logging.WARNING):
+            assert env_float("MYAPP", "X", 1.0, minimum=0.0) == 1.0
+        assert _warnings(caplog)
+
     def test_below_minimum_strict_raises(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("MYAPP_X", "-0.5")
         with pytest.raises(ConfigurationError) as exc:
@@ -248,6 +256,12 @@ class TestEnvFloat:
         with caplog.at_level(logging.WARNING):
             assert env_float("MYAPP", "X", 1.0, maximum=5.0) == 1.0
         assert _warnings(caplog)
+
+    def test_above_maximum_strict_raises(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MYAPP_X", "9.9")
+        with pytest.raises(ConfigurationError) as exc:
+            env_float("MYAPP", "X", 1.0, maximum=5.0, strict=True)
+        assert "<= 5" in str(exc.value)
 
     def test_boundaries_are_inclusive(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("MYAPP_X", "0.0")


### PR DESCRIPTION
## Summary

Adds `env_int` / `env_float` to the env-helper family — public, read-and-parse numeric env parsers downstream servers can consume instead of hand-rolling `try/except`-and-fallback per field. Both support the **two shapes** `markdown-vault-mcp` hand-rolls nine times today:

- **soft** (`strict=False`, default): on an invalid/out-of-range value, log a `WARNING` and return `default` — for soft limits.
- **strict** (`strict=True`): on an invalid/out-of-range value, raise `ConfigurationError` naming the var — for hard parameters.

Both take a `default` plus optional inclusive `minimum`/`maximum` bounds (reject-semantics, never clamp). `env_float` additionally rejects non-finite values (`nan`/`inf`/`-inf`). An unset/blank var returns `default` silently in both modes (delegates to `env()`'s strip semantics, keeping "unset" and "malformed" distinct).

`ServerConfig.from_env`'s `port` cast now consumes the helper: `env_int(env_prefix, "PORT", 8000, strict=True, minimum=1, maximum=65535)`.

## Behavior change (the live scope of #159)

`from_env` previously parsed `port` with a bare `int(port_str)`:
- a malformed `PORT` raised a context-free `ValueError` from `_config.py` → now raises `ConfigurationError` naming the var;
- `PORT` of `0` / `-5` / `70000` were **silently accepted** → now raise `ConfigurationError` (a server *listen* port outside `1..65535` is a misconfiguration).

## Closes

- **Closes #180** — the public dual-mode numeric helper itself.
- **Closes #159** — `env_int` supersedes #159's proposed *private* `_parse_int_env`/`_parse_float_env` with a public, dual-mode helper used internally for `port`. `port` is #159's only live numeric cast on `main`; its two file-exchange casts (`token_ttl`, `max_artifact_size`) no longer exist (parked off main), so this fully resolves #159's actionable scope.

## Out of scope (tracked)

- **#181** — converging `_debug.py`'s `DEBUG_PORT` (the second internal soft-mode callsite) onto `env_int`. Deferred because it carries a `port==0`-as-disable sentinel `env_int` does not model, and converting it churns the `test_debug.py` hotspot.
- Downstream adoption (MV's nine stanzas, image-gen's one callsite) — per-repo, after a pvl-core release.

## Design

`docs/superpowers/specs/2026-06-03-env-numeric-helper-design.md` — semantics matrix, error-message format, and the full failure-mode/test enumeration.

## Tests

TDD, one behavior each. `tests/test_env.py` (`TestEnvInt`, `TestEnvFloat`): unset/blank/valid/malformed/out-of-range across soft+strict, inclusive boundaries, `env_int` rejects float text, `env_float` rejects non-finite, prefix-underscore + no-double-underscore-in-key. `tests/test_config.py`: `from_env` port unset→8000, malformed→`ConfigurationError`, `0`/`-1`/`70000`→raise, `1`/`65535`→accepted.

Local checks green on this branch: `uv run pytest` (444), `ruff format --check`, `ruff check`, `mypy src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)