### PR TITLE
refactor(icons): extract three helpers from register_tool_icons

### DIFF
--- a/src/fastmcp_pvl_core/_icons.py
+++ b/src/fastmcp_pvl_core/_icons.py
@@ -113,6 +113,98 @@ accepted as-is.
 """
 
 
+def _resolve_static_dir(static_dir: str | Path) -> Path:
+    """Resolve and validate ``static_dir``, returning the absolute path.
+
+    Raises:
+        FileNotFoundError: the directory does not exist.
+        NotADirectoryError: the path exists but is not a directory.
+    """
+    base_dir = Path(static_dir).resolve()
+    if not base_dir.exists():
+        raise FileNotFoundError(f"static_dir does not exist: {base_dir}")
+    if not base_dir.is_dir():
+        raise NotADirectoryError(f"static_dir is not a directory: {base_dir}")
+    return base_dir
+
+
+def _index_tools_by_name(mcp: FastMCP) -> dict[str, list[Tool]]:
+    """Group a FastMCP instance's registered tools by tool name.
+
+    ``local_provider`` is the public access point on FastMCP; ``_components``
+    is its internal store keyed as ``"<prefix>:<name>@<version>"`` (the ``@``
+    is always present; version is empty for unversioned tools). FastMCP does
+    not expose a public sync ``tools`` accessor today, so we go one level
+    deep — the public async ``list_tools()`` would force callers to be async,
+    which is heavier than the maintenance risk of one private attr. Verified
+    against fastmcp >=3,<4 (see pyproject.toml).
+
+    Raises:
+        RuntimeError: FastMCP's internal component API changed (the guard
+            turns a future rename into an actionable error rather than a
+            bare ``AttributeError`` that looks like a caller bug).
+    """
+    # Imported lazily so callers that never use this helper don't pay for
+    # the fastmcp.tools import at package load time.
+    from fastmcp.tools.base import Tool
+
+    try:
+        components = mcp.local_provider._components
+    except AttributeError as exc:
+        raise RuntimeError(
+            "FastMCP internal API changed: cannot enumerate tools via "
+            "local_provider._components. Please file an issue against "
+            "fastmcp-pvl-core."
+        ) from exc
+
+    tools_by_name: dict[str, list[Tool]] = {}
+    for component in components.values():
+        if isinstance(component, Tool):
+            tools_by_name.setdefault(component.name, []).append(component)
+    return tools_by_name
+
+
+def _resolve_icon_entry(entry: str | Path, base_dir: Path, tool_name: str) -> Icon:
+    """Resolve one icon filename to an :class:`Icon`.
+
+    Relative paths are resolved under *base_dir* and must not escape it via
+    ``..``; absolute paths bypass *base_dir* by design (see the
+    :data:`IconSpec` docstring — the caller takes responsibility for what's
+    outside ``static_dir``). *tool_name* is used only for error-message
+    context.
+
+    Raises:
+        ValueError: a relative path escapes *base_dir*, or the file has an
+            unsupported extension.
+        FileNotFoundError: the referenced icon file does not exist.
+    """
+    entry_path = Path(entry)
+    if entry_path.is_absolute():
+        path = entry_path
+    else:
+        # Relative paths must stay inside static_dir; resolving collapses
+        # ``..`` so we can check containment after the fact.
+        path = (base_dir / entry_path).resolve()
+        if not _is_within(path, base_dir):
+            raise ValueError(
+                f"Icon path {str(entry)!r} for tool {tool_name!r} "
+                f"escapes static_dir ({base_dir})"
+            )
+
+    # Let make_icon do the read; that's the only place that touches the file,
+    # so any FileNotFoundError or ValueError comes straight from there and we
+    # wrap it once with the tool-name context the caller needs. This also
+    # closes the TOCTOU window that an ``is_file()`` pre-check would leave open.
+    try:
+        return make_icon(path)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Icon file for tool {tool_name!r} not found: {path}"
+        ) from exc
+    except ValueError as exc:
+        raise ValueError(f"Tool {tool_name!r}: {exc}") from exc
+
+
 def register_tool_icons(
     mcp: FastMCP,
     mapping: Mapping[str, IconSpec],
@@ -156,39 +248,12 @@ def register_tool_icons(
             file is missing.
         NotADirectoryError: If ``static_dir`` exists but is not a directory.
     """
