### PR TITLE
feat(transfer): TransferSink seam + make_transfer_handler route (#217)

### DIFF
--- a/src/fastmcp_pvl_core/_transfer/__init__.py
+++ b/src/fastmcp_pvl_core/_transfer/__init__.py
@@ -1,11 +1,13 @@
 """In-process transfer/ingest mechanics shared across the ``*-mcp`` family.
 
 Implements ADR 0001 (``docs/adr/0001-transfer-lift.md``): SSRF-hardened URL
-fetch, size-capped base64 decode, a one-time capability-link token store, and
-the ``/transfer`` route framework. Landed so far: ``fetch_url`` (§11 issue #1),
-``decode_base64_capped`` (§11 issue #2), and ``TransferStore`` in
-``store.py`` (§11 issue #3, kept internal until the sink/route layer consumes
-it); the sink protocols and route framework land in sibling issues.
+fetch, size-capped base64 decode, a capability-link token store, and the
+``/transfer`` route framework. Landed so far: ``fetch_url`` (§11 issue #1),
+``decode_base64_capped`` (§11 issue #2), ``TransferStore`` in ``store.py``
+(§11 issue #3), and — in ``sink.py`` and ``routes.py`` — the ``TransferSink`` /
+``TransferValidator`` domain seam plus ``make_transfer_handler`` (§11 issue #4).
+All of these except the two exported primitives stay internal until the
+route-registration layer (§11 issue #5) wires them into the public surface.
 
 Intra-package imports stay relative so a fold-in is a directory rename.
 """

--- a/src/fastmcp_pvl_core/_transfer/routes.py
+++ b/src/fastmcp_pvl_core/_transfer/routes.py
@@ -1,0 +1,208 @@
+"""The ``/transfer/{token}`` HTTP handler (ADR 0001 §3/§8 / §11 #4).
+
+:func:`make_transfer_handler` builds the Starlette handler that drives the
+capability-link state machine over HTTP:
+
+- **GET** downloads: claim the token, ``sink.read`` the bytes, serve them with
+  an RFC 6266 ``Content-Disposition``, then ``store.complete`` (grace-settle).
+- **POST/PUT** uploads: claim the token, read the request body under a
+  size cap (aborting early past it), ``sink.write`` it, return the sink's
+  payload as JSON, then ``store.complete`` (grace-settle).
+
+The link is **settled on success** (``store.complete`` — grace-settle, so a
+served-but-stalled transfer can retry within the grace window rather than be
+stranded) and **released on any failure** (``store.release`` — a transient
+failure must not spend the link; ADR §6.1). The handler is kept internal; the
+route-registration layer (§11 issue #5) mounts it via ``mcp.custom_route`` and
+wires the operator caps from config.
+
+Intra-package imports stay relative so a fold-in is a directory rename.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from types import MappingProxyType
+from typing import cast
+from urllib.parse import quote
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from .sink import TransferSink
+from .store import TokenInFlightError, TransferStore, TransferToken, TransferTokenError
+
+logger = logging.getLogger(__name__)
+
+_Handler = Callable[[Request], Awaitable[Response]]
+
+# A response that abandons an unread request body (an upload rejected before or
+# during the body read, or a method the handler does not serve) must close the
+# connection: leaving the body undrained on a keep-alive socket desyncs the next
+# request. Read-only so the shared instance can't be mutated through a Response.
+_CLOSE_CONN = MappingProxyType({"connection": "close"})
+
+
+class _BodyTooLargeError(Exception):
+    """Internal signal: the request body exceeded the upload cap."""
+
+
+def make_transfer_handler(
+    store: TransferStore,
+    sink: TransferSink,
+    *,
+    max_upload_bytes: int,
+) -> _Handler:
+    """Build the ``/transfer/{token}`` handler over *store* and *sink*.
+
+    Args:
+        store: The capability-link token store minted links are claimed from.
+        sink: The downstream domain hook — where bytes are read from / written
+            to. The handler never interprets the ``sink_handle``.
+        max_upload_bytes: Operator per-upload size cap (env, wired by the
+            route-registration layer). A body exceeding it is rejected 413.
+
+    Returns:
+        A Starlette async handler: ``async (Request) -> Response``.
+
+    Raises:
+        ValueError: If ``max_upload_bytes`` is not positive.
+    """
+    if max_upload_bytes <= 0:
+        raise ValueError(f"max_upload_bytes must be positive, got {max_upload_bytes}")
+
+    async def handler(request: Request) -> Response:
+        token = request.path_params["token"]
+        if request.method == "GET":
+            return await _download(store, sink, token)
+        if request.method in ("POST", "PUT"):
+            return await _upload(store, sink, token, request, max_upload_bytes)
+        # A method the handler does not serve may still carry a body it never
+        # reads → close the connection (same undrained-body class as an upload
+        # rejected before the read).
+        return Response(status_code=405, headers=_CLOSE_CONN)
+
+    return handler
+
+
+def _claim_error_status(exc: TransferTokenError) -> int:
+    """Map a claim failure to an HTTP status.
+
+    A live concurrent reservation is a 409 (retry later); every other claim
+    failure — unknown, expired, consumed, wrong-kind — reads to the client as
+    "no such link" (404), so the handler never discloses which of those it was.
+    """
+    if isinstance(exc, TokenInFlightError):
+        return 409
+    return 404
+
+
+async def _release_quietly(store: TransferStore, claim: TransferToken) -> None:
+    """Release *claim* on a failure path without masking the original error.
+
+    An ordinary failure inside ``store.release`` (e.g. a KV backend error) is
+    logged and swallowed so the transfer's own exception — the one the caller
+    needs — still propagates. A ``BaseException`` (e.g. ``CancelledError``) from
+    release is left to propagate, as cancellation must.
+    """
+    try:
+        await store.release(claim.token, claim.fence)
+    except Exception as exc:
+        # Log the error class only — never a traceback / message, which for some
+        # KV backends embeds the token-derived key (the token is a secret).
+        logger.warning(
+            "transfer link release failed after a handler error: %s",
+            type(exc).__name__,
+        )
+
+
+# The sink contract types ``handle`` as ``str``; the store types the stored
+# ``sink_handle`` as opaque ``object``. The ``str``-ness is guaranteed by the
+# TransferValidator, which returns the ``str`` handle stored at mint time — so
+# the cast is a trusted-boundary narrowing, not an unchecked guess.
+async def _download(store: TransferStore, sink: TransferSink, token: str) -> Response:
+    try:
+        claim = await store.claim(token, "download")
+    except TransferTokenError as exc:
+        logger.info("transfer download claim rejected: %s", type(exc).__name__)
+        return Response(status_code=_claim_error_status(exc))
+    try:
+        body, media_type, filename = await sink.read(cast(str, claim.sink_handle))
+    except BaseException:
+        # Release-on-failure: the link survives a transient failure. BaseException
+        # (not Exception) so a cancelled request also releases; then the error /
+        # cancellation propagates (Starlette → generic 500 for an ordinary error).
+        await _release_quietly(store, claim)
+        raise
+    await store.complete(claim.token, claim.fence)
+    return Response(
+        content=body,
+        media_type=media_type,
+        headers={"content-disposition": _content_disposition(filename)},
+    )
+
+
+async def _upload(
+    store: TransferStore,
+    sink: TransferSink,
+    token: str,
+    request: Request,
+    max_upload_bytes: int,
+) -> Response:
+    try:
+        claim = await store.claim(token, "upload")
+    except TransferTokenError as exc:
+        logger.info("transfer upload claim rejected: %s", type(exc).__name__)
+        # No claim held, and the request body is unread → close the connection.
+        return Response(status_code=_claim_error_status(exc), headers=_CLOSE_CONN)
+    try:
+        body = await _read_capped(request, max_upload_bytes)
+    except _BodyTooLargeError:
+        await _release_quietly(store, claim)
+        logger.info(
+            "transfer upload rejected: body exceeds the %d-byte cap", max_upload_bytes
+        )
+        # Body read aborted early → the rest is undrained → close the connection.
+        return Response(status_code=413, headers=_CLOSE_CONN)
+    except BaseException:
+        await _release_quietly(store, claim)
+        raise
+    try:
+        payload = await sink.write(cast(str, claim.sink_handle), body)
+    except BaseException:
+        await _release_quietly(store, claim)
+        raise
+    await store.complete(claim.token, claim.fence)
+    return JSONResponse(dict(payload))
+
+
+async def _read_capped(request: Request, max_bytes: int) -> bytes:
+    """Read the request body in chunks, aborting once it exceeds *max_bytes*.
+
+    Reads the receive-side stream chunk by chunk so an oversize body is rejected
+    early rather than fully buffered (ADR §8). The accepted body is still held
+    in memory, bounded by the cap (the sink is byte-oriented per ADR §3).
+    """
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > max_bytes:
+            raise _BodyTooLargeError
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _content_disposition(filename: str) -> str:
+    """Build an RFC 6266 ``attachment`` Content-Disposition for *filename*.
+
+    Emits both a plain ``filename`` (ASCII fallback) and an RFC 5987
+    ``filename*`` (percent-encoded UTF-8) so non-ASCII names survive. Strips
+    control characters (including CR/LF) and quoted-string breakers first, so a
+    hostile filename cannot inject a second header or break out of the value.
+    """
+    safe = "".join(c for c in filename if c.isprintable() and c not in '"\\')
+    ascii_fallback = safe.encode("ascii", "replace").decode("ascii")
+    encoded = quote(safe, safe="")
+    return f"attachment; filename=\"{ascii_fallback}\"; filename*=UTF-8''{encoded}"

--- a/src/fastmcp_pvl_core/_transfer/routes.py
+++ b/src/fastmcp_pvl_core/_transfer/routes.py
@@ -68,6 +68,17 @@ def make_transfer_handler(
 
     Raises:
         ValueError: If ``max_upload_bytes`` is not positive.
+
+    Note:
+        The handler serves ``GET``/``POST``/``PUT`` and answers any *other*
+        method routed to it with 405 + ``Connection: close`` (an unserved method
+        may carry an unread body). For that close to cover **every** unsupported
+        method, the route-registration layer (§11 issue #5) must register the
+        route so all methods reach this handler (e.g. omit ``methods=`` or pass a
+        superset) — otherwise Starlette's own 405 handles unregistered methods,
+        and *it* does not send ``Connection: close``. ``HEAD`` reaches this
+        branch (Starlette auto-adds it for ``GET``) but is bodyless, so its close
+        is harmless.
     """
     if max_upload_bytes <= 0:
         raise ValueError(f"max_upload_bytes must be positive, got {max_upload_bytes}")
@@ -78,10 +89,12 @@ def make_transfer_handler(
             return await _download(store, sink, token)
         if request.method in ("POST", "PUT"):
             return await _upload(store, sink, token, request, max_upload_bytes)
-        # A method the handler does not serve may still carry a body it never
-        # reads → close the connection (same undrained-body class as an upload
-        # rejected before the read).
-        return Response(status_code=405, headers=_CLOSE_CONN)
+        # A method the handler does not serve may carry a body it never reads →
+        # close the connection (same undrained-body class as an upload rejected
+        # before the read). Allow lists the served methods (RFC 7231 §6.5.5).
+        return Response(
+            status_code=405, headers={**_CLOSE_CONN, "allow": "GET, POST, PUT"}
+        )
 
     return handler
 

--- a/src/fastmcp_pvl_core/_transfer/sink.py
+++ b/src/fastmcp_pvl_core/_transfer/sink.py
@@ -1,0 +1,69 @@
+"""The transfer subsystem's domain seam (ADR 0001 §3 / §11 #4).
+
+Downstream servers implement exactly two things: *where* bytes land
+(:class:`TransferSink`) and *what* bytes are acceptable
+(:data:`TransferValidator`). Everything else — the ``/transfer/{token}`` route,
+the link tools, the token store, size caps, TTL, redaction — is pvl-core's
+shape.
+
+The stored token carries an opaque ``sink_handle`` string that **only the sink
+interprets** (e.g. a vault-relative path, an ``image://<id>`` URI). pvl-core
+stores it, echoes it in tool payloads, and hands it back to
+:meth:`TransferSink.read` / :meth:`TransferSink.write` — but never parses it, so
+no domain branch can leak into core.
+
+Intra-package imports stay relative so a fold-in is a directory rename.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any, Literal, NamedTuple, Protocol
+
+TransferKind = Literal["download", "upload"]
+"""The two link kinds; matched by the store on claim and passed to a validator."""
+
+
+class TransferReadResult(NamedTuple):
+    """What :meth:`TransferSink.read` returns — the bytes plus how to serve them.
+
+    A ``NamedTuple`` (not a bare 3-tuple) so ``media_type`` and ``filename`` —
+    both ``str`` — cannot be silently swapped at the construction site; it still
+    unpacks positionally for callers that prefer that.
+    """
+
+    body: bytes
+    media_type: str
+    filename: str
+
+
+class TransferSink(Protocol):
+    """Where transferred bytes come from and go to — a downstream domain hook.
+
+    ``handle`` is the opaque ``sink_handle`` the link was minted with; pvl-core
+    never interprets it. Both methods are **byte-oriented and bounded by the
+    size caps** (ADR §3): the whole body is materialised in memory and capped,
+    not streamed. A constant-memory streaming variant is a deferred, opt-in
+    future extension (ADR §12), not part of this contract.
+    """
+
+    async def read(self, handle: str) -> TransferReadResult:
+        """Return the body, media type, and filename for a download *handle*."""
+        ...
+
+    async def write(self, handle: str, body: bytes) -> Mapping[str, Any]:
+        """Commit an uploaded *body* to *handle*; return the tool result payload."""
+        ...
+
+
+TransferValidator = Callable[[str, TransferKind], Awaitable[str]]
+"""Map a caller-facing ref + kind to a validated, opaque ``sink_handle``.
+
+Raises to reject (bad extension, missing file, wrong kind, …). It is invoked at
+**link creation** by the link tools — not by the route handler — because
+content validation is *"what bytes are acceptable,"* a domain question pvl-core
+cannot answer for a downstream. ``kind`` lets a validator apply different rules
+to upload vs. download (e.g. an existence check on download, an extension
+allowlist on upload). The returned string is stored verbatim as the token's
+``sink_handle``.
+"""

--- a/tests/test_transfer_routes.py
+++ b/tests/test_transfer_routes.py
@@ -80,8 +80,12 @@ async def _client(
             Route(
                 "/transfer/{token}",
                 handler,
-                # DELETE is allowed only so the handler's own 405 branch is
-                # reachable in tests; the real registration allows GET/POST/PUT.
+                # DELETE is registered only so a request with an unserved method
+                # reaches the handler's own 405 branch here. In production the
+                # route-registration layer (§11 issue #5) must likewise route all
+                # methods to the handler for its 405 + Connection: close to apply
+                # — otherwise Starlette's built-in 405 (no Connection: close)
+                # answers unregistered methods. See make_transfer_handler's Note.
                 methods=["GET", "POST", "PUT", "DELETE"],
             )
         ]
@@ -340,11 +344,14 @@ async def test_unsupported_method_with_body_is_405_and_closes_connection() -> No
     sink = _FakeSink()
     token = await _mint_download(store)
     async with _client(store, sink) as client:
-        # A DELETE carrying a body the handler never reads → 405 + close, so the
-        # undrained body can't desync a keep-alive socket.
+        # A DELETE carrying a body the handler never reads → 405 + close (so the
+        # undrained body can't desync a keep-alive socket) + Allow (RFC 7231).
+        # This exercises the handler's own 405 branch; whether every unsupported
+        # method reaches it in production is the route layer's job (#218).
         resp = await client.request("DELETE", f"/transfer/{token}", content=b"body")
         assert resp.status_code == 405
         assert resp.headers.get("connection") == "close"
+        assert resp.headers.get("allow") == "GET, POST, PUT"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_transfer_routes.py
+++ b/tests/test_transfer_routes.py
@@ -1,0 +1,391 @@
+"""Contract tests for ``make_transfer_handler`` (ADR 0001 §3/§8 / §11 #4).
+
+The handler drives the capability-link state machine over HTTP: GET downloads
+via ``sink.read``, POST/PUT upload via ``sink.write``, grace-settles the token
+on success (``store.complete``) and releases it on any failure so a transient
+failure does not spend the link. Tests run the handler as a real Starlette route
+hit over ASGI (httpx), so routing, path params, streaming, and the response
+shape are all exercised.
+
+Failure modes pinned here:
+
+- **Download**: serves the sink's bytes + media type + RFC 6266 filename, then
+  grace-settles — a second GET within the grace window still succeeds
+  (re-serves); only after the window lapses is it 404.
+- **Upload**: reads a size-capped body, commits via ``sink.write``, returns the
+  sink's payload as JSON, then grace-settles (a retry within grace re-commits).
+- **Release-on-failure**: a sink read/write error releases the token (the link
+  survives and is usable again) and surfaces as 500.
+- **Over-cap upload**: rejected 413, and the link is released (survives).
+- **Bad token**: unknown / expired / consumed / wrong-kind → 404; a concurrent
+  in-flight claim → 409.
+- **Content-Disposition**: non-ASCII filename gets an RFC 5987 ``filename*``;
+  a CR/LF-injecting filename is sanitised (no header injection).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from key_value.aio.stores.memory import MemoryStore
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+from fastmcp_pvl_core._transfer.routes import make_transfer_handler
+from fastmcp_pvl_core._transfer.sink import TransferReadResult
+from fastmcp_pvl_core._transfer.store import TransferStore
+
+
+class _FakeSink:
+    """An in-memory sink recording writes and serving canned reads."""
+
+    def __init__(self) -> None:
+        self.reads: dict[str, tuple[bytes, str, str]] = {}
+        self.writes: dict[str, bytes] = {}
+        self.fail_read = False
+        self.fail_write = False
+
+    async def read(self, handle: str) -> TransferReadResult:
+        if self.fail_read:
+            raise RuntimeError("sink read boom")
+        return TransferReadResult(*self.reads[handle])
+
+    async def write(self, handle: str, body: bytes) -> Mapping[str, Any]:
+        if self.fail_write:
+            raise RuntimeError("sink write boom")
+        self.writes[handle] = body
+        return {"handle": handle, "bytes": len(body)}
+
+
+def _make_store(
+    *, lease_seconds: float = 300.0, grace_seconds: float = 300.0
+) -> TransferStore:
+    return TransferStore(
+        MemoryStore(), lease_seconds=lease_seconds, grace_seconds=grace_seconds
+    )
+
+
+@asynccontextmanager
+async def _client(
+    store: TransferStore, sink: _FakeSink, *, max_upload_bytes: int = 1024
+) -> AsyncIterator[AsyncClient]:
+    handler = make_transfer_handler(store, sink, max_upload_bytes=max_upload_bytes)
+    app = Starlette(
+        routes=[
+            Route(
+                "/transfer/{token}",
+                handler,
+                # DELETE is allowed only so the handler's own 405 branch is
+                # reachable in tests; the real registration allows GET/POST/PUT.
+                methods=["GET", "POST", "PUT", "DELETE"],
+            )
+        ]
+    )
+    # raise_app_exceptions=False so a re-raised handler error is observed as the
+    # server's generic 500 response (as a real client would see it), not
+    # propagated into the test.
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+async def _mint_download(
+    store: TransferStore, *, handle: str = "h1", ttl: float = 300.0
+) -> str:
+    return await store.mint(
+        kind="download", sink_handle=handle, caps={}, ttl_seconds=ttl
+    )
+
+
+async def _mint_upload(
+    store: TransferStore, *, handle: str = "u1", ttl: float = 300.0
+) -> str:
+    return await store.mint(kind="upload", sink_handle=handle, caps={}, ttl_seconds=ttl)
+
+
+# --------------------------------------------------------------------------- #
+# download
+# --------------------------------------------------------------------------- #
+
+
+async def test_download_serves_bytes_then_grace_settles() -> None:
+    store = _make_store(grace_seconds=300.0)
+    sink = _FakeSink()
+    sink.reads["h1"] = (b"hello world", "text/plain", "greeting.txt")
+    token = await _mint_download(store)
+    async with _client(store, sink) as client:
+        resp = await client.get(f"/transfer/{token}")
+        assert resp.status_code == 200
+        assert resp.content == b"hello world"
+        assert resp.headers["content-type"].startswith("text/plain")
+        assert "greeting.txt" in resp.headers["content-disposition"]
+        # Grace-settle, not burn: a served-but-stalled download can retry within
+        # the grace window (re-serves), rather than being stranded by a 404.
+        again = await client.get(f"/transfer/{token}")
+        assert again.status_code == 200
+        assert again.content == b"hello world"
+
+
+async def test_download_link_expires_after_grace() -> None:
+    # Once the grace window lapses, the settled link is gone (404) — grace is a
+    # short retry window, not an unbounded reuse.
+    store = _make_store(grace_seconds=0.05)
+    sink = _FakeSink()
+    sink.reads["h1"] = (b"data", "text/plain", "f.txt")
+    token = await _mint_download(store)
+    async with _client(store, sink) as client:
+        assert (await client.get(f"/transfer/{token}")).status_code == 200
+        await asyncio.sleep(0.1)  # grace window lapses
+        assert (await client.get(f"/transfer/{token}")).status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# upload
+# --------------------------------------------------------------------------- #
+
+
+async def test_upload_commits_via_sink_then_grace_settles() -> None:
+    store = _make_store(grace_seconds=300.0)
+    sink = _FakeSink()
+    token = await _mint_upload(store)
+    async with _client(store, sink) as client:
+        resp = await client.post(f"/transfer/{token}", content=b"payload-bytes")
+        assert resp.status_code == 200
+        assert resp.json() == {"handle": "u1", "bytes": len(b"payload-bytes")}
+        assert sink.writes["u1"] == b"payload-bytes"
+        # Grace-settle: a client that missed the ack can retry within grace
+        # (re-commits, last-writer-wins), rather than getting a 404.
+        again = await client.post(f"/transfer/{token}", content=b"retry")
+        assert again.status_code == 200
+        assert sink.writes["u1"] == b"retry"
+
+
+async def test_upload_accepts_put_as_well_as_post() -> None:
+    store = _make_store()
+    sink = _FakeSink()
+    token = await _mint_upload(store)
+    async with _client(store, sink) as client:
+        resp = await client.put(f"/transfer/{token}", content=b"via-put")
+        assert resp.status_code == 200
+        assert sink.writes["u1"] == b"via-put"
+
+
+# --------------------------------------------------------------------------- #
+# release-on-failure
+# --------------------------------------------------------------------------- #
+
+
+async def test_sink_read_failure_releases_the_link() -> None:
+    store = _make_store()
+    sink = _FakeSink()
+    sink.reads["h1"] = (b"data", "application/octet-stream", "f.bin")
+    token = await _mint_download(store)
+    async with _client(store, sink) as client:
+        sink.fail_read = True
+        resp = await client.get(f"/transfer/{token}")
+        assert resp.status_code == 500
+        # The link survived — a retry succeeds.
+        sink.fail_read = False
+        retry = await client.get(f"/transfer/{token}")
+        assert retry.status_code == 200
+        assert retry.content == b"data"
+
+
+async def test_sink_write_failure_releases_the_link() -> None:
+    store = _make_store()
+    sink = _FakeSink()
+    token = await _mint_upload(store)
+    async with _client(store, sink) as client:
+        sink.fail_write = True
+        resp = await client.post(f"/transfer/{token}", content=b"body")
+        assert resp.status_code == 500
+        sink.fail_write = False
+        retry = await client.post(f"/transfer/{token}", content=b"body")
+        assert retry.status_code == 200
+        assert sink.writes["u1"] == b"body"
+
+
+async def test_release_failure_does_not_mask_the_original_error(
+    monkeypatch, caplog
+) -> None:
+    # If store.release itself fails on the failure path, _release_quietly logs
+    # and swallows it so the sink's original error still surfaces (500) — the
+    # release failure must not mask it. (The token then lease-reclaims.)
+    store = _make_store()
+    sink = _FakeSink()
+    sink.reads["h1"] = (b"x", "text/plain", "f")
+    token = await _mint_download(store)
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("kv release unavailable")
+
+    monkeypatch.setattr(store, "release", _boom)
+    async with _client(store, sink) as client:
+        sink.fail_read = True
+        with caplog.at_level("WARNING"):
+            resp = await client.get(f"/transfer/{token}")
+        assert resp.status_code == 500  # the sink error propagated, not masked
+        assert any("release failed" in r.getMessage() for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# size cap
+# --------------------------------------------------------------------------- #
+
+
+async def test_over_cap_upload_is_rejected_and_releases_the_link() -> None:
+    store = _make_store()
+    sink = _FakeSink()
+    token = await _mint_upload(store)
+    async with _client(store, sink, max_upload_bytes=4) as client:
+        resp = await client.post(f"/transfer/{token}", content=b"toolong")
+        assert resp.status_code == 413
+        # The oversize body was abandoned unread → the connection must close so
+        # the undrained bytes don't desync a keep-alive socket.
+        assert resp.headers.get("connection") == "close"
+        assert "u1" not in sink.writes  # never committed
+        # Released — a within-cap retry on the same link succeeds.
+        retry = await client.post(f"/transfer/{token}", content=b"ok")
+        assert retry.status_code == 200
+        assert sink.writes["u1"] == b"ok"
+
+
+async def test_over_cap_across_many_under_cap_chunks_is_rejected() -> None:
+    # The cap is enforced by accumulating across streamed chunks. A body split
+    # into many individually-under-cap chunks whose SUM exceeds the cap must
+    # still be rejected — otherwise a chunked upload bypasses the memory bound.
+    store = _make_store()
+    sink = _FakeSink()
+    token = await _mint_upload(store)
+
+    async def _chunks() -> AsyncIterator[bytes]:
+        for _ in range(10):
+            yield b"xx"  # 10 × 2 = 20 bytes total, each chunk ≤ the 4-byte cap
+
+    async with _client(store, sink, max_upload_bytes=4) as client:
+        resp = await client.post(f"/transfer/{token}", content=_chunks())
+        assert resp.status_code == 413
+        assert resp.headers.get("connection") == "close"
+        assert "u1" not in sink.writes
+
+
+async def test_upload_exactly_at_cap_succeeds() -> None:
+    store = _make_store()
+    sink = _FakeSink()
+    token = await _mint_upload(store)
+    async with _client(store, sink, max_upload_bytes=4) as client:
+        resp = await client.post(f"/transfer/{token}", content=b"abcd")
+        assert resp.status_code == 200
+        assert sink.writes["u1"] == b"abcd"
+
+
+# --------------------------------------------------------------------------- #
+# bad token
+# --------------------------------------------------------------------------- #
+
+
+async def test_unknown_token_is_404() -> None:
+    store = _make_store()
+    sink = _FakeSink()
+    async with _client(store, sink) as client:
+        resp = await client.get("/transfer/no-such-token")
+        assert resp.status_code == 404
+
+
+async def test_expired_token_is_404() -> None:
+    store = _make_store()
+    sink = _FakeSink()
+    sink.reads["h1"] = (b"x", "text/plain", "f")
+    token = await _mint_download(store, ttl=0.05)
+    await asyncio.sleep(0.1)
+    async with _client(store, sink) as client:
+        resp = await client.get(f"/transfer/{token}")
+        assert resp.status_code == 404
+
+
+async def test_wrong_kind_is_404() -> None:
+    store = _make_store()
+    sink = _FakeSink()
+    sink.reads["h1"] = (b"x", "text/plain", "f")
+    download_token = await _mint_download(store)
+    upload_token = await _mint_upload(store)
+    async with _client(store, sink) as client:
+        # POST to a download token, GET an upload token — both wrong-kind → 404.
+        post = await client.post(f"/transfer/{download_token}", content=b"x")
+        assert post.status_code == 404
+        # An upload rejected at claim time leaves its body unread → close.
+        assert post.headers.get("connection") == "close"
+        assert (await client.get(f"/transfer/{upload_token}")).status_code == 404
+
+
+async def test_in_flight_token_is_409() -> None:
+    store = _make_store(lease_seconds=300.0)
+    sink = _FakeSink()
+    sink.reads["h1"] = (b"x", "text/plain", "f")
+    token = await _mint_download(store)
+    # Hold a live reservation out-of-band; the handler's claim must conflict.
+    await store.claim(token, "download")
+    async with _client(store, sink) as client:
+        resp = await client.get(f"/transfer/{token}")
+        assert resp.status_code == 409
+
+
+async def test_unsupported_method_with_body_is_405_and_closes_connection() -> None:
+    store = _make_store()
+    sink = _FakeSink()
+    token = await _mint_download(store)
+    async with _client(store, sink) as client:
+        # A DELETE carrying a body the handler never reads → 405 + close, so the
+        # undrained body can't desync a keep-alive socket.
+        resp = await client.request("DELETE", f"/transfer/{token}", content=b"body")
+        assert resp.status_code == 405
+        assert resp.headers.get("connection") == "close"
+
+
+# --------------------------------------------------------------------------- #
+# Content-Disposition (RFC 6266)
+# --------------------------------------------------------------------------- #
+
+
+async def test_non_ascii_filename_uses_rfc5987_encoding() -> None:
+    store = _make_store()
+    sink = _FakeSink()
+    sink.reads["h1"] = (b"x", "application/pdf", "résumé.pdf")
+    token = await _mint_download(store)
+    async with _client(store, sink) as client:
+        resp = await client.get(f"/transfer/{token}")
+        cd = resp.headers["content-disposition"]
+        assert cd.startswith("attachment;")
+        # RFC 5987 percent-encoded UTF-8 for the non-ASCII name.
+        assert "filename*=UTF-8''r%C3%A9sum%C3%A9.pdf" in cd
+
+
+async def test_filename_with_crlf_cannot_inject_headers() -> None:
+    store = _make_store()
+    sink = _FakeSink()
+    sink.reads["h1"] = (b"x", "text/plain", "a\r\nX-Injected: evil\r\n.txt")
+    token = await _mint_download(store)
+    async with _client(store, sink) as client:
+        resp = await client.get(f"/transfer/{token}")
+        assert resp.status_code == 200
+        assert "x-injected" not in {k.lower() for k in resp.headers}
+        cd = resp.headers["content-disposition"]
+        assert "\r" not in cd and "\n" not in cd
+
+
+# --------------------------------------------------------------------------- #
+# validation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_non_positive_upload_cap_rejected(bad: int) -> None:
+    store = _make_store()
+    sink = _FakeSink()
+    with pytest.raises(ValueError):
+        make_transfer_handler(store, sink, max_upload_bytes=bad)


### PR DESCRIPTION
Implements ADR 0001 §3/§4/§5/§8 / §11 issue #4 on top of the grace-settle store (#223/#224): the domain seam and the `/transfer/{token}` HTTP handler. Closes #217.

## What lands

- **`sink.py`** — the `TransferSink` Protocol (`read(handle) -> TransferReadResult`, `write(handle, body) -> payload`) + the `TransferValidator` type. `TransferReadResult` is a `NamedTuple` (not a bare 3-tuple) so `media_type`/`filename` — both `str` — are named rather than swap-prone positionals. These are the **only** things a downstream implements.
- **`routes.py`** — `make_transfer_handler(store, sink, *, max_upload_bytes)`, a Starlette handler. GET downloads via `sink.read` + an RFC 6266 `Content-Disposition`; POST/PUT upload via a receive-side chunked size-cap read + `sink.write`. On success `store.complete` (**grace-settle** — a served-but-stalled transfer can retry within the grace window instead of being stranded); on any failure incl. cancellation `store.release`. Claim errors map to HTTP: unknown/expired/consumed/wrong-kind → 404, in-flight → 409, over-cap → 413.

## Hardening

- **`Connection: close`** on every response that abandons an unread request body (413 over-cap, 404/409 upload claim errors, and the 405 unserved-method branch) — an undrained body on a keep-alive socket desyncs the next request. `_CLOSE_CONN` is a read-only `MappingProxyType`.
- **`_release_quietly`** — releases on the failure path, logging+swallowing an *ordinary* release error (a `BaseException`/cancellation still propagates) so the original transfer error is never masked. It logs only the release-error **class**, never a traceback/message — some KV backends embed the token-derived key in error text, and the token is a secret.
- A module logger (the Starlette route bypasses the MCP logging middleware): logs claim-rejection class, over-cap, and release failure — never the token.
- **Content-Disposition** strips CR/LF + quoted-string breakers (no header injection); RFC 5987 `filename*` for non-ASCII.

`TransferValidator` is defined here but invoked at link-creation by the link tools (#218), not by the handler. Kept internal until #218 registers the route and wires exports.

## Tests

19 handler contract tests over a real Starlette route via httpx ASGI — grace-settle reclaim-within-grace + expiry-after-grace, upload commit + grace retry, sink read/write failure release+retry, a **multi-chunk over-cap** test (pins the cross-chunk cap accumulation), `Connection: close` on every undrained-body branch, a release-failure-does-not-mask-the-original test, in-flight 409, 405, non-ASCII RFC 5987, and CRLF header-injection defense. The size-cap, release, burn-vs-grace-settle, 405-close, and release-mask guards are all mutation-verified.

## Note

This is the rebuild of the parked #217 handler onto grace-settle: the download burn-before-transmit gap the original review surfaced is dissolved (completing no longer strands the link), and all the other first-review findings (Connection: close, multi-chunk cap test, logging, release guard, NamedTuple, drop `@runtime_checkable`) are applied here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._