### PR TITLE
refactor(auth): extract three helpers from high-complexity builders

### DIFF
--- a/src/fastmcp_pvl_core/_auth.py
+++ b/src/fastmcp_pvl_core/_auth.py
@@ -56,6 +56,29 @@ def _is_valid_override(value: str) -> TypeGuard[Literal["remote", "oidc-proxy"]]
     return value in _VALID_MODES
 
 
+def _resolve_explicit_override(
+    raw: str | None,
+) -> Literal["remote", "oidc-proxy"] | None:
+    """Resolve the ``AUTH_MODE`` override to a valid OIDC mode, or ``None``.
+
+    The override only accepts ``remote`` or ``oidc-proxy`` (case- and
+    whitespace-insensitive). An empty/unset value yields ``None``
+    silently; any other non-empty value yields ``None`` with a warning.
+    Callers fall back to auto-detection whenever this returns ``None``.
+    """
+    explicit = (raw or "").strip().lower()
+    if not explicit:
+        return None
+    if _is_valid_override(explicit):
+        logger.info("auth_mode=%s (explicit via AUTH_MODE)", explicit)
+        return explicit
+    logger.warning(
+        "auth_mode_unknown value=%r — ignoring, falling back to auto-detection",
+        explicit,
+    )
+    return None
+
+
 def resolve_auth_mode(config: ServerConfig) -> AuthMode:
     """Decide which auth flavor to use based on configured fields.
 
@@ -86,15 +109,9 @@ def resolve_auth_mode(config: ServerConfig) -> AuthMode:
     Returns:
         One of the six :data:`AuthMode` literals.
     """
-    explicit = (config.auth_mode or "").strip().lower()
-    if explicit:
-        if _is_valid_override(explicit):
-            logger.info("auth_mode=%s (explicit via AUTH_MODE)", explicit)
-            return explicit
-        logger.warning(
-            "auth_mode_unknown value=%r — ignoring, falling back to auto-detection",
-            explicit,
-        )
+    override = _resolve_explicit_override(config.auth_mode)
+    if override is not None:
+        return override
 
     has_mapped_bearer = config.bearer_tokens_file is not None
     has_single_bearer = bool(config.bearer_token) and not has_mapped_bearer
@@ -127,6 +144,39 @@ def resolve_auth_mode(config: ServerConfig) -> AuthMode:
     if oidc_mode is not None:
         return oidc_mode
     return "none"
+
+
+def _coerce_token_subject(path: Path, token: str, subject: object) -> str:
+    """Validate one ``token -> subject`` row, returning the subject string.
+
+    Args:
+        path: Source file, used only for error messages.
+        token: The TOML table key (always a string per TOML).
+        subject: The raw TOML value for *token*.
+
+    Raises:
+        ConfigurationError: blank token key, nested-table subject,
+            non-string subject, or empty/whitespace-only subject.
+    """
+    # TOML keys are always strings, so just check they're non-blank.
+    if not token.strip():
+        raise ConfigurationError(
+            f"bearer tokens file at {path}: token key is empty or whitespace-only"
+        )
+    if isinstance(subject, dict):
+        raise ConfigurationError(
+            f"bearer tokens file at {path}: token entry is a "
+            f"nested table — quote token strings as "
+            f'\'"<token>" = "<subject>"\''
+        )
+    if not isinstance(subject, str):
+        raise ConfigurationError(
+            f"bearer tokens file at {path}: subject must be a "
+            f"string, got {type(subject).__name__}"
+        )
+    if not subject.strip():
+        raise ConfigurationError(f"bearer tokens file at {path}: subject is empty")
+    return subject
 
 
 def _load_bearer_tokens(path: Path) -> dict[str, str]:
@@ -168,25 +218,7 @@ def _load_bearer_tokens(path: Path) -> dict[str, str]:
         )
     result: dict[str, str] = {}
     for token, subject in tokens.items():
-        # TOML keys are always strings, so just check they're non-blank.
-        if not token.strip():
-            raise ConfigurationError(
-                f"bearer tokens file at {path}: token key is empty or whitespace-only"
-            )
-        if isinstance(subject, dict):
-            raise ConfigurationError(
-                f"bearer tokens file at {path}: token entry is a "
-                f"nested table — quote token strings as "
-                f'\'"<token>" = "<subject>"\''
-            )
-        if not isinstance(subject, str):
-            raise ConfigurationError(
-                f"bearer tokens file at {path}: subject must be a "
-                f"string, got {type(subject).__name__}"
-            )
-        if not subject.strip():
-            raise ConfigurationError(f"bearer tokens file at {path}: subject is empty")
-        result[token] = subject
+        result[token] = _coerce_token_subject(path, token, subject)
     return result
 
 
