### PR TITLE
feat(transfer): SSRF-hardened fetch_url primitive (#214)

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -53,12 +53,14 @@ from ._server_info import (
     register_server_info_tool,
 )
 from ._subject import get_claims, get_subject
+from ._transfer import FetchResult, fetch_url
 
 __version__ = "4.3.0"  # PSR overrides at build time
 
 __all__ = [
     "AuthMode",
     "ConfigurationError",
+    "FetchResult",
     "IconSpec",
     "SecretMaskFilter",
     "ServerConfig",
@@ -82,6 +84,7 @@ __all__ = [
     "env",
     "env_float",
     "env_int",
+    "fetch_url",
     "get_claims",
     "get_subject",
     "load_acl",

--- a/src/fastmcp_pvl_core/_transfer/__init__.py
+++ b/src/fastmcp_pvl_core/_transfer/__init__.py
@@ -1,0 +1,15 @@
+"""In-process transfer/ingest mechanics shared across the ``*-mcp`` family.
+
+Implements ADR 0001 (``docs/adr/0001-transfer-lift.md``): SSRF-hardened URL
+fetch, size-capped base64 decode, a one-time capability-link token store, and
+the ``/transfer`` route framework. This first module ships the standalone
+``fetch_url`` primitive (§11 issue #1); the rest land in sibling issues.
+
+Intra-package imports stay relative so a fold-in is a directory rename.
+"""
+
+from __future__ import annotations
+
+from .fetch import FetchResult, fetch_url
+
+__all__ = ["FetchResult", "fetch_url"]

--- a/src/fastmcp_pvl_core/_transfer/fetch.py
+++ b/src/fastmcp_pvl_core/_transfer/fetch.py
@@ -15,8 +15,8 @@ Hardening (lifted from ``markdown-vault-mcp``'s proven fetch, ADR §8):
   in the ``Host`` header and TLS SNI). This closes the TOCTOU window between
   validation and connect. Fails **closed** on any resolution error.
 - **No redirects** — a 3xx response is refused (never followed to a possibly
-  internal target). The explicit ``is_redirect`` check refuses every 3xx up
-  front with a purpose-specific error, rather than letting a redirect surface
+  internal target). An explicit ``300 <= status < 400`` check refuses every 3xx
+  up front with a purpose-specific error, rather than letting a redirect surface
   later as httpx's generic status error.
 - **No ambient environment** — the client runs with ``trust_env=False`` so an
   ``HTTP(S)_PROXY`` env var cannot divert the request past the pinned IP and
@@ -254,7 +254,14 @@ async def fetch_url(
     hostname = parsed.hostname
     if not hostname:
         raise ValueError("The fetch URL has no host.")
-    port = parsed.port or _SCHEME_DEFAULT_PORTS[parsed.scheme]
+    # `is not None` (not truthiness): an explicit port 0 must be kept, not
+    # silently coerced to the scheme default.
+    explicit_port = parsed.port
+    port = (
+        explicit_port
+        if explicit_port is not None
+        else _SCHEME_DEFAULT_PORTS[parsed.scheme]
+    )
 
     # Resolve + validate now and pin the resulting IP into the connection: the
     # address validated here is the one actually dialled. Fails closed.
@@ -264,15 +271,19 @@ async def fetch_url(
     # TLS SNI so vhost routing and certificate verification still work. Any
     # userinfo in the original URL is intentionally dropped (never relayed).
     ip_host = _bracket_host(pinned_ip)
-    pinned_netloc = f"{ip_host}:{parsed.port}" if parsed.port else ip_host
+    pinned_netloc = (
+        f"{ip_host}:{explicit_port}" if explicit_port is not None else ip_host
+    )
     pinned_url = urlunparse(parsed._replace(netloc=pinned_netloc))
     # The Host header carries the real hostname; bracket it if it is an IPv6
     # literal (urlparse hands it back unbracketed) so the header is well-formed.
     host_for_header = _bracket_host(hostname)
-    if parsed.port is None or parsed.port == _SCHEME_DEFAULT_PORTS.get(parsed.scheme):
+    if explicit_port is None or explicit_port == _SCHEME_DEFAULT_PORTS.get(
+        parsed.scheme
+    ):
         host_header = host_for_header
     else:
-        host_header = f"{host_for_header}:{parsed.port}"
+        host_header = f"{host_for_header}:{explicit_port}"
 
     chunks: list[bytes] = []
     downloaded = 0
@@ -294,7 +305,11 @@ async def fetch_url(
             extensions={"sni_hostname": hostname},
         ) as response,
     ):
-        if response.is_redirect:
+        # Refuse every 3xx explicitly by status range. (httpx's `is_redirect`
+        # is equivalent — True for all 300-399 in supported versions — but its
+        # semantics are easy to misread as Location-gated, so the range check is
+        # self-evidently "all 3xx".)
+        if 300 <= response.status_code < 400:
             raise ValueError(
                 f"Refusing the 3xx redirect response from {_redact_url(url)} "
                 "(redirects are not followed)."

--- a/src/fastmcp_pvl_core/_transfer/fetch.py
+++ b/src/fastmcp_pvl_core/_transfer/fetch.py
@@ -1,0 +1,335 @@
+"""SSRF-hardened URL→bytes fetch primitive (ADR 0001 §11 #1).
+
+A standalone, reusable capability: safely pull the bytes at an operator- or
+caller-supplied HTTP(S) URL without becoming a server-side request-forgery
+vector. Consumed by the transfer ingest plane, but useful anywhere a server
+needs to fetch a URL.
+
+Hardening (lifted from ``markdown-vault-mcp``'s proven fetch, ADR §8):
+
+- **Scheme allowlist** — only ``http``/``https`` (fixed shape, not
+  configurable; loosening it is an SSRF policy change pvl-core owns).
+- **Address validation + DNS-rebind pin** — the host is resolved, *every*
+  resolved address is rejected if non-public, and the validated IP is pinned
+  into the connection (we dial the IP literal, carrying the real hostname only
+  in the ``Host`` header and TLS SNI). This closes the TOCTOU window between
+  validation and connect. Fails **closed** on any resolution error.
+- **No redirects** — a 3xx response is refused (never followed to a possibly
+  internal target). The explicit ``is_redirect`` check refuses every 3xx up
+  front with a purpose-specific error, rather than letting a redirect surface
+  later as httpx's generic status error.
+- **No ambient environment** — the client runs with ``trust_env=False`` so an
+  ``HTTP(S)_PROXY`` env var cannot divert the request past the pinned IP and
+  ``.netrc`` cannot attach ambient credentials.
+- **Streaming size cap** — the body is read in chunks and aborted the moment it
+  exceeds ``max_bytes``; an oversize payload never fully materialises.
+- **Credential hygiene** — embedded ``user:pass@`` userinfo is dropped from the
+  dialled request (never relayed to the origin), and every URL this primitive
+  *itself* emits — its log line and the exceptions it raises, including the
+  ``HTTPStatusError`` re-raised on a 4xx/5xx — is redacted of userinfo + query
+  via :func:`_redact_url` (ADR §8: redaction covers *all* the emit-paths this
+  primitive owns, not only logs). httpx's own internal request logger also
+  emits the URL; that is the operator's logging-config concern (pvl-core ships
+  ``SecretMaskFilter``), not something a primitive should globally reconfigure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import socket
+from dataclasses import dataclass
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_FETCH_MAX_BYTES = 100 * 1024 * 1024  # 100 MiB
+DEFAULT_FETCH_TIMEOUT_S = 30.0
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+_BLOCKED_HOSTNAMES = frozenset(
+    {"localhost", "localhost.localdomain", "metadata.google.internal"}
+)
+_SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443}
+_BLOCKED_ADDR_MSG = (
+    "URLs targeting private, loopback, link-local, or reserved addresses "
+    "are not allowed."
+)
+_CHUNK_SIZE = 65536
+# RFC 6052 NAT64 well-known prefix. stdlib does not decode the IPv4 embedded in
+# its low 32 bits for is_global, so we validate that IPv4 explicitly.
+_NAT64_WKP = ipaddress.ip_network("64:ff9b::/96")
+
+
+@dataclass(frozen=True)
+class FetchResult:
+    """The outcome of a successful :func:`fetch_url`.
+
+    Attributes:
+        body: The full response body (materialised in memory, bounded by the
+            ``max_bytes`` cap the caller passed).
+        content_type: The response ``Content-Type`` header, or ``None``.
+
+    The byte count is exposed as the derived :attr:`size` property rather than a
+    stored field, so it can never drift from ``len(body)``.
+    """
+
+    body: bytes
+    content_type: str | None
+
+    @property
+    def size(self) -> int:
+        """Number of bytes downloaded — ``len(body)``."""
+        return len(self.body)
+
+
+def _ip_is_blocked(ip: str) -> bool:
+    """Return ``True`` if *ip* (an IP literal) is not a public, routable address.
+
+    Uses a **permit-list** model — block anything that is not globally routable
+    (``not is_global``) — which fails *closed* for every non-public range
+    without enumerating them one by one: private, loopback, link-local,
+    unspecified, reserved, benchmarking (198.18/15), and CGNAT / shared address
+    space (100.64/10, RFC 6598) are all covered structurally, on IPv4, IPv6,
+    and their IPv4-mapped forms. Multicast is blocked explicitly because the
+    stdlib classifies it as ``is_global`` on the supported interpreters. This is
+    the stricter posture the repo's earlier SSRF guard settled on (a plain
+    deny-list of ``is_private``/``is_loopback``/… silently allowed CGNAT).
+
+    NAT64 (RFC 6052 well-known prefix ``64:ff9b::/96``) is validated by decoding
+    its embedded IPv4 (the low 32 bits) and recursing — otherwise a deployed
+    NAT64 translator would route ``[64:ff9b::10.0.0.1]`` to a private/metadata
+    target, and ``is_global`` does not decode it. A NAT64 address embedding a
+    *public* IPv4 stays allowed. NAT64 is the **only** IPv4-embedding IPv6 form
+    decoded here, deliberately: ``ipv4_mapped`` (``::ffff:a.b.c.d``) and 6to4
+    (``2002::/16``) are already classified correctly by ``is_global``, and other
+    embedding literals (e.g. the deprecated IPv4-compatible ``::/96``) have no
+    routing guarantee — a modern stack dials the literal IPv6 address, which is
+    unreachable, rather than translating to the embedded IPv4 — so they are not
+    a practical SSRF vector.
+    """
+    addr = ipaddress.ip_address(ip)
+    if addr.version == 6 and addr in _NAT64_WKP:
+        embedded = ipaddress.IPv4Address(int(addr) & 0xFFFFFFFF)
+        return _ip_is_blocked(str(embedded))
+    return addr.is_multicast or not addr.is_global
+
+
+async def _resolve_addresses(hostname: str, port: int) -> list[str]:
+    """Resolve *hostname* to a list of IP-literal strings via the event loop.
+
+    A seam kept module-level so tests can inject resolution without real DNS.
+
+    Raises:
+        OSError: If resolution fails (``socket.gaierror`` is an ``OSError``).
+        UnicodeError: If the hostname fails IDNA encoding (e.g. an over-long
+            label). The caller converts both into a redacted ``ValueError``.
+    """
+    loop = asyncio.get_running_loop()
+    infos = await loop.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    return [str(info[4][0]) for info in infos]
+
+
+async def _resolve_pinned_ip(hostname: str, port: int) -> str:
+    """Resolve *hostname* and return one validated public IP to pin to.
+
+    Fails **closed**: raises :class:`ValueError` if the host is blocklisted,
+    resolution errors, returns no records, or **any** resolved address is
+    non-public. An IP-literal *hostname* is validated directly, without DNS.
+
+    Args:
+        hostname: The URL host (an IP literal or a domain name).
+        port: Target port, used as the ``getaddrinfo`` service hint.
+
+    Returns:
+        A validated, public IP literal to connect to.
+    """
+    if hostname in _BLOCKED_HOSTNAMES:
+        raise ValueError(_BLOCKED_ADDR_MSG)
+
+    # IP-literal fast path: validate directly, no DNS lookup.
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        if _ip_is_blocked(hostname):
+            raise ValueError(_BLOCKED_ADDR_MSG)
+        return hostname
+
+    # Domain name: resolve and validate every returned address. Fail closed on
+    # any resolution error so a DNS hiccup can never become an SSRF bypass.
+    try:
+        resolved = await _resolve_addresses(hostname, port)
+    except (OSError, UnicodeError) as exc:
+        # OSError = socket.gaierror (real resolution failure); UnicodeError =
+        # IDNA encoding failure on a malformed/over-long hostname label. Both
+        # funnel into one redacted ValueError so every resolution-failure class
+        # fails closed with the same shape.
+        raise ValueError(
+            f"Could not resolve host {hostname!r} for the fetch URL: {exc}"
+        ) from exc
+    if not resolved:
+        raise ValueError(f"Host {hostname!r} did not resolve to any address.")
+    for ip in resolved:
+        if _ip_is_blocked(ip):
+            raise ValueError(
+                f"Host {hostname!r} resolves to a non-public address ({ip}); "
+                "refusing to fetch."
+            )
+    return resolved[0]
+
+
+def _bracket_host(host: str) -> str:
+    """Wrap an IPv6 literal in ``[]`` for a netloc / ``Host`` header.
+
+    ``urlparse`` returns IPv6 hosts unbracketed, but a netloc or ``Host`` header
+    must bracket them (``[::1]``) to be well-formed. A domain or IPv4 literal
+    (no ``:``) is returned unchanged.
+    """
+    return f"[{host}]" if ":" in host else host
+
+
+def _redact_url(url: str) -> str:
+    """Return *url* with userinfo and query/fragment stripped.
+
+    Operator-/caller-supplied URLs carry credentials in ``user:pass@`` userinfo
+    and pre-signed tokens in the query string. Every message this primitive
+    itself emits — log lines and the exceptions it raises alike — passes the URL
+    through here first (ADR §8).
+    """
+    parsed = urlparse(url)
+    netloc = _bracket_host(parsed.hostname or "")
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunparse(parsed._replace(netloc=netloc, query="", fragment=""))
+
+
+async def fetch_url(
+    url: str,
+    *,
+    max_bytes: int = DEFAULT_FETCH_MAX_BYTES,
+    timeout_s: float = DEFAULT_FETCH_TIMEOUT_S,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> FetchResult:
+    """Fetch the bytes at *url* with SSRF hardening and a streaming size cap.
+
+    Args:
+        url: An ``http``/``https`` URL. The host is resolved and rejected if any
+            address is non-public; the validated IP is pinned for the
+            connection (DNS-rebind safe); redirects are not followed.
+        max_bytes: Positive per-fetch size cap; the download aborts the moment
+            it is exceeded.
+        timeout_s: Overall request timeout in seconds.
+        transport: An optional ``httpx`` transport (an extension point used by
+            tests to inject a ``MockTransport``); ``None`` uses real networking.
+
+    Returns:
+        A :class:`FetchResult` with the body, content type, and byte size.
+
+    Raises:
+        ValueError: On a non-positive *max_bytes* or *timeout_s*, a non-http(s)
+            scheme, a missing host, a blocked/non-public address, a resolution
+            failure, a refused redirect, or a body that exceeds *max_bytes*.
+        httpx.HTTPStatusError: On a 4xx/5xx response status (re-raised with a
+            redacted message; the type and ``request``/``response`` are kept for
+            programmatic inspection). Note: the retained ``exc.request.url``
+            still contains the query string, so callers should not log it
+            verbatim — the redacted message is the safe surface.
+        httpx.TransportError: Transport-level failures propagate uncaught — e.g.
+            ``httpx.TimeoutException`` when *timeout_s* expires, or a connection
+            error. This primitive does not wrap them.
+    """
+    if max_bytes <= 0:
+        raise ValueError(f"max_bytes must be positive, got {max_bytes}")
+    if timeout_s <= 0:
+        raise ValueError(f"timeout_s must be positive, got {timeout_s}")
+
+    parsed = urlparse(url)
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise ValueError(f"Only http and https URLs are allowed, got {parsed.scheme!r}")
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("The fetch URL has no host.")
+    port = parsed.port or _SCHEME_DEFAULT_PORTS[parsed.scheme]
+
+    # Resolve + validate now and pin the resulting IP into the connection: the
+    # address validated here is the one actually dialled. Fails closed.
+    pinned_ip = await _resolve_pinned_ip(hostname, port)
+
+    # Dial the validated IP, but keep the real hostname in the Host header and
+    # TLS SNI so vhost routing and certificate verification still work. Any
+    # userinfo in the original URL is intentionally dropped (never relayed).
+    ip_host = _bracket_host(pinned_ip)
+    pinned_netloc = f"{ip_host}:{parsed.port}" if parsed.port else ip_host
+    pinned_url = urlunparse(parsed._replace(netloc=pinned_netloc))
+    # The Host header carries the real hostname; bracket it if it is an IPv6
+    # literal (urlparse hands it back unbracketed) so the header is well-formed.
+    host_for_header = _bracket_host(hostname)
+    if parsed.port is None or parsed.port == _SCHEME_DEFAULT_PORTS.get(parsed.scheme):
+        host_header = host_for_header
+    else:
+        host_header = f"{host_for_header}:{parsed.port}"
+
+    chunks: list[bytes] = []
+    downloaded = 0
+    async with (
+        httpx.AsyncClient(
+            timeout=timeout_s,
+            follow_redirects=False,
+            trust_env=False,
+            # trust_env=False: ignore ambient HTTP(S)_PROXY / .netrc. A proxy env
+            # var would divert the request through an operator-uncontrolled host,
+            # bypassing the resolve-validate-pin chain entirely (an SSRF bypass);
+            # .netrc could attach ambient credentials to the outbound request.
+            transport=transport,
+        ) as client,
+        client.stream(
+            "GET",
+            pinned_url,
+            headers={"Host": host_header},
+            extensions={"sni_hostname": hostname},
+        ) as response,
+    ):
+        if response.is_redirect:
+            raise ValueError(
+                f"Refusing the 3xx redirect response from {_redact_url(url)} "
+                "(redirects are not followed)."
+            )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            # Re-raise with a redacted message: httpx embeds the request URL
+            # (query string included) in the default message, which carries any
+            # pre-signed token. Keep the type + request/response so callers can
+            # still inspect status programmatically. `from None` sets
+            # __suppress_context__ — otherwise httpx's original un-redacted
+            # message would still surface via __context__ (implicit chaining)
+            # in a rendered traceback (ADR §8: redact the messages this
+            # primitive itself raises).
+            raise httpx.HTTPStatusError(
+                f"HTTP {response.status_code} response from {_redact_url(url)}",
+                request=exc.request,
+                response=exc.response,
+            ) from None
+        content_type = response.headers.get("content-type")
+        async for chunk in response.aiter_bytes(chunk_size=_CHUNK_SIZE):
+            downloaded += len(chunk)
+            if downloaded > max_bytes:
+                raise ValueError(
+                    f"Download from {_redact_url(url)} exceeded the size cap "
+                    f"of {max_bytes} bytes."
+                )
+            chunks.append(chunk)
+
+    body = b"".join(chunks)
+    logger.info(
+        "fetch_url: downloaded %d bytes from %s (content-type=%s)",
+        downloaded,
+        _redact_url(url),
+        content_type,
+    )
+    return FetchResult(body=body, content_type=content_type)

--- a/tests/test_transfer_fetch.py
+++ b/tests/test_transfer_fetch.py
@@ -156,12 +156,12 @@ async def test_resolve_pinned_ip_empty_resolution_rejected(monkeypatch) -> None:
 
 
 def test_redact_url_strips_userinfo_and_query() -> None:
+    # Exact match, not substring checks: userinfo (user:s3cr3t), query
+    # (token=abc), and fragment are stripped; scheme, host, port, and path are
+    # kept. (Exact equality also avoids the `host in url` substring pattern that
+    # CodeQL flags as incomplete-URL-sanitization — and is a stronger assertion.)
     redacted = _redact_url("https://user:s3cr3t@example.com:8443/path?token=abc#f")
-    assert "s3cr3t" not in redacted
-    assert "user" not in redacted
-    assert "token" not in redacted
-    assert "abc" not in redacted
-    assert "example.com" in redacted  # host is safe to keep
+    assert redacted == "https://example.com:8443/path"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_transfer_fetch.py
+++ b/tests/test_transfer_fetch.py
@@ -1,0 +1,537 @@
+"""Contract tests for the SSRF-hardened ``fetch_url`` primitive (ADR 0001 §11 #1).
+
+The primitive is split into two testable planes:
+
+- **Pure SSRF validation** — ``_ip_is_blocked`` and ``_resolve_pinned_ip``
+  (with DNS resolution injected via ``_resolve_addresses``). No httpx needed;
+  this is where the security guarantee lives.
+- **HTTP mechanics** — ``fetch_url`` end-to-end, driven through an injected
+  ``httpx.MockTransport`` so we can assert on the exact request dialled
+  (pinned IP, Host header, no redirect, no relayed credentials) and drive the
+  streaming size cap.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+from fastmcp_pvl_core._transfer.fetch import (
+    FetchResult,
+    _ip_is_blocked,
+    _redact_url,
+    _resolve_pinned_ip,
+    fetch_url,
+)
+
+PUBLIC_V4 = "93.184.216.34"  # example.com
+PUBLIC_V6 = "2606:2800:220:1:248:1893:25c8:1946"
+
+
+# --------------------------------------------------------------------------- #
+# _ip_is_blocked — the non-public-range predicate (v4 + v6)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "127.0.0.1",  # loopback
+        "10.0.0.1",  # private
+        "192.168.1.1",  # private
+        "172.16.0.1",  # private
+        "169.254.169.254",  # link-local (cloud metadata)
+        "0.0.0.0",  # unspecified
+        "224.0.0.1",  # multicast
+        "240.0.0.1",  # reserved
+        "::1",  # v6 loopback
+        "fe80::1",  # v6 link-local
+        "fc00::1",  # v6 unique-local (private)
+        "ff02::1",  # v6 multicast
+        # IPv4-mapped IPv6 — must be blocked via the embedded IPv4. Locks the
+        # guarantee verified across Python 3.10–3.13 (is_private/is_link_local
+        # delegate to the mapped IPv4); guards against a future refactor that
+        # would open an SSRF bypass to cloud metadata.
+        "::ffff:169.254.169.254",  # mapped link-local (cloud metadata)
+        "::ffff:127.0.0.1",  # mapped loopback
+        "::ffff:10.0.0.1",  # mapped private
+        # Shared address space that a plain is_private/is_loopback deny-list
+        # silently allows — the permit-list (not is_global) closes these.
+        "100.64.0.1",  # CGNAT / shared address space (RFC 6598)
+        "::ffff:100.64.0.1",  # mapped CGNAT
+        "198.18.0.1",  # benchmarking (RFC 2544)
+        # NAT64 well-known prefix (RFC 6052) embedding a non-public IPv4 —
+        # stdlib does not decode this for is_global, so it must be blocked via
+        # explicit embedded-IPv4 validation (else a NAT64 translator reaches
+        # the private/metadata target).
+        "64:ff9b::169.254.169.254",  # NAT64 → cloud metadata
+        "64:ff9b::10.0.0.1",  # NAT64 → private
+        "64:ff9b::127.0.0.1",  # NAT64 → loopback
+    ],
+)
+def test_ip_is_blocked_true_for_non_public(ip: str) -> None:
+    assert _ip_is_blocked(ip) is True
+
+
+def test_ip_is_blocked_allows_nat64_public_embedded() -> None:
+    # A NAT64 address embedding a *public* IPv4 must stay allowed (a NAT64
+    # translator legitimately routes it to the public host) — the recursion
+    # validates the embedded IPv4, it does not blanket-block the prefix.
+    assert _ip_is_blocked(f"64:ff9b::{PUBLIC_V4}") is False
+
+
+@pytest.mark.parametrize("ip", [PUBLIC_V4, "8.8.8.8", PUBLIC_V6])
+def test_ip_is_blocked_false_for_public(ip: str) -> None:
+    assert _ip_is_blocked(ip) is False
+
+
+# --------------------------------------------------------------------------- #
+# _resolve_pinned_ip — blocked hosts, IP literals, DNS validation, fail-closed
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "host", ["localhost", "localhost.localdomain", "metadata.google.internal"]
+)
+async def test_resolve_pinned_ip_rejects_blocked_hostnames(host: str) -> None:
+    with pytest.raises(ValueError):
+        await _resolve_pinned_ip(host, 80)
+
+
+async def test_resolve_pinned_ip_public_literal_skips_dns(monkeypatch) -> None:
+    # An IP literal must be validated directly with no DNS lookup.
+    def _boom(*_a, **_k):
+        raise AssertionError("DNS must not be consulted for an IP literal")
+
+    monkeypatch.setattr("fastmcp_pvl_core._transfer.fetch._resolve_addresses", _boom)
+    assert await _resolve_pinned_ip(PUBLIC_V4, 443) == PUBLIC_V4
+
+
+async def test_resolve_pinned_ip_private_literal_rejected() -> None:
+    with pytest.raises(ValueError):
+        await _resolve_pinned_ip("127.0.0.1", 80)
+
+
+async def test_resolve_pinned_ip_domain_to_public_returns_ip(monkeypatch) -> None:
+    async def _fake(_host, _port):
+        return [PUBLIC_V4]
+
+    monkeypatch.setattr("fastmcp_pvl_core._transfer.fetch._resolve_addresses", _fake)
+    assert await _resolve_pinned_ip("example.com", 443) == PUBLIC_V4
+
+
+async def test_resolve_pinned_ip_domain_to_private_rejected(monkeypatch) -> None:
+    # Fail closed: even one non-public resolved address rejects the whole host.
+    async def _fake(_host, _port):
+        return [PUBLIC_V4, "10.0.0.5"]
+
+    monkeypatch.setattr("fastmcp_pvl_core._transfer.fetch._resolve_addresses", _fake)
+    with pytest.raises(ValueError):
+        await _resolve_pinned_ip("rebind.example", 443)
+
+
+async def test_resolve_pinned_ip_dns_error_fails_closed(monkeypatch) -> None:
+    async def _fake(_host, _port):
+        raise OSError("temporary DNS failure")
+
+    monkeypatch.setattr("fastmcp_pvl_core._transfer.fetch._resolve_addresses", _fake)
+    with pytest.raises(ValueError):
+        await _resolve_pinned_ip("example.com", 443)
+
+
+async def test_resolve_pinned_ip_empty_resolution_rejected(monkeypatch) -> None:
+    async def _fake(_host, _port):
+        return []
+
+    monkeypatch.setattr("fastmcp_pvl_core._transfer.fetch._resolve_addresses", _fake)
+    with pytest.raises(ValueError):
+        await _resolve_pinned_ip("example.com", 443)
+
+
+# --------------------------------------------------------------------------- #
+# _redact_url — strip userinfo + query from any emitted URL (#122: logs AND exc)
+# --------------------------------------------------------------------------- #
+
+
+def test_redact_url_strips_userinfo_and_query() -> None:
+    redacted = _redact_url("https://user:s3cr3t@example.com:8443/path?token=abc#f")
+    assert "s3cr3t" not in redacted
+    assert "user" not in redacted
+    assert "token" not in redacted
+    assert "abc" not in redacted
+    assert "example.com" in redacted  # host is safe to keep
+
+
+# --------------------------------------------------------------------------- #
+# fetch_url — scheme / host guards
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "url", ["ftp://example.com/x", "file:///etc/passwd", "gopher://h"]
+)
+async def test_fetch_url_rejects_non_http_scheme(url: str) -> None:
+    with pytest.raises(ValueError):
+        await fetch_url(url)
+
+
+async def test_fetch_url_rejects_missing_host() -> None:
+    with pytest.raises(ValueError):
+        await fetch_url("http:///no-host")
+
+
+# --------------------------------------------------------------------------- #
+# fetch_url — HTTP mechanics via injected MockTransport
+# --------------------------------------------------------------------------- #
+
+
+def _transport(handler) -> httpx.MockTransport:
+    return httpx.MockTransport(handler)
+
+
+def _exception_chain_text(exc: BaseException) -> str:
+    """Join the ``str()`` of an exception and its ``__cause__``/``__context__``
+    chain — the text that surfaces when the exception is logged/rendered."""
+    parts: list[str] = []
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        parts.append(str(cur))
+        cur = cur.__cause__ or (None if cur.__suppress_context__ else cur.__context__)
+    return " ".join(parts)
+
+
+async def test_fetch_url_happy_path_returns_result() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200, content=b"hello", headers={"content-type": "text/plain"}
+        )
+
+    result = await fetch_url(f"http://{PUBLIC_V4}/x", transport=_transport(handler))
+
+    assert isinstance(result, FetchResult)
+    assert result.body == b"hello"
+    assert result.size == 5
+    assert result.content_type == "text/plain"
+    assert len(seen) == 1
+
+
+async def test_fetch_url_aborts_over_size_cap() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"x" * 100)
+
+    # Credential-bearing URL so the assertion also guards message redaction on
+    # this emit-path (a _redact_url(url) → url regression would leak here).
+    url = f"http://user:pass@{PUBLIC_V4}/big?token=s3cr3t"
+    with pytest.raises(ValueError) as excinfo:
+        await fetch_url(url, max_bytes=10, transport=_transport(handler))
+    msg = str(excinfo.value)
+    assert "s3cr3t" not in msg
+    assert "pass" not in msg
+
+
+async def test_fetch_url_does_not_follow_redirects() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(302, headers={"location": "http://10.0.0.1/internal"})
+
+    url = f"http://user:pass@{PUBLIC_V4}/r?token=s3cr3t"
+    with pytest.raises(ValueError) as excinfo:
+        await fetch_url(url, transport=_transport(handler))
+    # The redirect target must never be dialled.
+    assert len(seen) == 1
+    assert "10.0.0.1" not in str(seen[0].url)
+    # ...and the refusal message must be redacted on this emit-path.
+    msg = str(excinfo.value)
+    assert "s3cr3t" not in msg
+    assert "pass" not in msg
+
+
+async def test_fetch_url_strips_embedded_credentials_from_request() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, content=b"ok")
+
+    await fetch_url(f"http://user:pass@{PUBLIC_V4}/x", transport=_transport(handler))
+    req = seen[0]
+    assert req.url.username == ""
+    assert req.url.password == ""
+    assert "pass" not in req.headers.get("authorization", "")
+
+
+async def test_fetch_url_pins_ip_and_keeps_host_header(monkeypatch) -> None:
+    async def _fake(_host, _port):
+        return [PUBLIC_V4]
+
+    monkeypatch.setattr("fastmcp_pvl_core._transfer.fetch._resolve_addresses", _fake)
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, content=b"ok")
+
+    await fetch_url("http://example.com/x", transport=_transport(handler))
+    req = seen[0]
+    assert req.url.host == PUBLIC_V4  # dialled the pinned IP
+    assert req.headers["host"] == "example.com"  # vhost preserved
+    # SNI carries the real hostname (drives TLS cert verification), not the
+    # pinned IP — a regression here would silently break HTTPS validation.
+    assert req.extensions["sni_hostname"] == "example.com"
+
+
+async def test_fetch_url_raises_on_http_error_status() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, content=b"boom")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await fetch_url(f"http://{PUBLIC_V4}/x", transport=_transport(handler))
+
+
+async def test_fetch_url_own_log_is_redacted(caplog) -> None:
+    # fetch_url controls only *its own* emit-paths. httpx's internal request
+    # logger also emits the URL (with query) — that is the operator's logging
+    # config concern (pvl-core ships SecretMaskFilter), not something a
+    # primitive should globally reconfigure. So we scope this to the fetch
+    # module's own logger records.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"ok")
+
+    with caplog.at_level(logging.INFO, logger="fastmcp_pvl_core._transfer.fetch"):
+        await fetch_url(
+            f"http://{PUBLIC_V4}/x?token=s3cr3t", transport=_transport(handler)
+        )
+    own = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "fastmcp_pvl_core._transfer.fetch"
+    ]
+    assert own, "expected fetch_url to emit its own log line"
+    assert "s3cr3t" not in " ".join(own)
+
+
+async def test_fetch_url_http_error_message_is_redacted() -> None:
+    # The HTTPStatusError fetch_url raises is its own declared emit-path; its
+    # message must not carry the query token (httpx's default message would).
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, content=b"nope")
+
+    url = f"http://{PUBLIC_V4}/x?token=s3cr3t"
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        await fetch_url(url, transport=_transport(handler))
+    assert "s3cr3t" not in str(excinfo.value)
+    # The token must also be absent from the whole exception *message chain* —
+    # a `raise ... from exc` would re-attach httpx's original un-redacted
+    # message via __cause__, which surfaces when the exception is rendered. We
+    # check the chained messages (the real logged surface), not the traceback
+    # frames (those legitimately show the caller's own source).
+    assert "s3cr3t" not in _exception_chain_text(excinfo.value)
+    assert excinfo.value.response.status_code == 404  # type preserved + usable
+
+
+async def test_fetch_url_pins_ipv6_and_brackets_literal(monkeypatch) -> None:
+    async def _fake(_host, _port):
+        return [PUBLIC_V6]
+
+    monkeypatch.setattr("fastmcp_pvl_core._transfer.fetch._resolve_addresses", _fake)
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, content=b"ok")
+
+    await fetch_url("http://example.com/x", transport=_transport(handler))
+    req = seen[0]
+    assert req.url.host == PUBLIC_V6  # dialled the pinned v6 literal
+    assert req.headers["host"] == "example.com"  # vhost preserved
+
+
+async def test_fetch_url_preserves_non_default_port(monkeypatch) -> None:
+    async def _fake(_host, _port):
+        return [PUBLIC_V4]
+
+    monkeypatch.setattr("fastmcp_pvl_core._transfer.fetch._resolve_addresses", _fake)
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, content=b"ok")
+
+    await fetch_url("http://example.com:8080/x", transport=_transport(handler))
+    req = seen[0]
+    assert req.url.host == PUBLIC_V4
+    assert req.url.port == 8080  # non-default port dialled on the pinned IP
+    assert req.headers["host"] == "example.com:8080"  # port carried in Host
+
+
+async def test_fetch_url_size_cap_boundary() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"x" * 10)
+
+    # Exactly at the cap succeeds (predicate is strict `>`), one over raises.
+    ok = await fetch_url(
+        f"http://{PUBLIC_V4}/x", max_bytes=10, transport=_transport(handler)
+    )
+    assert ok.size == 10
+
+    def over(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"x" * 11)
+
+    with pytest.raises(ValueError):
+        await fetch_url(
+            f"http://{PUBLIC_V4}/x", max_bytes=10, transport=_transport(over)
+        )
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+async def test_fetch_url_rejects_non_positive_max_bytes(bad: int) -> None:
+    with pytest.raises(ValueError):
+        await fetch_url(f"http://{PUBLIC_V4}/x", max_bytes=bad)
+
+
+@pytest.mark.parametrize("bad", [0, -1.0])
+async def test_fetch_url_rejects_non_positive_timeout(bad: float) -> None:
+    with pytest.raises(ValueError):
+        await fetch_url(f"http://{PUBLIC_V4}/x", timeout_s=bad)
+
+
+async def test_fetch_url_omits_explicit_default_port_from_host_header(
+    monkeypatch,
+) -> None:
+    async def _fake(_host, _port):
+        return [PUBLIC_V4]
+
+    monkeypatch.setattr("fastmcp_pvl_core._transfer.fetch._resolve_addresses", _fake)
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, content=b"ok")
+
+    # An explicit default port (80 for http) must be dialled but omitted from
+    # the Host header (RFC 7230 §5.4), so strict origin-matching vhosts accept.
+    await fetch_url("http://example.com:80/x", transport=_transport(handler))
+    req = seen[0]
+    assert req.url.port in (None, 80)
+    assert req.headers["host"] == "example.com"
+
+
+async def test_fetch_url_propagates_transport_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    # Transport-level failures are documented as propagating uncaught.
+    with pytest.raises(httpx.TransportError):
+        await fetch_url(f"http://{PUBLIC_V4}/x", transport=_transport(handler))
+
+
+async def test_fetch_url_client_disables_ambient_env(monkeypatch) -> None:
+    # trust_env=False is an SSRF control: an ambient HTTP(S)_PROXY / .netrc must
+    # not divert the request past the pinned IP. Its effect is unobservable
+    # through the injected MockTransport (which bypasses env-proxy mounting), so
+    # the only regression guard is asserting the AsyncClient constructor kwargs.
+    captured: dict[str, object] = {}
+    real_client = httpx.AsyncClient
+
+    def _spy(*args, **kwargs):
+        captured.update(kwargs)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _spy)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"ok")
+
+    await fetch_url(f"http://{PUBLIC_V4}/x", transport=_transport(handler))
+    assert captured.get("trust_env") is False
+    assert captured.get("follow_redirects") is False
+
+
+async def test_fetch_url_wraps_idna_failure_as_value_error() -> None:
+    # An over-long (>63 char) hostname label fails IDNA encoding in getaddrinfo,
+    # raising UnicodeError (a ValueError subclass, NOT OSError). It must still
+    # funnel into the redacted "Could not resolve host" ValueError and fail
+    # closed — no client is constructed. Uses real resolution (no transport).
+    bad = "a" * 64 + ".example.com"
+    with pytest.raises(ValueError, match="Could not resolve host"):
+        await fetch_url(f"http://{bad}/x")
+
+
+async def test_fetch_url_content_type_none_when_header_absent() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"ok")  # no content-type header
+
+    result = await fetch_url(f"http://{PUBLIC_V4}/x", transport=_transport(handler))
+    assert result.content_type is None
+
+
+async def test_fetch_url_size_cap_across_multiple_chunks() -> None:
+    # A body larger than the 64 KiB read chunk exercises the *cumulative*
+    # accumulation (downloaded += len(chunk)); a body of ~200 KiB against a
+    # 100 KiB cap must abort, catching a `+=` → `=` regression that a single
+    # sub-chunk body would not.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"x" * 200_000)
+
+    with pytest.raises(ValueError):
+        await fetch_url(
+            f"http://{PUBLIC_V4}/big",
+            max_bytes=100_000,
+            transport=_transport(handler),
+        )
+
+
+async def test_fetch_url_reassembles_multi_chunk_body_under_cap() -> None:
+    # A >64 KiB body under the cap must be reassembled completely and in order
+    # — guards a truncation/ordering regression in b"".join(chunks) (the worst
+    # failure mode: wrong bytes, no error).
+    payload = bytes(range(256)) * 1000  # 256 KiB, distinctive/order-sensitive
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=payload)
+
+    result = await fetch_url(
+        f"http://{PUBLIC_V4}/x", max_bytes=1_000_000, transport=_transport(handler)
+    )
+    assert result.body == payload
+    assert result.size == len(payload)
+
+
+async def test_fetch_url_brackets_ipv6_literal_host_header() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, content=b"ok")
+
+    await fetch_url(f"http://[{PUBLIC_V6}]/x", transport=_transport(handler))
+    # A v6-literal URL must produce a bracketed Host header, not the raw
+    # colon-bearing address (which is malformed per RFC 7230).
+    assert seen[0].headers["host"] == f"[{PUBLIC_V6}]"
+
+
+async def test_fetch_url_ipv6_with_non_default_port(monkeypatch) -> None:
+    async def _fake(_host, _port):
+        return [PUBLIC_V6]
+
+    monkeypatch.setattr("fastmcp_pvl_core._transfer.fetch._resolve_addresses", _fake)
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, content=b"ok")
+
+    await fetch_url("http://example.com:8080/x", transport=_transport(handler))
+    req = seen[0]
+    assert req.url.host == PUBLIC_V6  # bracketed v6 literal dialled
+    assert req.url.port == 8080
+    assert req.headers["host"] == "example.com:8080"

