### PR TITLE
Make pvl-core cleanly foldable for independent forks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,8 @@ compromise.
 Contributors preserve:
 
 - **Relative intra-package imports** (`from ._x import …`) so a fold-in is a
-  directory rename, not a find-replace.
+  directory rename, not a find-replace. (Docstring code examples that show
+  *downstream* usage stay absolute — they are not intra-package imports.)
 - **No self-name lookups** — never resolve pvl-core's own distribution name or
   package resources at runtime (`importlib.metadata.version(...)`,
   `importlib.resources.files("fastmcp_pvl_core")`). Naming the package in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,10 @@ Contributors preserve:
   directory rename, not a find-replace.
 - **No self-name lookups** — never resolve pvl-core's own distribution name or
   package resources at runtime (`importlib.metadata.version(...)`,
-  `importlib.resources.files("fastmcp_pvl_core")`). Package-name string literals
-  stay confined to human-facing hints.
+  `importlib.resources.files("fastmcp_pvl_core")`). Naming the package in
+  human-facing text (install hints, log/error messages, docstring
+  cross-references) is fine; the prohibition is on *runtime* resolution of the
+  name, not on mentioning it in prose.
 - **Parameterized identity** — env prefixes, CLI `prog`, and similar
   caller-facing identity stay arguments, never hard-coded to pvl-core's name.
 - **A narrow public surface** — the `__init__` re-export with `__all__` is the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,34 @@ pvl-core is wrong files against pvl-core; it does not fork the
 behaviour and reimplement. "pvl-core is wrong, so I'll do it myself" is
 the failure this principle exists to prevent.
 
+### Keep pvl-core cleanly foldable
+
+A fork is not a downstream. MIT lets anyone vendor pvl-core into their own tree
+— to take over a single server when the fleet is no longer maintained, or to run
+their own opinionated variant. We keep that exit ramp cheap: credible
+foldability lowers the cost of depending on pvl-core in the first place, and the
+seams that make the package vendorable are the same seams that keep it a clean
+load-bearing layer. Foldability is a modularity property, not a coherence
+compromise.
+
+Contributors preserve:
+
+- **Relative intra-package imports** (`from ._x import …`) so a fold-in is a
+  directory rename, not a find-replace.
+- **No self-name lookups** — never resolve pvl-core's own distribution name or
+  package resources at runtime (`importlib.metadata.version(...)`,
+  `importlib.resources.files("fastmcp_pvl_core")`). Package-name string literals
+  stay confined to human-facing hints.
+- **Parameterized identity** — env prefixes, CLI `prog`, and similar
+  caller-facing identity stay arguments, never hard-coded to pvl-core's name.
+- **A narrow public surface** — the `__init__` re-export with `__all__` is the
+  contract; internals stay `_`-prefixed.
+
+This does **not** authorize pre-flattening abstractions "in case someone forks."
+The factory/`Build*` layer, the `env(prefix, name)` indirection, and the
+optional extras exist because pvl-core serves the whole family; collapsing them
+is fork-side work documented in `docs/forking.md`, never done in pvl-core.
+
 ## Practical consequences
 
 - **Adding a new `register_*` helper or `Build*` factory**: every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ concerns so the server family stays coherent as it grows.
 ## The framing principle
 
 Shape decisions live in pvl-core. Downstream contributes
-domain-specific logic only. Five facets in detail.
+domain-specific logic only. Five facets in detail; a sixth keeps the
+exit clean for forks that leave the family.
 
 ### Shape decisions live in pvl-core
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ is to correct pvl-core centrally — one change, every downstream follows
 files the issue against pvl-core; it does not fork the behaviour and
 reimplement it locally.
 
-### Keep pvl-core foldable
+### Keep pvl-core cleanly foldable
 
 A fork is not a downstream. The MIT licence lets anyone vendor
 pvl-core into their own tree — to take over a single server when the

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ classification test that follows from it.
 `fastmcp-pvl-core` is not a buffet of helpers downstream picks from
 à la carte. It is the load-bearing layer that fixes the shape of
 cross-cutting concerns across the server family so the family stays
-coherent as it grows. Five principles follow from that role.
+coherent as it grows. Five principles follow from that role; a
+sixth keeps the exit clean for forks that leave the family.
 
 ### Shape decisions live in pvl-core
 
@@ -108,6 +109,20 @@ is to correct pvl-core centrally — one change, every downstream follows
 — or to evolve the spec. A downstream that believes pvl-core is wrong
 files the issue against pvl-core; it does not fork the behaviour and
 reimplement it locally.
+
+### Keep pvl-core foldable
+
+A fork is not a downstream. The MIT licence lets anyone vendor
+pvl-core into their own tree — to take over a single server when the
+family is no longer maintained, or to run their own opinionated
+variant. That exit ramp is kept cheap on purpose: the seams that make
+pvl-core foldable (relative intra-package imports, no runtime lookups
+of its own package name, identity passed in rather than hard-coded, a
+narrow public surface) are the same seams that keep it a clean
+load-bearing layer. Foldability is a modularity property, not a
+coherence compromise — and never an excuse to flatten pvl-core's own
+abstractions "in case someone forks"; collapsing those is fork-side
+work.
 
 > Planning to fork and cut the dependency? See [docs/forking.md](docs/forking.md)
 > for the fold-in recipe and what a single-server fork can safely collapse.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ is to correct pvl-core centrally — one change, every downstream follows
 files the issue against pvl-core; it does not fork the behaviour and
 reimplement it locally.
 
+> Planning to fork and cut the dependency? See [docs/forking.md](docs/forking.md)
+> for the fold-in recipe and what a single-server fork can safely collapse.
+
 ## API stability
 
 This package is stable at 2.x and follows

--- a/docs/forking.md
+++ b/docs/forking.md
@@ -31,7 +31,7 @@ pvl-core uses relative intra-package imports, so folding is a directory rename
 cp -r path/to/fastmcp_pvl_core  src/myfork/_core
 
 # 2. Update YOUR code's imports from the dependency to the vendored package:
-#    from fastmcp_pvl_core import build_app   ->   from myfork._core import build_app
+#    from fastmcp_pvl_core import wire_middleware_stack   ->   from myfork._core import wire_middleware_stack
 grep -rl 'fastmcp_pvl_core' src/myfork --include='*.py'   # find your call sites
 #    ...then rewrite those `from fastmcp_pvl_core` references to `from myfork._core`.
 

--- a/docs/forking.md
+++ b/docs/forking.md
@@ -1,0 +1,84 @@
+# Forking and folding in pvl-core
+
+`fastmcp-pvl-core` is the shared core of the `pvliesdonk/*-mcp` server family.
+It is MIT-licensed. If you want to take over a single server when the upstream
+is no longer maintained, or run your own opinionated variant, you can **fold
+pvl-core into your fork** and cut the upstream dependency entirely. A fork is
+not a downstream — none of the family's coherence rules bind you once you fold.
+
+## First decide: pin, or fold?
+
+**Pin and forget.** Keep `fastmcp-pvl-core==X.Y.Z` pinned and stop running
+`copier update`. Zero effort. You keep receiving nothing new — including no
+dependency or CVE bumps — and you cannot modify the core. Best if you are happy
+with the core as-is and only want to freeze it.
+
+**Fold in (vendor).** Copy the package into your tree, rename it, drop the
+dependency. You get full ownership and the freedom to modify, at the cost of
+owning the full maintenance burden — including tracking transitive CVEs that
+upstream used to handle for you. Choose this only if you actually intend to
+change the core or cannot rely on upstream at all.
+
+The rest of this guide covers folding in.
+
+## Fold-in recipe
+
+pvl-core uses relative intra-package imports, so folding is a directory rename
+— you do not edit the core's internal imports.
+
+```bash
+# 1. Copy the package into your fork (rename to your own internal package):
+cp -r path/to/fastmcp_pvl_core  src/myfork/_core
+
+# 2. Update YOUR code's imports from the dependency to the vendored package:
+#    from fastmcp_pvl_core import build_app   ->   from myfork._core import build_app
+grep -rl 'fastmcp_pvl_core' src/myfork --include='*.py'   # find your call sites
+#    ...then rewrite those `from fastmcp_pvl_core` references to `from myfork._core`.
+
+# 3. Drop the dependency from pyproject.toml (remove the fastmcp-pvl-core line).
+
+# 4. Reinstall and run your tests.
+```
+
+## Bring the tests
+
+Vendor the test suite too — it is your safety net for the flattening below:
+
+```bash
+cp -r path/to/tests  tests/_core
+# Rewrite the suite's absolute imports to your vendored package name:
+#   from fastmcp_pvl_core import X   ->   from myfork._core import X
+```
+
+## Collapsible-seams map
+
+pvl-core carries abstractions because it serves *five* servers. Your fork serves
+one, so you may collapse them. These are safe to flatten **in a fork** — do not
+ask pvl-core to pre-flatten them, that would break the family:
+
+- **`env(prefix, name)` indirection** — pvl-core parameterizes the env-var
+  prefix so each server picks its own. Your fork has one prefix; inline it.
+- **`Build*` / factory layer** — the factory exists to assemble a server from
+  config generically. With one server you can inline the construction at its
+  single call site.
+- **Parameterized CLI `prog`** — `make_serve_parser(prog=...)` lets each server
+  name its own program. Hard-code your fork's name.
+- **Optional-dependency extras** — pvl-core splits backends (`[redis]`,
+  `[dynamodb]`, `[mongodb]`, `[remote-auth]`, `[debug]`) behind extras. Keep
+  only the backends your fork uses and make them hard dependencies.
+
+## Cosmetic scrub list
+
+These reference pvl-core by name but are harmless until you want the fork to
+look fully its own. Search-and-replace at your leisure:
+
+- The version label in `_server_info.py` (reports `fastmcp-pvl-core` + version).
+- The `pip install fastmcp-pvl-core[...]` hints in `_debug.py`, `_auth.py`,
+  `_kv_store.py`, `_icons.py` (shown when an optional extra is missing).
+- Sphinx-style docstring cross-references (`:class:`~fastmcp_pvl_core....``) and
+  the `fastmcp_pvl_core_current_auth_mode` ContextVar name, if you rename the
+  package for real.
+
+None of these are functional couplings — pvl-core performs no runtime lookup of
+its own distribution name or package resources, so renaming never breaks
+imports or resource loading.

