### PR TITLE
feat(transfer): register_transfer_routes + link tools + TransferConfig (#218)

### DIFF
--- a/docs/adr/0001-transfer-lift.md
+++ b/docs/adr/0001-transfer-lift.md
@@ -329,7 +329,7 @@ Already generic in `ServerConfig`: `base_url`, `kv_store_url`. New
 | `TRANSFER_TTL_DEFAULT_S` | link lifetime when the caller omits one |
 | `TRANSFER_TTL_MAX_S` | ceiling; a caller-requested TTL is clamped to this |
 | `TRANSFER_GRACE_TTL_S` | post-success grace window; `complete` shrinks the TTL to `min(remaining, this)` (§6.2) |
-| `TRANSFER_LEASE_S` | crashed-handler reclaim window for an `in_flight` reservation (§6.1) |
+| `TRANSFER_LEASE_S` | crashed-handler reclaim window for an `in_flight` reservation (§6.2) |
 | `TRANSFER_MAX_UPLOAD_BYTES` | per-upload size cap |
 | `TRANSFER_FETCH_MAX_BYTES` | per-fetch size cap |
 | `TRANSFER_FETCH_TIMEOUT_S` | fetch timeout |

--- a/docs/adr/0001-transfer-lift.md
+++ b/docs/adr/0001-transfer-lift.md
@@ -329,6 +329,7 @@ Already generic in `ServerConfig`: `base_url`, `kv_store_url`. New
 | `TRANSFER_TTL_DEFAULT_S` | link lifetime when the caller omits one |
 | `TRANSFER_TTL_MAX_S` | ceiling; a caller-requested TTL is clamped to this |
 | `TRANSFER_GRACE_TTL_S` | post-success grace window; `complete` shrinks the TTL to `min(remaining, this)` (§6.2) |
+| `TRANSFER_LEASE_S` | crashed-handler reclaim window for an `in_flight` reservation (§6.1) |
 | `TRANSFER_MAX_UPLOAD_BYTES` | per-upload size cap |
 | `TRANSFER_FETCH_MAX_BYTES` | per-fetch size cap |
 | `TRANSFER_FETCH_TIMEOUT_S` | fetch timeout |

--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -53,7 +53,17 @@ from ._server_info import (
     register_server_info_tool,
 )
 from ._subject import get_claims, get_subject
-from ._transfer import FetchResult, decode_base64_capped, fetch_url
+from ._transfer import (
+    FetchResult,
+    TransferConfig,
+    TransferKind,
+    TransferReadResult,
+    TransferSink,
+    TransferValidator,
+    decode_base64_capped,
+    fetch_url,
+    register_transfer_routes,
+)
 
 __version__ = "4.3.0"  # PSR overrides at build time
 
@@ -65,6 +75,11 @@ __all__ = [
     "SecretMaskFilter",
     "ServerConfig",
     "Transport",
+    "TransferConfig",
+    "TransferKind",
+    "TransferReadResult",
+    "TransferSink",
+    "TransferValidator",
     "UpstreamProvider",
     "UpstreamResult",
     "any_check",
@@ -101,6 +116,7 @@ __all__ = [
     "parse_scopes",
     "register_server_info_tool",
     "register_tool_icons",
+    "register_transfer_routes",
     "resolve_auth_mode",
     "server_config_env_suffixes",
     "wire_middleware_stack",

--- a/src/fastmcp_pvl_core/_transfer/__init__.py
+++ b/src/fastmcp_pvl_core/_transfer/__init__.py
@@ -1,13 +1,16 @@
 """In-process transfer/ingest mechanics shared across the ``*-mcp`` family.
 
 Implements ADR 0001 (``docs/adr/0001-transfer-lift.md``): SSRF-hardened URL
-fetch, size-capped base64 decode, a capability-link token store, and the
-``/transfer`` route framework. Landed so far: ``fetch_url`` (§11 issue #1),
-``decode_base64_capped`` (§11 issue #2), ``TransferStore`` in ``store.py``
-(§11 issue #3), and — in ``sink.py`` and ``routes.py`` — the ``TransferSink`` /
-``TransferValidator`` domain seam plus ``make_transfer_handler`` (§11 issue #4).
-All of these except the two exported primitives stay internal until the
-route-registration layer (§11 issue #5) wires them into the public surface.
+fetch (§11 #1), size-capped base64 decode (§11 #2), a capability-link token
+store (§11 #3), the ``TransferSink`` / ``TransferValidator`` domain seam plus
+``make_transfer_handler`` (§11 #4), and ``register_transfer_routes`` — the entry
+point that wires the ``/transfer`` route and the two link tools (§11 #5).
+
+The public surface is the two standalone primitives (``fetch_url``,
+``decode_base64_capped``) plus the transfer feature's entry point and its two
+domain hooks: ``register_transfer_routes``, ``TransferConfig``, ``TransferSink``,
+``TransferValidator``, ``TransferReadResult``, ``TransferKind``. The store,
+handler, and route mechanics stay internal — pvl-core owns their shape.
 
 Intra-package imports stay relative so a fold-in is a directory rename.
 """
@@ -15,6 +18,19 @@ Intra-package imports stay relative so a fold-in is a directory rename.
 from __future__ import annotations
 
 from .base64 import decode_base64_capped
+from .config import TransferConfig
 from .fetch import FetchResult, fetch_url
+from .register import register_transfer_routes
+from .sink import TransferKind, TransferReadResult, TransferSink, TransferValidator
 
-__all__ = ["FetchResult", "decode_base64_capped", "fetch_url"]
+__all__ = [
+    "FetchResult",
+    "TransferConfig",
+    "TransferKind",
+    "TransferReadResult",
+    "TransferSink",
+    "TransferValidator",
+    "decode_base64_capped",
+    "fetch_url",
+    "register_transfer_routes",
+]

--- a/src/fastmcp_pvl_core/_transfer/__init__.py
+++ b/src/fastmcp_pvl_core/_transfer/__init__.py
@@ -6,11 +6,11 @@ store (§11 #3), the ``TransferSink`` / ``TransferValidator`` domain seam plus
 ``make_transfer_handler`` (§11 #4), and ``register_transfer_routes`` — the entry
 point that wires the ``/transfer`` route and the two link tools (§11 #5).
 
-The public surface is the two standalone primitives (``fetch_url``,
-``decode_base64_capped``) plus the transfer feature's entry point and its two
-domain hooks: ``register_transfer_routes``, ``TransferConfig``, ``TransferSink``,
-``TransferValidator``, ``TransferReadResult``, ``TransferKind``. The store,
-handler, and route mechanics stay internal — pvl-core owns their shape.
+The public surface is the two standalone primitives (``fetch_url`` with its
+``FetchResult``, and ``decode_base64_capped``) plus the transfer feature's entry
+point and its two domain hooks: ``register_transfer_routes``, ``TransferConfig``,
+``TransferSink``, ``TransferValidator``, ``TransferReadResult``, ``TransferKind``.
+The store, handler, and route mechanics stay internal — pvl-core owns their shape.
 
 Intra-package imports stay relative so a fold-in is a directory rename.
 """

--- a/src/fastmcp_pvl_core/_transfer/__init__.py
+++ b/src/fastmcp_pvl_core/_transfer/__init__.py
@@ -8,9 +8,10 @@ point that wires the ``/transfer`` route and the two link tools (§11 #5).
 
 The public surface is the two standalone primitives (``fetch_url`` with its
 ``FetchResult``, and ``decode_base64_capped``) plus the transfer feature's entry
-point and its two domain hooks: ``register_transfer_routes``, ``TransferConfig``,
-``TransferSink``, ``TransferValidator``, ``TransferReadResult``, ``TransferKind``.
-The store, handler, and route mechanics stay internal — pvl-core owns their shape.
+point (``register_transfer_routes``), its config (``TransferConfig``), its two
+domain hooks (``TransferSink``, ``TransferValidator``), and their supporting
+types (``TransferReadResult``, ``TransferKind``). The store, handler, and route
+mechanics stay internal — pvl-core owns their shape.
 
 Intra-package imports stay relative so a fold-in is a directory rename.
 """

--- a/src/fastmcp_pvl_core/_transfer/config.py
+++ b/src/fastmcp_pvl_core/_transfer/config.py
@@ -15,7 +15,9 @@ Intra-package imports stay relative so a fold-in is a directory rename.
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
+from math import isfinite
 
 from .._env import env_float, env_int
 from .._errors import ConfigurationError
@@ -31,9 +33,9 @@ _DEFAULT_MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MiB
 class TransferConfig:
     """Env-tunable knobs for the transfer subsystem.
 
-    All durations are seconds and all values must be positive; the default TTL
-    must not exceed the max TTL. Construct via :meth:`from_env` (the operator
-    path) or directly (tests). ``__post_init__`` validates both.
+    All durations are seconds and all values must be positive and finite; the
+    default TTL must not exceed the max TTL. Construct via :meth:`from_env` (the
+    operator path) or directly (tests). ``__post_init__`` validates both.
 
     Attributes:
         ttl_default_s: Link lifetime when the caller omits one.
@@ -52,16 +54,14 @@ class TransferConfig:
     max_upload_bytes: int = _DEFAULT_MAX_UPLOAD_BYTES
 
     def __post_init__(self) -> None:
-        for name, value in (
-            ("ttl_default_s", self.ttl_default_s),
-            ("ttl_max_s", self.ttl_max_s),
-            ("grace_ttl_s", self.grace_ttl_s),
-            ("lease_s", self.lease_s),
-            ("max_upload_bytes", self.max_upload_bytes),
-        ):
-            if value <= 0:
+        # Iterate the declared fields (not a hand-maintained list) so a field
+        # added later is validated automatically rather than silently escaping.
+        for field in dataclasses.fields(self):
+            value = getattr(self, field.name)
+            if not isfinite(value) or value <= 0:
                 raise ConfigurationError(
-                    f"TransferConfig.{name} must be positive, got {value}"
+                    f"TransferConfig.{field.name} must be a positive, finite "
+                    f"number, got {value}"
                 )
         if self.ttl_default_s > self.ttl_max_s:
             raise ConfigurationError(
@@ -73,9 +73,12 @@ class TransferConfig:
     def from_env(cls, env_prefix: str) -> TransferConfig:
         """Read the transfer env section under *env_prefix*.
 
-        Each var is parsed strictly (an invalid value raises
-        :class:`ConfigurationError` naming it) and falls back to a built-in
-        default when unset; :meth:`__post_init__` then validates the result.
+        Each var is parsed strictly (a malformed value raises
+        :class:`ConfigurationError` naming the env var) and falls back to a
+        built-in default when unset; :meth:`__post_init__` then validates the
+        result. A well-formed but out-of-range value (non-positive, or a default
+        exceeding the max) is caught there and surfaces under the **dataclass
+        field name**, not the env-var suffix.
         """
         return cls(
             ttl_default_s=env_float(

--- a/src/fastmcp_pvl_core/_transfer/config.py
+++ b/src/fastmcp_pvl_core/_transfer/config.py
@@ -54,8 +54,10 @@ class TransferConfig:
     max_upload_bytes: int = _DEFAULT_MAX_UPLOAD_BYTES
 
     def __post_init__(self) -> None:
-        # Iterate the declared fields (not a hand-maintained list) so a field
-        # added later is validated automatically rather than silently escaping.
+        # Iterate the declared fields (not a hand-maintained list) so a new
+        # numeric field is covered without editing this loop. Every field is a
+        # positive, finite number; a non-numeric field must not be added without
+        # extending this check (``isfinite`` / ``> 0`` assume a real number).
         for field in dataclasses.fields(self):
             value = getattr(self, field.name)
             if not isfinite(value) or value <= 0:

--- a/src/fastmcp_pvl_core/_transfer/config.py
+++ b/src/fastmcp_pvl_core/_transfer/config.py
@@ -1,0 +1,102 @@
+"""Operator configuration for the transfer subsystem (ADR 0001 §7 / §11 #5).
+
+``TransferConfig`` is the env section for the ``/transfer`` feature: link
+lifetimes, the post-success grace window, the crashed-handler lease, and the
+per-upload size cap. Per the ``CLAUDE.md`` axis, operator tuning is env config
+(never kwargs) and domain behaviour is hooks (never config) — so this holds the
+tuning while :data:`TransferSink` / :data:`TransferValidator` hold the domain
+seam.
+
+Reads use the literal ``env_float(prefix, "LITERAL")`` / ``env_int`` form so
+``domain_env_suffixes(TransferConfig)`` (the drift gate) sees the full surface.
+
+Intra-package imports stay relative so a fold-in is a directory rename.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .._env import env_float, env_int
+from .._errors import ConfigurationError
+
+_DEFAULT_TTL_DEFAULT_S = 3600.0  # 1 hour
+_DEFAULT_TTL_MAX_S = 86_400.0  # 24 hours
+_DEFAULT_GRACE_TTL_S = 60.0
+_DEFAULT_LEASE_S = 60.0
+_DEFAULT_MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MiB
+
+
+@dataclass(frozen=True)
+class TransferConfig:
+    """Env-tunable knobs for the transfer subsystem.
+
+    All durations are seconds and all values must be positive; the default TTL
+    must not exceed the max TTL. Construct via :meth:`from_env` (the operator
+    path) or directly (tests). ``__post_init__`` validates both.
+
+    Attributes:
+        ttl_default_s: Link lifetime when the caller omits one.
+        ttl_max_s: Ceiling; a caller-requested TTL is clamped to this.
+        grace_ttl_s: Post-success grace window — ``complete`` shrinks a token's
+            TTL to ``min(remaining, grace_ttl_s)`` so a served-but-stalled
+            transfer can retry within it (ADR §6.2).
+        lease_s: Crashed-handler reclaim window for an ``in_flight`` reservation.
+        max_upload_bytes: Per-upload size cap.
+    """
+
+    ttl_default_s: float = _DEFAULT_TTL_DEFAULT_S
+    ttl_max_s: float = _DEFAULT_TTL_MAX_S
+    grace_ttl_s: float = _DEFAULT_GRACE_TTL_S
+    lease_s: float = _DEFAULT_LEASE_S
+    max_upload_bytes: int = _DEFAULT_MAX_UPLOAD_BYTES
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("ttl_default_s", self.ttl_default_s),
+            ("ttl_max_s", self.ttl_max_s),
+            ("grace_ttl_s", self.grace_ttl_s),
+            ("lease_s", self.lease_s),
+            ("max_upload_bytes", self.max_upload_bytes),
+        ):
+            if value <= 0:
+                raise ConfigurationError(
+                    f"TransferConfig.{name} must be positive, got {value}"
+                )
+        if self.ttl_default_s > self.ttl_max_s:
+            raise ConfigurationError(
+                f"TransferConfig.ttl_default_s ({self.ttl_default_s}) must not "
+                f"exceed ttl_max_s ({self.ttl_max_s})"
+            )
+
+    @classmethod
+    def from_env(cls, env_prefix: str) -> TransferConfig:
+        """Read the transfer env section under *env_prefix*.
+
+        Each var is parsed strictly (an invalid value raises
+        :class:`ConfigurationError` naming it) and falls back to a built-in
+        default when unset; :meth:`__post_init__` then validates the result.
+        """
+        return cls(
+            ttl_default_s=env_float(
+                env_prefix,
+                "TRANSFER_TTL_DEFAULT_S",
+                _DEFAULT_TTL_DEFAULT_S,
+                strict=True,
+            ),
+            ttl_max_s=env_float(
+                env_prefix, "TRANSFER_TTL_MAX_S", _DEFAULT_TTL_MAX_S, strict=True
+            ),
+            grace_ttl_s=env_float(
+                env_prefix, "TRANSFER_GRACE_TTL_S", _DEFAULT_GRACE_TTL_S, strict=True
+            ),
+            lease_s=env_float(
+                env_prefix, "TRANSFER_LEASE_S", _DEFAULT_LEASE_S, strict=True
+            ),
+            max_upload_bytes=env_int(
+                env_prefix,
+                "TRANSFER_MAX_UPLOAD_BYTES",
+                _DEFAULT_MAX_UPLOAD_BYTES,
+                strict=True,
+            ),
+        )

--- a/src/fastmcp_pvl_core/_transfer/register.py
+++ b/src/fastmcp_pvl_core/_transfer/register.py
@@ -27,19 +27,17 @@ from .store import TransferStore
 
 _ROUTE_PATH = "/transfer/{token}"
 
-# Route every *body-carrying* method to the handler so each reaches its own 405
-# + ``Connection: close`` dispatch for an unread body (see ``make_transfer_handler``'s
-# Note). The keep-alive desync the close guards against is caused by an undrained
-# request body, so the set that must reach the handler is exactly the methods a
-# client can send a body with: GET/POST/PUT are served, and DELETE/PATCH fall to
-# the handler's closing 405. That is the complete body-carrying set — this
-# discharges #217's handoff (a superset reaches the handler; ``custom_route``
-# requires ``methods=``, so "omit it" is not available). Methods NOT listed
-# (OPTIONS, TRACE, CONNECT) are answered by Starlette's Router-level 405 without
-# ``Connection: close``, which is harmless: none carries a request body (TRACE
-# and OPTIONS are bodyless by spec), so there is no body to leave undrained. We
-# deliberately do *not* route OPTIONS here — funnelling it to a 405 would break
-# CORS preflight. HEAD is auto-added by Starlette for GET and is bodyless.
+# Route the methods a client realistically sends a request *body* with, so each
+# reaches the handler's own 405 + ``Connection: close`` dispatch (see
+# ``make_transfer_handler``'s Note) — an undrained body on a keep-alive socket
+# desyncs the next request. GET/POST/PUT are served; DELETE/PATCH fall to the
+# handler's closing 405. ``custom_route`` requires ``methods=``, so this is a
+# superset rather than "omit it". OPTIONS is deliberately NOT routed here: it must
+# stay with Starlette's router so a CORS preflight is answered normally, not
+# turned into a 405 (a preflight carries no body). A method not listed (a
+# non-preflight OPTIONS with a body, TRACE — which forbids a body per RFC 7231
+# §4.3.8 — or an exotic verb) falls to the router's 405 without the close header;
+# that residual is accepted. HEAD is auto-added by Starlette for GET.
 _ROUTE_METHODS = ("GET", "POST", "PUT", "DELETE", "PATCH")
 
 
@@ -108,8 +106,9 @@ def register_transfer_routes(
 
         *ref* is a domain reference the ``validate`` hook resolves to an opaque
         download handle (raising to reject). *ttl_s* is the requested lifetime in
-        seconds — omitted uses the configured default, and any value is clamped
-        to the configured maximum. Returns ``{"url", "expires_in_s"}``.
+        seconds — omitted uses the configured default, a value over the configured
+        maximum is clamped to it, and a non-positive value is rejected. Returns
+        ``{"url", "expires_in_s"}``.
         """
         return await _mint_link(ref, "download", ttl_s)
 
@@ -121,7 +120,8 @@ def register_transfer_routes(
 
         *ref* is a domain reference the ``validate`` hook resolves to an opaque
         upload handle (raising to reject). *ttl_s* is the requested lifetime in
-        seconds — omitted uses the configured default, and any value is clamped
-        to the configured maximum. Returns ``{"url", "expires_in_s"}``.
+        seconds — omitted uses the configured default, a value over the configured
+        maximum is clamped to it, and a non-positive value is rejected. Returns
+        ``{"url", "expires_in_s"}``.
         """
         return await _mint_link(ref, "upload", ttl_s)

--- a/src/fastmcp_pvl_core/_transfer/register.py
+++ b/src/fastmcp_pvl_core/_transfer/register.py
@@ -1,0 +1,120 @@
+"""Wire the ``/transfer`` feature onto a FastMCP server (ADR 0001 §3/§5 / §11 #5).
+
+:func:`register_transfer_routes` is the one public entry point: it builds a
+single shared :class:`TransferStore`, mounts the ``/transfer/{token}`` route
+(the #217 handler), and registers the two link tools ``create_download_link`` /
+``create_upload_link``. pvl-core owns every **shape** decision here — the tool
+names, the route path and its method set, the status codes, the TTL clamp, and
+the ``base_url``-required guard. The only hooks are ``sink`` (where bytes land)
+and ``validate`` (what bytes are acceptable); there are **no override kwargs**
+for any shape element (ADR §7/§10.2).
+
+Intra-package imports stay relative so a fold-in is a directory rename.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+
+from .._config import ServerConfig
+from .._errors import ConfigurationError
+from .config import TransferConfig
+from .routes import make_transfer_handler
+from .sink import TransferKind, TransferSink, TransferValidator
+from .store import TransferStore
+
+_ROUTE_PATH = "/transfer/{token}"
+
+# Register the body-carrying methods so each reaches the handler's own dispatch
+# (its 405 + ``Connection: close`` for an unread body). A method NOT in this set
+# is answered by Starlette's Router-level 405, which does not close the
+# connection — so listing DELETE/PATCH here closes the undrained-body keep-alive
+# gap for the realistic non-served methods (see ``make_transfer_handler``'s
+# Note). GET/POST/PUT are served; HEAD is auto-added by Starlette for GET.
+_ROUTE_METHODS = ("GET", "POST", "PUT", "DELETE", "PATCH")
+
+
+def register_transfer_routes(
+    mcp: FastMCP,
+    config: ServerConfig,
+    transfer_config: TransferConfig,
+    *,
+    sink: TransferSink,
+    validate: TransferValidator,
+) -> None:
+    """Register the ``/transfer`` route and the two link tools on *mcp*.
+
+    Args:
+        mcp: The FastMCP server to register the route and tools on.
+        config: The server's :class:`ServerConfig` — supplies ``base_url``
+            (required, to build link URLs) and ``kv_store_url`` (the token
+            store backend).
+        transfer_config: The transfer env section (TTL default/max, grace,
+            lease, upload cap).
+        sink: Domain hook — where bytes are read from / written to.
+        validate: Domain hook — maps a caller ref + kind to a validated opaque
+            ``sink_handle`` (raises to reject); invoked at link creation.
+
+    Raises:
+        ConfigurationError: If ``config.base_url`` is unset — a transfer link
+            cannot be minted without a public base URL, so this fails at
+            registration rather than deferring to the first tool call.
+    """
+    if not config.base_url:
+        raise ConfigurationError(
+            "base_url is required to mint transfer links; set <PREFIX>_BASE_URL"
+        )
+    base = config.base_url.rstrip("/")
+    store = TransferStore.from_config(
+        config,
+        lease_seconds=transfer_config.lease_s,
+        grace_seconds=transfer_config.grace_ttl_s,
+    )
+    handler = make_transfer_handler(
+        store, sink, max_upload_bytes=transfer_config.max_upload_bytes
+    )
+    mcp.custom_route(_ROUTE_PATH, methods=list(_ROUTE_METHODS))(handler)
+
+    def _clamp_ttl(ttl_s: float | None) -> float:
+        """Resolve the link TTL: the default when omitted, else clamped to the max."""
+        if ttl_s is None:
+            return transfer_config.ttl_default_s
+        return min(ttl_s, transfer_config.ttl_max_s)
+
+    async def _mint_link(
+        ref: str, kind: TransferKind, ttl_s: float | None
+    ) -> dict[str, Any]:
+        handle = await validate(ref, kind)
+        ttl = _clamp_ttl(ttl_s)
+        token = await store.mint(
+            kind=kind, sink_handle=handle, caps={}, ttl_seconds=ttl
+        )
+        return {"url": f"{base}/transfer/{token}", "expires_in_s": ttl}
+
+    @mcp.tool(name="create_download_link")
+    async def create_download_link(
+        ref: str, ttl_s: float | None = None
+    ) -> dict[str, Any]:
+        """Mint a capability link that serves the bytes for *ref* once.
+
+        *ref* is a domain reference the ``validate`` hook resolves to an opaque
+        download handle (raising to reject). *ttl_s* is the requested lifetime in
+        seconds — omitted uses the configured default, and any value is clamped
+        to the configured maximum. Returns ``{"url", "expires_in_s"}``.
+        """
+        return await _mint_link(ref, "download", ttl_s)
+
+    @mcp.tool(name="create_upload_link")
+    async def create_upload_link(
+        ref: str, ttl_s: float | None = None
+    ) -> dict[str, Any]:
+        """Mint a capability link that accepts one upload for *ref*.
+
+        *ref* is a domain reference the ``validate`` hook resolves to an opaque
+        upload handle (raising to reject). *ttl_s* is the requested lifetime in
+        seconds — omitted uses the configured default, and any value is clamped
+        to the configured maximum. Returns ``{"url", "expires_in_s"}``.
+        """
+        return await _mint_link(ref, "upload", ttl_s)

--- a/src/fastmcp_pvl_core/_transfer/register.py
+++ b/src/fastmcp_pvl_core/_transfer/register.py
@@ -7,7 +7,7 @@ single shared :class:`TransferStore`, mounts the ``/transfer/{token}`` route
 names, the route path and its method set, the status codes, the TTL clamp, and
 the ``base_url``-required guard. The only hooks are ``sink`` (where bytes land)
 and ``validate`` (what bytes are acceptable); there are **no override kwargs**
-for any shape element (ADR §7/§10.2).
+for any shape element (ADR §7 / §10 item 2).
 
 Intra-package imports stay relative so a fold-in is a directory rename.
 """
@@ -27,12 +27,19 @@ from .store import TransferStore
 
 _ROUTE_PATH = "/transfer/{token}"
 
-# Register the body-carrying methods so each reaches the handler's own dispatch
-# (its 405 + ``Connection: close`` for an unread body). A method NOT in this set
-# is answered by Starlette's Router-level 405, which does not close the
-# connection — so listing DELETE/PATCH here closes the undrained-body keep-alive
-# gap for the realistic non-served methods (see ``make_transfer_handler``'s
-# Note). GET/POST/PUT are served; HEAD is auto-added by Starlette for GET.
+# Route every *body-carrying* method to the handler so each reaches its own 405
+# + ``Connection: close`` dispatch for an unread body (see ``make_transfer_handler``'s
+# Note). The keep-alive desync the close guards against is caused by an undrained
+# request body, so the set that must reach the handler is exactly the methods a
+# client can send a body with: GET/POST/PUT are served, and DELETE/PATCH fall to
+# the handler's closing 405. That is the complete body-carrying set — this
+# discharges #217's handoff (a superset reaches the handler; ``custom_route``
+# requires ``methods=``, so "omit it" is not available). Methods NOT listed
+# (OPTIONS, TRACE, CONNECT) are answered by Starlette's Router-level 405 without
+# ``Connection: close``, which is harmless: none carries a request body (TRACE
+# and OPTIONS are bodyless by spec), so there is no body to leave undrained. We
+# deliberately do *not* route OPTIONS here — funnelling it to a 405 would break
+# CORS preflight. HEAD is auto-added by Starlette for GET and is bodyless.
 _ROUTE_METHODS = ("GET", "POST", "PUT", "DELETE", "PATCH")
 
 
@@ -58,9 +65,9 @@ def register_transfer_routes(
             ``sink_handle`` (raises to reject); invoked at link creation.
 
     Raises:
-        ConfigurationError: If ``config.base_url`` is unset — a transfer link
-            cannot be minted without a public base URL, so this fails at
-            registration rather than deferring to the first tool call.
+        ConfigurationError: If ``config.base_url`` is unset or blank — a
+            transfer link cannot be minted without a public base URL, so this
+            fails at registration rather than deferring to the first tool call.
     """
     if not config.base_url:
         raise ConfigurationError(

--- a/tests/test_transfer_config.py
+++ b/tests/test_transfer_config.py
@@ -1,0 +1,176 @@
+"""Contract tests for :class:`TransferConfig` (ADR 0001 §7 / §11 #5).
+
+Pins the env section for the ``/transfer`` feature: the default values, the
+``__post_init__`` invariants (all-positive, default ≤ max), the ``from_env``
+literal-suffix read surface, and the ``domain_env_suffixes`` drift gate.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from fastmcp_pvl_core import TransferConfig, domain_env_suffixes
+from fastmcp_pvl_core._errors import ConfigurationError
+
+# The full literal env surface TransferConfig.from_env reads; the drift gate
+# (domain_env_suffixes) and from_env must agree on exactly this set.
+_EXPECTED_SUFFIXES = frozenset(
+    {
+        "TRANSFER_TTL_DEFAULT_S",
+        "TRANSFER_TTL_MAX_S",
+        "TRANSFER_GRACE_TTL_S",
+        "TRANSFER_LEASE_S",
+        "TRANSFER_MAX_UPLOAD_BYTES",
+    }
+)
+
+
+class TestDefaults:
+    def test_construct_with_no_args_uses_defaults(self) -> None:
+        cfg = TransferConfig()
+        assert cfg.ttl_default_s == 3600.0
+        assert cfg.ttl_max_s == 86_400.0
+        assert cfg.grace_ttl_s == 60.0
+        assert cfg.lease_s == 60.0
+        assert cfg.max_upload_bytes == 100 * 1024 * 1024
+
+    def test_default_ttl_within_max(self) -> None:
+        # The default pair must itself satisfy the default ≤ max invariant.
+        cfg = TransferConfig()
+        assert cfg.ttl_default_s <= cfg.ttl_max_s
+
+    def test_is_frozen(self) -> None:
+        cfg = TransferConfig()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            cfg.lease_s = 5.0  # type: ignore[misc]
+
+
+class TestPostInitValidation:
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "ttl_default_s",
+            "ttl_max_s",
+            "grace_ttl_s",
+            "lease_s",
+            "max_upload_bytes",
+        ],
+    )
+    def test_non_positive_field_raises(self, field: str) -> None:
+        # A base that satisfies default ≤ max, then drive one field to zero.
+        base = dict(
+            ttl_default_s=100.0,
+            ttl_max_s=200.0,
+            grace_ttl_s=10.0,
+            lease_s=10.0,
+            max_upload_bytes=1024,
+        )
+        base[field] = 0
+        with pytest.raises(ConfigurationError, match=field):
+            TransferConfig(**base)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "ttl_default_s",
+            "ttl_max_s",
+            "grace_ttl_s",
+            "lease_s",
+            "max_upload_bytes",
+        ],
+    )
+    def test_negative_field_raises(self, field: str) -> None:
+        base = dict(
+            ttl_default_s=100.0,
+            ttl_max_s=200.0,
+            grace_ttl_s=10.0,
+            lease_s=10.0,
+            max_upload_bytes=1024,
+        )
+        base[field] = -1
+        with pytest.raises(ConfigurationError, match=field):
+            TransferConfig(**base)  # type: ignore[arg-type]
+
+    def test_default_exceeding_max_raises(self) -> None:
+        with pytest.raises(ConfigurationError, match="ttl_default_s"):
+            TransferConfig(ttl_default_s=200.0, ttl_max_s=100.0)
+
+    def test_default_equal_to_max_accepted(self) -> None:
+        # Boundary: default == max is allowed (the clamp is a no-op there).
+        cfg = TransferConfig(ttl_default_s=100.0, ttl_max_s=100.0)
+        assert cfg.ttl_default_s == cfg.ttl_max_s == 100.0
+
+
+class TestFromEnv:
+    def test_reads_all_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MYAPP_TRANSFER_TTL_DEFAULT_S", "111")
+        monkeypatch.setenv("MYAPP_TRANSFER_TTL_MAX_S", "222")
+        monkeypatch.setenv("MYAPP_TRANSFER_GRACE_TTL_S", "33")
+        monkeypatch.setenv("MYAPP_TRANSFER_LEASE_S", "44")
+        monkeypatch.setenv("MYAPP_TRANSFER_MAX_UPLOAD_BYTES", "555")
+        cfg = TransferConfig.from_env("MYAPP")
+        assert cfg.ttl_default_s == 111.0
+        assert cfg.ttl_max_s == 222.0
+        assert cfg.grace_ttl_s == 33.0
+        assert cfg.lease_s == 44.0
+        assert cfg.max_upload_bytes == 555
+
+    def test_unset_falls_back_to_defaults(self) -> None:
+        cfg = TransferConfig.from_env("MYAPP")
+        assert cfg == TransferConfig()
+
+    def test_lease_defaults_when_only_it_is_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Every other var set, lease absent → lease takes its default, not a
+        # silent zero. Guards the TRANSFER_LEASE_S wiring specifically.
+        monkeypatch.setenv("MYAPP_TRANSFER_TTL_DEFAULT_S", "111")
+        monkeypatch.setenv("MYAPP_TRANSFER_TTL_MAX_S", "222")
+        monkeypatch.setenv("MYAPP_TRANSFER_GRACE_TTL_S", "33")
+        monkeypatch.setenv("MYAPP_TRANSFER_MAX_UPLOAD_BYTES", "555")
+        cfg = TransferConfig.from_env("MYAPP")
+        assert cfg.lease_s == 60.0
+
+    def test_malformed_float_raises_naming_the_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MYAPP_TRANSFER_LEASE_S", "not-a-number")
+        with pytest.raises(ConfigurationError, match="TRANSFER_LEASE_S"):
+            TransferConfig.from_env("MYAPP")
+
+    def test_malformed_int_raises_naming_the_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MYAPP_TRANSFER_MAX_UPLOAD_BYTES", "1.5")
+        with pytest.raises(ConfigurationError, match="TRANSFER_MAX_UPLOAD_BYTES"):
+            TransferConfig.from_env("MYAPP")
+
+    def test_env_value_violating_invariant_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A well-formed but out-of-contract env pair (default > max) is caught
+        # by __post_init__ after parsing, not silently accepted.
+        monkeypatch.setenv("MYAPP_TRANSFER_TTL_DEFAULT_S", "500")
+        monkeypatch.setenv("MYAPP_TRANSFER_TTL_MAX_S", "100")
+        with pytest.raises(ConfigurationError, match="ttl_default_s"):
+            TransferConfig.from_env("MYAPP")
+
+    def test_negative_env_value_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MYAPP_TRANSFER_GRACE_TTL_S", "-5")
+        with pytest.raises(ConfigurationError, match="grace_ttl_s"):
+            TransferConfig.from_env("MYAPP")
+
+
+class TestDomainEnvSuffixes:
+    def test_returns_exactly_the_read_surface(self) -> None:
+        assert domain_env_suffixes(TransferConfig) == _EXPECTED_SUFFIXES
+
+    def test_drift_gate_matches_from_env(self) -> None:
+        """Anti-drift: the AST scan of from_env must equal the expected set.
+
+        A literal read added/removed/renamed in ``from_env`` without updating
+        ``_EXPECTED_SUFFIXES`` (and the ADR §7 table) fails here.
+        """
+        assert domain_env_suffixes(TransferConfig) == _EXPECTED_SUFFIXES

--- a/tests/test_transfer_config.py
+++ b/tests/test_transfer_config.py
@@ -102,6 +102,14 @@ class TestPostInitValidation:
         cfg = TransferConfig(ttl_default_s=100.0, ttl_max_s=100.0)
         assert cfg.ttl_default_s == cfg.ttl_max_s == 100.0
 
+    @pytest.mark.parametrize("bad", [float("inf"), float("nan")])
+    def test_non_finite_field_raises(self, bad: float) -> None:
+        # inf passes a naive value > 0 check (inf > 0 is True); the finiteness
+        # guard rejects it so an operator cannot mint a never-expiring link on
+        # the direct-construction path (the env path already rejects non-finite).
+        with pytest.raises(ConfigurationError, match="ttl_max_s"):
+            TransferConfig(ttl_max_s=bad)
+
 
 class TestFromEnv:
     def test_reads_all_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_transfer_register.py
+++ b/tests/test_transfer_register.py
@@ -164,6 +164,14 @@ class TestTtlClamp:
         res = await mcp.call_tool("create_download_link", {"ref": "doc", "ttl_s": 150})
         assert res.structured_content["expires_in_s"] == 150.0
 
+    async def test_non_positive_ttl_is_rejected(self) -> None:
+        # The clamp only bounds the ceiling; a non-positive request would mint a
+        # dead link, so store.mint rejects it (ValueError -> ToolError) rather
+        # than the clamp. Pins that the request fails loudly, not silently.
+        mcp, _, _ = _register()
+        with pytest.raises(ToolError):
+            await mcp.call_tool("create_download_link", {"ref": "doc", "ttl_s": 0})
+
 
 class TestValidatorRejection:
     async def test_rejection_surfaces_from_tool(self) -> None:
@@ -199,6 +207,28 @@ class TestEndToEnd:
         assert 'filename="f.txt"' in resp.headers["content-disposition"]
         # The handle the route handed the sink is the validator's download handle.
         assert sink.read_handles == ["handle:doc:download"]
+
+    async def test_minted_upload_link_redeems_over_http(self) -> None:
+        mcp, sink, _ = _register()
+        res = await mcp.call_tool("create_upload_link", {"ref": "dest"})
+        path = _path_of(res.structured_content["url"])
+        async with _client(mcp) as client:
+            resp = await client.put(path, content=b"PAYLOAD")
+        assert resp.status_code == 200
+        # The handler committed the body to the validator's upload handle.
+        assert sink.write_handles == ["handle:dest:upload"]
+
+    async def test_over_cap_upload_is_rejected_413(self) -> None:
+        # Pins that register threads transfer_config.max_upload_bytes into the
+        # handler: a tiny cap must reject an over-size body. If register dropped
+        # or hardcoded the cap, this would not 413.
+        mcp, sink, _ = _register(transfer_config=_tconfig(max_upload_bytes=4))
+        res = await mcp.call_tool("create_upload_link", {"ref": "dest"})
+        path = _path_of(res.structured_content["url"])
+        async with _client(mcp) as client:
+            resp = await client.put(path, content=b"way-too-long")
+        assert resp.status_code == 413
+        assert sink.write_handles == []  # over-cap body never reached the sink
 
     async def test_second_redeem_within_grace_still_serves(self) -> None:
         # Grace-settle wiring: complete() shrinks the TTL to the grace window

--- a/tests/test_transfer_register.py
+++ b/tests/test_transfer_register.py
@@ -230,6 +230,22 @@ class TestEndToEnd:
         assert resp.status_code == 413
         assert sink.write_handles == []  # over-cap body never reached the sink
 
+    @pytest.mark.parametrize("method", ["DELETE", "PATCH"])
+    async def test_body_carrying_unserved_method_gets_closing_405(
+        self, method: str
+    ) -> None:
+        # DELETE/PATCH are in _ROUTE_METHODS so they reach the handler's own
+        # 405 + ``Connection: close`` (an unserved method may carry an unread
+        # body). Pins the register-side wiring: if a refactor dropped them from
+        # the set, they would fall to Starlette's router 405 without the close.
+        mcp, _, _ = _register()
+        res = await mcp.call_tool("create_download_link", {"ref": "doc"})
+        path = _path_of(res.structured_content["url"])
+        async with _client(mcp) as client:
+            resp = await client.request(method, path, content=b"body")
+        assert resp.status_code == 405
+        assert resp.headers["connection"] == "close"
+
     async def test_second_redeem_within_grace_still_serves(self) -> None:
         # Grace-settle wiring: complete() shrinks the TTL to the grace window
         # rather than burning the link, so a retry inside that window re-serves.

--- a/tests/test_transfer_register.py
+++ b/tests/test_transfer_register.py
@@ -1,0 +1,214 @@
+"""Contract tests for :func:`register_transfer_routes` (ADR 0001 §3/§5 / §11 #5).
+
+``register_transfer_routes`` is the transfer feature's one entry point: it
+builds the shared store, mounts the ``/transfer/{token}`` route, and registers
+the ``create_download_link`` / ``create_upload_link`` tools. These tests pin the
+**wiring** it owns — the store's grace-settle timing is proven at the store /
+routes layer (``test_transfer_store``, ``test_transfer_routes``):
+
+- **base_url guard**: an unset/blank ``base_url`` fails fast at *registration*,
+  not at the first tool call.
+- **Link tools**: each mints via the validated handle, echoes ``{url,
+  expires_in_s}``, builds the URL from ``base_url`` (trailing slash stripped),
+  and passes the correct ``kind`` to the validator.
+- **TTL clamp**: an omitted TTL uses the configured default; a request over the
+  max is clamped to the max; an in-range request is honoured — observed via the
+  returned ``expires_in_s``.
+- **Validator rejection** surfaces from the tool call.
+- **End-to-end**: a minted download link redeems over real ASGI (tool → store →
+  route → handler → sink), and a second redeem within the grace window still
+  serves — confirming the grace-settle path is wired, not just the store.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+
+from fastmcp_pvl_core import (
+    ServerConfig,
+    TransferConfig,
+    TransferReadResult,
+    register_transfer_routes,
+)
+from fastmcp_pvl_core._errors import ConfigurationError
+
+
+class _RecordingSink:
+    """A sink that serves canned bytes and records the handles it is called with."""
+
+    def __init__(self) -> None:
+        self.read_handles: list[str] = []
+        self.write_handles: list[str] = []
+
+    async def read(self, handle: str) -> TransferReadResult:
+        self.read_handles.append(handle)
+        return TransferReadResult(b"BODY", "text/plain", "f.txt")
+
+    async def write(self, handle: str, body: bytes) -> Mapping[str, Any]:
+        self.write_handles.append(handle)
+        return {"stored": handle}
+
+
+class _RecordingValidator:
+    """Records (ref, kind) calls; encodes the kind into the returned handle.
+
+    A ``ref`` of ``"bad"`` raises, exercising the rejection path. The handle
+    embeds the kind so a downstream sink assertion can prove which kind was
+    minted.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def __call__(self, ref: str, kind: str) -> str:
+        self.calls.append((ref, kind))
+        if ref == "bad":
+            raise ValueError("validator rejected ref")
+        return f"handle:{ref}:{kind}"
+
+
+def _tconfig(**overrides: Any) -> TransferConfig:
+    base = dict(
+        ttl_default_s=100.0,
+        ttl_max_s=200.0,
+        grace_ttl_s=60.0,
+        lease_s=60.0,
+        max_upload_bytes=1024,
+    )
+    base.update(overrides)
+    return TransferConfig(**base)  # type: ignore[arg-type]
+
+
+def _register(
+    *,
+    base_url: str | None = "https://x.example.com",
+    transfer_config: TransferConfig | None = None,
+    sink: _RecordingSink | None = None,
+    validate: _RecordingValidator | None = None,
+) -> tuple[FastMCP, _RecordingSink, _RecordingValidator]:
+    mcp = FastMCP("t")
+    sink = sink or _RecordingSink()
+    validate = validate or _RecordingValidator()
+    config = ServerConfig(base_url=base_url, kv_store_url="memory://")
+    register_transfer_routes(
+        mcp,
+        config,
+        transfer_config or _tconfig(),
+        sink=sink,
+        validate=validate,
+    )
+    return mcp, sink, validate
+
+
+class TestBaseUrlGuard:
+    def test_unset_base_url_raises_at_register(self) -> None:
+        with pytest.raises(ConfigurationError, match="base_url"):
+            _register(base_url=None)
+
+    def test_blank_base_url_raises_at_register(self) -> None:
+        # An empty string is as unusable as None for building link URLs.
+        with pytest.raises(ConfigurationError, match="base_url"):
+            _register(base_url="")
+
+
+class TestToolRegistration:
+    async def test_both_link_tools_registered(self) -> None:
+        mcp, _, _ = _register()
+        # get_tool raises KeyError if the name is not registered.
+        assert await mcp.get_tool("create_download_link") is not None
+        assert await mcp.get_tool("create_upload_link") is not None
+
+
+class TestLinkMinting:
+    async def test_download_link_shape_and_kind(self) -> None:
+        mcp, _, validate = _register()
+        res = await mcp.call_tool("create_download_link", {"ref": "doc1"})
+        payload = res.structured_content
+        assert payload["url"].startswith("https://x.example.com/transfer/")
+        assert payload["expires_in_s"] == 100.0  # the configured default
+        assert validate.calls == [("doc1", "download")]
+
+    async def test_upload_link_uses_upload_kind(self) -> None:
+        mcp, _, validate = _register()
+        await mcp.call_tool("create_upload_link", {"ref": "dest1"})
+        assert validate.calls == [("dest1", "upload")]
+
+    async def test_base_url_trailing_slash_stripped(self) -> None:
+        mcp, _, _ = _register(base_url="https://x.example.com/")
+        res = await mcp.call_tool("create_download_link", {"ref": "doc1"})
+        # Exactly one slash between host and the route — no "//transfer".
+        assert "/transfer/" in res.structured_content["url"]
+        assert "com//transfer" not in res.structured_content["url"]
+
+
+class TestTtlClamp:
+    async def test_omitted_ttl_uses_default(self) -> None:
+        mcp, _, _ = _register()
+        res = await mcp.call_tool("create_download_link", {"ref": "doc"})
+        assert res.structured_content["expires_in_s"] == 100.0
+
+    async def test_over_max_ttl_is_clamped(self) -> None:
+        mcp, _, _ = _register()
+        res = await mcp.call_tool("create_download_link", {"ref": "doc", "ttl_s": 9999})
+        assert res.structured_content["expires_in_s"] == 200.0  # the max
+
+    async def test_in_range_ttl_is_honoured(self) -> None:
+        mcp, _, _ = _register()
+        res = await mcp.call_tool("create_download_link", {"ref": "doc", "ttl_s": 150})
+        assert res.structured_content["expires_in_s"] == 150.0
+
+
+class TestValidatorRejection:
+    async def test_rejection_surfaces_from_tool(self) -> None:
+        mcp, _, _ = _register()
+        with pytest.raises(ToolError, match="validator rejected ref"):
+            await mcp.call_tool("create_download_link", {"ref": "bad"})
+
+
+@asynccontextmanager
+async def _client(mcp: FastMCP):
+    """Yield an httpx client bound to the FastMCP ASGI app with lifespan active."""
+    app = mcp.http_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://tsvr") as client:
+        async with app.router.lifespan_context(app):
+            yield client
+
+
+def _path_of(url: str) -> str:
+    """Return the ``/transfer/{token}`` path from a minted absolute link URL."""
+    return "/" + url.split("/", 3)[3]
+
+
+class TestEndToEnd:
+    async def test_minted_download_link_redeems_over_http(self) -> None:
+        mcp, sink, _ = _register()
+        res = await mcp.call_tool("create_download_link", {"ref": "doc"})
+        path = _path_of(res.structured_content["url"])
+        async with _client(mcp) as client:
+            resp = await client.get(path)
+        assert resp.status_code == 200
+        assert resp.content == b"BODY"
+        assert 'filename="f.txt"' in resp.headers["content-disposition"]
+        # The handle the route handed the sink is the validator's download handle.
+        assert sink.read_handles == ["handle:doc:download"]
+
+    async def test_second_redeem_within_grace_still_serves(self) -> None:
+        # Grace-settle wiring: complete() shrinks the TTL to the grace window
+        # rather than burning the link, so a retry inside that window re-serves.
+        # The test runs in milliseconds, far inside the 60s grace default.
+        mcp, _, _ = _register()
+        res = await mcp.call_tool("create_download_link", {"ref": "doc"})
+        path = _path_of(res.structured_content["url"])
+        async with _client(mcp) as client:
+            first = await client.get(path)
+            second = await client.get(path)
+        assert first.status_code == 200
+        assert second.status_code == 200


### PR DESCRIPTION
## Summary

Wires the `/transfer` feature onto a FastMCP server — the final integration piece of the transfer-lift epic (ADR 0001 §11 #5). Downstream servers now enable the whole feature with one call plus two domain hooks.

`register_transfer_routes(mcp, config, transfer_config, *, sink, validate)`:
- builds the single shared `TransferStore` (from `ServerConfig.kv_store_url`),
- mounts the `/transfer/{token}` handler (the #216/#217 store + route layer),
- registers the `create_download_link` / `create_upload_link` tools that mint capability links via the `validate` hook and return `{"url", "expires_in_s"}`.

`TransferConfig` is the operator env section (TTL default/max, grace, lease, upload cap), read via the literal `env_float`/`env_int` suffix form so `domain_env_suffixes(TransferConfig)` gates config drift against the ADR §7 table.

New public exports: `register_transfer_routes`, `TransferConfig`, `TransferSink`, `TransferValidator`, `TransferReadResult`, `TransferKind`.

## Shape / hook discipline (CLAUDE.md)

Per the classification test, the only kwargs are the two genuine domain hooks — `sink` (where bytes land) and `validate` (what bytes are acceptable). Every shape decision (tool names, route path, method set, status codes, TTL clamp, the `base_url` guard) is pvl-core's, with **no override kwargs**. Operator tuning is env config (`TransferConfig`), not kwargs.

## Deviations from the issue text (noted for review)

- **`base_url` guard fires at registration, not mint.** The issue said "mint raises when `base_url` is unset"; failing fast at `register_transfer_routes` time (on unset *or blank*) is strictly better — misconfiguration surfaces at startup, not on the first tool call.
- **The "404 on second redeem" acceptance predates grace-settle** (#223/#224). The e2e test asserts the *shipped* behavior: a redeem within the grace window re-serves (200), and after-grace expiry is store-layer tested (`test_transfer_store.py`).

## Testing

- New `tests/test_transfer_config.py` (defaults, positive-and-finite + default≤max invariants, `from_env` strict-parse + fallback, the `domain_env_suffixes` drift gate).
- New `tests/test_transfer_register.py` (base_url guard, TTL clamp branches, validator kind, download + upload e2e redeem over real ASGI, over-cap 413 pinning `max_upload_bytes` threading, DELETE/PATCH → 405 + `Connection: close`, grace-window re-serve).
- Full suite: 687 passed. `ruff` + `mypy` clean. Load-bearing guards mutation-verified (base_url, TTL clamp, `max_upload_bytes` threading, `isfinite`, DELETE/PATCH routing).

Reviewed locally through three full preflight-circus rounds (5 core + 4 supplementary lenses), including an RFC-7231-verification pass on the `_ROUTE_METHODS` method-routing rationale.

Closes #218

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._