### PR TITLE
feat(transfer): grace-settle completion instead of hard burn (#223)

### DIFF
--- a/docs/adr/0001-transfer-lift.md
+++ b/docs/adr/0001-transfer-lift.md
@@ -75,9 +75,9 @@ external-spec adoption.** §10 enumerates the guardrails that keep it there.
    framework *consumes* it rather than owning it.
 3. **The token store is backed by the existing `build_kv_store` abstraction**
    (its docstring already names *"future file-exchange token store"* as an
-   intended consumer), preserving the full `available → in_flight → consumed`
-   state machine — including **release-on-failure** so a one-time link
-   survives a common transient serve failure.
+   intended consumer), preserving the `available ↔ in_flight` state machine
+   (grace-settle on success, explicit `burn` → `consumed`) — including
+   **release-on-failure** so the link survives a common transient serve failure.
 4. **The token carries an opaque `sink_handle`** that pvl-core stores and
    echoes but never interprets — the structural guarantee that no domain
    logic leaks into core.
@@ -203,9 +203,9 @@ building block of ingest.
 |---|---|---|
 | `fetch.py` | scheme allowlist, `_resolve_pinned_ip` (DNS-rebind pin), blocked-host set, streaming size cap, userinfo+query redaction (logs **and** exceptions — §8), Host/SNI handling, redirects disabled | `fetch_url` |
 | `base64.py` | decode + size cap | `decode_base64_capped` |
-| `store.py` | `TransferStore` over `build_kv_store(config, namespace="transfer")`; opaque handle; `available→in_flight→consumed`; TTL expiry; release-on-failure | `TransferStore` |
+| `store.py` | `TransferStore` over `build_kv_store(config, namespace="transfer")`; opaque handle; `available ↔ in_flight` with grace-settle on success (explicit `burn` → `consumed`); TTL expiry; release-on-failure | `TransferStore` |
 | `sink.py` | `TransferSink` Protocol + `TransferValidator` type — **the only things downstream implements** | `TransferSink`, `TransferValidator` |
-| `routes.py` | `make_transfer_handler(store, sink)` — GET=download, POST/PUT=upload, streaming caps, RFC 6266 Content-Disposition, burn/release | *(internal)* |
+| `routes.py` | `make_transfer_handler(store, sink)` — GET=download, POST/PUT=upload, streaming caps, RFC 6266 Content-Disposition, complete/release | *(internal)* |
 | `register.py` | `register_transfer_routes(mcp, config, *, sink, validate)` — owns route + both link tools + TTL clamp + `base_url` guard, wiring one shared store | `register_transfer_routes` |
 | `config.py` | `TransferConfig` (env section, §7) | `TransferConfig` |
 
@@ -236,15 +236,42 @@ behavior is load-bearing and must be preserved.
 The record lives in KV with the **token's expiry as the KV entry TTL**, so an
 expired token (and any abandoned reservation past its own TTL) vanishes with
 no sweep loop — this replaces vault's hand-rolled `_sweep_expired`. The record
-value carries `status ∈ {available, in_flight, consumed}` and, while
-`in_flight`, a short `lease_expires_at`:
+value carries `status ∈ {available, in_flight, consumed}`, a per-claim `fence`
+(a fresh id stamped on each claim so a superseded holder cannot mutate the
+reservation that replaced it), and, while `in_flight`, a short
+`lease_expires_at`:
 
 - `claim(token, kind)` → mark `in_flight` with `lease = now + lease_seconds`
-  (a *crashed* handler's reservation auto-frees once the lease lapses, even
-  without an explicit release);
-- `release(token)` → revert `in_flight → available` on transient failure
-  (**the one-time link survives**);
-- `complete(token)` → `consumed` (burn) on success.
+  and a fresh `fence` returned to the caller (a *crashed or slow* handler's
+  reservation auto-frees once the lease lapses; the fence lets a lapsed-then-
+  reclaimed holder's late `release`/`complete` no-op rather than corrupt the
+  new holder);
+- `release(token, fence)` → revert `in_flight → available` on transient
+  failure, keeping the **full remaining TTL** (a long retry window — the link
+  survives);
+- `complete(token, fence)` → **grace-settle** `in_flight → available` with the
+  TTL shrunk to `min(remaining, grace_seconds)` on success — **not** a hard
+  burn (see below);
+- `burn(token, fence)` → `consumed` (a hard, strict-one-shot burn) — the
+  explicit alternative to `complete`, kept for a caller that cannot tolerate a
+  grace-window replay.
+
+**Grace-settle over hard burn (revised from the original design).** The first
+cut had `complete → consumed` (burn on success). That reintroduces the exact
+hazard §6.1 rejects: for a *download*, the handler must signal "done" **before**
+the buffered response body is transmitted to the client (the body is sent after
+the handler returns), so a burn-on-complete spends the one-time link the instant
+the bytes leave the sink — a client stall or lost ack mid-transmission strands
+the caller with nothing delivered (the failure `markdown-vault-mcp` hit in
+practice). Since §6.3 already establishes that **the TTL is the security bound
+and strict single-use is only hygiene**, the resolution is to *shrink the TTL to
+a short grace* on success instead of burning: the link stays briefly reclaimable
+(a stalled download simply retries within the grace window) and then ordinary
+KV-TTL expiry removes it, with no sweep. `min(remaining, grace_seconds)` never
+*extends* the TTL, and once `remaining ≤ grace_seconds` it keeps the shrinking
+`remaining` — so the absolute expiry is pinned at the first settle and does not
+slide across retries. Strict one-shot remains available as the explicit `burn`.
+`grace_seconds` is operator config (`TRANSFER_GRACE_TTL_S`, §7).
 
 ### 6.3 Correctness boundary — stated honestly
 
