### PR TITLE
feat(transfer): KV-backed TransferStore — one-time token store (#216)

### DIFF
--- a/src/fastmcp_pvl_core/_transfer/__init__.py
+++ b/src/fastmcp_pvl_core/_transfer/__init__.py
@@ -2,9 +2,10 @@
 
 Implements ADR 0001 (``docs/adr/0001-transfer-lift.md``): SSRF-hardened URL
 fetch, size-capped base64 decode, a one-time capability-link token store, and
-the ``/transfer`` route framework. Landed so far: ``fetch_url`` (§11 issue #1)
-and ``decode_base64_capped`` (§11 issue #2); the token store and route
-framework land in sibling issues.
+the ``/transfer`` route framework. Landed so far: ``fetch_url`` (§11 issue #1),
+``decode_base64_capped`` (§11 issue #2), and ``TransferStore`` in
+``store.py`` (§11 issue #3, kept internal until the sink/route layer consumes
+it); the sink protocols and route framework land in sibling issues.
 
 Intra-package imports stay relative so a fold-in is a directory rename.
 """

--- a/src/fastmcp_pvl_core/_transfer/store.py
+++ b/src/fastmcp_pvl_core/_transfer/store.py
@@ -53,6 +53,9 @@ _TOKEN_COLLECTION = "tokens"
 _TOKEN_BYTES = 32
 """Entropy of a minted token — an unguessable 32-byte URL-safe secret."""
 
+_FENCE_BYTES = 8
+"""Entropy of a per-claim fence — a fresh reservation id each :meth:`claim`."""
+
 _NAMESPACE = "transfer"
 """The KV namespace pvl-core pins for the transfer subsystem (a shape decision:
 downstream does not choose the keyspace)."""
@@ -84,6 +87,11 @@ class _TokenRecord(TypedDict):
     sink_handle: object
     caps: Mapping[str, Any]
     lease_expires_at: float | None
+    # A fresh id stamped on each claim (the fencing token). ``release`` and
+    # ``complete`` only act when the caller's fence matches this — so a stale
+    # holder whose lease was reclaimed cannot mutate the new holder's
+    # reservation. ``None`` while ``available``/``consumed``.
+    fence: str | None
 
 
 class TransferTokenError(Exception):
@@ -107,7 +115,11 @@ class TokenInFlightError(TransferTokenError):
 
 
 class TokenNotClaimedError(TransferTokenError):
-    """:meth:`TransferStore.complete` was called on a token that was never claimed."""
+    """The token is not currently claimed.
+
+    Raised by :meth:`TransferStore.complete` when the token is ``available`` —
+    never claimed, or already released.
+    """
 
 
 @dataclass(frozen=True)
@@ -115,10 +127,14 @@ class TransferToken:
     """A successful claim: the opaque routing info the caller needs to proceed.
 
     ``sink_handle`` and ``caps`` are exactly what :meth:`TransferStore.mint`
-    stored — the store never interprets them.
+    stored — the store never interprets them. ``fence`` identifies *this*
+    reservation; pass it back to :meth:`TransferStore.release` /
+    :meth:`TransferStore.complete` so a reservation superseded by a lease
+    reclaim cannot mutate the current holder's state.
     """
 
     token: str
+    fence: str
     kind: str
     sink_handle: object
     caps: Mapping[str, Any]
@@ -210,6 +226,7 @@ class TransferStore:
             "sink_handle": sink_handle,
             "caps": caps,
             "lease_expires_at": None,
+            "fence": None,
         }
         await self._kv.put(
             token, record, collection=_TOKEN_COLLECTION, ttl=float(ttl_seconds)
@@ -219,9 +236,10 @@ class TransferStore:
     async def claim(self, token: str, kind: str) -> TransferToken:
         """Reserve *token* for *kind*, marking it ``in_flight`` under a lease.
 
-        Reclaims an ``in_flight`` token whose lease has lapsed (a crashed
-        handler). Preserves the token's remaining TTL on the re-put — dropping
-        it would make the one-time link immortal.
+        Reclaims an ``in_flight`` token whose lease has lapsed (a crashed *or
+        slow* handler) with a fresh :attr:`TransferToken.fence`. Preserves the
+        token's remaining TTL on the re-put — dropping it would make the
+        one-time link immortal.
 
         Raises:
             TokenNotFoundError: The token is missing or its TTL has lapsed.
@@ -242,25 +260,34 @@ class TransferStore:
                 lease = record["lease_expires_at"]
                 if lease is not None and self._clock() < lease:
                     raise TokenInFlightError("token is claimed and its lease is live")
-                # Lease lapsed → the previous holder crashed; reclaim below.
+                # Lease lapsed → the previous holder crashed or is too slow;
+                # reclaim below under a fresh fence so its late release/complete
+                # (carrying the old fence) can no longer mutate this reservation.
+            fence = secrets.token_urlsafe(_FENCE_BYTES)
             record["status"] = _IN_FLIGHT
             record["lease_expires_at"] = self._clock() + self._lease_seconds
+            record["fence"] = fence
             await self._kv.put(
                 token, record, collection=_TOKEN_COLLECTION, ttl=remaining
             )
             return TransferToken(
                 token=token,
+                fence=fence,
                 kind=record["kind"],
                 sink_handle=record["sink_handle"],
                 caps=record["caps"],
             )
 
-    async def release(self, token: str) -> None:
-        """Revert an ``in_flight`` reservation to ``available`` (release-on-failure).
+    async def release(self, token: str, fence: str) -> None:
+        """Revert *this* reservation to ``available`` (release-on-failure).
 
-        Idempotent and safe: a no-op if the token is missing, already
-        ``available``, or ``consumed`` — a late release after a successful
-        :meth:`complete` must never resurrect a burned link.
+        *fence* is the :attr:`TransferToken.fence` from the claim being
+        released. Idempotent and safe: a no-op if the token is missing, already
+        ``available`` or ``consumed`` (a late release after a successful
+        :meth:`complete` must never resurrect a burned link), or if *fence* does
+        not match the record's current fence — i.e. this reservation was
+        superseded by a lease reclaim, so reverting it would corrupt the new
+        holder's in-flight state.
         """
         async with self._lock:
             try:
@@ -269,20 +296,27 @@ class TransferStore:
                 return  # expired/gone — nothing to release
             if record["status"] != _IN_FLIGHT:
                 return  # available or consumed — nothing to revert
+            if record["fence"] != fence:
+                return  # superseded — this is no longer our reservation
             record["status"] = _AVAILABLE
             record["lease_expires_at"] = None
+            record["fence"] = None
             await self._kv.put(
                 token, record, collection=_TOKEN_COLLECTION, ttl=remaining
             )
 
-    async def complete(self, token: str) -> None:
-        """Burn *token* (``in_flight → consumed``) on a successful transfer.
+    async def complete(self, token: str, fence: str) -> None:
+        """Burn *this* reservation (``in_flight → consumed``) on success.
 
-        Idempotent on an already-``consumed`` token, and a no-op if the token
-        expired mid-transfer (its TTL lapsed).
+        *fence* is the :attr:`TransferToken.fence` from the claim being
+        completed. Idempotent on an already-``consumed`` token, a no-op if the
+        token expired mid-transfer (its TTL lapsed), and a no-op if *fence* does
+        not match the record's current fence — a reservation superseded by a
+        lease reclaim must not burn the new holder's live in-flight link.
 
         Raises:
-            TokenNotClaimedError: The token exists but was never claimed.
+            TokenNotClaimedError: The token is not currently claimed (it is
+                ``available`` — never claimed, or already released).
         """
         async with self._lock:
             try:
@@ -293,9 +327,12 @@ class TransferStore:
             if status == _CONSUMED:
                 return  # idempotent re-complete
             if status != _IN_FLIGHT:
-                raise TokenNotClaimedError("token was never claimed")
+                raise TokenNotClaimedError("token is not currently claimed")
+            if record["fence"] != fence:
+                return  # superseded — the current reservation is not ours
             record["status"] = _CONSUMED
             record["lease_expires_at"] = None
+            record["fence"] = None
             await self._kv.put(
                 token, record, collection=_TOKEN_COLLECTION, ttl=remaining
             )

--- a/src/fastmcp_pvl_core/_transfer/store.py
+++ b/src/fastmcp_pvl_core/_transfer/store.py
@@ -1,0 +1,318 @@
+"""KV-backed one-time capability-link token store (ADR 0001 §6 / §11 #3).
+
+A ``TransferStore`` persists one-time link tokens over an
+:class:`~key_value.aio.protocols.key_value.AsyncKeyValue` backend
+(``build_kv_store(config, namespace="transfer")``) and runs the
+``available → in_flight → consumed`` state machine on them:
+
+- :meth:`TransferStore.mint` creates an ``available`` token whose lifetime is
+  the KV entry TTL — there is no sweep loop; an expired token (and any
+  abandoned reservation past its TTL) simply vanishes from the backend.
+- :meth:`TransferStore.claim` marks a token ``in_flight`` under a short lease.
+  A *crashed* handler's reservation auto-frees once the lease lapses, so the
+  next claim reclaims it without an explicit release.
+- :meth:`TransferStore.release` reverts ``in_flight → available`` on a transient
+  failure. **The one-time link survives** — ADR §6.1 rejects delete-on-claim
+  precisely because mid-serve failures are common; a failed attempt must not
+  spend the link.
+- :meth:`TransferStore.complete` burns the token (``consumed``) on success.
+
+**Correctness boundary (ADR §6.3).** The KV facade exposes no compare-and-set,
+so one in-process :class:`asyncio.Lock` serialises every read-modify-write.
+Within the single ``serve --transport http`` process these servers run, that
+gives exact one-time semantics *and* restart survival (the record lives in KV).
+A future horizontally-scaled deployment sharing one backend would degrade to
+best-effort single-use — acceptable by design, because the TTL, not strict
+single-use, is the security-relevant bound.
+
+The token carries an **opaque ``sink_handle``** (where bytes land) and opaque
+``caps`` that the store never interprets — only ``kind`` is matched on claim.
+``sink_handle`` and ``caps`` must be JSON-serialisable: they round-trip through
+the KV backend. Intra-package imports stay relative so a fold-in is a directory
+rename.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, cast
+
+from .._config import ServerConfig
+from .._kv_store import build_kv_store
+
+if TYPE_CHECKING:
+    from key_value.aio.protocols.key_value import AsyncKeyValue
+
+_TOKEN_COLLECTION = "tokens"
+"""KV collection holding token records, under the ``transfer`` namespace."""
+
+_TOKEN_BYTES = 32
+"""Entropy of a minted token — an unguessable 32-byte URL-safe secret."""
+
+_NAMESPACE = "transfer"
+"""The KV namespace pvl-core pins for the transfer subsystem (a shape decision:
+downstream does not choose the keyspace)."""
+
+# The three token states as a Literal, so mypy checks every comparison and
+# assignment — a typo like ``"in-flight"`` fails the type check rather than
+# silently creating an unreachable state. The bare ``Final`` constants each
+# narrow to their individual literal type and give a single source of truth;
+# the stored value stays a plain string (JSON-serialisable).
+TokenStatus = Literal["available", "in_flight", "consumed"]
+_AVAILABLE: Final = "available"
+_IN_FLIGHT: Final = "in_flight"
+_CONSUMED: Final = "consumed"
+
+
+class _TokenRecord(TypedDict):
+    """The persisted shape of a token, round-tripped through the KV backend.
+
+    A ``TypedDict`` (not a class) so it stays a plain JSON-serialisable dict at
+    rest while mypy checks every field access in this module. ``sink_handle``
+    and ``caps`` are opaque passthrough the store never interprets:
+    ``sink_handle`` is typed ``object`` (not ``Any``), so a consumer of a claim
+    must narrow it before use; ``caps`` is a ``Mapping[str, Any]`` the store
+    never inspects.
+    """
+
+    status: TokenStatus
+    kind: str
+    sink_handle: object
+    caps: Mapping[str, Any]
+    lease_expires_at: float | None
+
+
+class TransferTokenError(Exception):
+    """Base class for the token-store's claim/complete failures."""
+
+
+class TokenNotFoundError(TransferTokenError):
+    """The token does not exist — never minted, or its TTL has lapsed."""
+
+
+class TokenKindMismatchError(TransferTokenError):
+    """The token exists but was minted for a different link kind."""
+
+
+class TokenAlreadyConsumedError(TransferTokenError):
+    """The token was already burned by a successful :meth:`TransferStore.complete`."""
+
+
+class TokenInFlightError(TransferTokenError):
+    """The token is claimed and its lease is still live — a concurrent holder."""
+
+
+class TokenNotClaimedError(TransferTokenError):
+    """:meth:`TransferStore.complete` was called on a token that was never claimed."""
+
+
+@dataclass(frozen=True)
+class TransferToken:
+    """A successful claim: the opaque routing info the caller needs to proceed.
+
+    ``sink_handle`` and ``caps`` are exactly what :meth:`TransferStore.mint`
+    stored — the store never interprets them.
+    """
+
+    token: str
+    kind: str
+    sink_handle: object
+    caps: Mapping[str, Any]
+
+
+class TransferStore:
+    """One-time capability-link token store backed by an ``AsyncKeyValue``.
+
+    Args:
+        kv: The backend store, typically from
+            ``build_kv_store(config, namespace="transfer")``. Injected so the
+            store is testable against an in-memory backend.
+        lease_seconds: Reclaim window for an ``in_flight`` reservation — a
+            crashed handler's token auto-frees this long after :meth:`claim`.
+            Operator-tunable timing (wired from config by the route layer);
+            must be positive.
+        clock: Wall-clock source for lease timestamps. Defaults to
+            :func:`time.time`; injected only for deterministic tests. Wall
+            clock (not monotonic) so a lease persisted in KV stays meaningful
+            across a process restart.
+    """
+
+    def __init__(
+        self,
+        kv: AsyncKeyValue,
+        *,
+        lease_seconds: float,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        if lease_seconds <= 0:
+            raise ValueError(f"lease_seconds must be positive, got {lease_seconds}")
+        self._kv = kv
+        self._lease_seconds = float(lease_seconds)
+        self._clock = clock
+        self._lock = asyncio.Lock()
+
+    @classmethod
+    def from_config(
+        cls,
+        config: ServerConfig,
+        *,
+        lease_seconds: float,
+        clock: Callable[[], float] = time.time,
+    ) -> TransferStore:
+        """Build a store from operator config, pinning ``namespace="transfer"``.
+
+        The namespace is pvl-core's decision, not the caller's — every transfer
+        deployment shares one keyspace regardless of downstream.
+        """
+        return cls(
+            build_kv_store(config, namespace=_NAMESPACE),
+            lease_seconds=lease_seconds,
+            clock=clock,
+        )
+
+    async def mint(
+        self,
+        *,
+        kind: str,
+        sink_handle: object,
+        caps: Mapping[str, Any],
+        ttl_seconds: float,
+    ) -> str:
+        """Create an ``available`` token and return its unguessable id.
+
+        Args:
+            kind: Link kind matched on :meth:`claim` (e.g. ``"download"``).
+            sink_handle: Opaque routing info the store never interprets.
+            caps: Opaque caps the store never interprets.
+            ttl_seconds: Token lifetime — the KV entry TTL, the security bound.
+
+        ``sink_handle`` and ``caps`` must be JSON-serialisable so they round-trip
+        through the KV backend. That is the caller's responsibility, enforced by
+        the backend at persist time (a serialising backend raises on a bad
+        value) — this method does not probe it.
+
+        Raises:
+            ValueError: On empty ``kind`` or non-positive ``ttl_seconds``.
+        """
+        if not kind:
+            raise ValueError("kind must be a non-empty string")
+        if ttl_seconds <= 0:
+            raise ValueError(f"ttl_seconds must be positive, got {ttl_seconds}")
+        # A fresh 32-byte secret cannot collide, so minting needs no lock.
+        token = secrets.token_urlsafe(_TOKEN_BYTES)
+        record: _TokenRecord = {
+            "status": _AVAILABLE,
+            "kind": kind,
+            "sink_handle": sink_handle,
+            "caps": caps,
+            "lease_expires_at": None,
+        }
+        await self._kv.put(
+            token, record, collection=_TOKEN_COLLECTION, ttl=float(ttl_seconds)
+        )
+        return token
+
+    async def claim(self, token: str, kind: str) -> TransferToken:
+        """Reserve *token* for *kind*, marking it ``in_flight`` under a lease.
+
+        Reclaims an ``in_flight`` token whose lease has lapsed (a crashed
+        handler). Preserves the token's remaining TTL on the re-put — dropping
+        it would make the one-time link immortal.
+
+        Raises:
+            TokenNotFoundError: The token is missing or its TTL has lapsed.
+            TokenKindMismatchError: The token was minted for a different kind.
+            TokenAlreadyConsumedError: The token was already burned.
+            TokenInFlightError: The token is claimed and its lease is still live.
+        """
+        async with self._lock:
+            record, remaining = await self._read(token)
+            if record["kind"] != kind:
+                raise TokenKindMismatchError(
+                    f"token is for kind {record['kind']!r}, not {kind!r}"
+                )
+            status = record["status"]
+            if status == _CONSUMED:
+                raise TokenAlreadyConsumedError("token was already consumed")
+            if status == _IN_FLIGHT:
+                lease = record["lease_expires_at"]
+                if lease is not None and self._clock() < lease:
+                    raise TokenInFlightError("token is claimed and its lease is live")
+                # Lease lapsed → the previous holder crashed; reclaim below.
+            record["status"] = _IN_FLIGHT
+            record["lease_expires_at"] = self._clock() + self._lease_seconds
+            await self._kv.put(
+                token, record, collection=_TOKEN_COLLECTION, ttl=remaining
+            )
+            return TransferToken(
+                token=token,
+                kind=record["kind"],
+                sink_handle=record["sink_handle"],
+                caps=record["caps"],
+            )
+
+    async def release(self, token: str) -> None:
+        """Revert an ``in_flight`` reservation to ``available`` (release-on-failure).
+
+        Idempotent and safe: a no-op if the token is missing, already
+        ``available``, or ``consumed`` — a late release after a successful
+        :meth:`complete` must never resurrect a burned link.
+        """
+        async with self._lock:
+            try:
+                record, remaining = await self._read(token)
+            except TokenNotFoundError:
+                return  # expired/gone — nothing to release
+            if record["status"] != _IN_FLIGHT:
+                return  # available or consumed — nothing to revert
+            record["status"] = _AVAILABLE
+            record["lease_expires_at"] = None
+            await self._kv.put(
+                token, record, collection=_TOKEN_COLLECTION, ttl=remaining
+            )
+
+    async def complete(self, token: str) -> None:
+        """Burn *token* (``in_flight → consumed``) on a successful transfer.
+
+        Idempotent on an already-``consumed`` token, and a no-op if the token
+        expired mid-transfer (its TTL lapsed).
+
+        Raises:
+            TokenNotClaimedError: The token exists but was never claimed.
+        """
+        async with self._lock:
+            try:
+                record, remaining = await self._read(token)
+            except TokenNotFoundError:
+                return  # expired mid-transfer — nothing left to burn
+            status = record["status"]
+            if status == _CONSUMED:
+                return  # idempotent re-complete
+            if status != _IN_FLIGHT:
+                raise TokenNotClaimedError("token was never claimed")
+            record["status"] = _CONSUMED
+            record["lease_expires_at"] = None
+            await self._kv.put(
+                token, record, collection=_TOKEN_COLLECTION, ttl=remaining
+            )
+
+    async def _read(self, token: str) -> tuple[_TokenRecord, float]:
+        """Read a live token record and its remaining TTL, or raise.
+
+        A single ``ttl()`` call returns both the value and its remaining
+        lifetime. A token with no positive remaining TTL is treated as gone —
+        this both handles expiry and fails closed on the anomalous no-TTL
+        record we never mint, so the remaining value is always safe to re-apply
+        on the caller's put.
+
+        The value is cast to :class:`_TokenRecord`: the store is the only writer
+        to this keyspace, so a live record is trusted to have the minted shape.
+        """
+        record, remaining = await self._kv.ttl(token, collection=_TOKEN_COLLECTION)
+        if record is None or remaining is None or remaining <= 0:
+            raise TokenNotFoundError("token not found or expired")
+        return cast("_TokenRecord", record), remaining

--- a/tests/test_transfer_store.py
+++ b/tests/test_transfer_store.py
@@ -1,0 +1,396 @@
+"""Contract tests for the KV-backed ``TransferStore`` (ADR 0001 §6 / §11 #3).
+
+The store is a one-time capability-link token store over an ``AsyncKeyValue``
+backend. It preserves the ``available → in_flight → consumed`` machine with
+**release-on-failure** (a failed reservation returns to ``available`` so the
+one-time link survives — ADR §6.1), reclaims a crashed handler's reservation
+once its lease lapses, and relies on the KV entry's TTL as the security-relevant
+lifetime bound (ADR §6.3). One in-process ``asyncio.Lock`` serialises the
+read-modify-write so single-use is exact under the single-process deployment.
+
+The failure modes pinned here:
+
+- **State machine**: claim→complete burns; a second claim is rejected.
+- **Release-on-failure**: claim→release keeps the link claimable again; a late
+  release must never resurrect a *consumed* token.
+- **Lease reclaim**: an ``in_flight`` token whose lease has lapsed (crashed,
+  never-released handler) is reclaimable without an explicit release.
+- **Live lease**: a second claim while the lease is still valid is rejected.
+- **TTL preservation**: a mutating op must re-put with the *remaining* token
+  TTL — putting with no TTL would make the one-time link immortal, defeating
+  the only security-relevant bound.
+- **TTL expiry**: once the KV entry lapses the token is gone (no sweep loop).
+- **Wrong-kind**: a claim with the wrong kind is rejected and does not consume.
+- **Concurrency**: two racing claims yield exactly one holder.
+- **Validation**: non-positive lease/TTL and empty kind are rejected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from key_value.aio.stores.memory import MemoryStore
+
+from fastmcp_pvl_core._config import ServerConfig
+from fastmcp_pvl_core._transfer.store import (
+    _TOKEN_COLLECTION,
+    TokenAlreadyConsumedError,
+    TokenInFlightError,
+    TokenKindMismatchError,
+    TokenNotClaimedError,
+    TokenNotFoundError,
+    TransferStore,
+    TransferToken,
+)
+
+
+class _Clock:
+    """A hand-cranked monotonic clock for deterministic lease tests."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _store(
+    *, lease_seconds: float = 30.0, clock: _Clock | None = None
+) -> TransferStore:
+    return TransferStore(
+        MemoryStore(), lease_seconds=lease_seconds, clock=clock or _Clock()
+    )
+
+
+async def _mint(
+    store: TransferStore, *, kind: str = "download", ttl: float = 3600.0
+) -> str:
+    return await store.mint(
+        kind=kind, sink_handle={"path": "a/b"}, caps={"max_bytes": 10}, ttl_seconds=ttl
+    )
+
+
+# --------------------------------------------------------------------------- #
+# state machine — claim / complete
+# --------------------------------------------------------------------------- #
+
+
+async def test_claim_returns_opaque_handle_and_caps() -> None:
+    store = _store()
+    token = await _mint(store)
+    claim = await store.claim(token, "download")
+    assert isinstance(claim, TransferToken)
+    assert claim.token == token
+    assert claim.kind == "download"
+    assert claim.sink_handle == {"path": "a/b"}
+    assert claim.caps == {"max_bytes": 10}
+
+
+async def test_claim_then_complete_burns_the_token() -> None:
+    store = _store()
+    token = await _mint(store)
+    await store.claim(token, "download")
+    await store.complete(token)
+    with pytest.raises(TokenAlreadyConsumedError):
+        await store.claim(token, "download")
+
+
+async def test_complete_is_idempotent() -> None:
+    store = _store()
+    token = await _mint(store)
+    await store.claim(token, "download")
+    await store.complete(token)
+    await store.complete(token)  # must not raise
+
+
+async def test_complete_without_claim_raises() -> None:
+    store = _store()
+    token = await _mint(store)
+    with pytest.raises(TokenNotClaimedError):
+        await store.complete(token)
+
+
+# --------------------------------------------------------------------------- #
+# release-on-failure (ADR §6.1) — the load-bearing behaviour
+# --------------------------------------------------------------------------- #
+
+
+async def test_claim_release_keeps_the_link_claimable() -> None:
+    store = _store()
+    token = await _mint(store)
+    await store.claim(token, "download")
+    await store.release(token)
+    # The one-time link survived a transient failure — claimable again.
+    reclaim = await store.claim(token, "download")
+    assert reclaim.token == token
+
+
+async def test_release_never_resurrects_a_consumed_token() -> None:
+    store = _store()
+    token = await _mint(store)
+    await store.claim(token, "download")
+    await store.complete(token)
+    await store.release(token)  # late release after success — must be a no-op
+    with pytest.raises(TokenAlreadyConsumedError):
+        await store.claim(token, "download")
+
+
+async def test_release_on_unclaimed_token_is_a_noop() -> None:
+    store = _store()
+    token = await _mint(store)
+    await store.release(token)  # never claimed — no-op, no raise
+    claim = await store.claim(token, "download")
+    assert claim.token == token
+
+
+# --------------------------------------------------------------------------- #
+# lease reclaim vs live lease
+# --------------------------------------------------------------------------- #
+
+
+async def test_live_lease_blocks_a_second_claim() -> None:
+    clock = _Clock()
+    store = _store(lease_seconds=30.0, clock=clock)
+    token = await _mint(store)
+    await store.claim(token, "download")
+    clock.advance(10.0)  # still within the 30s lease
+    with pytest.raises(TokenInFlightError):
+        await store.claim(token, "download")
+
+
+async def test_lapsed_lease_is_reclaimable_without_release() -> None:
+    clock = _Clock()
+    store = _store(lease_seconds=30.0, clock=clock)
+    token = await _mint(store)
+    await store.claim(token, "download")  # handler then "crashes" — no release
+    clock.advance(31.0)  # lease has lapsed
+    reclaim = await store.claim(token, "download")
+    assert reclaim.token == token
+
+
+# --------------------------------------------------------------------------- #
+# wrong kind
+# --------------------------------------------------------------------------- #
+
+
+async def test_wrong_kind_claim_rejected_and_not_consumed() -> None:
+    store = _store()
+    token = await _mint(store, kind="download")
+    with pytest.raises(TokenKindMismatchError):
+        await store.claim(token, "upload")
+    # Rejection must not burn the link — the right kind still claims it.
+    claim = await store.claim(token, "download")
+    assert claim.token == token
+
+
+# --------------------------------------------------------------------------- #
+# unknown token / TTL expiry
+# --------------------------------------------------------------------------- #
+
+
+async def test_claim_unknown_token_raises_not_found() -> None:
+    store = _store()
+    with pytest.raises(TokenNotFoundError):
+        await store.claim("no-such-token", "download")
+
+
+async def test_ttl_expiry_removes_the_token() -> None:
+    store = _store()
+    token = await _mint(store, ttl=0.05)
+    await asyncio.sleep(0.1)  # let the KV entry TTL lapse
+    with pytest.raises(TokenNotFoundError):
+        await store.claim(token, "download")
+
+
+async def test_complete_on_expired_token_is_a_noop() -> None:
+    store = _store()
+    token = await _mint(store, ttl=0.05)
+    await asyncio.sleep(0.1)
+    await store.complete(token)  # expired mid-transfer — no-op, no raise
+
+
+# --------------------------------------------------------------------------- #
+# TTL preservation — the immortal-token failure mode
+# --------------------------------------------------------------------------- #
+
+
+async def test_claim_preserves_the_token_ttl() -> None:
+    # A mutating op must re-put with the remaining TTL. If it dropped the TTL,
+    # the one-time link would live forever — defeating the security bound.
+    kv = MemoryStore()
+    store = TransferStore(kv, lease_seconds=30.0, clock=_Clock())
+    token = await store.mint(
+        kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
+    )
+    await store.claim(token, "download")
+    _value, remaining = await kv.ttl(token, collection=_TOKEN_COLLECTION)
+    assert remaining is not None
+    assert 0.0 < remaining <= 3600.0
+
+
+async def test_release_preserves_the_token_ttl() -> None:
+    kv = MemoryStore()
+    store = TransferStore(kv, lease_seconds=30.0, clock=_Clock())
+    token = await store.mint(
+        kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
+    )
+    await store.claim(token, "download")
+    await store.release(token)
+    _value, remaining = await kv.ttl(token, collection=_TOKEN_COLLECTION)
+    assert remaining is not None
+    assert 0.0 < remaining <= 3600.0
+
+
+async def test_complete_preserves_the_token_ttl() -> None:
+    # complete() writes the consumed tombstone; it too must keep the remaining
+    # TTL so a burned token still expires on schedule rather than lingering.
+    kv = MemoryStore()
+    store = TransferStore(kv, lease_seconds=30.0, clock=_Clock())
+    token = await store.mint(
+        kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
+    )
+    await store.claim(token, "download")
+    await store.complete(token)
+    _value, remaining = await kv.ttl(token, collection=_TOKEN_COLLECTION)
+    assert remaining is not None
+    assert 0.0 < remaining <= 3600.0
+
+
+# --------------------------------------------------------------------------- #
+# concurrency — the in-process lock serialises the read-modify-write
+# --------------------------------------------------------------------------- #
+
+
+class _YieldingKV:
+    """A KV wrapper that suspends the event loop *between* the read and the
+    write of a claim's read-modify-write.
+
+    A plain ``MemoryStore`` never awaits anything real, so two gathered claims
+    serialise on their own — the first runs to completion before the second is
+    stepped — and the test would pass even if the lock were deleted. Yielding
+    after the ``ttl()`` read forces the real interleave a production backend
+    (redis/disk, whose awaits genuinely suspend) would produce, so the test now
+    fails if the ``asyncio.Lock`` around the read-modify-write is removed.
+    """
+
+    def __init__(self, inner: MemoryStore) -> None:
+        self._inner = inner
+
+    async def ttl(self, *args, **kwargs):
+        result = await self._inner.ttl(*args, **kwargs)
+        await asyncio.sleep(0)  # let a concurrent claim interleave post-read
+        return result
+
+    async def put(self, *args, **kwargs):
+        return await self._inner.put(*args, **kwargs)
+
+
+async def test_racing_claims_yield_exactly_one_holder() -> None:
+    # Uses _YieldingKV so the two claims genuinely interleave; without the
+    # lock this yields two holders (double-claim of a one-time link).
+    store = TransferStore(
+        _YieldingKV(MemoryStore()), lease_seconds=30.0, clock=_Clock()
+    )
+    token = await store.mint(
+        kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
+    )
+    results = await asyncio.gather(
+        store.claim(token, "download"),
+        store.claim(token, "download"),
+        return_exceptions=True,
+    )
+    holders = [r for r in results if isinstance(r, TransferToken)]
+    rejected = [r for r in results if isinstance(r, TokenInFlightError)]
+    assert len(holders) == 1
+    assert len(rejected) == 1
+
+
+# --------------------------------------------------------------------------- #
+# minting
+# --------------------------------------------------------------------------- #
+
+
+async def test_mint_returns_distinct_unguessable_tokens() -> None:
+    store = _store()
+    a = await _mint(store)
+    b = await _mint(store)
+    assert a != b
+    assert len(a) >= 32  # token_urlsafe(32) → ~43 chars
+
+
+# --------------------------------------------------------------------------- #
+# validation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0])
+async def test_mint_rejects_non_positive_ttl(bad: float) -> None:
+    store = _store()
+    with pytest.raises(ValueError):
+        await store.mint(kind="download", sink_handle={}, caps={}, ttl_seconds=bad)
+
+
+async def test_mint_rejects_empty_kind() -> None:
+    store = _store()
+    with pytest.raises(ValueError):
+        await store.mint(kind="", sink_handle={}, caps={}, ttl_seconds=60.0)
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0])
+def test_constructor_rejects_non_positive_lease(bad: float) -> None:
+    with pytest.raises(ValueError):
+        TransferStore(MemoryStore(), lease_seconds=bad)
+
+
+# --------------------------------------------------------------------------- #
+# from_config — the store pins namespace="transfer" (shape owned by pvl-core)
+# --------------------------------------------------------------------------- #
+
+
+async def test_from_config_wires_a_working_store() -> None:
+    config = ServerConfig(kv_store_url="memory://")
+    store = TransferStore.from_config(config, lease_seconds=30.0)
+    token = await store.mint(
+        kind="download", sink_handle={"h": 1}, caps={}, ttl_seconds=60.0
+    )
+    claim = await store.claim(token, "download")
+    assert claim.sink_handle == {"h": 1}
+    await store.complete(token)
+    with pytest.raises(TokenAlreadyConsumedError):
+        await store.claim(token, "download")
+
+
+async def test_from_config_pins_the_transfer_namespace(monkeypatch) -> None:
+    # The keyspace is pvl-core's shape decision, not the caller's — from_config
+    # must always request namespace="transfer" from build_kv_store.
+    seen: dict[str, object] = {}
+
+    def _spy(config, *, namespace):
+        seen["namespace"] = namespace
+        return MemoryStore()
+
+    monkeypatch.setattr("fastmcp_pvl_core._transfer.store.build_kv_store", _spy)
+    TransferStore.from_config(
+        ServerConfig(kv_store_url="memory://"), lease_seconds=30.0
+    )
+    assert seen["namespace"] == "transfer"
+
+
+async def test_opaque_fields_round_trip_through_a_serialising_backend(tmp_path) -> None:
+    # The docstring promises sink_handle/caps "round-trip through the KV
+    # backend". MemoryStore keeps live objects; a file:// backend actually
+    # serialises, so this proves the JSON round-trip the contract advertises.
+    config = ServerConfig(kv_store_url=f"file://{tmp_path}/kv")
+    store = TransferStore.from_config(config, lease_seconds=30.0)
+    sink_handle = {"bucket": "b", "key": "k", "parts": [1, 2, 3]}
+    caps = {"max_bytes": 1024, "content_types": ["image/png"]}
+    token = await store.mint(
+        kind="upload", sink_handle=sink_handle, caps=caps, ttl_seconds=60.0
+    )
+    claim = await store.claim(token, "upload")
+    assert claim.sink_handle == sink_handle
+    assert claim.caps == caps

--- a/tests/test_transfer_store.py
+++ b/tests/test_transfer_store.py
@@ -93,8 +93,8 @@ async def test_claim_returns_opaque_handle_and_caps() -> None:
 async def test_claim_then_complete_burns_the_token() -> None:
     store = _store()
     token = await _mint(store)
-    await store.claim(token, "download")
-    await store.complete(token)
+    claim = await store.claim(token, "download")
+    await store.complete(token, claim.fence)
     with pytest.raises(TokenAlreadyConsumedError):
         await store.claim(token, "download")
 
@@ -102,16 +102,16 @@ async def test_claim_then_complete_burns_the_token() -> None:
 async def test_complete_is_idempotent() -> None:
     store = _store()
     token = await _mint(store)
-    await store.claim(token, "download")
-    await store.complete(token)
-    await store.complete(token)  # must not raise
+    claim = await store.claim(token, "download")
+    await store.complete(token, claim.fence)
+    await store.complete(token, claim.fence)  # must not raise
 
 
 async def test_complete_without_claim_raises() -> None:
     store = _store()
     token = await _mint(store)
     with pytest.raises(TokenNotClaimedError):
-        await store.complete(token)
+        await store.complete(token, "no-fence")
 
 
 # --------------------------------------------------------------------------- #
@@ -122,8 +122,8 @@ async def test_complete_without_claim_raises() -> None:
 async def test_claim_release_keeps_the_link_claimable() -> None:
     store = _store()
     token = await _mint(store)
-    await store.claim(token, "download")
-    await store.release(token)
+    claim = await store.claim(token, "download")
+    await store.release(token, claim.fence)
     # The one-time link survived a transient failure — claimable again.
     reclaim = await store.claim(token, "download")
     assert reclaim.token == token
@@ -132,9 +132,10 @@ async def test_claim_release_keeps_the_link_claimable() -> None:
 async def test_release_never_resurrects_a_consumed_token() -> None:
     store = _store()
     token = await _mint(store)
-    await store.claim(token, "download")
-    await store.complete(token)
-    await store.release(token)  # late release after success — must be a no-op
+    claim = await store.claim(token, "download")
+    await store.complete(token, claim.fence)
+    # late release after success — must be a no-op
+    await store.release(token, claim.fence)
     with pytest.raises(TokenAlreadyConsumedError):
         await store.claim(token, "download")
 
@@ -142,7 +143,7 @@ async def test_release_never_resurrects_a_consumed_token() -> None:
 async def test_release_on_unclaimed_token_is_a_noop() -> None:
     store = _store()
     token = await _mint(store)
-    await store.release(token)  # never claimed — no-op, no raise
+    await store.release(token, "no-fence")  # never claimed — no-op, no raise
     claim = await store.claim(token, "download")
     assert claim.token == token
 
@@ -170,6 +171,42 @@ async def test_lapsed_lease_is_reclaimable_without_release() -> None:
     clock.advance(31.0)  # lease has lapsed
     reclaim = await store.claim(token, "download")
     assert reclaim.token == token
+
+
+# --------------------------------------------------------------------------- #
+# fencing — a superseded holder must not mutate the current reservation
+# --------------------------------------------------------------------------- #
+
+
+async def test_superseded_holder_cannot_mutate_reclaimed_reservation() -> None:
+    # A slow-but-alive handler A whose lease lapsed and was reclaimed by B must
+    # not be able to revert (release) or burn (complete) B's active reservation
+    # with its now-stale fence — even single-process, where the lock alone does
+    # not stop a stale holder from mutating a superseded reservation.
+    clock = _Clock()
+    store = _store(lease_seconds=30.0, clock=clock)
+    token = await _mint(store)
+    a = await store.claim(token, "download")  # A holds fence a.fence
+    clock.advance(31.0)  # A's lease lapses — A is slow, not crashed
+    b = await store.claim(token, "download")  # B reclaims → B is the holder now
+    assert b.fence != a.fence
+
+    # A's late release with its stale fence must NOT revert B's reservation —
+    # the token must still be B's live in-flight claim.
+    await store.release(token, a.fence)
+    with pytest.raises(TokenInFlightError):
+        await store.claim(token, "download")
+
+    # A's late complete with its stale fence must NOT burn B's reservation —
+    # the token must still be B's live in-flight claim, not consumed.
+    await store.complete(token, a.fence)
+    with pytest.raises(TokenInFlightError):
+        await store.claim(token, "download")
+
+    # B completes its own reservation with its live fence — that burns it.
+    await store.complete(token, b.fence)
+    with pytest.raises(TokenAlreadyConsumedError):
+        await store.claim(token, "download")
 
 
 # --------------------------------------------------------------------------- #
@@ -209,8 +246,10 @@ async def test_ttl_expiry_removes_the_token() -> None:
 async def test_complete_on_expired_token_is_a_noop() -> None:
     store = _store()
     token = await _mint(store, ttl=0.05)
+    claim = await store.claim(token, "download")
     await asyncio.sleep(0.1)
-    await store.complete(token)  # expired mid-transfer — no-op, no raise
+    # expired mid-transfer — no-op, no raise
+    await store.complete(token, claim.fence)
 
 
 # --------------------------------------------------------------------------- #
@@ -238,8 +277,8 @@ async def test_release_preserves_the_token_ttl() -> None:
     token = await store.mint(
         kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
     )
-    await store.claim(token, "download")
-    await store.release(token)
+    claim = await store.claim(token, "download")
+    await store.release(token, claim.fence)
     _value, remaining = await kv.ttl(token, collection=_TOKEN_COLLECTION)
     assert remaining is not None
     assert 0.0 < remaining <= 3600.0
@@ -253,8 +292,8 @@ async def test_complete_preserves_the_token_ttl() -> None:
     token = await store.mint(
         kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
     )
-    await store.claim(token, "download")
-    await store.complete(token)
+    claim = await store.claim(token, "download")
+    await store.complete(token, claim.fence)
     _value, remaining = await kv.ttl(token, collection=_TOKEN_COLLECTION)
     assert remaining is not None
     assert 0.0 < remaining <= 3600.0
@@ -359,7 +398,7 @@ async def test_from_config_wires_a_working_store() -> None:
     )
     claim = await store.claim(token, "download")
     assert claim.sink_handle == {"h": 1}
-    await store.complete(token)
+    await store.complete(token, claim.fence)
     with pytest.raises(TokenAlreadyConsumedError):
         await store.claim(token, "download")
 


### PR DESCRIPTION
Implements **ADR 0001 §6 / §11 issue #3** (`docs/adr/0001-transfer-lift.md`): the one-time capability-link token store that the sink/route layer (#217/#218) will build on.

Closes #216.

## What lands

`TransferStore` in `src/fastmcp_pvl_core/_transfer/store.py`, backed by `build_kv_store(config, namespace="transfer")`, running the `available → in_flight → consumed` state machine:

- **`mint`/`claim`/`release`/`complete`** serialised by one in-process `asyncio.Lock` — exact single-use under the single-process deployment (ADR §6.3). `mint` is lock-free (a fresh 32-byte secret cannot collide).
- **Release-on-failure preserved (ADR §6.1)** — a failed reservation reverts `in_flight → available` so the one-time link survives a transient serve failure; delete-on-claim is rejected. A late `release` after a successful `complete` never resurrects the burned token.
- **Lease-based reclaim** of a crashed handler's `in_flight` token, checked read-side in `claim` (no sweep loop).
- **TTL is the security bound** — the KV entry TTL governs lifetime; every mutating op re-puts with the *remaining* TTL so the link never becomes immortal. (Empirically, drift is net-negative: ~−0.06s over 500 claim/release cycles — links expire slightly sooner, never later.)
- **Opaque `sink_handle`** (typed `object`, so consumers must narrow) + `caps` the store never interprets; only `kind` is matched on claim. `from_config` pins `namespace="transfer"` as a pvl-core shape decision.
- The persisted record is a `TypedDict` with a `Literal` status, so mypy checks every status comparison/assignment (a mistyped state fails the type check) while the value stays a plain JSON-serialisable dict.

Store only — no routes/tools. Kept internal (importable via `._transfer.store`) until the sink/route layer consumes it; not added to any public `__all__`.

## Tests

26 contract tests cover the state machine, release-on-failure, late-release-not-resurrect, lease reclaim vs live lease, TTL expiry, TTL preservation on claim/release/complete, wrong-kind, validation, the pinned `transfer` namespace, and a **file-backed round-trip** of the opaque fields. The concurrency test uses a `_YieldingKV` wrapper that forces a real read→write interleave (a plain in-memory backend never suspends) — mutation-verified to fail with a double-claim when the lock is removed.

## Deliberately deferred

For this single-shape, internal, not-yet-consumed store: a discriminated-union / schema-version guard on the record, and a mint-time JSON-serialisability probe (the backend enforces serialisability at persist time, inside `mint`). Revisit when a second record shape lands under a live consumer.

## Follow-up (minor)

`TokenNotClaimedError`'s message says "never claimed" but also fires on the claim→release→complete misuse path (the token *was* claimed then released). Reword to "not currently claimed (never claimed, or already released)" — cosmetic, on a misuse path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._