-    # Imported lazily so callers that never use this helper don't pay for
-    # the fastmcp.tools import at package load time.
-    from fastmcp.tools.base import Tool
+    base_dir = _resolve_static_dir(static_dir)
+    tools_by_name = _index_tools_by_name(mcp)
 
-    base_dir = Path(static_dir).resolve()
-    if not base_dir.exists():
-        raise FileNotFoundError(f"static_dir does not exist: {base_dir}")
-    if not base_dir.is_dir():
-        raise NotADirectoryError(f"static_dir is not a directory: {base_dir}")
-
-    # ``local_provider`` is the public access point on FastMCP; ``_components``
-    # is its internal store keyed as ``"<prefix>:<name>@<version>"`` (the ``@``
-    # is always present; version is empty for unversioned tools). FastMCP does
-    # not expose a public sync ``tools`` accessor today, so we go one level
-    # deep — the public async ``list_tools()`` would force this helper to be
-    # async, which is heavier than the maintenance risk of one private attr.
-    # Verified against fastmcp >=3,<4 (see pyproject.toml). The guard turns a
-    # future rename into an actionable error rather than a bare AttributeError
-    # that looks like a caller bug.
-    try:
-        components = mcp.local_provider._components
-    except AttributeError as exc:
-        raise RuntimeError(
-            "FastMCP internal API changed: cannot enumerate tools via "
-            "local_provider._components. Please file an issue against "
-            "fastmcp-pvl-core."
-        ) from exc
-
-    tools_by_name: dict[str, list[Tool]] = {}
-    for component in components.values():
-        if isinstance(component, Tool):
-            tools_by_name.setdefault(component.name, []).append(component)
-
+    # Resolve and validate every entry first; the apply loop below only runs
+    # once nothing can fail, so a missing file or unknown tool name aborts
+    # without leaving a half-applied state (the atomicity contract above).
     resolved: list[tuple[str, list[Tool], list[Icon], list[str]]] = []
 
     for tool_name, files in mapping.items():
@@ -205,38 +270,8 @@ def register_tool_icons(
         else:
             entries = list(files)
 
-        icons: list[Icon] = []
-        display: list[str] = []
-        for entry in entries:
-            entry_path = Path(entry)
-            if entry_path.is_absolute():
-                # Absolute paths bypass static_dir resolution by design — see
-                # ``IconSpec`` docstring.  Caller takes responsibility for
-                # what's outside static_dir.
-                path = entry_path
-            else:
-                # Relative paths must stay inside static_dir; resolving
-                # collapses ``..`` so we can check containment after the fact.
-                path = (base_dir / entry_path).resolve()
-                if not _is_within(path, base_dir):
-                    raise ValueError(
-                        f"Icon path {str(entry)!r} for tool {tool_name!r} "
-                        f"escapes static_dir ({base_dir})"
-                    )
-            # Let make_icon do the read; that's the only place that touches
-            # the file, so any FileNotFoundError or ValueError comes straight
-            # from there and we wrap it once with the tool-name context the
-            # caller needs.  This also closes the TOCTOU window that an
-            # ``is_file()`` pre-check would have left open.
-            try:
-                icons.append(make_icon(path))
-            except FileNotFoundError as exc:
-                raise FileNotFoundError(
-                    f"Icon file for tool {tool_name!r} not found: {path}"
-                ) from exc
-            except ValueError as exc:
-                raise ValueError(f"Tool {tool_name!r}: {exc}") from exc
-            display.append(str(entry))
+        icons = [_resolve_icon_entry(entry, base_dir, tool_name) for entry in entries]
+        display = [str(entry) for entry in entries]
         resolved.append((tool_name, targets, icons, display))
 
     for tool_name, targets, icons, filenames in resolved:

--- a/src/fastmcp_pvl_core/_icons.py
+++ b/src/fastmcp_pvl_core/_icons.py
@@ -173,6 +173,10 @@ def _resolve_icon_entry(entry: str | Path, base_dir: Path, tool_name: str) -> Ic
     outside ``static_dir``). *tool_name* is used only for error-message
     context.
 
+    *base_dir* must already be absolute and resolved (the output of
+    :func:`_resolve_static_dir`); the containment check via :func:`_is_within`
+    relies on it being normalised.
+
     Raises:
         ValueError: a relative path escapes *base_dir*, or the file has an
             unsupported extension.