@@ -255,7 +282,7 @@ on deployment topology:
 | Topology | Store URL | One-time correctness | Restart survival |
 |---|---|---|---|
 | single worker | `memory://` | **correct** (in-process lock) | no |
-| single worker | `file://` / `redis://` / … | **correct** (in-process `asyncio.Lock` serializes claim/release/complete against the shared KV) | yes |
+| single worker | `file://` / `redis://` / … | **correct** (in-process `asyncio.Lock` serializes claim/release/complete/burn against the shared KV) | yes |
 | multiple worker **processes** / replicas sharing one backend *(not planned)* | `redis://` / `dynamodb://` / … | **best-effort by design** — a narrow same-token retry race; TTL still bounds the link (see below) | yes |
 
 The key insight: within one process (one event loop) an `asyncio.Lock` around
@@ -301,6 +328,7 @@ Already generic in `ServerConfig`: `base_url`, `kv_store_url`. New
 |---|---|
 | `TRANSFER_TTL_DEFAULT_S` | link lifetime when the caller omits one |
 | `TRANSFER_TTL_MAX_S` | ceiling; a caller-requested TTL is clamped to this |
+| `TRANSFER_GRACE_TTL_S` | post-success grace window; `complete` shrinks the TTL to `min(remaining, this)` (§6.2) |
 | `TRANSFER_MAX_UPLOAD_BYTES` | per-upload size cap |
 | `TRANSFER_FETCH_MAX_BYTES` | per-fetch size cap |
 | `TRANSFER_FETCH_TIMEOUT_S` | fetch timeout |
@@ -332,8 +360,8 @@ pvl-core to change the shape for everyone — not to grow a kwarg.
   but missed the exception path); Host header + TLS SNI preservation
   with pinned-IP dial; redirects disabled;
 - RFC 6266 Content-Disposition builder;