--- a/docs/forking.md
+++ b/docs/forking.md
@@ -77,6 +77,9 @@ look fully its own. Search-and-replace at your leisure:
   `_kv_store.py` (shown when an optional extra is missing).
 - The `"file an issue against fastmcp-pvl-core"` pointer in the
   FastMCP-internal-API `RuntimeError` in `_icons.py`.
+- The `from fastmcp_pvl_core import SecretMaskFilter` usage example in the
+  `SecretMaskFilter` docstring in `_logging.py` — a downstream-facing import
+  path; point it at your vendored package name.
 - Sphinx-style docstring cross-references (`:class:`~fastmcp_pvl_core....``) and
   the `fastmcp_pvl_core_current_auth_mode` ContextVar name, if you rename the
   package for real.

--- a/docs/forking.md
+++ b/docs/forking.md
@@ -74,7 +74,9 @@ look fully its own. Search-and-replace at your leisure:
 
 - The version label in `_server_info.py` (reports `fastmcp-pvl-core` + version).
 - The `pip install fastmcp-pvl-core[...]` hints in `_debug.py`, `_auth.py`,
-  `_kv_store.py`, `_icons.py` (shown when an optional extra is missing).
+  `_kv_store.py` (shown when an optional extra is missing).
+- The `"file an issue against fastmcp-pvl-core"` pointer in the
+  FastMCP-internal-API `RuntimeError` in `_icons.py`.
 - Sphinx-style docstring cross-references (`:class:`~fastmcp_pvl_core....``) and
   the `fastmcp_pvl_core_current_auth_mode` ContextVar name, if you rename the
   package for real.

--- a/docs/superpowers/plans/2026-06-20-foldability-forking.md
+++ b/docs/superpowers/plans/2026-06-20-foldability-forking.md
@@ -322,7 +322,12 @@ look fully its own. Search-and-replace at your leisure:
 
 - The version label in `_server_info.py` (reports `fastmcp-pvl-core` + version).
 - The `pip install fastmcp-pvl-core[...]` hints in `_debug.py`, `_auth.py`,
-  `_kv_store.py`, `_icons.py` (shown when an optional extra is missing).
+  `_kv_store.py` (shown when an optional extra is missing).
+- The `"file an issue against fastmcp-pvl-core"` pointer in the
+  FastMCP-internal-API `RuntimeError` in `_icons.py`.
+- The `from fastmcp_pvl_core import SecretMaskFilter` usage example in the
+  `SecretMaskFilter` docstring in `_logging.py` — a downstream-facing import
+  path; point it at your vendored package name.
 - Sphinx-style docstring cross-references (`:class:`~fastmcp_pvl_core....``) and
   the `fastmcp_pvl_core_current_auth_mode` ContextVar name, if you rename the
   package for real.
@@ -400,11 +405,14 @@ compromise.
 Contributors preserve:
 
 - **Relative intra-package imports** (`from ._x import …`) so a fold-in is a
-  directory rename, not a find-replace.
+  directory rename, not a find-replace. (Docstring code examples that show
+  *downstream* usage stay absolute — they are not intra-package imports.)
 - **No self-name lookups** — never resolve pvl-core's own distribution name or
   package resources at runtime (`importlib.metadata.version(...)`,
-  `importlib.resources.files("fastmcp_pvl_core")`). Package-name string literals
-  stay confined to human-facing hints.
+  `importlib.resources.files("fastmcp_pvl_core")`). Naming the package in
+  human-facing text (install hints, log/error messages, docstring
+  cross-references) is fine; the prohibition is on *runtime* resolution of the
+  name, not on mentioning it in prose.
 - **Parameterized identity** — env prefixes, CLI `prog`, and similar
   caller-facing identity stay arguments, never hard-coded to pvl-core's name.
 - **A narrow public surface** — the `__init__` re-export with `__all__` is the

--- a/docs/superpowers/plans/2026-06-20-foldability-forking.md
+++ b/docs/superpowers/plans/2026-06-20-foldability-forking.md
@@ -77,7 +77,7 @@ EOF
 )"
 ```
 
-Record the issue number returned as `PVLCORE_ISSUE`.
+The pvl-core issue created here is **#194** — the `Refs`/`Closes` lines below use it.
 
 - [ ] **Step 3: Create the template detach issue** (filed into the template repo, NOT implemented here)
 
@@ -218,14 +218,14 @@ preserving; tests (external consumers) keep absolute imports. Docstring
 cross-references and the auth-mode ContextVar name are intentionally left
 unchanged.
 
-Refs #PVLCORE_ISSUE
+Refs #194
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
 EOF
 )"
 ```
 
-Replace `#PVLCORE_ISSUE` with the number from Task 0.
+(`#194` is the Task 0 issue.)
 
 ---
 
@@ -360,7 +360,7 @@ test-vendoring step, the collapsible-seams map (which abstractions a
 single-server fork may flatten), and the cosmetic scrub list. Link it from the
 README design-principles section.
 
-Refs #PVLCORE_ISSUE
+Refs #194
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
 EOF
@@ -430,7 +430,7 @@ self-name lookups, parameterized identity, narrow public surface) so it does not
 regress, while explicitly forbidding pre-flattening of abstractions — that stays
 fork-side, documented in docs/forking.md.
 
-Refs #PVLCORE_ISSUE
+Refs #194
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
 EOF
@@ -472,7 +472,7 @@ disentanglement.
 The copier-template detach (the fork's other half) is tracked separately in
 fastmcp-server-template.
 
-Closes #PVLCORE_ISSUE
+Closes #194
 
 Design: docs/superpowers/specs/2026-06-20-foldability-forking-design.md
 
@@ -483,7 +483,7 @@ EOF
 )"
 ```
 
-Replace `#PVLCORE_ISSUE`. Do NOT merge (human-only).
+Do NOT merge (human-only).
 
 ---
 
@@ -497,7 +497,7 @@ Replace `#PVLCORE_ISSUE`. Do NOT merge (human-only).
 - Spec §8 (plumbing: pvl-core issue, template issue) → Task 0. ✓
 - Spec §9 (testing: suite green; doc accuracy) → Task 1 Step 4, Task 2 Step 3, Task 4 Step 1. ✓
 
-**Placeholder scan:** `#PVLCORE_ISSUE` is an intentional fill-in (issue number unknown until Task 0 runs) and is flagged at each use. No TBD/TODO/"handle edge cases". Doc and directive content are complete verbatim.
+**Placeholder scan:** issue references resolved to `#194` (created in Task 0). No TBD/TODO/"handle edge cases". Doc and directive content are complete verbatim.
 
 **Type/identifier consistency:** No new code symbols introduced (refactor preserves the public API). The MUST-NOT-touch list and the two sed rules are mutually exclusive by anchor (`^\s*from fastmcp_pvl_core`), verified in Task 1 Step 3.
 

