### PR TITLE
chore: gitignore local codebase-intelligence artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ build/
 coverage.xml
 .claude/
 .superpowers/
+
+# Local codebase-intelligence tooling: regenerated index cache and a
+# machine-specific MCP server registration (absolute checkout path).
+.repowise/
+.mcp.json


### PR DESCRIPTION
## What

Adds `.repowise/` and `.mcp.json` to `.gitignore`.

- **`.repowise/`** — a regenerated Repowise index cache (`lancedb/`, ~3 MB `wiki.db` + WAL/SHM, `knowledge-graph.json`, job state, transient `.update.*` lock/log files). Pure regenerable tooling state.
- **`.mcp.json`** — registers the `repowise` MCP server with a hardcoded absolute checkout path (`/mnt/code/mcp-servers/fastmcp-pvl-core`) in its `args`, making it machine-specific and non-portable.

Both join the existing local-tooling ignores (`.claude/`, `.superpowers/`) directly above them.

## Why

Neither path was ever tracked, but without an ignore entry a blanket `git add -A` stages all ~90 cache files into unrelated commits — which is exactly what happened (and was caught at diff-review) on #203.

## Verification

- `git log --all -- .mcp.json .repowise/` and `git ls-files` both return nothing → never tracked on any ref, so a `.gitignore` entry is the complete fix (no `git rm --cached` needed, nothing orphaned).
- `git check-ignore .repowise/ .mcp.json .repowise/wiki.db` → all reported ignored.
- After the change, `git status` shows neither path as untracked.

Closes #204

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._