### PR TITLE
feat: add title annotation to get_server_info tool

### DIFF
--- a/src/fastmcp_pvl_core/_server_info.py
+++ b/src/fastmcp_pvl_core/_server_info.py
@@ -49,6 +49,7 @@ def register_server_info_tool(
     upstream_label: str = "upstream",
     tool_name: str = "get_server_info",
     description: str | None = None,
+    title: str | None = None,
 ) -> None:
     """Register a ``get_server_info`` tool on a FastMCP instance.
 
@@ -87,6 +88,10 @@ def register_server_info_tool(
             built-in description that mentions the wrapper name.  Pass
             ``""`` to register an empty description; only ``None`` triggers
             the default.
+        title: Human-readable ``annotations.title`` for the tool, used as
+            the label by title-aware MCP clients (e.g. VS Code) instead of
+            the raw tool name.  Defaults to ``"Server Info"``; pass ``""``
+            to register an empty title; only ``None`` triggers the default.
 
     Raises:
         ValueError: If ``upstream_label`` collides with a reserved payload
@@ -148,5 +153,8 @@ def register_server_info_tool(
     mcp.tool(
         name=tool_name,
         description=default_description if description is None else description,
-        annotations=ToolAnnotations(readOnlyHint=True),
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            title="Server Info" if title is None else title,
+        ),
     )(get_server_info)

--- a/tests/test_server_info.py
+++ b/tests/test_server_info.py
@@ -173,6 +173,46 @@ class TestRegisterServerInfoTool:
         assert target.annotations is not None
         assert target.annotations.readOnlyHint is True
 
+    async def test_tool_has_default_title(self):
+        """Title-aware clients (e.g. VS Code) need a human-readable label."""
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+        )
+        tools = await mcp.list_tools()
+        target = next(t for t in tools if t.name == "get_server_info")
+        assert target.annotations is not None
+        assert target.annotations.title == "Server Info"
+
+    async def test_custom_title(self):
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+            title="About This Server",
+        )
+        tools = await mcp.list_tools()
+        target = next(t for t in tools if t.name == "get_server_info")
+        assert target.annotations is not None
+        assert target.annotations.title == "About This Server"
+
+    async def test_empty_string_title_not_replaced_by_default(self):
+        """Only None triggers the default; an explicit "" stays empty."""
+        mcp = FastMCP("t")
+        register_server_info_tool(
+            mcp,
+            server_version="1.0.0",
+            server_name="my-mcp",
+            title="",
+        )
+        tools = await mcp.list_tools()
+        target = next(t for t in tools if t.name == "get_server_info")
+        assert target.annotations is not None
+        assert target.annotations.title == ""
+
     async def test_custom_description(self):
         mcp = FastMCP("t")
         register_server_info_tool(


### PR DESCRIPTION
## Summary
`register_server_info_tool` registered `get_server_info` with only `readOnlyHint` and no `title`. Title-aware MCP clients (e.g. VS Code, which honours only `title` and `readOnlyHint` among annotations) therefore rendered it under its raw machine name instead of a friendly label.

## Changes
- Add a `title: str | None = None` parameter to `register_server_info_tool`, set on the tool's `annotations.title`.
- Default is `"Server Info"`. Mirrors the existing `description` parameter's semantics: only `None` triggers the default; an explicit `""` stays empty — so callers that register under a custom `tool_name` can supply a fitting title.
- Three TDD tests (default title, custom title, empty-string-stays-empty), all round-tripping through the real `list_tools()` path.

## Context
Surfaced while titling every tool in a downstream server (`pvliesdonk/markdown-vault-mcp#751`): that repo could title all of its own tools but not `get_server_info`, which is registered here. Once this ships and the dep is bumped downstream, the downstream title-enforcement test can drop its `get_server_info` exclusion.

## Testing
- `uv run pytest -q` — 452 passed.
- `uv run mypy src/` — clean (the CI gate).
- `uv run ruff check . && uv run ruff format --check .` — clean.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._