### PR TITLE
chore: sync uv.lock self-version to 4.3.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -852,7 +852,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp-pvl-core"
-version = "4.2.0"
+version = "4.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

One-line `uv.lock` sync: the project's own `fastmcp-pvl-core` package entry moves `4.2.0` → `4.3.0` to match `pyproject.toml` / `__init__.py`.

The `4.3.0` release (commit 9218762) bumped the version in `pyproject.toml` and `__init__.py` via python-semantic-release but did not regenerate `uv.lock`, so the lock's self-entry stayed at `4.2.0`. Because the pre-commit `ruff`/`mypy` hooks run through `uv run`, `uv` rewrote the lock's self-version on every commit and pre-commit aborted with "files were modified by this hook" — every commit on the last few branches had to bypass the hook. `uv lock` resolves it with a **single-line** `4.2.0`→`4.3.0` change and no dependency movement.

Verified the fix: this commit passed all three pre-commit hooks (`ruff check`, `ruff format`, `mypy`) **without** modifying `uv.lock`.

## Scope

This is the one-time resync only. A durable fix — having the release automation run `uv lock` and include `uv.lock` in the release commit so this stops recurring at 4.4.0+ — is noted as an open question in #227, to be tracked separately.

## Verification

```
grep -A1 'name = "fastmcp-pvl-core"' uv.lock | grep version   # version = "4.3.0"
uv lock --check                                               # exits 0, no changes
```

Closes #227

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._