@@ -255,6 +287,33 @@ def build_bearer_auth(config: ServerConfig) -> StaticTokenVerifier | None:
     )
 
 
+def _warn_oidc_caveats(
+    *, required_scopes: list[str], verify_id_token: bool, signing_key: str | None
+) -> None:
+    """Emit operator warnings for misconfiguration-prone OIDC-proxy settings.
+
+    Warns when id_token verification is on but ``openid`` is absent from
+    *required_scopes* (the id_token may never be issued), and when no JWT
+    signing key is set on Linux (tokens are invalidated on every restart).
+    """
+    if verify_id_token and "openid" not in required_scopes:
+        logger.warning(
+            "oidc_proxy_auth_scope_warning "
+            "verify_id_token=True missing_scope=openid — "
+            "the id_token may be absent from the token response; "
+            "add 'openid' to required_scopes or set "
+            "oidc_verify_access_token=True"
+        )
+
+    if signing_key is None and sys.platform.startswith("linux"):
+        logger.warning(
+            "oidc_proxy_auth_ephemeral_signing_key "
+            "oidc_jwt_signing_key=<unset> — tokens will be invalidated on "
+            "every server restart; configure OIDC_JWT_SIGNING_KEY in "
+            "production"
+        )
+
+
 def build_oidc_proxy_auth(config: ServerConfig) -> OIDCProxy | None:
     """Build an :class:`OIDCProxy` provider, or return ``None``.
 
@@ -303,22 +362,11 @@ def build_oidc_proxy_auth(config: ServerConfig) -> OIDCProxy | None:
     verify_access_token = config.oidc_verify_access_token
     verify_id_token = not verify_access_token
 
-    if verify_id_token and "openid" not in required_scopes:
-        logger.warning(
-            "oidc_proxy_auth_scope_warning "
-            "verify_id_token=True missing_scope=openid — "
-            "the id_token may be absent from the token response; "
-            "add 'openid' to required_scopes or set "
-            "oidc_verify_access_token=True"
-        )
-
-    if config.oidc_jwt_signing_key is None and sys.platform.startswith("linux"):
-        logger.warning(
-            "oidc_proxy_auth_ephemeral_signing_key "
-            "oidc_jwt_signing_key=<unset> — tokens will be invalidated on "
-            "every server restart; configure OIDC_JWT_SIGNING_KEY in "
-            "production"
-        )
+    _warn_oidc_caveats(
+        required_scopes=required_scopes,
+        verify_id_token=verify_id_token,
+        signing_key=config.oidc_jwt_signing_key,
+    )
 
     from fastmcp.server.auth.oidc_proxy import OIDCProxy
 

--- a/tests/test_auth_internal_helpers.py
+++ b/tests/test_auth_internal_helpers.py
@@ -1,0 +1,157 @@
+"""Unit tests for the internal helpers extracted from ``_auth.py``.
+
+These cover the three helpers carved out of the high-complexity builders
+(``resolve_auth_mode``, ``_load_bearer_tokens``, ``build_oidc_proxy_auth``)
+directly, at a finer grain than the public-builder tests exercise them.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+from fastmcp_pvl_core._auth import (
+    _coerce_token_subject,
+    _resolve_explicit_override,
+    _warn_oidc_caveats,
+)
+from fastmcp_pvl_core._errors import ConfigurationError
+
+# --------------------------------------------------------------------------
+# _resolve_explicit_override
+# --------------------------------------------------------------------------
+
+
+def test_override_none_returns_none() -> None:
+    assert _resolve_explicit_override(None) is None
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "\t\n"])
+def test_override_blank_returns_none_without_warning(
+    raw: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
+        assert _resolve_explicit_override(raw) is None
+    assert not [r for r in caplog.records if "auth_mode_unknown" in r.getMessage()]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("remote", "remote"),
+        ("oidc-proxy", "oidc-proxy"),
+        ("  REMOTE  ", "remote"),
+        ("OIDC-Proxy", "oidc-proxy"),
+    ],
+)
+def test_override_valid_is_normalised(raw: str, expected: str) -> None:
+    assert _resolve_explicit_override(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["bearer-single", "multi", "none", "garbage"])
+def test_override_invalid_returns_none_and_warns(
+    raw: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
+        assert _resolve_explicit_override(raw) is None
+    assert [r for r in caplog.records if "auth_mode_unknown" in r.getMessage()]
+
+
+# --------------------------------------------------------------------------
+# _coerce_token_subject
+# --------------------------------------------------------------------------
+
+_P = Path("/tmp/tokens.toml")
+
+
+def test_coerce_subject_valid_returns_subject() -> None:
+    assert _coerce_token_subject(_P, "tok", "alice") == "alice"
+
+
+def test_coerce_subject_blank_token_key_raises() -> None:
+    with pytest.raises(ConfigurationError, match="token key is empty"):
+        _coerce_token_subject(_P, "   ", "alice")
+
+
+def test_coerce_subject_nested_table_raises() -> None:
+    with pytest.raises(ConfigurationError, match="nested table"):
+        _coerce_token_subject(_P, "tok", {"sub": "alice"})
+
+
+def test_coerce_subject_non_string_raises() -> None:
+    with pytest.raises(ConfigurationError, match="must be a string"):
+        _coerce_token_subject(_P, "tok", 123)
+
+
+def test_coerce_subject_empty_string_raises() -> None:
+    with pytest.raises(ConfigurationError, match="subject is empty"):
+        _coerce_token_subject(_P, "tok", "   ")
+
+
+# --------------------------------------------------------------------------
+# _warn_oidc_caveats
+# --------------------------------------------------------------------------
+
+
+def test_caveats_warns_missing_openid_scope(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
+        _warn_oidc_caveats(
+            required_scopes=["email"], verify_id_token=True, signing_key="k"
+        )
+    assert [r for r in caplog.records if "scope_warning" in r.getMessage()]
+
+
+def test_caveats_no_scope_warning_when_openid_present(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
+        _warn_oidc_caveats(
+            required_scopes=["openid"], verify_id_token=True, signing_key="k"
+        )
+    assert not [r for r in caplog.records if "scope_warning" in r.getMessage()]
+
+
+def test_caveats_no_scope_warning_when_verifying_access_token(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
+        _warn_oidc_caveats(
+            required_scopes=["email"], verify_id_token=False, signing_key="k"
+        )
+    assert not [r for r in caplog.records if "scope_warning" in r.getMessage()]
+
+
+def test_caveats_warns_ephemeral_key_on_linux(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
+        _warn_oidc_caveats(
+            required_scopes=["openid"], verify_id_token=True, signing_key=None
+        )
+    assert [r for r in caplog.records if "ephemeral_signing_key" in r.getMessage()]
+
+
+def test_caveats_no_ephemeral_warning_when_key_set(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
+        _warn_oidc_caveats(
+            required_scopes=["openid"], verify_id_token=True, signing_key="k"
+        )
+    assert not [r for r in caplog.records if "ephemeral_signing_key" in r.getMessage()]
+
+
+def test_caveats_no_ephemeral_warning_off_linux(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
+        _warn_oidc_caveats(
+            required_scopes=["openid"], verify_id_token=True, signing_key=None
+        )
+    assert not [r for r in caplog.records if "ephemeral_signing_key" in r.getMessage()]


### PR DESCRIPTION
## What

Behaviour-preserving refactor of `_auth.py` — the package's #1 churn × complexity hotspot (#206 investigation). Extracts three private helpers from the most complex builders, lowering per-function cyclomatic complexity without touching any auth logic:

| Helper | Extracted from | CCN |
|---|---|---|
| `_resolve_explicit_override` | `resolve_auth_mode` | 15 → **13** |
| `_coerce_token_subject` | `_load_bearer_tokens` | 12 → **8** |
| `_warn_oidc_caveats` | `build_oidc_proxy_auth` | 11 → **7** |

New helpers are CCN 4/5/5, each independently unit-tested.

## Scope — deliberately conservative

This is the **accidental-complexity-only** scope from the #206 investigation. The remaining complexity is *essential* and was left intact:
- `resolve_auth_mode`'s residual CCN 13 is the genuine 6-mode precedence cascade (the branches *are* the spec).
- `build_auth` (CCN 10) and `build_remote_auth` were not touched.

No wholesale restructure of the package's most security-sensitive file — modest metric gain isn't worth the regression risk.

## Behaviour preservation

Each extraction moves logic verbatim; no condition, warning, error message, or control-flow path changed. Specifically preserved:
- The AUTH_MODE override's strict `remote`/`oidc-proxy`-only subset (excluding bearer/multi/none to avoid silent-unauth startup).
- All four bearer-token `ConfigurationError` diagnostics, in order.
- Both OIDC warnings, including the Linux-gated ephemeral-signing-key guard.
- The fail-closed invariant: an invalid AUTH_MODE still falls through to auto-detection, never to weaker auth.

## Tests

- **23 new tests** in `tests/test_auth_internal_helpers.py` covering each helper's contract edges directly (TDD: written before the helpers existed, watched fail, then extracted).
- All **73 existing auth tests pass unchanged** — the regression net for behaviour preservation.
- Full suite: 477 passed. ruff / format / mypy clean.

Closes #206

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._