--- a/docs/superpowers/plans/2026-06-20-foldability-forking.md
+++ b/docs/superpowers/plans/2026-06-20-foldability-forking.md
@@ -1,0 +1,504 @@
+# Foldability / Forking Enablement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `fastmcp-pvl-core` cleanly foldable into an independent fork, and document the full disentanglement, so the fleet survives the maintainer stepping back.
+
+**Architecture:** Three deliverables in one PR on pvl-core: (1) convert intra-package absolute imports to relative so a fold-in is a directory rename; (2) add `docs/forking.md`, the forker-facing guide; (3) add a standing "keep pvl-core foldable" directive to the contributor `CLAUDE.md`. A separate comprehensive issue is filed into `fastmcp-server-template` for the copier-detach story (not implemented here).
+
+**Tech Stack:** Python ≥3.10, `uv`, `ruff`, `mypy`, `pytest`, `gh` CLI.
+
+## Global Constraints
+
+- Local checks before any push (verbatim from the repo CLAUDE.md):
+  `uv sync --all-extras` → `uv run pytest` → `uv run ruff format --check .` → `uv run ruff check .` → `uv run mypy src`.
+- Every PR closes ≥1 issue; merging is human-only (never `gh pr merge`).
+- Every GitHub post authored via the token MUST end with the agent-signature line (see Task 0); commits end with the `Co-Authored-By:` trailer.
+- Preflight-circus is mandatory before the push that opens/updates the PR.
+- Do NOT pre-flatten any pvl-core abstraction (factory/`Build*`, `env(prefix, name)`, parameterized `prog`, optional extras). Those stay; collapsing them is fork-side and documented only.
+- Spec authority: `docs/superpowers/specs/2026-06-20-foldability-forking-design.md`.
+
+---
+
+## File Structure
+
+- `src/fastmcp_pvl_core/*.py` — modified: absolute self-imports → relative (12 files).
+- `docs/forking.md` — created: the forker-facing guide.
+- `README.md` — modified: one pointer to `docs/forking.md` near design principles.
+- `CLAUDE.md` (project root, contributor guidance) — modified: new "Keep pvl-core cleanly foldable" directive.
+
+---
+
+### Task 0: Branch and tracking issues
+
+**Files:** none (git + GitHub plumbing).
+
+- [ ] **Step 1: Create the feature branch** (we are on `main`)
+
+```bash
+git checkout -b feat/foldability-forking
+```
+
+- [ ] **Step 2: Create the pvl-core tracking issue**
+
+```bash
+gh issue create --repo pvliesdonk/fastmcp-pvl-core \
+  --title "Make pvl-core cleanly foldable for independent forks" \
+  --body "$(cat <<'EOF'
+## Why
+
+`fastmcp-pvl-core` is the opinionated shared core for the `pvliesdonk/*-mcp`
+fleet, written for personal convenience. The maintainer may not maintain it
+forever. A **fork is not a downstream**: when someone takes over a single
+server (succession) or wants their own opinionated variant (divergence), they
+must stop depending on an unmaintained upstream and fold pvl-core into their
+tree. MIT permits this; we make the exit ramp cheap. A credible exit ramp also
+lowers the cost of depending on pvl-core in the first place.
+
+## Deliverables
+
+1. Convert the 30 absolute intra-package imports in `src/fastmcp_pvl_core/` to
+   relative imports, so a fold-in is a directory rename rather than a
+   30-site find-replace. Behavior-preserving; tests keep absolute imports.
+2. Add `docs/forking.md` — fold-vs-pin tradeoff, fold-in recipe,
+   bring-the-tests, collapsible-seams map, cosmetic scrub list.
+3. Add a "Keep pvl-core cleanly foldable" directive to the contributor
+   `CLAUDE.md` that forbids pre-flattening abstractions.
+
+## Non-goals
+
+No pre-flattening of abstractions; no vendor-automation script; no change to
+the human-facing `pip install fastmcp-pvl-core[...]` hints or version label.
+
+Design: `docs/superpowers/specs/2026-06-20-foldability-forking-design.md`.
+
+— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
+EOF
+)"
+```
+
+Record the issue number returned as `PVLCORE_ISSUE`.
+
+- [ ] **Step 3: Create the template detach issue** (filed into the template repo, NOT implemented here)
+
+```bash
+gh issue create --repo pvliesdonk/fastmcp-server-template \
+  --title "Document and enable clean detach from the copier template for independent forks" \
+  --body "$(cat <<'EOF'
+## Why
+
+A fork that takes over a single server (or wants its own opinionated variant)
+must detach from this copier template and from the opinionated fleet guidance
+it ships. This is the template-side half of the pvl-core foldability work
+(pvliesdonk/fastmcp-pvl-core: "Make pvl-core cleanly foldable for independent
+forks"). A fork is not a downstream; we make the detach mechanical and
+documented.
+
+## Deliverables
+
+1. **Detach guide** (e.g. `docs/forking.md` in the template's rendered output,
+   or a top-level section): stop tracking the template — delete
+   `.copier-answers.yml`, stop running `copier update`.
+2. **Strip template-origin CI**: identify which rendered `.github/workflows/*`
+   a standalone fork should not inherit (template-update automation, fleet-wide
+   review wiring) versus keep (the fork's own CI/release). Document the prune.
+3. **Scrub opinionated guidance**: reduce the rendered `CLAUDE.md` /
+   `.claude/CLAUDE.md` to fork-neutral contributor guidance — remove
+   maintainer-personal opinion and fleet-coherence rules that do not apply to a
+   standalone fork.
+4. **Test/CI updates**: any template smoke tests asserting the old state get
+   updated to assert the detached state — rewritten, not deleted.
+
+## Verification (run before closing)
+
+```bash
+# After applying the documented detach to a rendered project:
+test ! -f .copier-answers.yml && echo "copier answers removed"
+grep -rn "copier" .github/ ; echo "<-- expect no template-update workflow refs"
+grep -rniE "fleet|downstream conforms|shape lives in pvl-core" CLAUDE.md .claude/CLAUDE.md ; echo "<-- expect none"
+```
+
+## Non-goals
+
+Does not touch pvl-core itself (separate issue/PR). Does not remove the
+template's own ability to render new fleet members — this documents the
+*fork's* exit, not a template teardown.
+
+— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
+EOF
+)"
+```
+
+This issue is **not** closed by this PR.
+
+---
+
+### Task 1: Relative intra-package imports
+
+**Files:**
+- Modify: all 12 `src/fastmcp_pvl_core/*.py` files containing absolute self-imports (`__init__.py`, `_apps`? no — exact set below).
+- Test: existing suite (no new tests; behavior-preserving).
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: identical public API; `import fastmcp_pvl_core` and all `from fastmcp_pvl_core import …` from *outside* the package still resolve unchanged.
+
+**The exact set of import statements to convert** (30 statements, 12 files). Two transform rules, both anchored to lines starting (after optional indentation) with `from fastmcp_pvl_core`:
+
+- **Rule A (dotted submodule):** `from fastmcp_pvl_core._X import …` → `from ._X import …`
+- **Rule B (package-level):** `from fastmcp_pvl_core import …` → `from . import …`
+
+Rule B covers exactly these 4 deferred/package-level imports (do NOT miss them — Rule A's pattern skips them):
+- `_logging.py:80  from fastmcp_pvl_core import SecretMaskFilter`
+- `_server_info.py:105  from fastmcp_pvl_core import __version__ as core_version`
+
+(The other Rule-B-shaped lines are dotted and handled by Rule A.)
+
+**MUST NOT touch** — these contain `fastmcp_pvl_core` but are NOT imports (docstrings, a runtime ContextVar name, a JSON example string). Leave them exactly as-is:
+- `_factory.py:90` `:class:`~fastmcp_pvl_core.ServerConfig`` (docstring)
+- `_authorization.py:169` ``fastmcp_pvl_core.get_subject`` (docstring)
+- `_server_info.py:60` `"core_version": "<fastmcp_pvl_core.__version__>"` (JSON example)
+- `_config.py:73, _config.py:131` `:func:` docstring refs
+- `_subject.py:46` `"fastmcp_pvl_core_current_auth_mode"` (ContextVar name — a runtime identifier)
+- `_subject.py:54` `:func:` docstring ref
+- `_logging_middleware.py:9` `:func:` docstring ref
+
+- [ ] **Step 1: Snapshot the import lines before changing (baseline for diff review)**
+
+```bash
+grep -rnE '^[[:space:]]*from fastmcp_pvl_core' src/fastmcp_pvl_core/*.py | tee /tmp/foldability_imports_before.txt
+wc -l < /tmp/foldability_imports_before.txt   # expect 30
+```
+
+- [ ] **Step 2: Apply Rule A then Rule B, anchored to import lines only**
+
+```bash
+# Rule A: dotted submodule imports -> single-dot relative
+sed -i -E 's/^([[:space:]]*)from fastmcp_pvl_core\./\1from ./' src/fastmcp_pvl_core/*.py
+# Rule B: package-level imports -> "from . import"
+sed -i -E 's/^([[:space:]]*)from fastmcp_pvl_core import/\1from . import/' src/fastmcp_pvl_core/*.py
+```
+
+Both `sed` patterns are anchored to `^[[:space:]]*from fastmcp_pvl_core`, so docstring/string occurrences (which never start with `from fastmcp_pvl_core`) are untouched.
+
+- [ ] **Step 3: Verify no absolute self-import statements remain, and preserved refs survived**
+
+```bash
+# Expect EMPTY — no import statement references the absolute package name:
+grep -rnE '^[[:space:]]*(from fastmcp_pvl_core|import fastmcp_pvl_core)' src/fastmcp_pvl_core/*.py
+# Expect the 8 docstring/string refs STILL present (unchanged):
+grep -rn 'fastmcp_pvl_core' src/fastmcp_pvl_core/*.py
+```
+
+First grep MUST print nothing. Second grep MUST still show the docstring/ContextVar/JSON lines from the MUST-NOT-touch list (proof we did not over-reach).
+
+- [ ] **Step 4: Run the full local-checks block**
+
+```bash
+uv sync --all-extras
+uv run pytest
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
+```
+
+Expected: all green. (A behavior-preserving import-style change keeps the existing 27 test files passing; `ruff` may also confirm relative-import preference.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/
+git commit -m "$(cat <<'EOF'
+refactor: use relative intra-package imports for foldability
+
+Convert the 30 absolute `from fastmcp_pvl_core...` self-imports in src/ to
+relative imports so a fork can vendor the package by renaming the directory
+rather than find-replacing the package name across every module. Behavior
+preserving; tests (external consumers) keep absolute imports. Docstring
+cross-references and the auth-mode ContextVar name are intentionally left
+unchanged.
+
+Refs #PVLCORE_ISSUE
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Replace `#PVLCORE_ISSUE` with the number from Task 0.
+
+---
+
+### Task 2: `docs/forking.md` and README pointer
+
+**Files:**
+- Create: `docs/forking.md`
+- Modify: `README.md` (one pointer near the design-principles section)
+
+**Interfaces:** documentation only; every factual claim must match the audited code state in the spec §3 baseline.
+
+- [ ] **Step 1: Write `docs/forking.md` with this exact content**
+
+````markdown
+# Forking and folding in pvl-core
+
+`fastmcp-pvl-core` is the shared core of the `pvliesdonk/*-mcp` server family.
+It is MIT-licensed. If you want to take over a single server when the upstream
+is no longer maintained, or run your own opinionated variant, you can **fold
+pvl-core into your fork** and cut the upstream dependency entirely. A fork is
+not a downstream — none of the family's coherence rules bind you once you fold.
+
+## First decide: pin, or fold?
+
+**Pin and forget.** Keep `fastmcp-pvl-core==X.Y.Z` pinned and stop running
+`copier update`. Zero effort. You keep receiving nothing new — including no
+dependency or CVE bumps — and you cannot modify the core. Best if you are happy
+with the core as-is and only want to freeze it.
+
+**Fold in (vendor).** Copy the package into your tree, rename it, drop the
+dependency. You get full ownership and the freedom to modify, at the cost of
+owning the full maintenance burden — including tracking transitive CVEs that
+upstream used to handle for you. Choose this only if you actually intend to
+change the core or cannot rely on upstream at all.
+
+The rest of this guide covers folding in.
+
+## Fold-in recipe
+
+pvl-core uses relative intra-package imports, so folding is a directory rename
+— you do not edit the core's internal imports.
+
+```bash
+# 1. Copy the package into your fork (rename to your own internal package):
+cp -r path/to/fastmcp_pvl_core  src/myfork/_core
+
+# 2. Update YOUR code's imports from the dependency to the vendored package:
+#    from fastmcp_pvl_core import build_app   ->   from myfork._core import build_app
+grep -rl 'fastmcp_pvl_core' src/myfork --include='*.py'   # find your call sites
+#    ...then rewrite those `from fastmcp_pvl_core` references to `from myfork._core`.
+
+# 3. Drop the dependency from pyproject.toml (remove the fastmcp-pvl-core line).
+
+# 4. Reinstall and run your tests.
+```
+
+## Bring the tests
+
+Vendor the test suite too — it is your safety net for the flattening below:
+
+```bash
+cp -r path/to/tests  tests/_core
+# Rewrite the suite's absolute imports to your vendored package name:
+#   from fastmcp_pvl_core import X   ->   from myfork._core import X
+```
+
+## Collapsible-seams map
+
+pvl-core carries abstractions because it serves *five* servers. Your fork serves
+one, so you may collapse them. These are safe to flatten **in a fork** — do not
+ask pvl-core to pre-flatten them, that would break the family:
+
+- **`env(prefix, name)` indirection** — pvl-core parameterizes the env-var
+  prefix so each server picks its own. Your fork has one prefix; inline it.
+- **`Build*` / factory layer** — the factory exists to assemble a server from
+  config generically. With one server you can inline the construction at its
+  single call site.
+- **Parameterized CLI `prog`** — `make_serve_parser(prog=...)` lets each server
+  name its own program. Hard-code your fork's name.
+- **Optional-dependency extras** — pvl-core splits backends (`[redis]`,
+  `[dynamodb]`, `[mongodb]`, `[remote-auth]`, `[debug]`) behind extras. Keep
+  only the backends your fork uses and make them hard dependencies.
+
+## Cosmetic scrub list
+
+These reference pvl-core by name but are harmless until you want the fork to
+look fully its own. Search-and-replace at your leisure:
+
+- The version label in `_server_info.py` (reports `fastmcp-pvl-core` + version).
+- The `pip install fastmcp-pvl-core[...]` hints in `_debug.py`, `_auth.py`,
+  `_kv_store.py`, `_icons.py` (shown when an optional extra is missing).
+- Sphinx-style docstring cross-references (`:class:`~fastmcp_pvl_core....``) and
+  the `fastmcp_pvl_core_current_auth_mode` ContextVar name, if you rename the
+  package for real.
+
+None of these are functional couplings — pvl-core performs no runtime lookup of
+its own distribution name or package resources, so renaming never breaks
+imports or resource loading.
+````
+
+- [ ] **Step 2: Add a pointer from `README.md`** near the design-principles section
+
+Find the `## Design principles` section heading in `README.md` and add, immediately after its closing paragraph, this line:
+
+```markdown
+> Planning to fork and cut the dependency? See [docs/forking.md](docs/forking.md)
+> for the fold-in recipe and what a single-server fork can safely collapse.
+```
+
+(Use Grep to locate `## Design principles` first; insert after that section's prose, not mid-paragraph.)
+
+- [ ] **Step 3: Verify the guide's claims against the code**
+
+```bash
+# pvl-core performs NO runtime self-name lookup (claim in the guide):
+grep -rnE "metadata\.version\(|resources\.files\(" src/fastmcp_pvl_core/ ; echo "<-- expect none"
+# The optional extras named in the guide exist:
+grep -nE "redis|dynamodb|mongodb|remote-auth|debug" pyproject.toml
+```
+
+Both must confirm the guide (no self-name lookups; the named extras exist).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/forking.md README.md
+git commit -m "$(cat <<'EOF'
+docs: add forking/fold-in guide for independent forks
+
+Document the pin-vs-fold decision, the directory-rename fold-in recipe, the
+test-vendoring step, the collapsible-seams map (which abstractions a
+single-server fork may flatten), and the cosmetic scrub list. Link it from the
+README design-principles section.
+
+Refs #PVLCORE_ISSUE
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: `CLAUDE.md` foldability directive
+
+**Files:**
+- Modify: `CLAUDE.md` (project root contributor guidance)
+
+**Interfaces:** documentation/policy; aligns with the existing framing principles and the README design-principles section.
+
+- [ ] **Step 1: Insert the directive** as a new subsection under the framing principles
+
+Use Grep to locate the `## Practical consequences` heading in `CLAUDE.md`. Insert the following as a new `###` subsection immediately *before* `## Practical consequences` (i.e., as the last item of the framing-principle group):
+
+```markdown
+### Keep pvl-core cleanly foldable
+
+A fork is not a downstream. MIT lets anyone vendor pvl-core into their own tree
+— to take over a single server when the fleet is no longer maintained, or to run
+their own opinionated variant. We keep that exit ramp cheap: credible
+foldability lowers the cost of depending on pvl-core in the first place, and the
+seams that make the package vendorable are the same seams that keep it a clean
+load-bearing layer. Foldability is a modularity property, not a coherence
+compromise.
+
+Contributors preserve:
+
+- **Relative intra-package imports** (`from ._x import …`) so a fold-in is a
+  directory rename, not a find-replace.
+- **No self-name lookups** — never resolve pvl-core's own distribution name or
+  package resources at runtime (`importlib.metadata.version(...)`,
+  `importlib.resources.files("fastmcp_pvl_core")`). Package-name string literals
+  stay confined to human-facing hints.
+- **Parameterized identity** — env prefixes, CLI `prog`, and similar
+  caller-facing identity stay arguments, never hard-coded to pvl-core's name.
+- **A narrow public surface** — the `__init__` re-export with `__all__` is the
+  contract; internals stay `_`-prefixed.
+
+This does **not** authorize pre-flattening abstractions "in case someone forks."
+The factory/`Build*` layer, the `env(prefix, name)` indirection, and the
+optional extras exist because pvl-core serves the whole family; collapsing them
+is fork-side work documented in `docs/forking.md`, never done in pvl-core.
+```
+
+- [ ] **Step 2: Verify placement and links**
+
+```bash
+grep -n "Keep pvl-core cleanly foldable" CLAUDE.md            # exists once
+grep -n "docs/forking.md" CLAUDE.md                           # the cross-link is present
+grep -n "## Practical consequences" CLAUDE.md                 # directive sits before it
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs: add "keep pvl-core foldable" contributor directive
+
+Encode foldability as a standing modularity property (relative imports, no
+self-name lookups, parameterized identity, narrow public surface) so it does not
+regress, while explicitly forbidding pre-flattening of abstractions — that stays
+fork-side, documented in docs/forking.md.
+
+Refs #PVLCORE_ISSUE
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Preflight-circus and open the PR
+
+**Files:** none (review + PR).
+
+- [ ] **Step 1: Re-run the full local-checks block** (final, on the complete diff)
+
+```bash
+uv sync --all-extras && uv run pytest && uv run ruff format --check . && uv run ruff check . && uv run mypy src
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Run the preflight-circus skill** against `main..HEAD` and resolve any findings *in the artifacts* (not by reply). Re-run until clean at the push threshold.
+
+- [ ] **Step 3: Push and open the PR** (closes the pvl-core issue)
+
+```bash
+git push -u origin feat/foldability-forking
+gh pr create --repo pvliesdonk/fastmcp-pvl-core \
+  --title "Make pvl-core cleanly foldable for independent forks" \
+  --body "$(cat <<'EOF'
+Enables a fork to vendor pvl-core by directory rename, and documents the full
+disentanglement.
+
+## Changes
+- Relative intra-package imports (30 statements, behavior-preserving).
+- `docs/forking.md` — pin-vs-fold, fold-in recipe, bring-the-tests,
+  collapsible-seams map, cosmetic scrub list.
+- `CLAUDE.md` — "keep pvl-core foldable" directive (forbids pre-flattening).
+
+The copier-template detach (the fork's other half) is tracked separately in
+fastmcp-server-template.
+
+Closes #PVLCORE_ISSUE
+
+Design: docs/superpowers/specs/2026-06-20-foldability-forking-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
+EOF
+)"
+```
+
+Replace `#PVLCORE_ISSUE`. Do NOT merge (human-only).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec §4 (relative imports) → Task 1. ✓
+- Spec §5 (`docs/forking.md`, all 5 sections + README pointer) → Task 2. ✓
+- Spec §6 (CLAUDE.md directive + README alignment) → Task 3 (+ README pointer already in Task 2). ✓
+- Spec §7 (template issue) → Task 0 Step 3. ✓
+- Spec §8 (plumbing: pvl-core issue, template issue) → Task 0. ✓
+- Spec §9 (testing: suite green; doc accuracy) → Task 1 Step 4, Task 2 Step 3, Task 4 Step 1. ✓
+
+**Placeholder scan:** `#PVLCORE_ISSUE` is an intentional fill-in (issue number unknown until Task 0 runs) and is flagged at each use. No TBD/TODO/"handle edge cases". Doc and directive content are complete verbatim.
+
+**Type/identifier consistency:** No new code symbols introduced (refactor preserves the public API). The MUST-NOT-touch list and the two sed rules are mutually exclusive by anchor (`^\s*from fastmcp_pvl_core`), verified in Task 1 Step 3.
+
+**Risk note:** the only behavioral risk is an import that the two sed rules miss or mis-rewrite; Task 1 Step 3's two greps (zero remaining import-refs; preserved docstring refs intact) plus the full suite in Step 4 catch that before commit.

--- a/docs/superpowers/plans/2026-06-20-foldability-forking.md
+++ b/docs/superpowers/plans/2026-06-20-foldability-forking.md
@@ -279,7 +279,7 @@ pvl-core uses relative intra-package imports, so folding is a directory rename
 cp -r path/to/fastmcp_pvl_core  src/myfork/_core
 
 # 2. Update YOUR code's imports from the dependency to the vendored package:
-#    from fastmcp_pvl_core import build_app   ->   from myfork._core import build_app
+#    from fastmcp_pvl_core import wire_middleware_stack   ->   from myfork._core import wire_middleware_stack
 grep -rl 'fastmcp_pvl_core' src/myfork --include='*.py'   # find your call sites
 #    ...then rewrite those `from fastmcp_pvl_core` references to `from myfork._core`.
 

--- a/docs/superpowers/plans/2026-06-20-foldability-forking.md
+++ b/docs/superpowers/plans/2026-06-20-foldability-forking.md
@@ -22,7 +22,7 @@
 
 ## File Structure
 
-- `src/fastmcp_pvl_core/*.py` — modified: absolute self-imports → relative (12 files).
+- `src/fastmcp_pvl_core/*.py` — modified: absolute self-imports → relative (11 files; `_logging.py` nets to unchanged — its one match is a docstring example that is converted then reverted).
 - `docs/forking.md` — created: the forker-facing guide.
 - `README.md` — modified: one pointer to `docs/forking.md` near design principles.
 - `CLAUDE.md` (project root, contributor guidance) — modified: new "Keep pvl-core cleanly foldable" directive.

--- a/docs/superpowers/plans/2026-06-20-foldability-forking.md
+++ b/docs/superpowers/plans/2026-06-20-foldability-forking.md
@@ -57,9 +57,9 @@ lowers the cost of depending on pvl-core in the first place.
 
 ## Deliverables
 
-1. Convert the 30 absolute intra-package imports in `src/fastmcp_pvl_core/` to
+1. Convert the 29 absolute intra-package imports in `src/fastmcp_pvl_core/` to
    relative imports, so a fold-in is a directory rename rather than a
-   30-site find-replace. Behavior-preserving; tests keep absolute imports.
+   29-site find-replace. Behavior-preserving; tests keep absolute imports.
 2. Add `docs/forking.md` — fold-vs-pin tradeoff, fold-in recipe,
    bring-the-tests, collapsible-seams map, cosmetic scrub list.
 3. Add a "Keep pvl-core cleanly foldable" directive to the contributor
@@ -143,19 +143,16 @@ This issue is **not** closed by this PR.
 - Consumes: nothing.
 - Produces: identical public API; `import fastmcp_pvl_core` and all `from fastmcp_pvl_core import …` from *outside* the package still resolve unchanged.
 
-**The exact set of import statements to convert** (30 statements, 12 files). Two transform rules, both anchored to lines starting (after optional indentation) with `from fastmcp_pvl_core`:
+**The exact set.** The anchored grep `^[[:space:]]*from fastmcp_pvl_core` matches **30 lines**: 29 real import statements (15 in `__init__.py`, 14 across 10 sibling modules) plus **one docstring usage example** at `_logging.py:80` that is downstream-facing, not an import. The sed below cannot distinguish that docstring line — it too begins, after indentation, with `from fastmcp_pvl_core` — so the sed rewrites all 30 and Step 2b reverts the one docstring line. Two transform rules:
 
 - **Rule A (dotted submodule):** `from fastmcp_pvl_core._X import …` → `from ._X import …`
 - **Rule B (package-level):** `from fastmcp_pvl_core import …` → `from . import …`
 
-Rule B covers exactly these 4 deferred/package-level imports (do NOT miss them — Rule A's pattern skips them):
-- `_logging.py:80  from fastmcp_pvl_core import SecretMaskFilter`
-- `_server_info.py:105  from fastmcp_pvl_core import __version__ as core_version`
+Rule B covers exactly **one** real import: `_server_info.py:105  from fastmcp_pvl_core import __version__ as core_version`. (The other Rule-B-shaped line, `_logging.py:80`, is the docstring example handled by Step 2b. All other self-imports are dotted → Rule A.)
 
-(The other Rule-B-shaped lines are dotted and handled by Rule A.)
-
-**MUST NOT touch** — these contain `fastmcp_pvl_core` but are NOT imports (docstrings, a runtime ContextVar name, a JSON example string). Leave them exactly as-is:
-- `_factory.py:90` `:class:`~fastmcp_pvl_core.ServerConfig`` (docstring)
+**MUST stay absolute** — these contain `fastmcp_pvl_core` but are NOT intra-package imports; they must read with the absolute name at the end of this task:
+- `_logging.py:80` `from fastmcp_pvl_core import SecretMaskFilter` — a **docstring usage example** (downstream-facing); the sed rewrites it, Step 2b reverts it. This is the only one of these the sed touches.
+- `_factory.py:90` `:class:`~fastmcp_pvl_core.ServerConfig`` (docstring) — mid-line, sed never matches it.
 - `_authorization.py:169` ``fastmcp_pvl_core.get_subject`` (docstring)
 - `_server_info.py:60` `"core_version": "<fastmcp_pvl_core.__version__>"` (JSON example)
 - `_config.py:73, _config.py:131` `:func:` docstring refs
@@ -163,14 +160,14 @@ Rule B covers exactly these 4 deferred/package-level imports (do NOT miss them �
 - `_subject.py:54` `:func:` docstring ref
 - `_logging_middleware.py:9` `:func:` docstring ref
 
-- [ ] **Step 1: Snapshot the import lines before changing (baseline for diff review)**
+- [ ] **Step 1: Snapshot the matching lines before changing (baseline for diff review)**
 
 ```bash
 grep -rnE '^[[:space:]]*from fastmcp_pvl_core' src/fastmcp_pvl_core/*.py | tee /tmp/foldability_imports_before.txt
-wc -l < /tmp/foldability_imports_before.txt   # expect 30
+wc -l < /tmp/foldability_imports_before.txt   # expect 30 (29 imports + the _logging.py:80 docstring example)
 ```
 
-- [ ] **Step 2: Apply Rule A then Rule B, anchored to import lines only**
+- [ ] **Step 2: Apply Rule A then Rule B**
 
 ```bash
 # Rule A: dotted submodule imports -> single-dot relative
@@ -179,18 +176,27 @@ sed -i -E 's/^([[:space:]]*)from fastmcp_pvl_core\./\1from ./' src/fastmcp_pvl_c
 sed -i -E 's/^([[:space:]]*)from fastmcp_pvl_core import/\1from . import/' src/fastmcp_pvl_core/*.py
 ```
 
-Both `sed` patterns are anchored to `^[[:space:]]*from fastmcp_pvl_core`, so docstring/string occurrences (which never start with `from fastmcp_pvl_core`) are untouched.
+The anchor `^[[:space:]]*from fastmcp_pvl_core` also matches the indented `_logging.py:80` docstring line, so the sed rewrites it along with the 29 real imports. Mid-line occurrences (Sphinx xrefs, the JSON example, the ContextVar string) never start a line with `from fastmcp_pvl_core` and are untouched.
 
-- [ ] **Step 3: Verify no absolute self-import statements remain, and preserved refs survived**
+- [ ] **Step 2b: Revert the `_logging.py:80` docstring example back to absolute**
 
 ```bash
-# Expect EMPTY — no import statement references the absolute package name:
+# Restore the downstream-facing usage example — it is not an intra-package import
+# (a fork repoints it later, per docs/forking.md's cosmetic scrub list):
+sed -i -E 's/^([[:space:]]*)from \. import SecretMaskFilter/\1from fastmcp_pvl_core import SecretMaskFilter/' src/fastmcp_pvl_core/_logging.py
+grep -n 'from fastmcp_pvl_core import SecretMaskFilter' src/fastmcp_pvl_core/_logging.py   # expect line 80
+```
+
+- [ ] **Step 3: Verify only the docstring example keeps the absolute name**
+
+```bash
+# Expect EXACTLY ONE match — _logging.py:80, the reverted docstring example:
 grep -rnE '^[[:space:]]*(from fastmcp_pvl_core|import fastmcp_pvl_core)' src/fastmcp_pvl_core/*.py
-# Expect the 8 docstring/string refs STILL present (unchanged):
+# Expect the docstring/ContextVar/JSON refs STILL present (unchanged):
 grep -rn 'fastmcp_pvl_core' src/fastmcp_pvl_core/*.py
 ```
 
-First grep MUST print nothing. Second grep MUST still show the docstring/ContextVar/JSON lines from the MUST-NOT-touch list (proof we did not over-reach).
+First grep MUST print exactly one line (`_logging.py:80`). Second grep MUST still show the docstring/ContextVar/JSON refs from the MUST-stay-absolute list (proof we did not over-reach).
 
 - [ ] **Step 4: Run the full local-checks block**
 
@@ -211,7 +217,7 @@ git add src/fastmcp_pvl_core/
 git commit -m "$(cat <<'EOF'
 refactor: use relative intra-package imports for foldability
 
-Convert the 30 absolute `from fastmcp_pvl_core...` self-imports in src/ to
+Convert the 29 absolute `from fastmcp_pvl_core...` self-imports in src/ to
 relative imports so a fork can vendor the package by renaming the directory
 rather than find-replacing the package name across every module. Behavior
 preserving; tests (external consumers) keep absolute imports. Docstring
@@ -464,7 +470,7 @@ Enables a fork to vendor pvl-core by directory rename, and documents the full
 disentanglement.
 
 ## Changes
-- Relative intra-package imports (30 statements, behavior-preserving).
+- Relative intra-package imports (29 statements, behavior-preserving).
 - `docs/forking.md` — pin-vs-fold, fold-in recipe, bring-the-tests,
   collapsible-seams map, cosmetic scrub list.
 - `CLAUDE.md` — "keep pvl-core foldable" directive (forbids pre-flattening).

--- a/docs/superpowers/specs/2026-06-20-foldability-forking-design.md
+++ b/docs/superpowers/specs/2026-06-20-foldability-forking-design.md
@@ -1,0 +1,205 @@
+# Design: keep pvl-core cleanly foldable for independent forks
+
+**Date:** 2026-06-20
+**Status:** approved (brainstorming) — pending spec review
+**Scope:** this PR is pvl-core only. The downstream copier-detach story is
+filed as a separate comprehensive issue in `fastmcp-server-template` (see
+§7) and executed in a parallel template-repo session.
+
+## 1. Motivation
+
+`fastmcp-pvl-core` is the opinionated shared core for the `pvliesdonk/*-mcp`
+fleet. It exists so the same cross-cutting concerns are not implemented five
+times, and so a new server idea starts from a coherent base.
+
+But it was written for personal use and convenience. The maintainer may not
+maintain the fleet — or pvl-core — forever. Two realistic futures need a clean
+exit ramp:
+
+- **Succession.** Someone who actively uses *one* server forks it and takes it
+  over. They cannot depend on an unmaintained upstream pvl-core, so they fold
+  it into their tree.
+- **Divergence.** Someone wants their own opinionated implementation. MIT fully
+  permits this; folding pvl-core in is the natural way to own it.
+
+A **fork is not a downstream.** The repo's coherence rules ("shape lives in
+pvl-core, downstream conforms") govern *members of the family*. A fork has left
+the family; releasing it cleanly is orthogonal to family coherence — there is
+no override-kwarg and no shape migration involved. Moreover, a credible exit
+ramp *lowers* the cost of depending on pvl-core in the first place, and the
+seams that make the package foldable are the same seams that keep it a clean
+load-bearing layer.
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- Make folding pvl-core into a fork a *directory rename*, not a find-replace.
+- Ship a comprehensive, forker-facing guide covering the full disentanglement.
+- Encode "keep pvl-core foldable" as a standing contributor directive so the
+  property does not regress.
+
+**Non-goals**
+
+- **No pre-flattening of abstractions.** The `Build*`/factory layer, the
+  `env(prefix, name)` indirection, parameterized `prog`, and the optional-extra
+  split exist because pvl-core serves the whole fleet. Collapsing them is
+  *fork-side* work (a single-server fork can flatten them); pvl-core must not
+  do it "in case someone forks." It is documented, never pre-done.
+- **No vendor-automation script.** Once imports are relative the manual recipe
+  is ~5 commands; a `vendor.py` would be over-engineering for a hypothetical.
+- **No cosmetic self-name changes.** The `pip install fastmcp-pvl-core[...]`
+  hints and the `_server_info.py` version label correctly name the real package
+  for the *unforked* case. They are listed as fork-side scrub items in the
+  guide, not changed here.
+
+## 3. Current foldability assessment (baseline)
+
+Audited 2026-06-20. pvl-core is already remarkably foldable, mostly via good
+hygiene rather than intent:
+
+| Fold-in hazard | Status | Notes |
+|---|---|---|
+| License | OK — MIT | Vendoring legally trivial. |
+| Self-metadata lookups (`importlib.metadata.version`, `resources.files("pkg")`) | OK — none | Every `fastmcp-pvl-core` literal is a human-facing pip hint, not a runtime lookup. |
+| Env var prefix | OK — parameterized | `env(prefix, name)`; prefix injected by caller, not baked to `FASTMCP_PVL_CORE_*`. |
+| CLI `prog` | OK — parameterized | `make_serve_parser(prog=...)`; no console-script under pvl-core's dist name. |
+| Public API surface | OK — narrow | Single `__init__` re-export with `__all__`; internals `_`-prefixed. |
+| `__version__` | OK — literal | A string in `__init__.py`, not read from dist metadata; survives vendoring (reports stale name cosmetically). |
+| Intra-package imports | **friction — 30 absolute** | `from fastmcp_pvl_core._x import …` (15 in `__init__.py`'s re-export block, 15 across 11 sibling modules), 0 relative. The one real obstacle. |
+
+The single high-leverage change is the last row.
+
+## 4. Deliverable 1 — relative intra-package imports (code)
+
+Convert the 30 absolute self-import statements (across 12 files) inside
+`src/fastmcp_pvl_core/` to relative imports:
+
+- `src/fastmcp_pvl_core/__init__.py` — the 15 re-export statements
+  (`from fastmcp_pvl_core._apps import …` → `from ._apps import …`).
+- The 15 cross-module imports across 11 sibling modules
+  (`from fastmcp_pvl_core._x import …` → `from ._x import …`).
+
+**Out of scope of this change:** test files keep their absolute
+`fastmcp_pvl_core` imports — tests are *external consumers* of the package and
+exercise the public import path. Only `src/` is touched.
+
+**Why this is the enabler:** with relative imports, a fold-in becomes
+`cp -r src/fastmcp_pvl_core myfork/src/myfork/_core` plus a directory rename,
+with **zero** internal-import edits. With absolute imports it is a 15-site
+package-name find-replace.
+
+**No behavior change**, therefore no new tests. The safety net is the existing
+27 test files plus the standard local-checks block staying green:
+
+```bash
+uv sync --all-extras
+uv run pytest
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
+```
+
+A pure import-style change that keeps all of the above green is complete.
+
+## 5. Deliverable 2 — `docs/forking.md` (the guide)
+
+Forker/operator-facing. Lives at `docs/forking.md` — **not** `docs/specs/`,
+which is reserved for wire-format interop specs. Sections:
+
+1. **When to fold vs. pin.** The two strategies and their tradeoff:
+   - *Pin-and-forget* — keep `fastmcp-pvl-core==X.Y.Z` pinned forever, stop
+     `copier update`. Zero effort, but cannot modify the core and stops
+     receiving upstream dependency/CVE bumps.
+   - *Fold-in / vendor* — full ownership and modification freedom, at the cost
+     of inheriting the full maintenance burden including transitive CVE
+     tracking. Choose deliberately; many forks are better served by pinning.
+
+2. **Fold-in recipe.** Copy the package directory, rename it, update the fork's
+   own `from fastmcp_pvl_core import …` call sites to the new name, drop the
+   `fastmcp-pvl-core` dependency. Short, because relative imports made it short.
+
+3. **Bring the tests.** Copy `tests/`, rewrite the absolute `fastmcp_pvl_core`
+   imports to the new package name. This is the fork's safety net for the
+   flattening in §4 of the guide.
+
+4. **Collapsible-seams map.** Which abstractions a *single-server* fork can
+   flatten, each with a "why it exists / how to collapse" line. Explicitly
+   framed as fork-side work pvl-core cannot pre-do without breaking the family:
+   - `env(prefix, name)` → inline your one prefix.
+   - `Build*` / factory layer → inline the construction at the single call site.
+   - parameterized `prog` → hard-code the fork's program name.
+   - optional-dependency extras → keep only the backends the fork actually uses.
+
+5. **Cosmetic scrub list.** The self-name string literals to search-and-replace:
+   the `_server_info.py` version label and the `pip install fastmcp-pvl-core[...]`
+   optional-extra hints scattered across `_debug.py`, `_auth.py`, `_kv_store.py`,
+   and `_icons.py`. None are functional; all are human-facing text.
+
+The guide gets a one-line pointer from `README.md` near the design-principles
+section.
+
+## 6. Deliverable 3 — foldability directive in `CLAUDE.md` (project)
+
+Add a directive to the project contributor `CLAUDE.md` (the framing-principles
+file) so the property does not regress. Proposed text:
+
+> ### Keep pvl-core cleanly foldable
+>
+> A fork is not a downstream. MIT lets anyone vendor pvl-core into their own
+> tree — to take over a single server when the fleet is no longer maintained,
+> or to run their own opinionated variant. We keep that exit ramp cheap:
+> credible foldability lowers the cost of depending on pvl-core in the first
+> place, and the seams that make the package vendorable are the same seams that
+> keep it a clean load-bearing layer. Foldability is a modularity property, not
+> a coherence compromise.
+>
+> Contributors preserve:
+> - **Relative intra-package imports** (`from ._x import …`) so a fold-in is a
+>   directory rename, not a find-replace.
+> - **No self-name lookups** — never resolve pvl-core's own distribution name or
+>   package resources at runtime (`importlib.metadata.version(...)`,
+>   `importlib.resources.files("fastmcp_pvl_core")`). Package-name string
+>   literals stay confined to human-facing hints.
+> - **Parameterized identity** — env prefixes, CLI `prog`, and similar
+>   caller-facing identity stay arguments, never hard-coded to pvl-core's name.
+> - **A narrow public surface** — the `__init__` re-export with `__all__` is the
+>   contract; internals stay `_`-prefixed.
+>
+> This does **not** authorize pre-flattening abstractions "in case someone
+> forks." The factory/`Build*` layer, the `env(prefix, name)` indirection, and
+> the optional extras exist because pvl-core serves the whole family; collapsing
+> them is fork-side work documented in `docs/forking.md`, never done in
+> pvl-core.
+
+Keep the README design-principles section aligned per the existing "keep them
+aligned" rule.
+
+## 7. Out of scope here — the template detach (separate issue)
+
+Filed as a comprehensive issue in `fastmcp-server-template`, executed in a
+parallel template-repo session. It covers the maintainer's points 1 and 3:
+
+- Stop tracking the template: delete `.copier-answers.yml`, stop
+  `copier update`.
+- Strip template-origin GitHub workflows a standalone fork should not inherit.
+- Scrub the opinionated `CLAUDE.md` / `.claude/CLAUDE.md` down to fork-neutral
+  contributor guidance.
+
+Written to the issue-writing discipline: separate concerns, explicit
+verification commands (grep/find that mechanically confirm detach), test/CI
+updates listed as deliverables.
+
+## 8. Plumbing
+
+- One new pvl-core issue: *"Make pvl-core cleanly foldable for independent
+  forks"* — closed by this PR. Deliverables 1–3 land together (one coherent
+  goal; no removal bundled with addition).
+- One new `fastmcp-server-template` issue (§7), not closed by this PR.
+
+## 9. Testing strategy
+
+- **Deliverable 1:** behavior-preserving; full existing suite + ruff + mypy
+  green is the contract. No new tests.
+- **Deliverables 2–3:** documentation; reviewed for accuracy against the §3
+  baseline (every claim in the guide must match the audited code state).

--- a/docs/superpowers/specs/2026-06-20-foldability-forking-design.md
+++ b/docs/superpowers/specs/2026-06-20-foldability-forking-design.md
@@ -133,8 +133,9 @@ which is reserved for wire-format interop specs. Sections:
 
 5. **Cosmetic scrub list.** The self-name string literals to search-and-replace:
    the `_server_info.py` version label and the `pip install fastmcp-pvl-core[...]`
-   optional-extra hints scattered across `_debug.py`, `_auth.py`, `_kv_store.py`,
-   and `_icons.py`. None are functional; all are human-facing text.
+   optional-extra hints in `_debug.py`, `_auth.py`, and `_kv_store.py` (plus the
+   "file an issue against fastmcp-pvl-core" pointer in `_icons.py`'s RuntimeError).
+   None are functional; all are human-facing text.
 
 The guide gets a one-line pointer from `README.md` near the design-principles
 section.

--- a/docs/superpowers/specs/2026-06-20-foldability-forking-design.md
+++ b/docs/superpowers/specs/2026-06-20-foldability-forking-design.md
@@ -66,19 +66,23 @@ hygiene rather than intent:
 | CLI `prog` | OK — parameterized | `make_serve_parser(prog=...)`; no console-script under pvl-core's dist name. |
 | Public API surface | OK — narrow | Single `__init__` re-export with `__all__`; internals `_`-prefixed. |
 | `__version__` | OK — literal | A string in `__init__.py`, not read from dist metadata; survives vendoring (reports stale name cosmetically). |
-| Intra-package imports | **friction — 30 absolute** | `from fastmcp_pvl_core._x import …` (15 in `__init__.py`'s re-export block, 15 across 11 sibling modules), 0 relative. The one real obstacle. |
+| Intra-package imports | **friction — 29 absolute** | `from fastmcp_pvl_core._x import …` (15 in `__init__.py`'s re-export block, 14 across 10 sibling modules), 0 relative. The one real obstacle. (A 30th `from fastmcp_pvl_core` line in a `_logging.py` docstring example is downstream-facing usage, not an import.) |
 
 The single high-leverage change is the last row.
 
 ## 4. Deliverable 1 — relative intra-package imports (code)
 
-Convert the 30 absolute self-import statements (across 12 files) inside
+Convert the 29 absolute self-import statements (across 11 files) inside
 `src/fastmcp_pvl_core/` to relative imports:
 
 - `src/fastmcp_pvl_core/__init__.py` — the 15 re-export statements
   (`from fastmcp_pvl_core._apps import …` → `from ._apps import …`).
-- The 15 cross-module imports across 11 sibling modules
+- The 14 cross-module imports across 10 sibling modules
   (`from fastmcp_pvl_core._x import …` → `from ._x import …`).
+
+One further `from fastmcp_pvl_core import SecretMaskFilter` appears in a
+`_logging.py` docstring code example — downstream-facing usage, not an
+intra-package import — and is left unchanged.
 
 **Out of scope of this change:** test files keep their absolute
 `fastmcp_pvl_core` imports — tests are *external consumers* of the package and

--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -5,8 +5,8 @@ middleware wiring, logging setup, config helpers, and server
 factory building blocks without duplicating them per repo.
 """
 
-from fastmcp_pvl_core._apps import app_tool_address, app_tool_meta, client_supports_apps
-from fastmcp_pvl_core._auth import (
+from ._apps import app_tool_address, app_tool_meta, client_supports_apps
+from ._auth import (
     AuthMode,
     build_auth,
     build_bearer_auth,
@@ -14,17 +14,17 @@ from fastmcp_pvl_core._auth import (
     build_remote_auth,
     resolve_auth_mode,
 )
-from fastmcp_pvl_core._authorization import (
+from ._authorization import (
     any_check,
     load_acl,
     make_acl_check,
     make_claims_check,
     parse_claim_grants,
 )
-from fastmcp_pvl_core._cli import make_serve_parser, normalise_http_path
-from fastmcp_pvl_core._config import ServerConfig, Transport
-from fastmcp_pvl_core._debug import maybe_start_debugpy
-from fastmcp_pvl_core._env import (
+from ._cli import make_serve_parser, normalise_http_path
+from ._config import ServerConfig, Transport
+from ._debug import maybe_start_debugpy
+from ._env import (
     env,
     env_float,
     env_int,
@@ -32,22 +32,22 @@ from fastmcp_pvl_core._env import (
     parse_list,
     parse_scopes,
 )
-from fastmcp_pvl_core._errors import ConfigurationError
-from fastmcp_pvl_core._factory import (
+from ._errors import ConfigurationError
+from ._factory import (
     build_event_store,
     build_instructions,
     compute_app_domain,
 )
-from fastmcp_pvl_core._icons import IconSpec, make_icon, register_tool_icons
-from fastmcp_pvl_core._kv_store import build_kv_store
-from fastmcp_pvl_core._logging import SecretMaskFilter, configure_logging_from_env
-from fastmcp_pvl_core._middleware import wire_middleware_stack
-from fastmcp_pvl_core._server_info import (
+from ._icons import IconSpec, make_icon, register_tool_icons
+from ._kv_store import build_kv_store
+from ._logging import SecretMaskFilter, configure_logging_from_env
+from ._middleware import wire_middleware_stack
+from ._server_info import (
     UpstreamProvider,
     UpstreamResult,
     register_server_info_tool,
 )
-from fastmcp_pvl_core._subject import get_claims, get_subject
+from ._subject import get_claims, get_subject
 
 __version__ = "4.0.0"  # PSR overrides at build time
 

--- a/src/fastmcp_pvl_core/_auth.py
+++ b/src/fastmcp_pvl_core/_auth.py
@@ -24,9 +24,9 @@ else:  # pragma: no cover - fallback for Python 3.10
     import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
     from typing_extensions import assert_never
 
-from fastmcp_pvl_core._config import ServerConfig
-from fastmcp_pvl_core._errors import ConfigurationError
-from fastmcp_pvl_core._subject import set_current_auth_mode
+from ._config import ServerConfig
+from ._errors import ConfigurationError
+from ._subject import set_current_auth_mode
 
 if TYPE_CHECKING:
     from fastmcp.server.auth import (

--- a/src/fastmcp_pvl_core/_authorization.py
+++ b/src/fastmcp_pvl_core/_authorization.py
@@ -34,7 +34,7 @@ else:  # pragma: no cover - fallback for Python 3.10
     # ``tomli`` is installed and the ignore would otherwise be flagged.
     import tomli as tomllib  # type: ignore[import-not-found,unused-ignore]
 
-from fastmcp_pvl_core._errors import ConfigurationError
+from ._errors import ConfigurationError
 
 # ---------------------------------------------------------------------------
 # Module-level logger

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from fastmcp_pvl_core._env import env, env_int, parse_bool, parse_scopes
+from ._env import env, env_int, parse_bool, parse_scopes
 
 Transport = Literal["stdio", "http", "sse"]
 

--- a/src/fastmcp_pvl_core/_debug.py
+++ b/src/fastmcp_pvl_core/_debug.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 
 import logging
 
-from fastmcp_pvl_core._env import env, env_int, parse_bool
+from ._env import env, env_int, parse_bool
 
 logger = logging.getLogger(__name__)
 

--- a/src/fastmcp_pvl_core/_env.py
+++ b/src/fastmcp_pvl_core/_env.py
@@ -11,7 +11,7 @@ import math
 import os
 from typing import TypeVar, overload
 
-from fastmcp_pvl_core._errors import ConfigurationError
+from ._errors import ConfigurationError
 
 logger = logging.getLogger(__name__)
 

--- a/src/fastmcp_pvl_core/_factory.py
+++ b/src/fastmcp_pvl_core/_factory.py
@@ -22,7 +22,7 @@ import logging
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from fastmcp_pvl_core._config import ServerConfig
+from ._config import ServerConfig
 
 if TYPE_CHECKING:
     from fastmcp.server.event_store import EventStore
@@ -104,7 +104,7 @@ def build_event_store(env_prefix: str, config: ServerConfig) -> EventStore:
     # use this helper.
     from fastmcp.server.event_store import EventStore as _EventStore
 
-    from fastmcp_pvl_core._kv_store import build_kv_store
+    from ._kv_store import build_kv_store
 
     del env_prefix  # accepted for API compatibility; not consumed here
 

--- a/src/fastmcp_pvl_core/_kv_store.py
+++ b/src/fastmcp_pvl_core/_kv_store.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
-from fastmcp_pvl_core._config import ServerConfig
+from ._config import ServerConfig
 
 if TYPE_CHECKING:
     from key_value.aio.protocols.key_value import AsyncKeyValue

--- a/src/fastmcp_pvl_core/_logging.py
+++ b/src/fastmcp_pvl_core/_logging.py
@@ -77,7 +77,7 @@ class SecretMaskFilter(logging.Filter):
     modules that log request/response details at ``DEBUG`` level::
 
         import logging
-        from fastmcp_pvl_core import SecretMaskFilter
+        from . import SecretMaskFilter
 
         logger = logging.getLogger(__name__)
         logger.addFilter(SecretMaskFilter())

--- a/src/fastmcp_pvl_core/_logging.py
+++ b/src/fastmcp_pvl_core/_logging.py
@@ -77,7 +77,7 @@ class SecretMaskFilter(logging.Filter):
     modules that log request/response details at ``DEBUG`` level::
 
         import logging
-        from . import SecretMaskFilter
+        from fastmcp_pvl_core import SecretMaskFilter
 
         logger = logging.getLogger(__name__)
         logger.addFilter(SecretMaskFilter())

--- a/src/fastmcp_pvl_core/_middleware.py
+++ b/src/fastmcp_pvl_core/_middleware.py
@@ -12,8 +12,8 @@ import os
 
 from fastmcp import FastMCP
 
-from fastmcp_pvl_core._env import parse_bool
-from fastmcp_pvl_core._logging_middleware import RequestLoggingMiddleware
+from ._env import parse_bool
+from ._logging_middleware import RequestLoggingMiddleware
 
 
 def wire_middleware_stack(mcp: FastMCP) -> None:

--- a/src/fastmcp_pvl_core/_server_info.py
+++ b/src/fastmcp_pvl_core/_server_info.py
@@ -102,7 +102,7 @@ def register_server_info_tool(
     # for the mcp.types import.
     from mcp.types import ToolAnnotations
 
-    from fastmcp_pvl_core import __version__ as core_version
+    from . import __version__ as core_version
 
     default_description = (
         f"Report wrapper and upstream version info for {server_name}. "

--- a/src/fastmcp_pvl_core/_subject.py
+++ b/src/fastmcp_pvl_core/_subject.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
     # Imported only for typing; runtime import would create a cycle
     # (``_auth`` imports ``set_current_auth_mode`` from this module).
-    from fastmcp_pvl_core._auth import AuthMode
+    from ._auth import AuthMode
 
 # Per-context pointer to the auth mode resolved at server startup.
 # ``build_auth`` calls ``set_current_auth_mode`` once after resolving


### PR DESCRIPTION
Enables a fork to vendor pvl-core by a directory rename, and documents the full
disentanglement. A fork is not a downstream — these seams are a modularity
property, not a coherence compromise.

## Changes
- **Relative intra-package imports** (29 statements, behavior-preserving) so a
  fold-in is a directory rename, not a 29-site find-replace. Tests keep absolute
  imports; the `_logging.py` docstring usage example stays absolute
  (downstream-facing).
- **`docs/forking.md`** — pin-vs-fold tradeoff, fold-in recipe, bring-the-tests,
  collapsible-seams map (which abstractions a single-server fork may flatten),
  and cosmetic scrub list.
- **`CLAUDE.md`** — a standing "Keep pvl-core cleanly foldable" directive that
  forbids pre-flattening abstractions, mirrored as a sixth README design
  principle.

The copier-template detach (the fork's other half) is tracked separately in
`fastmcp-server-template#182`.

## Verification
- `uv run pytest` — 449 passed; `ruff format`/`ruff check`/`mypy src` clean.
- No runtime self-name lookups in `src/` (the guide's load-bearing claim).
- Preflight review circus run to a clean round.

Closes #194

Design: `docs/superpowers/specs/2026-06-20-foldability-forking-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._