--- a/tests/test_icons_internal_helpers.py
+++ b/tests/test_icons_internal_helpers.py
@@ -1,0 +1,177 @@
+"""Unit tests for the internal helpers extracted from ``register_tool_icons``.
+
+These cover the three helpers carved out of the high-complexity
+``register_tool_icons`` orchestrator (``_resolve_static_dir``,
+``_index_tools_by_name``, ``_resolve_icon_entry``) directly, at a finer
+grain than the public-builder tests in ``test_icons.py`` reach them.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+from fastmcp import FastMCP
+from fastmcp.tools.base import Tool
+
+from fastmcp_pvl_core._icons import (
+    _index_tools_by_name,
+    _resolve_icon_entry,
+    _resolve_static_dir,
+)
+
+SVG_BYTES = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></svg>'
+
+
+def _write(tmp_path: Path, name: str, data: bytes) -> Path:
+    path = tmp_path / name
+    path.write_bytes(data)
+    return path
+
+
+def _make_mcp_with_tool(tool_name: str = "ping") -> FastMCP:
+    mcp = FastMCP("t")
+
+    @mcp.tool(name=tool_name)
+    def _ping() -> str:
+        return "pong"
+
+    return mcp
+
+
+# --------------------------------------------------------------------------
+# _resolve_static_dir
+# --------------------------------------------------------------------------
+
+
+def test_resolve_static_dir_returns_resolved_dir(tmp_path: Path) -> None:
+    result = _resolve_static_dir(tmp_path)
+    assert result == tmp_path.resolve()
+    assert result.is_absolute()
+
+
+def test_resolve_static_dir_accepts_string(tmp_path: Path) -> None:
+    assert _resolve_static_dir(str(tmp_path)) == tmp_path.resolve()
+
+
+def test_resolve_static_dir_missing_raises(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        _resolve_static_dir(missing)
+
+
+def test_resolve_static_dir_file_raises(tmp_path: Path) -> None:
+    regular_file = _write(tmp_path, "not-a-dir.txt", b"hi")
+    with pytest.raises(NotADirectoryError, match="not a directory"):
+        _resolve_static_dir(regular_file)
+
+
+def test_resolve_static_dir_collapses_dotdot(tmp_path: Path) -> None:
+    # The returned base_dir is what _resolve_icon_entry's containment check
+    # compares against, so it must be fully normalised — a ``..`` segment
+    # has to collapse rather than survive into the comparison.
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    assert _resolve_static_dir(sub / "..") == tmp_path.resolve()
+
+
+# --------------------------------------------------------------------------
+# _index_tools_by_name
+# --------------------------------------------------------------------------
+
+
+def test_index_single_tool() -> None:
+    mcp = _make_mcp_with_tool("ping")
+    index = _index_tools_by_name(mcp)
+    assert list(index["ping"])[0].name == "ping"
+    assert len(index["ping"]) == 1
+
+
+def test_index_multiple_tools() -> None:
+    mcp = FastMCP("t")
+
+    @mcp.tool(name="alpha")
+    def _alpha() -> str:
+        return "a"
+
+    @mcp.tool(name="beta")
+    def _beta() -> str:
+        return "b"
+
+    index = _index_tools_by_name(mcp)
+    assert {"alpha", "beta"} <= set(index)
+
+
+def test_index_groups_multiple_versions_under_one_name() -> None:
+    # The dict[str, list[Tool]] return type exists for exactly this case:
+    # one tool name registered at multiple versions must accumulate into a
+    # list, not overwrite. Mimic a second version by injecting another
+    # same-named component under a distinct store key.
+    mcp = _make_mcp_with_tool("ping")
+
+    def _ping_v2() -> str:
+        return "pong2"
+
+    mcp.local_provider._components["tool:ping@v2"] = Tool.from_function(
+        _ping_v2, name="ping"
+    )
+
+    index = _index_tools_by_name(mcp)
+    assert len(index["ping"]) == 2
+    assert all(tool.name == "ping" for tool in index["ping"])
+
+
+def test_index_unknown_tool_absent() -> None:
+    index = _index_tools_by_name(_make_mcp_with_tool("ping"))
+    assert "ghost" not in index
+
+
+def test_index_raises_runtime_error_on_api_change() -> None:
+    class _NotFastMCP:
+        pass
+
+    with pytest.raises(RuntimeError, match="FastMCP internal API changed"):
+        _index_tools_by_name(_NotFastMCP())  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# _resolve_icon_entry
+# --------------------------------------------------------------------------
+
+
+def test_resolve_entry_relative_returns_icon(tmp_path: Path) -> None:
+    _write(tmp_path, "ping.svg", SVG_BYTES)
+    icon = _resolve_icon_entry("ping.svg", tmp_path.resolve(), "ping")
+    assert icon.mimeType == "image/svg+xml"
+    assert base64.b64decode(icon.src.split(",", 1)[1]) == SVG_BYTES
+
+
+def test_resolve_entry_absolute_bypasses_containment(
+    tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    elsewhere = tmp_path_factory.mktemp("elsewhere")
+    absolute = _write(elsewhere, "abs.svg", SVG_BYTES)
+    icon = _resolve_icon_entry(absolute, tmp_path.resolve(), "ping")
+    assert icon.mimeType == "image/svg+xml"
+
+
+def test_resolve_entry_relative_traversal_rejected(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.svg").write_bytes(SVG_BYTES)
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    with pytest.raises(ValueError, match="escapes static_dir"):
+        _resolve_icon_entry("../outside/secret.svg", static_dir.resolve(), "ping")
+
+
+def test_resolve_entry_missing_file_raises_with_tool(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="for tool 'ping' not found"):
+        _resolve_icon_entry("missing.svg", tmp_path.resolve(), "ping")
+
+
+def test_resolve_entry_unsupported_extension_includes_tool(tmp_path: Path) -> None:
+    _write(tmp_path, "ping.bmp", b"bmp")
+    with pytest.raises(ValueError, match=r"Tool 'ping'"):
+        _resolve_icon_entry("ping.bmp", tmp_path.resolve(), "ping")

--- a/tests/test_icons_internal_helpers.py
+++ b/tests/test_icons_internal_helpers.py
@@ -128,11 +128,17 @@ def test_index_unknown_tool_absent() -> None:
 
 
 def test_index_raises_runtime_error_on_api_change() -> None:
-    class _NotFastMCP:
-        pass
+    # Mirror the documented failure mode: ``local_provider`` is present but
+    # ``_components`` is gone (a rename), so the AttributeError fires at the
+    # ``._components`` access the guard describes — not at ``.local_provider``.
+    class _FakeProvider:
+        pass  # no _components attribute
+
+    class _FakeMCP:
+        local_provider = _FakeProvider()
 
     with pytest.raises(RuntimeError, match="FastMCP internal API changed"):
-        _index_tools_by_name(_NotFastMCP())  # type: ignore[arg-type]
+        _index_tools_by_name(_FakeMCP())  # type: ignore[arg-type]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What

Behaviour-preserving refactor of `_icons.py` — the package's worst-health file and the single most complex function per the #207 audit. Decomposes `register_tool_icons` from CCN 16 into a thin orchestrator over three new private helpers:

| Helper | Responsibility | CCN |
|---|---|---|
| `_resolve_static_dir` | static_dir resolve + exists + is_dir guards | 3 |
| `_index_tools_by_name` | FastMCP `local_provider._components` access + name-keyed index, isolating the one private-API coupling point behind a named, guarded boundary | 4 |
| `_resolve_icon_entry` | per-entry absolute/relative resolution, `..`-escape containment, once-wrapped `make_icon` error context | 5 |

`register_tool_icons` drops to **CCN 8**.

## Scope — conservative

The **essential** complexity is preserved untouched:
- The **validate-everything-before-mutating-anything atomicity** (a missing file or unknown tool name aborts with nothing half-applied) — resolution still completes fully before the apply loop runs.
- The **path-traversal containment** check (relative paths can't escape `static_dir` via `..`; absolute paths bypass by design).
- The **TOCTOU-closing** deferral of the read to `make_icon`, and the once-wrapped tool-name error context.

## Tests

- **15 new tests** in `tests/test_icons_internal_helpers.py` covering each helper's contract edges directly (TDD: written before the helpers existed, watched fail, then extracted).
- Includes a **multi-version grouping** test pinning the `dict[str, list[Tool]]` accumulation contract (the reason the return type isn't `dict[str, Tool]`) and a **`..`-collapse** test pinning that `base_dir` is normalised before the containment comparison. Both were mutation-verified to catch the regressions they target.
- All **29 existing icon tests pass unchanged** — the regression net for behaviour preservation.
- Full suite: 492 passed. ruff / format / mypy clean.

Closes #207

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._