### PR TITLE
feat: add domain_env_suffixes() for decomposed-config drift checks

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -22,7 +22,12 @@ from ._authorization import (
     parse_claim_grants,
 )
 from ._cli import make_serve_parser, normalise_http_path
-from ._config import ServerConfig, Transport, server_config_env_suffixes
+from ._config import (
+    ServerConfig,
+    Transport,
+    domain_env_suffixes,
+    server_config_env_suffixes,
+)
 from ._debug import maybe_start_debugpy
 from ._env import (
     env,
@@ -73,6 +78,7 @@ __all__ = [
     "client_supports_apps",
     "compute_app_domain",
     "configure_logging_from_env",
+    "domain_env_suffixes",
     "env",
     "env_float",
     "env_int",

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -228,9 +228,12 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
     Recursion is depth-first with a visited-set, so nested sections and
     reference cycles terminate. Only literal-string suffixes are seen — a
     suffix built from a variable or passed by keyword is invisible; keep reads
-    in the ``env(prefix, "LITERAL")`` form. Sub-config types must be resolvable
-    via :func:`typing.get_type_hints` (importable in the config module's
-    namespace), which matters under ``from __future__ import annotations``.
+    in the ``env(prefix, "LITERAL")`` form. Sub-config types are discovered via
+    two mechanisms: (1) primary — resolved annotations from
+    :func:`typing.get_type_hints` (works when the config is defined at module
+    scope); (2) fallback — a field's ``default_factory`` when the annotation
+    cannot be resolved (e.g. a config defined inside a local scope under
+    ``from __future__ import annotations``).
 
     Args:
         config_cls: The domain config dataclass (its ``from_env`` classmethod is
@@ -245,7 +248,7 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
     visited: set[type] = set()
 
     def _literals_in(cls: type) -> None:
-        src = textwrap.dedent(inspect.getsource(cls.from_env))  # type: ignore[attr-defined]
+        src = textwrap.dedent(inspect.getsource(cls.from_env))  # type: ignore[attr-defined]  # cls is a dataclass type; from_env is guarded by hasattr above
         for node in ast.walk(ast.parse(src)):
             if (
                 isinstance(node, ast.Call)
@@ -277,6 +280,13 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
             candidates: tuple[object, ...]
             factory: object = f.default_factory
             if not isinstance(ftype, type) and factory is not dataclasses.MISSING:
+                # Primary discovery failed (ftype is still a string under
+                # stringified annotations).  ``factory`` is the real discovery
+                # source here.  ``get_args`` can only extract the inner type of
+                # e.g. ``Optional[Section]`` when the annotation has already
+                # been resolved to an object; on a bare string it returns ``()``
+                # and is therefore a no-op — the walk falls entirely to
+                # ``factory``.
                 candidates = (factory, *typing.get_args(ftype))
             else:
                 candidates = (ftype, *typing.get_args(ftype))

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -8,6 +8,11 @@ MCP Apps domain.
 
 from __future__ import annotations
 
+import ast
+import dataclasses
+import inspect
+import textwrap
+import typing
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -206,3 +211,83 @@ def server_config_env_suffixes() -> frozenset[str]:
     surface.
     """
     return _SERVER_CONFIG_ENV_SUFFIXES
+
+
+def domain_env_suffixes(config_cls: type) -> frozenset[str]:
+    """Return the ``{PREFIX}_``-stripped env suffixes a domain config reads.
+
+    AST-scans ``config_cls.from_env`` for ``env``/``env_int``/``env_float``
+    calls whose suffix is a string literal, then recurses into the config's
+    dataclass fields whose resolved type is itself a dataclass exposing a
+    ``from_env`` classmethod — so a config that delegates env reads to
+    sub-config *sections* (each with its own ``from_env``) reports its full
+    surface. The composed :class:`ServerConfig` field is skipped (its surface
+    is :func:`server_config_env_suffixes`). A flat config with no sub-config
+    fields scans only its own ``from_env``.
+
+    Recursion is depth-first with a visited-set, so nested sections and
+    reference cycles terminate. Only literal-string suffixes are seen — a
+    suffix built from a variable or passed by keyword is invisible; keep reads
+    in the ``env(prefix, "LITERAL")`` form. Sub-config types must be resolvable
+    via :func:`typing.get_type_hints` (importable in the config module's
+    namespace), which matters under ``from __future__ import annotations``.
+
+    Args:
+        config_cls: The domain config dataclass (its ``from_env`` classmethod is
+            the scan root).
+
+    Returns:
+        The frozenset of literal env suffixes read by ``config_cls.from_env``
+        and its sub-config sections, excluding the :class:`ServerConfig` field.
+    """
+    read_funcs = {"env", "env_int", "env_float"}
+    found: set[str] = set()
+    visited: set[type] = set()
+
+    def _literals_in(cls: type) -> None:
+        src = textwrap.dedent(inspect.getsource(cls.from_env))  # type: ignore[attr-defined]
+        for node in ast.walk(ast.parse(src)):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id in read_funcs
+                and len(node.args) >= 2
+                and isinstance(node.args[1], ast.Constant)
+                and isinstance(node.args[1].value, str)
+            ):
+                found.add(node.args[1].value)
+
+    def _visit(cls: type) -> None:
+        if cls in visited or cls is ServerConfig or not dataclasses.is_dataclass(cls):
+            return
+        visited.add(cls)
+        if hasattr(cls, "from_env"):
+            _literals_in(cls)
+        try:
+            hints = typing.get_type_hints(cls)
+        except Exception:  # noqa: BLE001 — unresolved hint: scan top level only
+            hints = {}
+        for f in dataclasses.fields(cls):
+            ftype = hints.get(f.name, f.type)
+            # When ``from __future__ import annotations`` is active and the type
+            # is locally defined (e.g. inside a test method), ``get_type_hints``
+            # may fail and ``f.type`` is a plain string.  Fall back to
+            # ``f.default_factory`` when it is a type, so that the common
+            # ``field(default_factory=SomeSubConfig)`` pattern is still visited.
+            candidates: tuple[object, ...]
+            factory: object = f.default_factory
+            if not isinstance(ftype, type) and factory is not dataclasses.MISSING:
+                candidates = (factory, *typing.get_args(ftype))
+            else:
+                candidates = (ftype, *typing.get_args(ftype))
+            for candidate in candidates:
+                if (
+                    isinstance(candidate, type)
+                    and dataclasses.is_dataclass(candidate)
+                    and candidate is not ServerConfig
+                    and hasattr(candidate, "from_env")
+                ):
+                    _visit(candidate)
+
+    _visit(config_cls)
+    return frozenset(found)

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -8,10 +8,7 @@ MCP Apps domain.
 
 from __future__ import annotations
 
-import ast
 import dataclasses
-import inspect
-import textwrap
 import typing
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -236,6 +233,10 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
     (``mod.env(...)``), or a variable/keyword-form suffix is invisible to the
     scan; keep reads in the literal ``env(prefix, "LITERAL")`` form.
 
+    Only one level of :func:`typing.get_args` is expanded — ``list[Section]``
+    (element type) and ``Section | None`` (direct union member) are traversed,
+    but a nested container generic such as ``list[Optional[Section]]`` is not.
+
     Args:
         config_cls: The domain config dataclass; its ``from_env`` classmethod
             is the scan root.
@@ -243,7 +244,25 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
     Returns:
         The frozenset of literal env suffixes read by ``config_cls.from_env``
         and its sub-config sections, excluding the :class:`ServerConfig` field.
+
+    Raises:
+        TypeError: If ``config_cls`` is not a dataclass.
+        OSError: If a sub-config's ``from_env`` source cannot be read
+            (compiled, frozen, or dynamically-defined class).
+        NameError: If a field annotation cannot be resolved at
+            :func:`typing.get_type_hints` time — the config or a sub-config
+            is not defined at module scope, or contains a broken forward
+            reference.
     """
+    import ast
+    import inspect
+    import textwrap
+
+    if not dataclasses.is_dataclass(config_cls):
+        raise TypeError(
+            f"domain_env_suffixes: expected a dataclass type, got {config_cls!r}"
+        )
+
     read_funcs = {"env", "env_int", "env_float"}
     found: set[str] = set()
     visited: set[type] = set()
@@ -251,7 +270,7 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
     def _literals_in(cls: type) -> None:
         try:
             src = textwrap.dedent(inspect.getsource(cls.from_env))  # type: ignore[attr-defined]
-        except OSError as exc:  # source unavailable (compiled/frozen/dynamic class)
+        except (OSError, TypeError) as exc:  # source unreadable / not a Python function
             raise OSError(
                 f"domain_env_suffixes: cannot read source for "
                 f"{cls.__qualname__}.from_env: {exc}"
@@ -273,7 +292,14 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
         visited.add(cls)
         if hasattr(cls, "from_env"):
             _literals_in(cls)
-        hints = typing.get_type_hints(cls)
+        try:
+            hints = typing.get_type_hints(cls)
+        except NameError as exc:
+            raise NameError(
+                f"domain_env_suffixes: cannot resolve type hints for "
+                f"{cls.__qualname__} — annotations must be importable at module "
+                f"scope: {exc}"
+            ) from exc
         for f in dataclasses.fields(cls):
             resolved = hints.get(f.name, f.type)
             for candidate in (resolved, *typing.get_args(resolved)):

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -258,7 +258,9 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
     import inspect
     import textwrap
 
-    if not dataclasses.is_dataclass(config_cls):
+    # ``is_dataclass`` is true for instances too; require the class itself so a
+    # mistakenly-passed instance fails loudly rather than silently scanning.
+    if not isinstance(config_cls, type) or not dataclasses.is_dataclass(config_cls):
         raise TypeError(
             f"domain_env_suffixes: expected a dataclass type, got {config_cls!r}"
         )
@@ -271,7 +273,9 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
         try:
             src = textwrap.dedent(inspect.getsource(cls.from_env))  # type: ignore[attr-defined]
         except (OSError, TypeError) as exc:  # source unreadable / not a Python function
-            raise OSError(
+            # Re-raise preserving the original type (OSError vs TypeError) with
+            # class context, so a type error isn't masqueraded as I/O.
+            raise type(exc)(
                 f"domain_env_suffixes: cannot read source for "
                 f"{cls.__qualname__}.from_env: {exc}"
             ) from exc

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import ast
 import dataclasses
 import inspect
+import logging
 import textwrap
 import typing
 from dataclasses import dataclass, field
@@ -18,6 +19,8 @@ from pathlib import Path
 from typing import Literal
 
 from ._env import env, env_int, parse_bool, parse_scopes
+
+logger = logging.getLogger(__name__)
 
 Transport = Literal["stdio", "http", "sse"]
 
@@ -228,12 +231,19 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
     Recursion is depth-first with a visited-set, so nested sections and
     reference cycles terminate. Only literal-string suffixes are seen — a
     suffix built from a variable or passed by keyword is invisible; keep reads
-    in the ``env(prefix, "LITERAL")`` form. Sub-config types are discovered via
-    two mechanisms: (1) primary — resolved annotations from
-    :func:`typing.get_type_hints` (works when the config is defined at module
-    scope); (2) fallback — a field's ``default_factory`` when the annotation
-    cannot be resolved (e.g. a config defined inside a local scope under
-    ``from __future__ import annotations``).
+    in the ``env(prefix, "LITERAL")`` form (a renamed import ``env as _env``
+    or attribute-form call ``mod.env(prefix, "X")`` is also invisible).
+    Sub-config types are discovered via two mechanisms:
+
+    * **Primary** — a field whose resolved annotation is a plain dataclass type
+      (the usual module-level case) is recursed directly.
+    * **Fallback** — when the resolved annotation is *not* a plain type — either
+      a generic alias like ``Optional[Section]`` / ``Section | None`` (even when
+      :func:`typing.get_type_hints` succeeded) or still a bare string because
+      resolution failed — the field's ``default_factory`` (if present) and
+      :func:`typing.get_args` of the annotation supply the candidate sub-config
+      type(s).  A field with neither a resolvable type nor a ``default_factory``
+      is skipped.
 
     Args:
         config_cls: The domain config dataclass (its ``from_env`` classmethod is
@@ -268,7 +278,17 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
             _literals_in(cls)
         try:
             hints = typing.get_type_hints(cls)
-        except Exception:  # noqa: BLE001 — unresolved hint: scan top level only
+        except NameError:
+            # Stringified annotation (from __future__ import annotations)
+            # referencing a name not resolvable from the class's module
+            # globals (e.g. a locally-scoped config). Fall back to
+            # default_factory discovery below. Any other resolution failure
+            # propagates — a genuinely broken config must surface, not yield a
+            # silently-incomplete suffix set in a drift gate.
+            logger.debug(
+                "domain_env_suffixes hint_resolution_failed cls=%s",
+                getattr(cls, "__name__", cls),
+            )
             hints = {}
         for f in dataclasses.fields(cls):
             ftype = hints.get(f.name, f.type)
@@ -280,13 +300,14 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
             candidates: tuple[object, ...]
             factory: object = f.default_factory
             if not isinstance(ftype, type) and factory is not dataclasses.MISSING:
-                # Primary discovery failed (ftype is still a string under
-                # stringified annotations).  ``factory`` is the real discovery
-                # source here.  ``get_args`` can only extract the inner type of
-                # e.g. ``Optional[Section]`` when the annotation has already
-                # been resolved to an object; on a bare string it returns ``()``
-                # and is therefore a no-op — the walk falls entirely to
-                # ``factory``.
+                # ftype is not a plain type. Two sub-cases land here:
+                #  (a) get_type_hints succeeded but returned a generic alias
+                #      (Optional[Section], Section | None): get_args(ftype) yields
+                #      the inner type(s) (Section, NoneType).
+                #  (b) resolution failed and ftype is still a bare string:
+                #      get_args(ftype) returns () and default_factory is the only
+                #      discovery source.
+                # A field with neither a factory nor an args-bearing alias is skipped.
                 candidates = (factory, *typing.get_args(ftype))
             else:
                 candidates = (ftype, *typing.get_args(ftype))

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import ast
 import dataclasses
 import inspect
-import logging
 import textwrap
 import typing
 from dataclasses import dataclass, field
@@ -19,8 +18,6 @@ from pathlib import Path
 from typing import Literal
 
 from ._env import env, env_int, parse_bool, parse_scopes
-
-logger = logging.getLogger(__name__)
 
 Transport = Literal["stdio", "http", "sse"]
 
@@ -220,34 +217,28 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
     """Return the ``{PREFIX}_``-stripped env suffixes a domain config reads.
 
     AST-scans ``config_cls.from_env`` for ``env``/``env_int``/``env_float``
-    calls whose suffix is a string literal, then recurses into the config's
-    dataclass fields whose resolved type is itself a dataclass exposing a
-    ``from_env`` classmethod — so a config that delegates env reads to
-    sub-config *sections* (each with its own ``from_env``) reports its full
-    surface. The composed :class:`ServerConfig` field is skipped (its surface
-    is :func:`server_config_env_suffixes`). A flat config with no sub-config
-    fields scans only its own ``from_env``.
+    calls whose suffix is a string literal, and recurses into the config's
+    dataclass fields whose resolved type — or a type argument of it, e.g. the
+    inner ``Section`` of ``Optional[Section]`` or the element type of
+    ``list[Section]`` — is a dataclass exposing a ``from_env`` classmethod. So
+    a config that delegates env reads to sub-config *sections* reports its full
+    surface. The composed :class:`ServerConfig` field is excluded (its surface
+    is :func:`server_config_env_suffixes`); a flat config with no sub-config
+    fields scans only its own ``from_env``. Recursion is depth-first with a
+    visited-set, so reference cycles and a type shared by two fields terminate
+    and de-duplicate.
 
-    Recursion is depth-first with a visited-set, so nested sections and
-    reference cycles terminate. Only literal-string suffixes are seen — a
-    suffix built from a variable or passed by keyword is invisible; keep reads
-    in the ``env(prefix, "LITERAL")`` form (a renamed import ``env as _env``
-    or attribute-form call ``mod.env(prefix, "X")`` is also invisible).
-    Sub-config types are discovered via two mechanisms:
-
-    * **Primary** — a field whose resolved annotation is a plain dataclass type
-      (the usual module-level case) is recursed directly.
-    * **Fallback** — when the resolved annotation is *not* a plain type — either
-      a generic alias like ``Optional[Section]`` / ``Section | None`` (even when
-      :func:`typing.get_type_hints` succeeded) or still a bare string because
-      resolution failed — the field's ``default_factory`` (if present) and
-      :func:`typing.get_args` of the annotation supply the candidate sub-config
-      type(s).  A field with neither a resolvable type nor a ``default_factory``
-      is skipped.
+    Field types are resolved with :func:`typing.get_type_hints`, so the config
+    and its sub-configs must be defined at module scope (the normal case); a
+    resolution failure propagates rather than yielding a silently-incomplete
+    set in a drift gate. Only unqualified ``env(prefix, "LITERAL")`` reads are
+    seen — a renamed import (``env as _e``), an attribute-form call
+    (``mod.env(...)``), or a variable/keyword-form suffix is invisible to the
+    scan; keep reads in the literal ``env(prefix, "LITERAL")`` form.
 
     Args:
-        config_cls: The domain config dataclass (its ``from_env`` classmethod is
-            the scan root).
+        config_cls: The domain config dataclass; its ``from_env`` classmethod
+            is the scan root.
 
     Returns:
         The frozenset of literal env suffixes read by ``config_cls.from_env``
@@ -258,7 +249,13 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
     visited: set[type] = set()
 
     def _literals_in(cls: type) -> None:
-        src = textwrap.dedent(inspect.getsource(cls.from_env))  # type: ignore[attr-defined]  # cls is a dataclass type; from_env is guarded by hasattr above
+        try:
+            src = textwrap.dedent(inspect.getsource(cls.from_env))  # type: ignore[attr-defined]
+        except OSError as exc:  # source unavailable (compiled/frozen/dynamic class)
+            raise OSError(
+                f"domain_env_suffixes: cannot read source for "
+                f"{cls.__qualname__}.from_env: {exc}"
+            ) from exc
         for node in ast.walk(ast.parse(src)):
             if (
                 isinstance(node, ast.Call)
@@ -276,42 +273,10 @@ def domain_env_suffixes(config_cls: type) -> frozenset[str]:
         visited.add(cls)
         if hasattr(cls, "from_env"):
             _literals_in(cls)
-        try:
-            hints = typing.get_type_hints(cls)
-        except NameError:
-            # Stringified annotation (from __future__ import annotations)
-            # referencing a name not resolvable from the class's module
-            # globals (e.g. a locally-scoped config). Fall back to
-            # default_factory discovery below. Any other resolution failure
-            # propagates — a genuinely broken config must surface, not yield a
-            # silently-incomplete suffix set in a drift gate.
-            logger.debug(
-                "domain_env_suffixes hint_resolution_failed cls=%s",
-                getattr(cls, "__name__", cls),
-            )
-            hints = {}
+        hints = typing.get_type_hints(cls)
         for f in dataclasses.fields(cls):
-            ftype = hints.get(f.name, f.type)
-            # When ``from __future__ import annotations`` is active and the type
-            # is locally defined (e.g. inside a test method), ``get_type_hints``
-            # may fail and ``f.type`` is a plain string.  Fall back to
-            # ``f.default_factory`` when it is a type, so that the common
-            # ``field(default_factory=SomeSubConfig)`` pattern is still visited.
-            candidates: tuple[object, ...]
-            factory: object = f.default_factory
-            if not isinstance(ftype, type) and factory is not dataclasses.MISSING:
-                # ftype is not a plain type. Two sub-cases land here:
-                #  (a) get_type_hints succeeded but returned a generic alias
-                #      (Optional[Section], Section | None): get_args(ftype) yields
-                #      the inner type(s) (Section, NoneType).
-                #  (b) resolution failed and ftype is still a bare string:
-                #      get_args(ftype) returns () and default_factory is the only
-                #      discovery source.
-                # A field with neither a factory nor an args-bearing alias is skipped.
-                candidates = (factory, *typing.get_args(ftype))
-            else:
-                candidates = (ftype, *typing.get_args(ftype))
-            for candidate in candidates:
+            resolved = hints.get(f.name, f.type)
+            for candidate in (resolved, *typing.get_args(resolved)):
                 if (
                     isinstance(candidate, type)
                     and dataclasses.is_dataclass(candidate)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -432,6 +432,11 @@ class TestDomainEnvSuffixes:
         with pytest.raises(TypeError, match="dataclass"):
             domain_env_suffixes(int)
 
+    def test_dataclass_instance_raises_typeerror(self) -> None:
+        """An instance (vs the class) is rejected — is_dataclass alone accepts both."""
+        with pytest.raises(TypeError, match="dataclass"):
+            domain_env_suffixes(_Flat())  # type: ignore[arg-type]
+
     def test_list_subconfig_field_traversed(self) -> None:
         """list[Sub] fields are traversed via get_args (one level)."""
         assert domain_env_suffixes(_ListTypedField) == frozenset(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,11 +2,47 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
 
-from fastmcp_pvl_core import ConfigurationError, ServerConfig, build_bearer_auth
+from fastmcp_pvl_core import (
+    ConfigurationError,
+    ServerConfig,
+    build_bearer_auth,
+    domain_env_suffixes,
+)
+from fastmcp_pvl_core._env import env, env_int
+
+# ---------------------------------------------------------------------------
+# Module-level fixture classes for TestDomainEnvSuffixes
+# (defined at module scope so typing.get_type_hints can resolve them —
+# the primary discovery path used by real production configs).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ModuleSection:
+    n: int = 0
+
+    @classmethod
+    def from_env(cls, prefix: str) -> _ModuleSection:
+        return cls(n=env_int(prefix, "MODULE_SECTION_N", 0))
+
+
+@dataclass(frozen=True)
+class _ModuleComposed:
+    section: _ModuleSection = field(default_factory=_ModuleSection)
+    server: ServerConfig = field(default_factory=ServerConfig)
+
+    @classmethod
+    def from_env(cls, prefix: str = "X") -> _ModuleComposed:
+        _ = env(prefix, "MODULE_TOP")
+        return cls(
+            section=_ModuleSection.from_env(prefix),
+            server=ServerConfig.from_env(prefix),
+        )
 
 
 class TestServerConfigDefaults:
@@ -337,3 +373,11 @@ class TestDomainEnvSuffixes:
                 return cls()
 
         assert {"A_VAR", "B_VAR"} <= domain_env_suffixes(B)
+
+    def test_primary_get_type_hints_path_module_level(self) -> None:
+        """Module-level config: recursion resolves via get_type_hints, not the
+        default_factory fallback. Proves the production path (real configs are
+        module-level) and ServerConfig exclusion through that path."""
+        result = domain_env_suffixes(_ModuleComposed)
+        assert {"MODULE_TOP", "MODULE_SECTION_N"} <= result
+        assert "TRANSPORT" not in result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -259,3 +259,81 @@ class TestServerConfigEnvSuffixes:
         from fastmcp_pvl_core import server_config_env_suffixes
 
         assert server_config_env_suffixes() == _suffixes_read_by_from_env()
+
+
+class TestDomainEnvSuffixes:
+    def test_flat_config_returns_own_reads(self):
+        """A config that reads only in its own from_env (no sub-configs)."""
+        from dataclasses import dataclass, field
+
+        from fastmcp_pvl_core import ServerConfig, domain_env_suffixes, env
+
+        @dataclass(frozen=True)
+        class Flat:
+            server: ServerConfig = field(default_factory=ServerConfig)
+
+            @classmethod
+            def from_env(cls, prefix: str = "X") -> Flat:
+                _ = env(prefix, "WIDGET")
+                _ = env(prefix, "GADGET")
+                return cls()
+
+        assert domain_env_suffixes(Flat) == frozenset({"WIDGET", "GADGET"})
+
+    def test_recurses_into_subconfigs_and_excludes_server(self):
+        """Sub-config reads are collected; the ServerConfig field is not."""
+        from dataclasses import dataclass, field
+
+        from fastmcp_pvl_core import ServerConfig, domain_env_suffixes, env, env_int
+
+        @dataclass(frozen=True)
+        class Section:
+            n: int = 0
+
+            @classmethod
+            def from_env(cls, prefix: str) -> Section:
+                return cls(n=env_int(prefix, "SECTION_N", 0))
+
+        @dataclass(frozen=True)
+        class Composed:
+            section: Section = field(default_factory=Section)
+            server: ServerConfig = field(default_factory=ServerConfig)
+
+            @classmethod
+            def from_env(cls, prefix: str = "X") -> Composed:
+                _ = env(prefix, "TOP_LEVEL")
+                return cls(
+                    section=Section.from_env(prefix),
+                    server=ServerConfig.from_env(prefix),
+                )
+
+        result = domain_env_suffixes(Composed)
+        assert {"TOP_LEVEL", "SECTION_N"} <= result
+        # ServerConfig's own suffixes are NOT folded in here.
+        assert "TRANSPORT" not in result
+
+    def test_cycle_safe(self):
+        """A reference cycle between sections does not infinite-loop."""
+        from dataclasses import dataclass, field
+
+        from fastmcp_pvl_core import domain_env_suffixes, env
+
+        @dataclass(frozen=True)
+        class A:
+            b: B | None = None
+
+            @classmethod
+            def from_env(cls, prefix: str = "X") -> A:
+                _ = env(prefix, "A_VAR")
+                return cls()
+
+        @dataclass(frozen=True)
+        class B:
+            a: A = field(default_factory=A)
+
+            @classmethod
+            def from_env(cls, prefix: str = "X") -> B:
+                _ = env(prefix, "B_VAR")
+                return cls()
+
+        assert {"A_VAR", "B_VAR"} <= domain_env_suffixes(B)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,94 +12,102 @@ from fastmcp_pvl_core import (
     ServerConfig,
     build_bearer_auth,
     domain_env_suffixes,
+    env,
+    env_float,
+    env_int,
 )
-from fastmcp_pvl_core._env import env, env_float, env_int
 
 # ---------------------------------------------------------------------------
 # Module-level fixture classes for TestDomainEnvSuffixes
 # (defined at module scope so typing.get_type_hints can resolve them —
-# the primary discovery path used by real production configs).
+# the only shape real configs take).
 # ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
-class _ModuleSection:
-    n: int = 0
-
+class _Sec:
     @classmethod
-    def from_env(cls, prefix: str) -> _ModuleSection:
-        return cls(n=env_int(prefix, "MODULE_SECTION_N", 0))
-
-
-@dataclass(frozen=True)
-class _ModuleComposed:
-    section: _ModuleSection = field(default_factory=_ModuleSection)
-    server: ServerConfig = field(default_factory=ServerConfig)
-
-    @classmethod
-    def from_env(cls, prefix: str = "X") -> _ModuleComposed:
-        _ = env(prefix, "MODULE_TOP")
-        _ = env_float(prefix, "FLOAT_VAR", 1.0)
-        return cls(
-            section=_ModuleSection.from_env(prefix),
-            server=ServerConfig.from_env(prefix),
-        )
-
-
-# ---------------------------------------------------------------------------
-# Fixtures for item E: Optional[Sub] / Sub|None via get_args path
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class _ModuleOptSection:
-    n: int = 0
-
-    @classmethod
-    def from_env(cls, prefix: str) -> _ModuleOptSection:
-        return cls(n=env_int(prefix, "MODULE_OPT_SEC", 0))
-
-
-@dataclass(frozen=True)
-class _ModuleComposedOptional:
-    section: _ModuleOptSection | None = None
-    server: ServerConfig = field(default_factory=ServerConfig)
-
-    @classmethod
-    def from_env(cls, prefix: str = "X") -> _ModuleComposedOptional:
-        _ = env(prefix, "MODULE_OPT_TOP")
-        return cls(section=_ModuleOptSection.from_env(prefix))
-
-
-# ---------------------------------------------------------------------------
-# Fixtures for item G: module-scope mutual cycle to exercise visited guard
-#
-# _ModuleCycleA is defined first; _ModuleCycleB references it via a
-# string-annotated field (from __future__ import annotations at file top)
-# whose default is None — no default_factory ordering issue. At module scope
-# both classes are fully defined by the time get_type_hints runs, so the
-# A↔B cycle resolves in both directions and the visited-set is what
-# terminates the walk.
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class _ModuleCycleA:
-    b: _ModuleCycleB | None = None
-
-    @classmethod
-    def from_env(cls, prefix: str = "X") -> _ModuleCycleA:
-        _ = env(prefix, "CYCLE_A")
+    def from_env(cls, prefix: str) -> _Sec:
+        _ = env(prefix, "SEC_TOKEN")
+        _ = env_int(prefix, "SEC_COUNT", 0)
         return cls()
 
 
 @dataclass(frozen=True)
-class _ModuleCycleB:
-    a: _ModuleCycleA | None = None
+class _Flat:
+    server: ServerConfig = field(default_factory=ServerConfig)
 
     @classmethod
-    def from_env(cls, prefix: str = "X") -> _ModuleCycleB:
-        _ = env(prefix, "CYCLE_B")
+    def from_env(cls, prefix: str = "X") -> _Flat:
+        _ = env(prefix, "FLAT_S")
+        _ = env_int(prefix, "FLAT_I", 0)
+        _ = env_float(prefix, "FLAT_F", 1.0)
+        return cls()
+
+
+@dataclass(frozen=True)
+class _Composed:
+    sec: _Sec = field(default_factory=_Sec)
+    server: ServerConfig = field(default_factory=ServerConfig)
+
+    @classmethod
+    def from_env(cls, prefix: str = "X") -> _Composed:
+        _ = env(prefix, "TOP")
+        return cls(sec=_Sec.from_env(prefix), server=ServerConfig.from_env(prefix))
+
+
+@dataclass(frozen=True)
+class _OptComposed:
+    sec: _Sec | None = None
+
+    @classmethod
+    def from_env(cls, prefix: str = "X") -> _OptComposed:
+        _ = env(prefix, "OPT_TOP")
+        return cls()
+
+
+@dataclass(frozen=True)
+class _CycA:
+    b: _CycB | None = None
+
+    @classmethod
+    def from_env(cls, prefix: str = "X") -> _CycA:
+        _ = env(prefix, "CYC_A")
+        return cls()
+
+
+@dataclass(frozen=True)
+class _CycB:
+    a: _CycA | None = None
+
+    @classmethod
+    def from_env(cls, prefix: str = "X") -> _CycB:
+        _ = env(prefix, "CYC_B")
+        return cls()
+
+
+@dataclass(frozen=True)
+class _TwoFields:
+    x: _Sec = field(default_factory=_Sec)
+    y: _Sec = field(default_factory=_Sec)
+
+    @classmethod
+    def from_env(cls, prefix: str = "X") -> _TwoFields:
+        return cls()
+
+
+@dataclass(frozen=True)
+class _Plain:
+    v: int = 0
+
+
+@dataclass(frozen=True)
+class _HasPlain:
+    p: _Plain = field(default_factory=_Plain)
+
+    @classmethod
+    def from_env(cls, prefix: str = "X") -> _HasPlain:
+        _ = env(prefix, "HP_TOP")
         return cls()
 
 
@@ -356,105 +364,37 @@ class TestServerConfigEnvSuffixes:
 
 
 class TestDomainEnvSuffixes:
-    def test_flat_config_returns_own_reads(self) -> None:
-        """A config that reads only in its own from_env (no sub-configs)."""
-        from dataclasses import dataclass, field
+    def test_flat_exact_surface_and_all_read_funcs(self) -> None:
+        """Flat config: env/env_int/env_float all matched, ServerConfig excluded."""
+        assert domain_env_suffixes(_Flat) == frozenset({"FLAT_S", "FLAT_I", "FLAT_F"})
 
-        from fastmcp_pvl_core import ServerConfig, domain_env_suffixes, env
-
-        @dataclass(frozen=True)
-        class Flat:
-            server: ServerConfig = field(default_factory=ServerConfig)
-
-            @classmethod
-            def from_env(cls, prefix: str = "X") -> Flat:
-                _ = env(prefix, "WIDGET")
-                _ = env(prefix, "GADGET")
-                return cls()
-
-        assert domain_env_suffixes(Flat) == frozenset({"WIDGET", "GADGET"})
-
-    def test_recurses_into_subconfigs_and_excludes_server(self) -> None:
-        """Sub-config reads are collected; the ServerConfig field is not."""
-        from dataclasses import dataclass, field
-
-        from fastmcp_pvl_core import ServerConfig, domain_env_suffixes, env, env_int
-
-        @dataclass(frozen=True)
-        class Section:
-            n: int = 0
-
-            @classmethod
-            def from_env(cls, prefix: str) -> Section:
-                return cls(n=env_int(prefix, "SECTION_N", 0))
-
-        @dataclass(frozen=True)
-        class Composed:
-            section: Section = field(default_factory=Section)
-            server: ServerConfig = field(default_factory=ServerConfig)
-
-            @classmethod
-            def from_env(cls, prefix: str = "X") -> Composed:
-                _ = env(prefix, "TOP_LEVEL")
-                return cls(
-                    section=Section.from_env(prefix),
-                    server=ServerConfig.from_env(prefix),
-                )
-
-        result = domain_env_suffixes(Composed)
-        assert {"TOP_LEVEL", "SECTION_N"} <= result
-        # ServerConfig's own suffixes are NOT folded in here.
-        assert "TRANSPORT" not in result
-
-    def test_cycle_safe(self) -> None:
-        """A reference cycle between sections does not infinite-loop."""
-        from dataclasses import dataclass, field
-
-        from fastmcp_pvl_core import domain_env_suffixes, env
-
-        @dataclass(frozen=True)
-        class A:
-            b: B | None = None
-
-            @classmethod
-            def from_env(cls, prefix: str = "X") -> A:
-                _ = env(prefix, "A_VAR")
-                return cls()
-
-        @dataclass(frozen=True)
-        class B:
-            a: A = field(default_factory=A)
-
-            @classmethod
-            def from_env(cls, prefix: str = "X") -> B:
-                _ = env(prefix, "B_VAR")
-                return cls()
-
-        assert {"A_VAR", "B_VAR"} <= domain_env_suffixes(B)
-
-    def test_primary_get_type_hints_path_module_level(self) -> None:
-        """Module-level config: recursion resolves via get_type_hints, not the
-        default_factory fallback. Proves the production path (real configs are
-        module-level) and ServerConfig exclusion through that path."""
-        result = domain_env_suffixes(_ModuleComposed)
-        assert {"MODULE_TOP", "MODULE_SECTION_N"} <= result
-        assert "TRANSPORT" not in result
-
-    def test_env_float_suffix_is_collected(self) -> None:
-        """env_float reads are discovered by the AST scan (declared in read_funcs)."""
-        result = domain_env_suffixes(_ModuleComposed)
-        assert "FLOAT_VAR" in result
+    def test_recurses_into_subconfig_excludes_server(self) -> None:
+        """Sub-config reads collected exactly; the ServerConfig field is not."""
+        assert domain_env_suffixes(_Composed) == frozenset(
+            {"TOP", "SEC_TOKEN", "SEC_COUNT"}
+        )
+        assert "TRANSPORT" not in domain_env_suffixes(_Composed)
 
     def test_optional_subconfig_discovered_via_get_args(self) -> None:
-        """Optional[Sub]/Sub|None at module scope: get_type_hints resolves to a
-        Union (not a plain type), so the inner type is found via get_args."""
-        result = domain_env_suffixes(_ModuleComposedOptional)
-        assert {"MODULE_OPT_TOP", "MODULE_OPT_SEC"} <= result
-        assert "TRANSPORT" not in result
+        """Optional[Sub]/Sub|None resolves to a Union; the inner type is found
+        via typing.get_args (no default_factory needed)."""
+        assert domain_env_suffixes(_OptComposed) == frozenset(
+            {"OPT_TOP", "SEC_TOKEN", "SEC_COUNT"}
+        )
 
-    def test_module_scope_cycle_hits_visited_guard(self) -> None:
-        """A↔B mutual references at module scope resolve via get_type_hints in
-        both directions; the visited-set (not a resolution failure) is what
-        terminates the walk."""
-        result = domain_env_suffixes(_ModuleCycleA)
-        assert {"CYCLE_A", "CYCLE_B"} <= result
+    def test_module_scope_cycle_terminates_via_visited(self) -> None:
+        """A<->B mutual references resolve via get_type_hints in both directions;
+        the visited-set is what terminates the walk."""
+        assert domain_env_suffixes(_CycA) == frozenset({"CYC_A", "CYC_B"})
+
+    def test_same_type_two_fields_deduped(self) -> None:
+        """A type referenced by two fields is scanned once (visited-set)."""
+        assert domain_env_suffixes(_TwoFields) == frozenset({"SEC_TOKEN", "SEC_COUNT"})
+
+    def test_dataclass_field_without_from_env_is_skipped(self) -> None:
+        """A dataclass field lacking from_env is not scanned and does not crash."""
+        assert domain_env_suffixes(_HasPlain) == frozenset({"HP_TOP"})
+
+    def test_server_config_as_root_returns_empty(self) -> None:
+        """ServerConfig as root yields empty; use server_config_env_suffixes."""
+        assert domain_env_suffixes(ServerConfig) == frozenset()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ from fastmcp_pvl_core import (
     build_bearer_auth,
     domain_env_suffixes,
 )
-from fastmcp_pvl_core._env import env, env_int
+from fastmcp_pvl_core._env import env, env_float, env_int
 
 # ---------------------------------------------------------------------------
 # Module-level fixture classes for TestDomainEnvSuffixes
@@ -39,10 +39,68 @@ class _ModuleComposed:
     @classmethod
     def from_env(cls, prefix: str = "X") -> _ModuleComposed:
         _ = env(prefix, "MODULE_TOP")
+        _ = env_float(prefix, "FLOAT_VAR", 1.0)
         return cls(
             section=_ModuleSection.from_env(prefix),
             server=ServerConfig.from_env(prefix),
         )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures for item E: Optional[Sub] / Sub|None via get_args path
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ModuleOptSection:
+    n: int = 0
+
+    @classmethod
+    def from_env(cls, prefix: str) -> _ModuleOptSection:
+        return cls(n=env_int(prefix, "MODULE_OPT_SEC", 0))
+
+
+@dataclass(frozen=True)
+class _ModuleComposedOptional:
+    section: _ModuleOptSection | None = None
+    server: ServerConfig = field(default_factory=ServerConfig)
+
+    @classmethod
+    def from_env(cls, prefix: str = "X") -> _ModuleComposedOptional:
+        _ = env(prefix, "MODULE_OPT_TOP")
+        return cls(section=_ModuleOptSection.from_env(prefix))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures for item G: module-scope mutual cycle to exercise visited guard
+#
+# _ModuleCycleA is defined first; _ModuleCycleB references it via a
+# string-annotated field (from __future__ import annotations at file top)
+# whose default is None — no default_factory ordering issue. At module scope
+# both classes are fully defined by the time get_type_hints runs, so the
+# A↔B cycle resolves in both directions and the visited-set is what
+# terminates the walk.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ModuleCycleA:
+    b: _ModuleCycleB | None = None
+
+    @classmethod
+    def from_env(cls, prefix: str = "X") -> _ModuleCycleA:
+        _ = env(prefix, "CYCLE_A")
+        return cls()
+
+
+@dataclass(frozen=True)
+class _ModuleCycleB:
+    a: _ModuleCycleA | None = None
+
+    @classmethod
+    def from_env(cls, prefix: str = "X") -> _ModuleCycleB:
+        _ = env(prefix, "CYCLE_B")
+        return cls()
 
 
 class TestServerConfigDefaults:
@@ -298,7 +356,7 @@ class TestServerConfigEnvSuffixes:
 
 
 class TestDomainEnvSuffixes:
-    def test_flat_config_returns_own_reads(self):
+    def test_flat_config_returns_own_reads(self) -> None:
         """A config that reads only in its own from_env (no sub-configs)."""
         from dataclasses import dataclass, field
 
@@ -316,7 +374,7 @@ class TestDomainEnvSuffixes:
 
         assert domain_env_suffixes(Flat) == frozenset({"WIDGET", "GADGET"})
 
-    def test_recurses_into_subconfigs_and_excludes_server(self):
+    def test_recurses_into_subconfigs_and_excludes_server(self) -> None:
         """Sub-config reads are collected; the ServerConfig field is not."""
         from dataclasses import dataclass, field
 
@@ -348,7 +406,7 @@ class TestDomainEnvSuffixes:
         # ServerConfig's own suffixes are NOT folded in here.
         assert "TRANSPORT" not in result
 
-    def test_cycle_safe(self):
+    def test_cycle_safe(self) -> None:
         """A reference cycle between sections does not infinite-loop."""
         from dataclasses import dataclass, field
 
@@ -381,3 +439,22 @@ class TestDomainEnvSuffixes:
         result = domain_env_suffixes(_ModuleComposed)
         assert {"MODULE_TOP", "MODULE_SECTION_N"} <= result
         assert "TRANSPORT" not in result
+
+    def test_env_float_suffix_is_collected(self) -> None:
+        """env_float reads are discovered by the AST scan (declared in read_funcs)."""
+        result = domain_env_suffixes(_ModuleComposed)
+        assert "FLOAT_VAR" in result
+
+    def test_optional_subconfig_discovered_via_get_args(self) -> None:
+        """Optional[Sub]/Sub|None at module scope: get_type_hints resolves to a
+        Union (not a plain type), so the inner type is found via get_args."""
+        result = domain_env_suffixes(_ModuleComposedOptional)
+        assert {"MODULE_OPT_TOP", "MODULE_OPT_SEC"} <= result
+        assert "TRANSPORT" not in result
+
+    def test_module_scope_cycle_hits_visited_guard(self) -> None:
+        """A↔B mutual references at module scope resolve via get_type_hints in
+        both directions; the visited-set (not a resolution failure) is what
+        terminates the walk."""
+        result = domain_env_suffixes(_ModuleCycleA)
+        assert {"CYCLE_A", "CYCLE_B"} <= result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,6 +111,34 @@ class _HasPlain:
         return cls()
 
 
+@dataclass(frozen=True)
+class _SubForList:
+    @classmethod
+    def from_env(cls, prefix: str) -> _SubForList:
+        _ = env(prefix, "LIST_SUB")
+        return cls()
+
+
+@dataclass(frozen=True)
+class _ListTypedField:
+    subs: list[_SubForList] = field(default_factory=list)
+
+    @classmethod
+    def from_env(cls, prefix: str = "X") -> _ListTypedField:
+        _ = env(prefix, "LIST_TOP")
+        return cls()
+
+
+@dataclass(frozen=True)
+class _BadRef:
+    x: NonExistentType = 0  # type: ignore[name-defined]  # noqa: F821 — unresolvable on purpose
+
+    @classmethod
+    def from_env(cls, prefix: str = "X") -> _BadRef:
+        _ = env(prefix, "BAD")
+        return cls()
+
+
 class TestServerConfigDefaults:
     def test_default_transport_is_stdio(self):
         config = ServerConfig()
@@ -398,3 +426,34 @@ class TestDomainEnvSuffixes:
     def test_server_config_as_root_returns_empty(self) -> None:
         """ServerConfig as root yields empty; use server_config_env_suffixes."""
         assert domain_env_suffixes(ServerConfig) == frozenset()
+
+    def test_non_dataclass_input_raises_typeerror(self) -> None:
+        """A non-dataclass argument is a caller error, not a silent empty result."""
+        with pytest.raises(TypeError, match="dataclass"):
+            domain_env_suffixes(int)
+
+    def test_list_subconfig_field_traversed(self) -> None:
+        """list[Sub] fields are traversed via get_args (one level)."""
+        assert domain_env_suffixes(_ListTypedField) == frozenset(
+            {"LIST_TOP", "LIST_SUB"}
+        )
+
+    def test_source_unavailable_raises_oserror_with_context(self) -> None:
+        """A class whose from_env source can't be read raises OSError naming it."""
+        ns: dict[str, object] = {}
+        exec(  # noqa: S102 — building a source-less class on purpose
+            "from dataclasses import dataclass\n"
+            "@dataclass\n"
+            "class ExecCfg:\n"
+            "    @classmethod\n"
+            "    def from_env(cls, prefix='X'):\n"
+            "        return cls()\n",
+            ns,
+        )
+        with pytest.raises(OSError, match="ExecCfg.from_env"):
+            domain_env_suffixes(ns["ExecCfg"])  # type: ignore[arg-type]
+
+    def test_unresolvable_forward_ref_raises_nameerror(self) -> None:
+        """An annotation not importable at module scope propagates as NameError."""
+        with pytest.raises(NameError, match="domain_env_suffixes"):
+            domain_env_suffixes(_BadRef)


### PR DESCRIPTION
Closes #210.

## What

Adds a public `domain_env_suffixes(config_cls) -> frozenset[str]` to `_config.py` — the domain-side sibling of `server_config_env_suffixes()`. It AST-scans a config's `from_env` for literal `env`/`env_int`/`env_float` reads and recurses into sub-config dataclass fields (resolving types via `typing.get_type_hints`, unwrapping one level of `typing.get_args` so `Optional[Section]` / `list[Section]` are followed), excluding the composed `ServerConfig` field. Depth-first with a visited-set, so cycles and a type shared by two fields terminate/dedupe.

## Why

`server_config_env_suffixes()` lets a config-wizard drift gate measure the `ServerConfig` env surface, but a downstream that decomposes its config into sub-config *sections* (each with its own `from_env`) had no way to be measured — a single-function AST scan of `ProjectConfig.from_env` undercounts and the gate's coverage check passes vacuously. This gives decomposed configs a first-class, gate-legible surface. (Context: `markdown-vault-mcp` split its config into a `config_sections/` package; the template's v2.7.0 drift gate can't see it.)

## Design notes

- **Module-scope contract.** Real domain configs are module-level, where `get_type_hints` resolves their annotations (including `Optional[...]`). A resolution failure (broken/forward-ref annotation, or a non-module-scope config) **propagates** with a class-named message rather than silently yielding an incomplete set — appropriate for a drift gate.
- **Input + failure-path hardening.** Non-dataclass input raises `TypeError`; unreadable `from_env` source raises `OSError`; unresolvable hints raise `NameError` — each re-raised naming the offending class. Scan-only stdlib (`ast`/`inspect`/`textwrap`) is imported lazily inside the function so every consumer of `_config.py` doesn't pay for it.
- **Known limits (documented):** only unqualified `env(prefix, "LITERAL")` reads are seen (a renamed import / attribute-form / variable / keyword suffix is invisible); only one level of `get_args` is expanded (`list[Optional[Section]]` is not scanned).

## Tests

`tests/test_config.py::TestDomainEnvSuffixes` — flat (exact surface, all three read funcs), sub-config recursion + `ServerConfig` exclusion, `Optional[Sub]` via `get_args`, `list[Sub]` traversal, module-scope cycle (visited-set), same-type dedup, field-without-`from_env`, `ServerConfig`-as-root, and the three failure paths (non-dataclass → `TypeError`, source-unavailable → `OSError`, unresolvable hint → `NameError`). The `get_args` and `ServerConfig`-exclusion guards are mutation-checked. Full suite: 503 passing; `mypy src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