-- the `available → in_flight → consumed` state machine + lease reclaim
-  (re-expressed over KV TTL per §6);
+- the `available ↔ in_flight` state machine + lease reclaim (re-expressed over
+  KV TTL, grace-settling on success, per §6);
 - TTL clamp and `base_url`-required guard.
 
 **Salvage as principles/tests** (from archived #139 / #140 / #141): path

--- a/src/fastmcp_pvl_core/_transfer/store.py
+++ b/src/fastmcp_pvl_core/_transfer/store.py
@@ -1,9 +1,10 @@
-"""KV-backed one-time capability-link token store (ADR 0001 §6 / §11 #3).
+"""KV-backed capability-link token store (ADR 0001 §6 / §11 #3).
 
-A ``TransferStore`` persists one-time link tokens over an
+A ``TransferStore`` persists capability-link tokens over an
 :class:`~key_value.aio.protocols.key_value.AsyncKeyValue` backend
-(``build_kv_store(config, namespace="transfer")``) and runs the
-``available → in_flight → consumed`` state machine on them:
+(``build_kv_store(config, namespace="transfer")``) and runs an
+``available ↔ in_flight`` state machine (plus an explicit ``consumed`` burn) on
+them:
 
 - :meth:`TransferStore.mint` creates an ``available`` token whose lifetime is
   the KV entry TTL — there is no sweep loop; an expired token (and any
@@ -12,18 +13,34 @@ A ``TransferStore`` persists one-time link tokens over an
   A *crashed* handler's reservation auto-frees once the lease lapses, so the
   next claim reclaims it without an explicit release.
 - :meth:`TransferStore.release` reverts ``in_flight → available`` on a transient
-  failure. **The one-time link survives** — ADR §6.1 rejects delete-on-claim
-  precisely because mid-serve failures are common; a failed attempt must not
-  spend the link.
-- :meth:`TransferStore.complete` burns the token (``consumed``) on success.
+  failure, keeping the **full remaining TTL** — the link survives for a full
+  retry window (ADR §6.1 rejects delete-on-claim; mid-serve failures are common
+  and must not spend the link).
+- :meth:`TransferStore.complete` grace-settles ``in_flight → available`` on
+  success with the TTL shrunk to ``min(remaining, grace_seconds)``. It does
+  **not** hard-burn: a transfer whose bytes were served but whose delivery then
+  stalled can re-claim within the grace window rather than be stranded by a
+  spent link. The ``min`` never extends and does not slide across retries, so
+  the absolute expiry is pinned at the first settle.
+- :meth:`TransferStore.burn` is the strict-one-shot alternative — it marks the
+  token ``consumed`` (a later claim raises ``TokenAlreadyConsumedError``), for a
+  caller that cannot tolerate even a grace-window replay.
+
+**Why grace-settle over a hard burn (ADR §6).** The TTL is the
+security-relevant bound; strict single-use is *hygiene*. A hard burn on success
+spends the link the instant the bytes leave the sink — before they reach the
+client — so a download stall or a lost ack strands the caller (the failure
+markdown-vault-mcp hit in practice). Shrinking the TTL to a short grace instead
+keeps the link briefly reclaimable while still letting normal KV-TTL expiry
+remove it, with no sweep loop.
 
 **Correctness boundary (ADR §6.3).** The KV facade exposes no compare-and-set,
 so one in-process :class:`asyncio.Lock` serialises every read-modify-write.
 Within the single ``serve --transport http`` process these servers run, that
-gives exact one-time semantics *and* restart survival (the record lives in KV).
-A future horizontally-scaled deployment sharing one backend would degrade to
-best-effort single-use — acceptable by design, because the TTL, not strict
-single-use, is the security-relevant bound.
+gives exact semantics *and* restart survival (the record lives in KV). A future
+horizontally-scaled deployment sharing one backend would degrade to best-effort
+— acceptable by design, because the TTL, not strict single-use, is the
+security-relevant bound.
 
 The token carries an **opaque ``sink_handle``** (where bytes land) and opaque
 ``caps`` that the store never interprets — only ``kind`` is matched on claim.
@@ -87,15 +104,15 @@ class _TokenRecord(TypedDict):
     sink_handle: object
     caps: Mapping[str, Any]
     lease_expires_at: float | None
-    # A fresh id stamped on each claim (the fencing token). ``release`` and
-    # ``complete`` only act when the caller's fence matches this — so a stale
-    # holder whose lease was reclaimed cannot mutate the new holder's
+    # A fresh id stamped on each claim (the fencing token). ``release``,
+    # ``complete``, and ``burn`` only act when the caller's fence matches this —
+    # so a stale holder whose lease was reclaimed cannot mutate the new holder's
     # reservation. ``None`` while ``available``/``consumed``.
     fence: str | None
 
 
 class TransferTokenError(Exception):
-    """Base class for the token-store's claim/complete failures."""
+    """Base class for the token-store's claim/complete/burn failures."""
 
 
 class TokenNotFoundError(TransferTokenError):
@@ -107,7 +124,7 @@ class TokenKindMismatchError(TransferTokenError):
 
 
 class TokenAlreadyConsumedError(TransferTokenError):
-    """The token was already burned by a successful :meth:`TransferStore.complete`."""
+    """The token was hard-burned by :meth:`TransferStore.burn` and cannot be reused."""
 
 
 class TokenInFlightError(TransferTokenError):
@@ -117,8 +134,8 @@ class TokenInFlightError(TransferTokenError):
 class TokenNotClaimedError(TransferTokenError):
     """The token is not currently claimed.
 
-    Raised by :meth:`TransferStore.complete` when the token is ``available`` —
-    never claimed, or already released.
+    Raised by :meth:`TransferStore.complete` / :meth:`TransferStore.burn` when
+    the token is ``available`` — never claimed, or already settled/released.
     """
 
 
@@ -128,9 +145,10 @@ class TransferToken:
 
     ``sink_handle`` and ``caps`` are exactly what :meth:`TransferStore.mint`
     stored — the store never interprets them. ``fence`` identifies *this*
-    reservation; pass it back to :meth:`TransferStore.release` /
-    :meth:`TransferStore.complete` so a reservation superseded by a lease
-    reclaim cannot mutate the current holder's state.
+    reservation; pass it back to :meth:`TransferStore.release`,
+    :meth:`TransferStore.complete`, or :meth:`TransferStore.burn` so a
+    reservation superseded by a lease reclaim cannot mutate the current holder's
+    state.
     """
 
     token: str
@@ -141,7 +159,7 @@ class TransferToken:
 
 
 class TransferStore:
-    """One-time capability-link token store backed by an ``AsyncKeyValue``.
+    """Capability-link token store backed by an ``AsyncKeyValue``.
 
     Args:
         kv: The backend store, typically from
@@ -151,6 +169,12 @@ class TransferStore:
             crashed handler's token auto-frees this long after :meth:`claim`.
             Operator-tunable timing (wired from config by the route layer);
             must be positive.
+        grace_seconds: Post-success grace window. :meth:`complete` settles a
+            token back to ``available`` with its TTL shrunk to
+            ``min(remaining, grace_seconds)``, so a stalled/retried transfer can
+            re-claim within this window rather than being stranded by a hard
+            burn (ADR §6 — the TTL, not strict single-use, is the security
+            bound). Operator-tunable; must be positive.
         clock: Wall-clock source for lease timestamps. Defaults to
             :func:`time.time`; injected only for deterministic tests. Wall
             clock (not monotonic) so a lease persisted in KV stays meaningful
@@ -162,12 +186,16 @@ class TransferStore:
         kv: AsyncKeyValue,
         *,
         lease_seconds: float,
+        grace_seconds: float,
         clock: Callable[[], float] = time.time,
     ) -> None:
         if lease_seconds <= 0:
             raise ValueError(f"lease_seconds must be positive, got {lease_seconds}")
+        if grace_seconds <= 0:
+            raise ValueError(f"grace_seconds must be positive, got {grace_seconds}")
         self._kv = kv
         self._lease_seconds = float(lease_seconds)
+        self._grace_seconds = float(grace_seconds)
         self._clock = clock
         self._lock = asyncio.Lock()
 
@@ -177,6 +205,7 @@ class TransferStore:
         config: ServerConfig,
         *,
         lease_seconds: float,
+        grace_seconds: float,
         clock: Callable[[], float] = time.time,
     ) -> TransferStore:
         """Build a store from operator config, pinning ``namespace="transfer"``.
@@ -187,6 +216,7 @@ class TransferStore:
         return cls(
             build_kv_store(config, namespace=_NAMESPACE),
             lease_seconds=lease_seconds,
+            grace_seconds=grace_seconds,
             clock=clock,
         )
 
@@ -238,8 +268,8 @@ class TransferStore:
 
         Reclaims an ``in_flight`` token whose lease has lapsed (a crashed *or
         slow* handler) with a fresh :attr:`TransferToken.fence`. Preserves the
-        token's remaining TTL on the re-put — dropping it would make the
-        one-time link immortal.
+        token's remaining TTL on the re-put — dropping it would make the link
+        immortal.
 
         Raises:
             TokenNotFoundError: The token is missing or its TTL has lapsed.
@@ -261,8 +291,9 @@ class TransferStore:
                 if lease is not None and self._clock() < lease:
                     raise TokenInFlightError("token is claimed and its lease is live")
                 # Lease lapsed → the previous holder crashed or is too slow;
-                # reclaim below under a fresh fence so its late release/complete
-                # (carrying the old fence) can no longer mutate this reservation.
+                # reclaim below under a fresh fence so its late
+                # release/complete/burn (carrying the old fence) can no longer
+                # mutate this reservation.
             fence = secrets.token_urlsafe(_FENCE_BYTES)
             record["status"] = _IN_FLIGHT
             record["lease_expires_at"] = self._clock() + self._lease_seconds
@@ -283,11 +314,10 @@ class TransferStore:
 
         *fence* is the :attr:`TransferToken.fence` from the claim being
         released. Idempotent and safe: a no-op if the token is missing, already
-        ``available`` or ``consumed`` (a late release after a successful
-        :meth:`complete` must never resurrect a burned link), or if *fence* does
-        not match the record's current fence — i.e. this reservation was
-        superseded by a lease reclaim, so reverting it would corrupt the new
-        holder's in-flight state.
+        ``available`` or ``consumed`` (a late release after a :meth:`burn` must
+        never resurrect a hard-burned link), or if *fence* does not match the
+        record's current fence — i.e. this reservation was superseded by a lease
+        reclaim, so reverting it would corrupt the new holder's in-flight state.
         """
         async with self._lock:
             try:
@@ -306,36 +336,79 @@ class TransferStore:
             )
 
     async def complete(self, token: str, fence: str) -> None:
-        """Burn *this* reservation (``in_flight → consumed``) on success.
+        """Grace-settle *this* reservation on a successful transfer.
+
+        The token reverts to ``available`` with its TTL shrunk to
+        ``min(remaining, grace_seconds)`` — **not** hard-burned. So a transfer
+        whose bytes were served but whose delivery then stalled (a client drop
+        mid-download, a lost upload ack) can re-claim within the grace window
+        instead of being stranded by a spent link (ADR §6: the TTL is the
+        security bound, strict single-use is hygiene). Use :meth:`burn` when a
+        caller genuinely needs strict one-shot.
+
+        The ``min`` never *extends* the TTL, and once ``remaining <=
+        grace_seconds`` it keeps the shrinking ``remaining`` — so the absolute
+        expiry is pinned at the first settle and does not slide across retries.
 
         *fence* is the :attr:`TransferToken.fence` from the claim being
-        completed. Idempotent on an already-``consumed`` token, a no-op if the
-        token expired mid-transfer (its TTL lapsed), and a no-op if *fence* does
-        not match the record's current fence — a reservation superseded by a
-        lease reclaim must not burn the new holder's live in-flight link.
+        completed. A no-op if the token expired mid-transfer, if it was already
+        hard-burned (``consumed``), or if *fence* does not match the record's
+        current fence (a reservation superseded by a lease reclaim must not
+        disturb the new holder's live in-flight link).
 
         Raises:
             TokenNotClaimedError: The token is not currently claimed (it is
-                ``available`` — never claimed, or already released).
+                ``available`` — never claimed, or already settled/released).
+        """
+        await self._finish(token, fence, new_status=_AVAILABLE, shrink_to_grace=True)
+
+    async def burn(self, token: str, fence: str) -> None:
+        """Hard-burn *this* reservation (``in_flight → consumed``) — strict one-shot.
+
+        The stricter alternative to :meth:`complete`: the token becomes
+        ``consumed`` and can never be claimed again (a later claim raises
+        :class:`TokenAlreadyConsumedError`), for a caller that cannot tolerate
+        even a grace-window replay (e.g. a sensitive one-time secret). The
+        remaining TTL is preserved as a consumed tombstone until it lapses.
+
+        Same fence/expiry/idempotency no-op rules as :meth:`complete`.
+
+        Raises:
+            TokenNotClaimedError: The token is not currently claimed.
+        """
+        await self._finish(token, fence, new_status=_CONSUMED, shrink_to_grace=False)
+
+    async def _finish(
+        self,
+        token: str,
+        fence: str,
+        *,
+        new_status: TokenStatus,
+        shrink_to_grace: bool,
+    ) -> None:
+        """Shared terminal transition for :meth:`complete` / :meth:`burn`.
+
+        Both move an ``in_flight`` reservation out of flight under the lock and
+        the fence guard; they differ only in the resulting status and whether
+        the TTL is shrunk to the grace window.
         """
         async with self._lock:
             try:
                 record, remaining = await self._read(token)
             except TokenNotFoundError:
-                return  # expired mid-transfer — nothing left to burn
+                return  # expired mid-transfer — nothing left to settle
             status = record["status"]
             if status == _CONSUMED:
-                return  # idempotent re-complete
+                return  # already hard-burned — idempotent
             if status != _IN_FLIGHT:
                 raise TokenNotClaimedError("token is not currently claimed")
             if record["fence"] != fence:
                 return  # superseded — the current reservation is not ours
-            record["status"] = _CONSUMED
+            record["status"] = new_status
             record["lease_expires_at"] = None
             record["fence"] = None
-            await self._kv.put(
-                token, record, collection=_TOKEN_COLLECTION, ttl=remaining
-            )
+            ttl = min(remaining, self._grace_seconds) if shrink_to_grace else remaining
+            await self._kv.put(token, record, collection=_TOKEN_COLLECTION, ttl=ttl)
 
     async def _read(self, token: str) -> tuple[_TokenRecord, float]:
         """Read a live token record and its remaining TTL, or raise.

--- a/tests/test_transfer_store.py
+++ b/tests/test_transfer_store.py
@@ -1,28 +1,21 @@
-"""Contract tests for the KV-backed ``TransferStore`` (ADR 0001 §6 / §11 #3).
+"""Contract tests for the KV-backed ``TransferStore`` (ADR 0001 §6 / §11 #3, #4).
 
-The store is a one-time capability-link token store over an ``AsyncKeyValue``
-backend. It preserves the ``available → in_flight → consumed`` machine with
-**release-on-failure** (a failed reservation returns to ``available`` so the
-one-time link survives — ADR §6.1), reclaims a crashed handler's reservation
-once its lease lapses, and relies on the KV entry's TTL as the security-relevant
-lifetime bound (ADR §6.3). One in-process ``asyncio.Lock`` serialises the
-read-modify-write so single-use is exact under the single-process deployment.
+The store runs an ``available ↔ in_flight`` machine over an ``AsyncKeyValue``
+backend, plus an explicit ``consumed`` burn:
 
-The failure modes pinned here:
-
-- **State machine**: claim→complete burns; a second claim is rejected.
-- **Release-on-failure**: claim→release keeps the link claimable again; a late
-  release must never resurrect a *consumed* token.
-- **Lease reclaim**: an ``in_flight`` token whose lease has lapsed (crashed,
-  never-released handler) is reclaimable without an explicit release.
-- **Live lease**: a second claim while the lease is still valid is rejected.
-- **TTL preservation**: a mutating op must re-put with the *remaining* token
-  TTL — putting with no TTL would make the one-time link immortal, defeating
-  the only security-relevant bound.
-- **TTL expiry**: once the KV entry lapses the token is gone (no sweep loop).
-- **Wrong-kind**: a claim with the wrong kind is rejected and does not consume.
-- **Concurrency**: two racing claims yield exactly one holder.
-- **Validation**: non-positive lease/TTL and empty kind are rejected.
+- **release-on-failure**: a failed reservation returns to ``available`` with the
+  full remaining TTL, so the link survives for a full retry window (ADR §6.1).
+- **grace-settle on success** (``complete``): the reservation returns to
+  ``available`` with its TTL shrunk to ``min(remaining, grace_seconds)`` — not
+  hard-burned — so a served-but-stalled transfer can re-claim within the grace
+  window rather than being stranded. The ``min`` never extends and does not
+  slide across retries.
+- **explicit hard burn** (``burn``): marks ``consumed`` (strict one-shot) for a
+  caller that cannot tolerate a grace-window replay.
+- lease reclaim of a crashed/slow handler; a per-claim fence so a superseded
+  holder cannot mutate the current reservation; the KV TTL is the security
+  bound (ADR §6.3); one in-process ``asyncio.Lock`` serialises the
+  read-modify-write.
 """
 
 from __future__ import annotations
@@ -59,10 +52,16 @@ class _Clock:
 
 
 def _store(
-    *, lease_seconds: float = 30.0, clock: _Clock | None = None
+    *,
+    lease_seconds: float = 30.0,
+    grace_seconds: float = 60.0,
+    clock: _Clock | None = None,
 ) -> TransferStore:
     return TransferStore(
-        MemoryStore(), lease_seconds=lease_seconds, clock=clock or _Clock()
+        MemoryStore(),
+        lease_seconds=lease_seconds,
+        grace_seconds=grace_seconds,
+        clock=clock or _Clock(),
     )
 
 
@@ -75,7 +74,7 @@ async def _mint(
 
 
 # --------------------------------------------------------------------------- #
-# state machine — claim / complete
+# state machine — claim / complete (grace-settle)
 # --------------------------------------------------------------------------- #
 
 
@@ -90,21 +89,26 @@ async def test_claim_returns_opaque_handle_and_caps() -> None:
     assert claim.caps == {"max_bytes": 10}
 
 
-async def test_claim_then_complete_burns_the_token() -> None:
+async def test_complete_grace_settles_link_reclaimable_within_grace() -> None:
+    # complete() does NOT burn — it grace-settles back to available, so a
+    # served-but-stalled transfer can re-claim within the grace window.
+    store = _store(grace_seconds=60.0)
+    token = await _mint(store)
+    claim = await store.claim(token, "download")
+    await store.complete(token, claim.fence)
+    reclaim = await store.claim(token, "download")
+    assert reclaim.token == token
+
+
+async def test_complete_after_settle_without_reclaim_raises() -> None:
+    # After grace-settle the token is available (not in_flight); completing it
+    # again without re-claiming is completing something you no longer hold.
     store = _store()
     token = await _mint(store)
     claim = await store.claim(token, "download")
     await store.complete(token, claim.fence)
-    with pytest.raises(TokenAlreadyConsumedError):
-        await store.claim(token, "download")
-
-
-async def test_complete_is_idempotent() -> None:
-    store = _store()
-    token = await _mint(store)
-    claim = await store.claim(token, "download")
-    await store.complete(token, claim.fence)
-    await store.complete(token, claim.fence)  # must not raise
+    with pytest.raises(TokenNotClaimedError):
+        await store.complete(token, claim.fence)
 
 
 async def test_complete_without_claim_raises() -> None:
@@ -115,7 +119,59 @@ async def test_complete_without_claim_raises() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# release-on-failure (ADR §6.1) — the load-bearing behaviour
+# grace-settle TTL shrink (the security bound — ADR §6)
+# --------------------------------------------------------------------------- #
+
+
+async def test_complete_shrinks_ttl_to_grace() -> None:
+    # A long-lived link's TTL is cut to the grace window on success.
+    kv = MemoryStore()
+    store = TransferStore(kv, lease_seconds=30.0, grace_seconds=5.0, clock=_Clock())
+    token = await store.mint(
+        kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
+    )
+    claim = await store.claim(token, "download")
+    await store.complete(token, claim.fence)
+    _value, remaining = await kv.ttl(token, collection=_TOKEN_COLLECTION)
+    assert remaining is not None
+    assert 0.0 < remaining <= 5.0
+
+
+async def test_complete_never_extends_ttl_below_grace() -> None:
+    # min(remaining, grace): a link already shorter than grace keeps its
+    # remaining life — complete must never *extend* it up to the grace window.
+    kv = MemoryStore()
+    store = TransferStore(kv, lease_seconds=30.0, grace_seconds=3600.0, clock=_Clock())
+    token = await store.mint(kind="download", sink_handle={}, caps={}, ttl_seconds=2.0)
+    claim = await store.claim(token, "download")
+    await store.complete(token, claim.fence)
+    _value, remaining = await kv.ttl(token, collection=_TOKEN_COLLECTION)
+    assert remaining is not None
+    assert 0.0 < remaining <= 2.0
+
+
+async def test_grace_settle_does_not_slide_absolute_expiry() -> None:
+    # The absolute expiry is pinned at the first settle: re-claiming and
+    # re-completing within the grace window keeps the shrinking remaining TTL
+    # (min never resets it back up to the full grace), so retries can't extend
+    # the link indefinitely.
+    kv = MemoryStore()
+    store = TransferStore(kv, lease_seconds=30.0, grace_seconds=1.0, clock=_Clock())
+    token = await store.mint(
+        kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
+    )
+    c1 = await store.claim(token, "download")
+    await store.complete(token, c1.fence)  # remaining ≈ 1.0 (grace)
+    await asyncio.sleep(0.2)
+    c2 = await store.claim(token, "download")  # still within grace
+    await store.complete(token, c2.fence)
+    _value, remaining = await kv.ttl(token, collection=_TOKEN_COLLECTION)
+    assert remaining is not None
+    assert remaining < 0.95  # elapsed time survived; NOT reset back up to 1.0
+
+
+# --------------------------------------------------------------------------- #
+# release-on-failure (ADR §6.1) — keeps the full remaining TTL
 # --------------------------------------------------------------------------- #
 
 
@@ -124,20 +180,9 @@ async def test_claim_release_keeps_the_link_claimable() -> None:
     token = await _mint(store)
     claim = await store.claim(token, "download")
     await store.release(token, claim.fence)
-    # The one-time link survived a transient failure — claimable again.
+    # The link survived a transient failure — claimable again.
     reclaim = await store.claim(token, "download")
     assert reclaim.token == token
-
-
-async def test_release_never_resurrects_a_consumed_token() -> None:
-    store = _store()
-    token = await _mint(store)
-    claim = await store.claim(token, "download")
-    await store.complete(token, claim.fence)
-    # late release after success — must be a no-op
-    await store.release(token, claim.fence)
-    with pytest.raises(TokenAlreadyConsumedError):
-        await store.claim(token, "download")
 
 
 async def test_release_on_unclaimed_token_is_a_noop() -> None:
@@ -146,6 +191,54 @@ async def test_release_on_unclaimed_token_is_a_noop() -> None:
     await store.release(token, "no-fence")  # never claimed — no-op, no raise
     claim = await store.claim(token, "download")
     assert claim.token == token
+
+
+# --------------------------------------------------------------------------- #
+# burn — the explicit strict one-shot
+# --------------------------------------------------------------------------- #
+
+
+async def test_burn_consumes_and_second_claim_raises() -> None:
+    store = _store()
+    token = await _mint(store)
+    claim = await store.claim(token, "download")
+    await store.burn(token, claim.fence)
+    with pytest.raises(TokenAlreadyConsumedError):
+        await store.claim(token, "download")
+
+
+async def test_burn_is_idempotent() -> None:
+    store = _store()
+    token = await _mint(store)
+    claim = await store.claim(token, "download")
+    await store.burn(token, claim.fence)
+    await store.burn(token, claim.fence)  # already consumed — no-op
+
+
+async def test_burn_preserves_remaining_ttl_not_grace() -> None:
+    # burn keeps the full remaining TTL as a consumed tombstone — unlike
+    # complete, it does not shrink to the (shorter) grace window.
+    kv = MemoryStore()
+    store = TransferStore(kv, lease_seconds=30.0, grace_seconds=5.0, clock=_Clock())
+    token = await store.mint(
+        kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
+    )
+    claim = await store.claim(token, "download")
+    await store.burn(token, claim.fence)
+    _value, remaining = await kv.ttl(token, collection=_TOKEN_COLLECTION)
+    assert remaining is not None
+    assert remaining > 5.0  # NOT shrunk to grace
+    assert remaining <= 3600.0
+
+
+async def test_late_release_after_burn_does_not_resurrect() -> None:
+    store = _store()
+    token = await _mint(store)
+    claim = await store.claim(token, "download")
+    await store.burn(token, claim.fence)
+    await store.release(token, claim.fence)  # late release — must NOT resurrect
+    with pytest.raises(TokenAlreadyConsumedError):
+        await store.claim(token, "download")
 
 
 # --------------------------------------------------------------------------- #
@@ -180,9 +273,8 @@ async def test_lapsed_lease_is_reclaimable_without_release() -> None:
 
 async def test_superseded_holder_cannot_mutate_reclaimed_reservation() -> None:
     # A slow-but-alive handler A whose lease lapsed and was reclaimed by B must
-    # not be able to revert (release) or burn (complete) B's active reservation
-    # with its now-stale fence — even single-process, where the lock alone does
-    # not stop a stale holder from mutating a superseded reservation.
+    # not be able to revert (release) or settle (complete) B's active
+    # reservation with its now-stale fence — even single-process.
     clock = _Clock()
     store = _store(lease_seconds=30.0, clock=clock)
     token = await _mint(store)
@@ -191,22 +283,21 @@ async def test_superseded_holder_cannot_mutate_reclaimed_reservation() -> None:
     b = await store.claim(token, "download")  # B reclaims → B is the holder now
     assert b.fence != a.fence
 
-    # A's late release with its stale fence must NOT revert B's reservation —
-    # the token must still be B's live in-flight claim.
+    # A's late release with its stale fence must NOT revert B's reservation.
     await store.release(token, a.fence)
     with pytest.raises(TokenInFlightError):
         await store.claim(token, "download")
 
-    # A's late complete with its stale fence must NOT burn B's reservation —
-    # the token must still be B's live in-flight claim, not consumed.
+    # A's late complete with its stale fence must NOT settle B's reservation.
     await store.complete(token, a.fence)
     with pytest.raises(TokenInFlightError):
         await store.claim(token, "download")
 
-    # B completes its own reservation with its live fence — that burns it.
+    # B settles its own reservation with its live fence — grace-settled, so it
+    # is reclaimable within the grace window (not burned).
     await store.complete(token, b.fence)
-    with pytest.raises(TokenAlreadyConsumedError):
-        await store.claim(token, "download")
+    reclaim = await store.claim(token, "download")
+    assert reclaim.token == token
 
 
 # --------------------------------------------------------------------------- #
@@ -219,7 +310,7 @@ async def test_wrong_kind_claim_rejected_and_not_consumed() -> None:
     token = await _mint(store, kind="download")
     with pytest.raises(TokenKindMismatchError):
         await store.claim(token, "upload")
-    # Rejection must not burn the link — the right kind still claims it.
+    # Rejection must not settle the link — the right kind still claims it.
     claim = await store.claim(token, "download")
     assert claim.token == token
 
@@ -253,15 +344,15 @@ async def test_complete_on_expired_token_is_a_noop() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# TTL preservation — the immortal-token failure mode
+# TTL preservation on claim / release (the immortal-token failure mode)
 # --------------------------------------------------------------------------- #
 
 
 async def test_claim_preserves_the_token_ttl() -> None:
     # A mutating op must re-put with the remaining TTL. If it dropped the TTL,
-    # the one-time link would live forever — defeating the security bound.
+    # the link would live forever — defeating the security bound.
     kv = MemoryStore()
-    store = TransferStore(kv, lease_seconds=30.0, clock=_Clock())
+    store = TransferStore(kv, lease_seconds=30.0, grace_seconds=60.0, clock=_Clock())
     token = await store.mint(
         kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
     )
@@ -273,27 +364,12 @@ async def test_claim_preserves_the_token_ttl() -> None:
 
 async def test_release_preserves_the_token_ttl() -> None:
     kv = MemoryStore()
-    store = TransferStore(kv, lease_seconds=30.0, clock=_Clock())
+    store = TransferStore(kv, lease_seconds=30.0, grace_seconds=60.0, clock=_Clock())
     token = await store.mint(
         kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
     )
     claim = await store.claim(token, "download")
     await store.release(token, claim.fence)
-    _value, remaining = await kv.ttl(token, collection=_TOKEN_COLLECTION)
-    assert remaining is not None
-    assert 0.0 < remaining <= 3600.0
-
-
-async def test_complete_preserves_the_token_ttl() -> None:
-    # complete() writes the consumed tombstone; it too must keep the remaining
-    # TTL so a burned token still expires on schedule rather than lingering.
-    kv = MemoryStore()
-    store = TransferStore(kv, lease_seconds=30.0, clock=_Clock())
-    token = await store.mint(
-        kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
-    )
-    claim = await store.claim(token, "download")
-    await store.complete(token, claim.fence)
     _value, remaining = await kv.ttl(token, collection=_TOKEN_COLLECTION)
     assert remaining is not None
     assert 0.0 < remaining <= 3600.0
@@ -330,9 +406,12 @@ class _YieldingKV:
 
 async def test_racing_claims_yield_exactly_one_holder() -> None:
     # Uses _YieldingKV so the two claims genuinely interleave; without the
-    # lock this yields two holders (double-claim of a one-time link).
+    # lock this yields two holders (double-claim of the link).
     store = TransferStore(
-        _YieldingKV(MemoryStore()), lease_seconds=30.0, clock=_Clock()
+        _YieldingKV(MemoryStore()),
+        lease_seconds=30.0,
+        grace_seconds=60.0,
+        clock=_Clock(),
     )
     token = await store.mint(
         kind="download", sink_handle={}, caps={}, ttl_seconds=3600.0
@@ -382,7 +461,13 @@ async def test_mint_rejects_empty_kind() -> None:
 @pytest.mark.parametrize("bad", [0.0, -1.0])
 def test_constructor_rejects_non_positive_lease(bad: float) -> None:
     with pytest.raises(ValueError):
-        TransferStore(MemoryStore(), lease_seconds=bad)
+        TransferStore(MemoryStore(), lease_seconds=bad, grace_seconds=60.0)
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0])
+def test_constructor_rejects_non_positive_grace(bad: float) -> None:
+    with pytest.raises(ValueError):
+        TransferStore(MemoryStore(), lease_seconds=30.0, grace_seconds=bad)
 
 
 # --------------------------------------------------------------------------- #
@@ -392,15 +477,16 @@ def test_constructor_rejects_non_positive_lease(bad: float) -> None:
 
 async def test_from_config_wires_a_working_store() -> None:
     config = ServerConfig(kv_store_url="memory://")
-    store = TransferStore.from_config(config, lease_seconds=30.0)
+    store = TransferStore.from_config(config, lease_seconds=30.0, grace_seconds=60.0)
     token = await store.mint(
         kind="download", sink_handle={"h": 1}, caps={}, ttl_seconds=60.0
     )
     claim = await store.claim(token, "download")
     assert claim.sink_handle == {"h": 1}
     await store.complete(token, claim.fence)
-    with pytest.raises(TokenAlreadyConsumedError):
-        await store.claim(token, "download")
+    # grace-settled → reclaimable within the window (not burned).
+    reclaim = await store.claim(token, "download")
+    assert reclaim.token == token
 
 
 async def test_from_config_pins_the_transfer_namespace(monkeypatch) -> None:
@@ -414,7 +500,7 @@ async def test_from_config_pins_the_transfer_namespace(monkeypatch) -> None:
 
     monkeypatch.setattr("fastmcp_pvl_core._transfer.store.build_kv_store", _spy)
     TransferStore.from_config(
-        ServerConfig(kv_store_url="memory://"), lease_seconds=30.0
+        ServerConfig(kv_store_url="memory://"), lease_seconds=30.0, grace_seconds=60.0
     )
     assert seen["namespace"] == "transfer"
 
@@ -424,7 +510,7 @@ async def test_opaque_fields_round_trip_through_a_serialising_backend(tmp_path) 
     # backend". MemoryStore keeps live objects; a file:// backend actually
     # serialises, so this proves the JSON round-trip the contract advertises.
     config = ServerConfig(kv_store_url=f"file://{tmp_path}/kv")
-    store = TransferStore.from_config(config, lease_seconds=30.0)
+    store = TransferStore.from_config(config, lease_seconds=30.0, grace_seconds=60.0)
     sink_handle = {"bucket": "b", "key": "k", "parts": [1, 2, 3]}
     caps = {"max_bytes": 1024, "content_types": ["image/png"]}
     token = await store.mint(


### PR DESCRIPTION
Revises the `TransferStore` completion semantics (from #216) and ADR §6. Closes #223.

## Why

The original `complete()` hard-burned the token (→ `consumed`) on success. But for a **download**, the handler must signal "done" *before* the buffered response body is transmitted (Starlette sends it after the handler returns) — so burn-on-complete spends the one-time link the instant the bytes leave the sink, and a client stall or lost ack mid-transmission strands the caller with nothing delivered. That is the failure `markdown-vault-mcp` hit in practice, and exactly what ADR §6.1 rejects. ADR §6.3 already establishes the **TTL as the security bound and strict single-use as hygiene** — so the resolution is to lean on the TTL rather than a hard burn.

## What changes

- **`complete(token, fence)` now grace-settles**: `status → available`, `fence → None`, `TTL → min(remaining, grace_seconds)`. The link stays briefly reclaimable (a stalled download retries within the grace window), then normal KV-TTL expiry removes it — no sweep. `min` never *extends*, and once `remaining ≤ grace` it keeps the shrinking `remaining`, so the absolute expiry is **pinned at the first settle and does not slide across retries**.
- **`release(token, fence)`** unchanged → `available` with the **full remaining TTL** (long retry window).
- **`burn(token, fence)`** is new → `consumed` (strict one-shot); kept for a caller that cannot tolerate a grace-window replay. `consumed` / `TokenAlreadyConsumedError` are now reached only via `burn`.
- Constructor + `from_config` gain `grace_seconds` (operator config; #218 wires `TRANSFER_GRACE_TTL_S`). `complete`/`burn` share a guarded `_finish` helper, so the fence/expiry/idempotency rules cannot drift between them.
- ADR §6.2 amended to the grace-settle state machine (+ the per-claim fence), §6.3 rationale, §7 config table; §5/§11 machine descriptions swept to match.

The fencing invariant, TTL-never-extends/no-immortal-token invariant, and lease reclaim are all preserved through `_finish` (mutation-verified). A `complete` after a settle is no longer idempotent — it raises `TokenNotClaimedError` (documented) — because success returns the token to `available`.

## Note for the route layer (#217)

The success terminal is now `complete` (grace-settle), with `burn` reserved for strict one-shot. The route handler should call `complete` on success and must not rely on `complete`'s old idempotent-on-consumed behaviour.

## Tests

34 store contract tests rewritten to the new contract: grace-settle reclaimable-within-grace, shrink-to-grace / never-extend / no-slide-of-absolute-expiry, `burn` consumes / preserves-full-TTL / idempotent, late-release-after-burn does not resurrect, superseded-holder fence guard (release + complete paths), grace validation. All four grace-settle guards mutation-verified.

## Deferred (unchanged, acknowledged)

A discriminated-union / `_Outcome` enum for `_finish`'s `(new_status, shrink_to_grace)` pair, a schema-version guard on the cast, and `TransferKind` on the claim path — all sub-threshold, tracked for a future type-rigor pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._