### PR TITLE
feat(transfer): decode_base64_capped — size-capped base64 decode primitive (#215)

### DIFF
--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -53,7 +53,7 @@ from ._server_info import (
     register_server_info_tool,
 )
 from ._subject import get_claims, get_subject
-from ._transfer import FetchResult, fetch_url
+from ._transfer import FetchResult, decode_base64_capped, fetch_url
 
 __version__ = "4.3.0"  # PSR overrides at build time
 
@@ -80,6 +80,7 @@ __all__ = [
     "client_supports_apps",
     "compute_app_domain",
     "configure_logging_from_env",
+    "decode_base64_capped",
     "domain_env_suffixes",
     "env",
     "env_float",

--- a/src/fastmcp_pvl_core/_transfer/__init__.py
+++ b/src/fastmcp_pvl_core/_transfer/__init__.py
@@ -2,8 +2,9 @@
 
 Implements ADR 0001 (``docs/adr/0001-transfer-lift.md``): SSRF-hardened URL
 fetch, size-capped base64 decode, a one-time capability-link token store, and
-the ``/transfer`` route framework. This first module ships the standalone
-``fetch_url`` primitive (§11 issue #1); the rest land in sibling issues.
+the ``/transfer`` route framework. Landed so far: ``fetch_url`` (§11 issue #1)
+and ``decode_base64_capped`` (§11 issue #2); the token store and route
+framework land in sibling issues.
 
 Intra-package imports stay relative so a fold-in is a directory rename.
 """

--- a/src/fastmcp_pvl_core/_transfer/__init__.py
+++ b/src/fastmcp_pvl_core/_transfer/__init__.py
@@ -10,6 +10,7 @@ Intra-package imports stay relative so a fold-in is a directory rename.
 
 from __future__ import annotations
 
+from .base64 import decode_base64_capped
 from .fetch import FetchResult, fetch_url
 
-__all__ = ["FetchResult", "fetch_url"]
+__all__ = ["FetchResult", "decode_base64_capped", "fetch_url"]

--- a/src/fastmcp_pvl_core/_transfer/base64.py
+++ b/src/fastmcp_pvl_core/_transfer/base64.py
@@ -1,0 +1,62 @@
+"""Size-capped base64 decode primitive (ADR 0001 §11 #2).
+
+A standalone, reusable capability: decode a base64 payload while bounding the
+decoded size, so an attacker-supplied ``content_base64`` cannot expand into an
+oversized in-memory buffer. Consumed by the base64-inline ingest source, but
+usable anywhere a server accepts inline base64.
+
+Strict by design:
+
+- **Reject before materialising** — the decoded size is computed from the
+  encoded length + padding and checked *before* :func:`base64.b64decode` runs,
+  so an over-cap payload is never fully decoded into memory.
+- **Reject invalid input** — decoding uses ``validate=True``, so non-alphabet
+  characters (including embedded whitespace/newlines) raise rather than being
+  silently discarded. Callers that hold wrapped base64 must unwrap it first.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+
+
+def decode_base64_capped(data: str | bytes, *, max_bytes: int) -> bytes:
+    """Decode standard base64 *data*, rejecting invalid or over-cap input.
+
+    Args:
+        data: A standard (unwrapped) base64 payload, ``str`` or ``bytes``.
+        max_bytes: Positive cap on the **decoded** byte size.
+
+    Returns:
+        The decoded bytes (``len(result) <= max_bytes``).
+
+    Raises:
+        ValueError: On a non-positive *max_bytes*, invalid base64, or a payload
+            whose decoded size exceeds *max_bytes*.
+    """
+    if max_bytes <= 0:
+        raise ValueError(f"max_bytes must be positive, got {max_bytes}")
+
+    # Reject an oversized payload before decoding it. For valid base64 the
+    # decoded size is exactly ``len(data) // 4 * 3 - padding``; invalid-length
+    # input is caught by the decode below. (A loose ``len * 3 // 4`` upper bound
+    # would false-reject a padded payload sitting exactly on the cap.)
+    padding = (
+        data.count(b"=") if isinstance(data, (bytes, bytearray)) else data.count("=")
+    )
+    if (len(data) // 4) * 3 - padding > max_bytes:
+        raise ValueError(f"base64 input decodes to more than the {max_bytes}-byte cap")
+
+    try:
+        decoded = base64.b64decode(data, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError(f"invalid base64: {exc}") from exc
+
+    # Defensive exact check — the pre-check is exact for valid base64, but this
+    # guards against any padding/estimation edge the pre-check missed.
+    if len(decoded) > max_bytes:
+        raise ValueError(
+            f"base64 payload is {len(decoded)} bytes, exceeds the {max_bytes}-byte cap"
+        )
+    return decoded

--- a/src/fastmcp_pvl_core/_transfer/base64.py
+++ b/src/fastmcp_pvl_core/_transfer/base64.py
@@ -42,10 +42,18 @@ def decode_base64_capped(data: str | bytes, *, max_bytes: int) -> bytes:
     # decoded size is exactly ``len(data) // 4 * 3 - padding``; invalid-length
     # input is caught by the decode below. (A loose ``len * 3 // 4`` upper bound
     # would false-reject a padded payload sitting exactly on the cap.)
-    padding = (
+    #
+    # Valid base64 has at most 2 padding chars, so clamp the count to 2: a
+    # crafted payload padded with many ``=`` (e.g. ``"AB" + "=" * 1_000_000``)
+    # would otherwise drive the estimate negative, slip the pre-check, and hand
+    # the full attacker-sized string to b64decode — which allocates its output
+    # buffer before rejecting the bad padding, defeating the "never materialise"
+    # guarantee. Clamping keeps the estimate a true lower bound of the decoded
+    # size while staying exact for valid input.
+    raw_padding = (
         data.count(b"=") if isinstance(data, (bytes, bytearray)) else data.count("=")
     )
-    if (len(data) // 4) * 3 - padding > max_bytes:
+    if (len(data) // 4) * 3 - min(raw_padding, 2) > max_bytes:
         raise ValueError(f"base64 input decodes to more than the {max_bytes}-byte cap")
 
     try:

--- a/tests/test_transfer_base64.py
+++ b/tests/test_transfer_base64.py
@@ -101,6 +101,28 @@ def test_over_cap_rejected_before_materialising(monkeypatch) -> None:
         decode_base64_capped(_b64(b"x" * 6), max_bytes=3)
 
 
+@pytest.mark.parametrize(
+    "attack",
+    [
+        "AB" + "=" * 100_000,  # all-trailing '=' — inflates a naive count
+        "A=B=" * 50_000,  # embedded '=' interspersed
+    ],
+)
+def test_padding_inflated_bomb_rejected_before_materialising(
+    monkeypatch, attack: str
+) -> None:
+    # A crafted payload padded with many '=' must still be rejected on the
+    # pre-check, before b64decode is handed the full attacker-sized string.
+    # Clamping the padding count to 2 (max valid) keeps the estimate a true
+    # lower bound so the estimate cannot be driven negative.
+    def _boom(*_a, **_k):
+        raise AssertionError("b64decode must not run for an over-cap payload")
+
+    monkeypatch.setattr(base64, "b64decode", _boom)
+    with pytest.raises(ValueError, match="decodes to more than"):
+        decode_base64_capped(attack, max_bytes=64)
+
+
 @pytest.mark.parametrize("bad", [0, -1])
 def test_non_positive_max_bytes_raises(bad: int) -> None:
     with pytest.raises(ValueError):

--- a/tests/test_transfer_base64.py
+++ b/tests/test_transfer_base64.py
@@ -1,0 +1,107 @@
+"""Contract tests for the ``decode_base64_capped`` primitive (ADR 0001 §11 #2).
+
+The primitive decodes standard base64 with a decoded-size cap, and is strict:
+invalid base64 raises rather than silently dropping non-alphabet characters, and
+an over-cap payload is rejected *before* the full output is materialised (so a
+base64 memory-bomb cannot defeat the cap).
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from fastmcp_pvl_core._transfer.base64 import decode_base64_capped
+
+
+def _b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode("ascii")
+
+
+# --------------------------------------------------------------------------- #
+# happy path
+# --------------------------------------------------------------------------- #
+
+
+def test_decodes_valid_base64_str() -> None:
+    assert decode_base64_capped(_b64(b"hello"), max_bytes=100) == b"hello"
+
+
+def test_decodes_valid_base64_bytes_input() -> None:
+    # Accepts the encoded payload as bytes too (b64decode does).
+    assert decode_base64_capped(base64.b64encode(b"hello"), max_bytes=100) == b"hello"
+
+
+def test_empty_input_decodes_to_empty_bytes() -> None:
+    assert decode_base64_capped("", max_bytes=100) == b""
+
+
+# --------------------------------------------------------------------------- #
+# invalid base64 → ValueError (strict: no silent drop of non-alphabet chars)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "!!!!",  # non-alphabet characters
+        "abc",  # wrong length / incorrect padding
+        "YQ=",  # truncated padding
+        "aGVs bG8=",  # embedded whitespace (strict rejects — not silently stripped)
+        "aGVs\nbG8=",  # embedded newline (MIME/PEM wrapping — must be unwrapped)
+        "café",  # non-ASCII str: b64decode's internal .encode("ascii") fails,
+        # and base64 re-raises it as a plain ValueError ("string argument should
+        # contain only ASCII characters") — a ValueError, not a binascii.Error —
+        # so it is caught by the `ValueError` arm of the except clause.
+    ],
+)
+def test_invalid_base64_raises(bad: str) -> None:
+    with pytest.raises(ValueError):
+        decode_base64_capped(bad, max_bytes=100)
+
+
+def test_over_cap_bytes_input_raises() -> None:
+    # Exercise the `bytes` branch of the padding pre-check on the over-cap path.
+    with pytest.raises(ValueError):
+        decode_base64_capped(base64.b64encode(b"x" * 100), max_bytes=10)
+
+
+# --------------------------------------------------------------------------- #
+# size cap
+# --------------------------------------------------------------------------- #
+
+
+def test_decoded_over_cap_raises() -> None:
+    with pytest.raises(ValueError):
+        decode_base64_capped(_b64(b"x" * 100), max_bytes=10)
+
+
+def test_exact_cap_boundary_succeeds() -> None:
+    # Decoded size exactly == max_bytes must pass (strict `>` overflow check).
+    payload = b"x" * 10
+    assert decode_base64_capped(_b64(payload), max_bytes=10) == payload
+
+
+def test_one_over_cap_raises() -> None:
+    with pytest.raises(ValueError):
+        decode_base64_capped(_b64(b"x" * 11), max_bytes=10)
+
+
+def test_over_cap_rejected_before_materialising(monkeypatch) -> None:
+    # An over-cap payload must be rejected on the length pre-check, *before*
+    # b64decode runs — otherwise the cap would not protect against a decode
+    # memory-bomb. Make b64decode explode if reached, and assert the raise is
+    # the pre-check's ValueError, not the sabotaged decode.
+    def _boom(*_a, **_k):
+        raise AssertionError("b64decode must not run for an over-cap payload")
+
+    monkeypatch.setattr(base64, "b64decode", _boom)
+    with pytest.raises(ValueError, match="decodes to more than"):
+        decode_base64_capped(_b64(b"x" * 6), max_bytes=3)
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_non_positive_max_bytes_raises(bad: int) -> None:
+    with pytest.raises(ValueError):
+        decode_base64_capped(_b64(b"hi"), max_bytes=bad)


### PR DESCRIPTION
Implements **#215** (second slice of the ADR 0001 decomposition, §11 issue #2). Closes #215.

## What

A tiny standalone primitive `decode_base64_capped(data, *, max_bytes) -> bytes` in `src/fastmcp_pvl_core/_transfer/base64.py`, exported from the package `__init__`. It's independent of the other transfer pieces (no store, no routes) and will back the base64-inline ingest source.

## Behaviour (strict + memory-safe)

- **Reject before materialising** — the decoded size is computed *exactly* from the encoded length + padding (`len//4*3 - padding`) and checked **before** `b64decode` runs, so an over-cap payload is never fully decoded into memory (the base64 analog of `fetch_url`'s streaming cap). A loose `len*3//4` upper bound would false-reject a padded payload sitting exactly on the cap — the exact formula does not.
- **Reject invalid input** — decodes with `validate=True`, so non-alphabet characters (including embedded whitespace/newlines) raise rather than being silently discarded; callers holding wrapped MIME/PEM base64 must unwrap first.
- **Input validation** — `max_bytes > 0`.
- A defensive post-decode exact check backstops the pre-check.

## Tests

16 contract cells: valid `str`/`bytes`, empty, invalid (non-alphabet / bad padding / embedded whitespace / newline / non-ASCII `str`), over-cap (str + bytes), exact-cap boundary, one-over, non-positive `max_bytes`, and a monkeypatched **reject-before-materialise** guard that asserts `b64decode` is never reached for an over-cap payload. Green on Python 3.10–3.13; ruff/mypy/full-suite clean.

## Review

Built on the merged ADR (#213) and sibling `fetch_url` (#219). Ran the local preflight circus (five core lenses + code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer) to convergence. All `base64`/stdlib exception-mechanics claims were verified empirically against the CPython source (notably: a non-ASCII `str` makes `base64` re-raise a plain `ValueError`, not a `UnicodeEncodeError`).

Docs-note: no dependency change; the pre-existing `uv.lock` self-version drift is unrelated and kept out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._