### PR TITLE
feat(config): add server_config_env_suffixes() to enumerate the env surface

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -22,7 +22,7 @@ from ._authorization import (
     parse_claim_grants,
 )
 from ._cli import make_serve_parser, normalise_http_path
-from ._config import ServerConfig, Transport
+from ._config import ServerConfig, Transport, server_config_env_suffixes
 from ._debug import maybe_start_debugpy
 from ._env import (
     env,
@@ -92,5 +92,6 @@ __all__ = [
     "register_server_info_tool",
     "register_tool_icons",
     "resolve_auth_mode",
+    "server_config_env_suffixes",
     "wire_middleware_stack",
 ]

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -159,3 +159,50 @@ class ServerConfig:
             bearer_tokens_file=bearer_tokens_file,
             bearer_default_subject=bearer_default_subject,
         )
+
+
+# The env-var suffixes ``ServerConfig.from_env`` reads (the part after a
+# project's ``{PREFIX}_``). Kept in lockstep with ``from_env`` by
+# ``test_config.py::TestServerConfigEnvSuffixes``, which AST-scans ``from_env``
+# for ``env``/``env_int``/``env_float`` calls whose suffix is a string literal
+# and fails if such a read is added/removed/renamed without updating this set.
+# Keep every ``from_env`` read in the ``env(prefix, "LITERAL")`` form: a suffix
+# built from a variable or passed by keyword would not be seen by the scan.
+_SERVER_CONFIG_ENV_SUFFIXES: frozenset[str] = frozenset(
+    {
+        "TRANSPORT",
+        "HOST",
+        "PORT",
+        "BASE_URL",
+        "BEARER_TOKEN",
+        "BEARER_TOKENS_FILE",
+        "BEARER_DEFAULT_SUBJECT",
+        "OIDC_CONFIG_URL",
+        "OIDC_CLIENT_ID",
+        "OIDC_CLIENT_SECRET",
+        "OIDC_AUDIENCE",
+        "OIDC_REQUIRED_SCOPES",
+        "OIDC_JWT_SIGNING_KEY",
+        "OIDC_VERIFY_ACCESS_TOKEN",
+        "KV_STORE_URL",
+        "EVENT_STORE_URL",
+        "APP_DOMAIN",
+        "AUTH_MODE",
+    }
+)
+
+
+def server_config_env_suffixes() -> frozenset[str]:
+    """Return the env-var suffixes :meth:`ServerConfig.from_env` reads.
+
+    Each suffix is the part after a project's ``{PREFIX}_`` (e.g. ``BASE_URL``
+    for ``MYAPP_BASE_URL``), so a consumer can check whether a given
+    ``{PREFIX}_{SUFFIX}`` variable is part of the upstream ``ServerConfig``
+    surface — for instance to detect drift between a config-wizard spec and the
+    real config surface.
+
+    Excludes native ``FASTMCP_*`` variables and consumer-specific
+    (``ProjectConfig``) variables: it is purely the ``ServerConfig.from_env``
+    surface.
+    """
+    return _SERVER_CONFIG_ENV_SUFFIXES

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -199,3 +199,63 @@ class TestServerConfigFromEnv:
         monkeypatch.delenv("MYAPP_BEARER_DEFAULT_SUBJECT", raising=False)
         config = ServerConfig.from_env("MYAPP")
         assert config.bearer_default_subject == "bearer-anon"
+
+
+def _suffixes_read_by_from_env() -> set[str]:
+    """The literal env suffixes ``ServerConfig.from_env`` actually reads.
+
+    Statically extracts the second positional argument of each
+    ``env``/``env_int``/``env_float`` call in ``from_env``'s source **whose
+    suffix is a string literal** (calls with a variable, keyword, or
+    attribute-form suffix are skipped), so the test reflects the literal read
+    surface rather than a hand-copied list.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    src = textwrap.dedent(inspect.getsource(ServerConfig.from_env))
+    read_funcs = {"env", "env_int", "env_float"}
+    found: set[str] = set()
+    for node in ast.walk(ast.parse(src)):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in read_funcs
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+        ):
+            found.add(node.args[1].value)
+    return found
+
+
+class TestServerConfigEnvSuffixes:
+    def test_returns_frozenset_with_known_suffixes(self):
+        from fastmcp_pvl_core import server_config_env_suffixes
+
+        suffixes = server_config_env_suffixes()
+        assert isinstance(suffixes, frozenset)
+        # Representative members across the categories from_env reads.
+        assert {
+            "TRANSPORT",
+            "HOST",
+            "PORT",
+            "BASE_URL",
+            "BEARER_TOKEN",
+            "OIDC_CONFIG_URL",
+            "KV_STORE_URL",
+            "AUTH_MODE",
+        } <= suffixes
+
+    def test_matches_what_from_env_actually_reads(self):
+        """Anti-drift: the declared set must equal the literal suffixes from_env reads.
+
+        A literal-string read added/removed/renamed in ``from_env`` without
+        updating the declared set fails here. (A suffix built from a variable or
+        passed by keyword is invisible to the scan — see
+        ``_suffixes_read_by_from_env``.)
+        """
+        from fastmcp_pvl_core import server_config_env_suffixes
+
+        assert server_config_env_suffixes() == _suffixes_read_by_from_env()


### PR DESCRIPTION
## What

A public helper enumerating the env-var suffixes `ServerConfig.from_env` reads:

```python
def server_config_env_suffixes() -> frozenset[str]: ...
```

Returns the 18 suffixes (the part after a project's `{PREFIX}_`): `TRANSPORT, HOST, PORT, BASE_URL, BEARER_TOKEN, BEARER_TOKENS_FILE, BEARER_DEFAULT_SUBJECT, OIDC_CONFIG_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_AUDIENCE, OIDC_REQUIRED_SCOPES, OIDC_JWT_SIGNING_KEY, OIDC_VERIFY_ACCESS_TOKEN, KV_STORE_URL, EVENT_STORE_URL, APP_DOMAIN, AUTH_MODE`. Excludes native `FASTMCP_*` and consumer (`ProjectConfig`) vars — it is purely the `ServerConfig.from_env` surface.

## Why

Consumers that introspect "which env vars does the upstream `ServerConfig` consume" — e.g. a config-wizard drift guard ([fastmcp-server-template#203](https://github.com/pvliesdonk/fastmcp-server-template/issues/203)) — currently have to hardcode the list and let it rot. This exposes it programmatically.

## How

- Backed by an explicit module constant `_SERVER_CONFIG_ENV_SUFFIXES`; the public function returns it directly (immutable frozenset, safe to expose).
- Exported via `__init__.py` (`__all__`).
- **Anti-drift test** (`TestServerConfigEnvSuffixes`): AST-scans `from_env`'s source for the literal suffix of every `env`/`env_int`/`env_float` call and asserts it equals the declared set. Any literal read added/removed/renamed in `from_env` without updating the constant fails CI. The constant comment and test docstrings precisely scope this to *string-literal positional* reads and instruct maintainers to keep reads in the `env(prefix, "LITERAL")` form (a variable/keyword/attribute-form suffix is invisible to the scan).

## Validation

TDD (tests written first, watched failing). Full gate green: `ruff check`, `ruff format --check`, `mypy src/`, `pytest` (454 tests). Local five-lens preflight review clean.

Closes #200

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._