--- a/tests/test_transfer_fetch.py
+++ b/tests/test_transfer_fetch.py
@@ -255,6 +255,36 @@ async def test_fetch_url_does_not_follow_redirects() -> None:
     assert "pass" not in msg
 
 
+@pytest.mark.parametrize("code", [300, 302, 304, 307, 308])
+async def test_fetch_url_refuses_3xx_without_location(code: int) -> None:
+    # Every 3xx is refused by status range — including a Location-less 3xx
+    # (e.g. 304, or a bare 302 without a Location header). This locks that the
+    # refusal does not depend on a Location header being present.
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(code)  # no Location header
+
+    with pytest.raises(ValueError):
+        await fetch_url(f"http://{PUBLIC_V4}/x", transport=_transport(handler))
+    assert len(seen) == 1  # refused before any second dial
+
+
+async def test_fetch_url_keeps_explicit_port_zero() -> None:
+    # An explicit port 0 must be dialled as 0, not silently coerced to the
+    # scheme default (80). Uses `is not None`, not truthiness, in the port logic.
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, content=b"ok")
+
+    await fetch_url(f"http://{PUBLIC_V4}:0/x", transport=_transport(handler))
+    assert seen[0].url.port == 0
+    assert seen[0].headers["host"] == f"{PUBLIC_V4}:0"
+
+
 async def test_fetch_url_strips_embedded_credentials_from_request() -> None:
     seen: list[httpx.Request] = []
 


### PR DESCRIPTION
Implements **#214** (first slice of the ADR 0001 decomposition, §11 issue #1). Closes #214.

## What

Introduces the `_transfer/` package with a standalone, SSRF-hardened URL→bytes primitive **`fetch_url`** (+ `FetchResult`), exported from the package `__init__`. It is usable directly — no token store, no routes — and will be consumed by the later transfer ingest plane. The SSRF algorithm is lifted from `markdown-vault-mcp`'s proven fetch per ADR §8, then hardened further during review.

Also removes the empty untracked `_file_exchange/` residue (ADR §2.5/§10.4).

## Hardening (all tested as behavior contracts)

- **Address validation + DNS-rebind pin** — resolves the host, rejects if *any* resolved address is non-public, and pins the validated IP into the connection (dials the IP literal; real hostname rides only in `Host` + TLS SNI), closing the TOCTOU window. Fails **closed** on every resolution-error class (`OSError` + IDNA `UnicodeError`).
- **Permit-list block predicate** — `is_multicast or not is_global`, which structurally covers private/loopback/link-local/unspecified/reserved/benchmarking/**CGNAT (100.64/10)** on v4, v6, and IPv4-mapped forms, plus explicit **NAT64 (`64:ff9b::/96`)** embedded-IPv4 recursion (the one embedding form `is_global` doesn't decode).
- **No redirects** — every 3xx refused up front (`is_redirect`), never followed.
- **No ambient environment** — `trust_env=False` so `HTTP(S)_PROXY` / `.netrc` can't divert past the pinned IP.
- **Streaming size cap** — aborts mid-stream before an oversize body materialises.
- **Credential hygiene** — embedded userinfo dropped from the dialled request; every URL the primitive itself emits (log line + all raised messages, incl. the `HTTPStatusError` re-raised `from None`) redacted of userinfo + query via `_redact_url`.
- **Input validation** — `max_bytes > 0`, `timeout_s > 0`.

## Design for testability

Security-critical SSRF validation (`_ip_is_blocked`, `_resolve_pinned_ip` with an injected `_resolve_addresses` seam) is a pure, directly-unit-tested plane; HTTP mechanics are driven through an injected `httpx.MockTransport`. **63 contract tests**, green on Python 3.10–3.13; `ruff`/`mypy` clean; full suite (567) green.

## Review

Design brainstormed and approved (ADR 0001, PR #213, merged). Ran the local preflight circus (5 core lenses + code-reviewer, silent-failure-hunter, type-design-analyzer, pr-test-analyzer, comment-analyzer) to convergence — 7 rounds, ending fully clean. Every finding was real and fixed (CGNAT bypass, chained-cause credential leak, `trust_env` proxy bypass, NAT64 bypass, IPv6 Host-header bracketing, redaction coverage on all emit-paths). All version-dependent `ipaddress`/`httpx` claims were verified empirically across 3.10–3.13.

Docs-note: no dependency change (httpx is already core); the pre-existing `uv.lock` self-version drift (4.2.0→4.3.0) is unrelated and kept out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._