### PR TITLE
feat(config): field metadata + server_config_surface() for generated config docs

### DIFF
--- a/docs/superpowers/plans/2026-07-25-config-field-metadata.md
+++ b/docs/superpowers/plans/2026-07-25-config-field-metadata.md
@@ -1,0 +1,833 @@
+# ServerConfig field metadata + `server_config_surface()` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every `ServerConfig` env field self-describing metadata (help text, tags, wizard hints) and expose it through a new `server_config_surface()` accessor, so downstream projects can *generate* their config documentation instead of hand-copying it.
+
+**Architecture:** `ServerConfig` is already a frozen stdlib dataclass whose 18 fields map 1:1 onto the 18 env suffixes `from_env` reads. This plan converts all 18 declarations to `field(default=…, metadata={…})` and adds a `ConfigField` record plus a `server_config_surface()` accessor that returns them **in declaration order** as a tuple. Declaration order matters: it gives consumers a deterministic iteration order, which the existing `frozenset`-returning `server_config_env_suffixes()` cannot.
+
+**Tech Stack:** Python 3.10+, stdlib `dataclasses` only (no new dependencies), pytest, mypy strict, ruff.
+
+**Upstream spec:** `docs/superpowers/specs/2026-07-25-config-generation-and-ownership-model-design.md` in the `fastmcp-server-template` repo, Stage 0. This is a **cross-repo prerequisite**: template Stages 1–3 cannot merge until this ships as v4.5.0.
+
+## Global Constraints
+
+- **Python floor is `>=3.10`.** No `StrEnum` (3.11+), no `match` statements. `requires-python` in `pyproject.toml` is `>=3.10` and ruff `target-version = "py310"`.
+- **No new dependencies.** Field metadata is stdlib `dataclasses` only.
+- **mypy runs on `src` only, in strict mode** (`uv run mypy src`). Test files carry no return-type annotations — match the existing style in `tests/test_config.py`, which has none.
+- **`from __future__ import annotations` is already at the top of `_config.py`.** Consequently `dataclasses.Field.type` is a **string**, not a type object. Code that reads `f.type` must treat it as `str`.
+- **Behaviour must not change.** All 18 current defaults are immutable, so converting `x: T = value` to `x: T = field(default=value, metadata={…})` is behaviour-preserving. Do not alter any default value.
+- **Help text must not restate a scalar default.** `ConfigField.default` already carries it structurally, and the downstream generator renders both. The one deliberate exception is `transport`, where naming the accepted literal values *is* the documentation.
+- **Gate before every commit:** `uv run ruff format --check .` · `uv run ruff check .` · `uv run mypy src` · `uv run pytest`
+- **Branch from fresh `origin/main`.** As of writing that is `4cf1755`. Do **not** branch from the local `chore/uv-lock-sync-4.3.0`, whose commit already merged as #228.
+- **Do not run the release.** Release dispatch is human-only. This plan ends at a merged PR; publishing v4.5.0 is the maintainer's manual step.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/fastmcp_pvl_core/_config.py` | `ServerConfig`, its field metadata, `ConfigField`, `server_config_surface()`, the env-suffix set | Modify |
+| `src/fastmcp_pvl_core/__init__.py` | public re-exports and `__all__` | Modify |
+| `tests/test_config.py` | `ServerConfig` tests, including the new `TestServerConfigSurface` class | Modify |
+
+No new files. `_config.py` is the correct home: the metadata lives on the field declarations it describes, and the accessor is the reader of those same declarations.
+
+---
+
+## Task 1: `ConfigField` record + `server_config_surface()` accessor
+
+Build the accessor first, against the *current* metadata-free declarations. It returns 18 records with empty `help` and `tags`, which is correct at this point — Task 2 fills them in. This ordering means Task 2's tests can assert on real content through a shipped, tested interface.
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_config.py`
+- Modify: `src/fastmcp_pvl_core/__init__.py`
+- Test: `tests/test_config.py`
+
+**Interfaces:**
+- Consumes: `ServerConfig` (existing), `server_config_env_suffixes()` (existing).
+- Produces:
+  - `ConfigField` — frozen dataclass with fields `suffix: str`, `name: str`, `type_name: str`, `default: object`, `help: str`, `tags: tuple[str, ...]`, `inferred: bool`, `wizard: Mapping[str, object]`.
+  - `server_config_surface() -> tuple[ConfigField, ...]` — declaration-ordered.
+  - Both exported from `fastmcp_pvl_core`.
+
+- [ ] **Step 1: Write the failing tests**
+
+First replace lines 1–18 of `tests/test_config.py` — the whole header through the
+closing paren of the import block — with exactly this. The file currently imports
+only the *names* `dataclass, field` from `dataclasses`, not the module, and the
+tests below need `dataclasses.fields` and `dataclasses.FrozenInstanceError`:
+
+```python
+"""Tests for ServerConfig."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from fastmcp_pvl_core import (
+    ConfigField,
+    ConfigurationError,
+    ServerConfig,
+    build_bearer_auth,
+    domain_env_suffixes,
+    env,
+    env_float,
+    env_int,
+    server_config_env_suffixes,
+    server_config_surface,
+)
+```
+
+Two existing tests import `server_config_env_suffixes` inside the method body
+(around lines 365 and 389 before this edit). Leave those local imports alone —
+they keep working, and removing them is not this task's business.
+
+Then append this class at the end of the file:
+
+```python
+class TestServerConfigSurface:
+    def test_surface_returns_config_field_records(self):
+        assert all(isinstance(c, ConfigField) for c in server_config_surface())
+
+    def test_covers_every_field_in_declaration_order(self):
+        """Declaration order is the contract — it is what makes generated output stable."""
+        surface = server_config_surface()
+        assert tuple(c.name for c in surface) == tuple(
+            f.name for f in dataclasses.fields(ServerConfig)
+        )
+
+    def test_returns_eighteen_fields(self):
+        assert len(server_config_surface()) == 18
+
+    def test_suffix_is_the_upper_cased_field_name(self):
+        assert all(c.suffix == c.name.upper() for c in server_config_surface())
+
+    def test_suffixes_match_the_env_suffix_set(self):
+        """The surface and the existing frozenset describe the same 18 vars."""
+        assert {c.suffix for c in server_config_surface()} == server_config_env_suffixes()
+
+    def test_scalar_default_is_carried_through(self):
+        host = next(c for c in server_config_surface() if c.name == "host")
+        assert host.default == "127.0.0.1"
+
+    def test_default_factory_is_resolved_to_a_value(self):
+        """oidc_required_scopes uses default_factory=tuple; the surface reports ()."""
+        scopes = next(
+            c for c in server_config_surface() if c.name == "oidc_required_scopes"
+        )
+        assert scopes.default == ()
+
+    def test_type_name_is_the_annotation_string(self):
+        port = next(c for c in server_config_surface() if c.name == "port")
+        assert port.type_name == "int"
+
+    def test_records_are_frozen(self):
+        record = server_config_surface()[0]
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            record.help = "mutated"  # type: ignore[misc]
+
+    def test_order_is_stable_under_hash_randomisation(self):
+        """Guards the generated-output byte-stability failure mode.
+
+        server_config_env_suffixes() returns a frozenset, whose iteration order
+        varies between processes because CPython randomises string hashing. The
+        surface must not inherit that.
+        """
+        program = (
+            "from fastmcp_pvl_core import server_config_surface;"
+            "print(','.join(c.suffix for c in server_config_surface()))"
+        )
+        outputs = set()
+        for seed in ("1", "2", "3"):
+            result = subprocess.run(
+                [sys.executable, "-c", program],
+                capture_output=True,
+                text=True,
+                check=True,
+                env={**os.environ, "PYTHONHASHSEED": seed},
+            )
+            outputs.add(result.stdout.strip())
+        assert len(outputs) == 1
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_config.py::TestServerConfigSurface -v`
+
+Expected: collection error — `ImportError: cannot import name 'ConfigField' from 'fastmcp_pvl_core'`.
+
+- [ ] **Step 3: Add `ConfigField` and `server_config_surface()` to `_config.py`**
+
+Add `from collections.abc import Mapping` to the imports at the top of `src/fastmcp_pvl_core/_config.py`. Then insert both definitions immediately **after** the `server_config_env_suffixes()` function and **before** `domain_env_suffixes()`. Placement after the `ServerConfig` class is required — `dataclasses.fields(ServerConfig)` needs the class to exist.
+
+```python
+@dataclass(frozen=True)
+class ConfigField:
+    """One env-configurable :class:`ServerConfig` field and its metadata.
+
+    ``help`` deliberately does **not** restate a scalar default: ``default``
+    carries it structurally, and a documentation generator renders both. The
+    one exception is ``transport``, where naming the accepted literal values is
+    the documentation.
+    """
+
+    suffix: str
+    """Env suffix, i.e. the part after ``{PREFIX}_`` — e.g. ``BASE_URL``."""
+
+    name: str
+    """Python field name — e.g. ``base_url``."""
+
+    type_name: str
+    """The annotation as written, e.g. ``str | None``."""
+
+    default: object
+    """The declared default. ``default_factory`` fields report the built value."""
+
+    help: str
+    """One-or-two-sentence description. Empty when undocumented."""
+
+    tags: tuple[str, ...]
+    """Semantic tags used to route this field into documentation sections.
+
+    Layout-agnostic by design: core says *what* a field is about, never which
+    file it belongs in. A field may carry several tags, and appearing in more
+    than one destination is intentional.
+    """
+
+    inferred: bool
+    """True when the value is derived rather than set directly, so no control
+    should be offered for it."""
+
+    wizard: Mapping[str, object]
+    """Presentation hints for a config wizard — e.g. ``group``, ``secret``,
+    ``when``. Empty for inferred fields."""
+
+
+def server_config_surface() -> tuple[ConfigField, ...]:
+    """Return every :class:`ServerConfig` env field, in declaration order.
+
+    Declaration order is part of the contract: a consumer that renders this
+    tuple produces byte-identical output on every run. Prefer this over
+    :func:`server_config_env_suffixes`, which returns a ``frozenset`` whose
+    iteration order varies between processes under hash randomisation.
+
+    Covers the same 18 variables as :func:`server_config_env_suffixes`, adding
+    each field's type, default, help text, tags, and wizard hints.
+    """
+    records: list[ConfigField] = []
+    for f in dataclasses.fields(ServerConfig):
+        if f.default is not dataclasses.MISSING:
+            default: object = f.default
+        elif f.default_factory is not dataclasses.MISSING:
+            default = f.default_factory()
+        else:  # pragma: no cover — every current field has a default
+            default = None
+
+        tags = tuple(str(tag) for tag in f.metadata.get("tags", ()))
+
+        # ``metadata={"wizard": "inferred"}`` is the shorthand for a field with
+        # no control; anything else is a mapping of presentation hints.
+        raw_wizard = f.metadata.get("wizard", {})
+        inferred = raw_wizard == "inferred"
+        wizard: dict[str, object] = {}
+        if not inferred and raw_wizard:
+            wizard = {str(k): v for k, v in raw_wizard.items()}
+
+        records.append(
+            ConfigField(
+                suffix=f.name.upper(),
+                name=f.name,
+                type_name=f.type if isinstance(f.type, str) else str(f.type),
+                default=default,
+                help=str(f.metadata.get("help", "")),
+                tags=tags,
+                inferred=inferred,
+                wizard=wizard,
+            )
+        )
+    return tuple(records)
+```
+
+- [ ] **Step 4: Export both symbols**
+
+In `src/fastmcp_pvl_core/__init__.py`, add `ConfigField` and `server_config_surface` to the existing `from ._config import (...)` block, and add both to `__all__`. Both lists are alphabetically sorted — insert accordingly: `"ConfigField"` sorts before `"ServerConfig"`; `"server_config_surface"` sorts immediately after `"server_config_env_suffixes"`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py::TestServerConfigSurface -v`
+
+Expected: 10 passed.
+
+- [ ] **Step 6: Run the full gate**
+
+```bash
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
+uv run pytest
+```
+
+Expected: all clean. If `ruff format --check` fails, run `uv run ruff format .` and re-run the gate.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_config.py src/fastmcp_pvl_core/__init__.py tests/test_config.py
+git commit -m "feat(config): add ConfigField + server_config_surface() accessor
+
+Exposes every ServerConfig env field in declaration order with its type,
+default, help, tags, and wizard hints. Declaration order is contractual:
+it gives consumers byte-stable output, which the frozenset returned by
+server_config_env_suffixes() cannot.
+
+Metadata values themselves land in the next commit.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01As25PstUQeTR47J5SP5g7P"
+```
+
+---
+
+## Task 2: Populate metadata on all 18 fields
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_config.py` (the `ServerConfig` class body)
+- Test: `tests/test_config.py`
+
+**Interfaces:**
+- Consumes: `ConfigField`, `server_config_surface()` from Task 1.
+- Produces: no new symbols. Every `ConfigField` now carries non-empty `help` and at least one tag; `auth_mode` is the only field with `inferred=True`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these methods to the `TestServerConfigSurface` class created in Task 1.
+
+```python
+    def test_every_field_is_documented(self):
+        undocumented = [c.name for c in server_config_surface() if not c.help]
+        assert undocumented == []
+
+    def test_every_field_is_tagged(self):
+        untagged = [c.name for c in server_config_surface() if not c.tags]
+        assert untagged == []
+
+    def test_auth_mode_is_the_only_inferred_field(self):
+        """AUTH_MODE is derived from which auth vars are set, so it gets no control."""
+        assert [c.name for c in server_config_surface() if c.inferred] == ["auth_mode"]
+
+    def test_inferred_field_carries_no_wizard_hints(self):
+        auth_mode = next(c for c in server_config_surface() if c.name == "auth_mode")
+        assert auth_mode.wizard == {}
+
+    def test_base_url_carries_several_tags(self):
+        """A field can honestly belong to several documentation sections."""
+        base_url = next(c for c in server_config_surface() if c.name == "base_url")
+        assert set(base_url.tags) == {"server", "oidc", "apps"}
+
+    def test_secret_fields_are_marked(self):
+        secrets = {c.suffix for c in server_config_surface() if c.wizard.get("secret")}
+        assert secrets == {
+            "BEARER_TOKEN",
+            "OIDC_CLIENT_SECRET",
+            "OIDC_JWT_SIGNING_KEY",
+        }
+
+    def test_oidc_fields_share_the_oidc_tag(self):
+        tagged = {c.suffix for c in server_config_surface() if "oidc" in c.tags}
+        assert tagged == {
+            "BASE_URL",
+            "OIDC_CONFIG_URL",
+            "OIDC_CLIENT_ID",
+            "OIDC_CLIENT_SECRET",
+            "OIDC_AUDIENCE",
+            "OIDC_REQUIRED_SCOPES",
+            "OIDC_JWT_SIGNING_KEY",
+            "OIDC_VERIFY_ACCESS_TOKEN",
+        }
+
+    def test_kv_store_url_is_readme_prominent(self):
+        """The consuming README shows a 3-row curated table; this is its core row."""
+        kv = next(c for c in server_config_surface() if c.name == "kv_store_url")
+        assert "readme" in kv.tags
+
+    def test_defaults_are_unchanged_by_the_metadata_migration(self):
+        """Behaviour guard: converting to field(default=...) must not alter values."""
+        config = ServerConfig()
+        assert config.host == "127.0.0.1"
+        assert config.port == 8000
+        assert config.transport == "stdio"
+        assert config.oidc_required_scopes == ()
+        assert config.oidc_verify_access_token is False
+        assert config.bearer_default_subject == DEFAULT_BEARER_SUBJECT
+        assert config.base_url is None
+```
+
+`DEFAULT_BEARER_SUBJECT` is **not** exported from the package and no test
+currently imports it. Add this line directly below the
+`from fastmcp_pvl_core import (...)` block:
+
+```python
+from fastmcp_pvl_core._config import DEFAULT_BEARER_SUBJECT
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_config.py::TestServerConfigSurface -v`
+
+Expected: `test_every_field_is_documented` fails listing all 18 field names; `test_every_field_is_tagged` likewise; the tag/secret/inferred tests fail on empty sets.
+
+- [ ] **Step 3: Replace the `ServerConfig` field declarations**
+
+In `src/fastmcp_pvl_core/_config.py`, replace the entire run of 18 field declarations in the `ServerConfig` class body — from `transport: Transport = "stdio"` through `bearer_default_subject: str = DEFAULT_BEARER_SUBJECT` — with the block below.
+
+Two existing code comments are **deleted** by this replacement because their content moves into `help`: the four-line comment above `event_store_url` and the two-line comment above `bearer_default_subject`. That is intentional — the help text is now the single home for that explanation. Do not leave the comments behind.
+
+Field order is unchanged. `server` is not a field of `ServerConfig` and does not appear here.
+
+```python
+    transport: Transport = field(
+        default="stdio",
+        metadata={
+            "help": (
+                "Transport the server speaks: ``stdio`` for local Claude "
+                "Desktop/Code, ``http`` or ``sse`` for a network server."
+            ),
+            "tags": ("server",),
+            # Emitted by a routing select in the wizard, not a free-text field.
+            "wizard": {"control": "emit"},
+        },
+    )
+    host: str = field(
+        default="127.0.0.1",
+        metadata={
+            "help": "Interface the HTTP server binds to.",
+            "tags": ("server",),
+            "wizard": {"group": "Server", "when": "server"},
+        },
+    )
+    port: int = field(
+        default=8000,
+        metadata={
+            "help": "TCP port for the HTTP server.",
+            "tags": ("server",),
+            "wizard": {"group": "Server", "when": "server"},
+        },
+    )
+    base_url: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Public base URL of the deployed server, e.g. "
+                "``https://mcp.example.com``. Required for OIDC and for MCP "
+                "Apps resource URLs."
+            ),
+            "tags": ("server", "oidc", "apps"),
+            "wizard": {"when": "server"},
+        },
+    )
+
+    bearer_token: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Single shared bearer token; any non-empty value enables "
+                "bearer auth."
+            ),
+            "tags": ("auth", "bearer"),
+            "wizard": {"when": "bearer", "secret": True},
+        },
+    )
+
+    oidc_config_url: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "OIDC discovery document URL, e.g. "
+                "``https://auth.example.com/.well-known/openid-configuration``."
+            ),
+            "tags": ("auth", "oidc"),
+            "wizard": {"when": "oidc"},
+        },
+    )
+    oidc_client_id: str | None = field(
+        default=None,
+        metadata={
+            "help": "OIDC client identifier registered with the provider.",
+            "tags": ("auth", "oidc"),
+            "wizard": {"when": "oidc"},
+        },
+    )
+    oidc_client_secret: str | None = field(
+        default=None,
+        metadata={
+            "help": "OIDC client secret registered with the provider.",
+            "tags": ("auth", "oidc"),
+            "wizard": {"when": "oidc", "secret": True},
+        },
+    )
+    oidc_audience: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Expected ``aud`` claim; tokens issued for another audience "
+                "are rejected."
+            ),
+            "tags": ("auth", "oidc"),
+            "wizard": {"group": "Auth", "when": "oidc"},
+        },
+    )
+    oidc_required_scopes: tuple[str, ...] = field(
+        default_factory=tuple,
+        metadata={
+            "help": "Comma-separated scopes a caller must present to be authorised.",
+            "tags": ("auth", "oidc"),
+            "wizard": {"group": "Auth", "when": "oidc"},
+        },
+    )
+    oidc_jwt_signing_key: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Signing key for issued JWTs. Required on Linux/Docker — the "
+                "generated fallback is ephemeral and invalidates every token "
+                "on restart. Generate with ``openssl rand -hex 32``."
+            ),
+            "tags": ("auth", "oidc"),
+            "wizard": {"when": "oidc", "secret": True},
+        },
+    )
+    oidc_verify_access_token: bool = field(
+        default=False,
+        metadata={
+            "help": "Validate the access token instead of the id token.",
+            "tags": ("auth", "oidc"),
+            "wizard": {"group": "Auth", "when": "oidc"},
+        },
+    )
+
+    kv_store_url: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Persistent-state backend URL for pvl-core subsystems: "
+                "``file:///path`` survives restarts, ``memory://`` is "
+                "ephemeral and for development only."
+            ),
+            "tags": ("persistence", "readme"),
+            "wizard": {"group": "Persistence", "when": "server"},
+        },
+    )
+    event_store_url: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Legacy override for HTTP resumability, honoured by "
+                "``build_event_store`` and ``build_kv_store`` only when "
+                "``kv_store_url`` is unset. Prefer ``kv_store_url`` for new "
+                "deployments — a single URL drives every pvl-core subsystem "
+                "that needs persistent state."
+            ),
+            "tags": ("persistence",),
+            "wizard": {"group": "Persistence", "when": "server"},
+        },
+    )
+    app_domain: str | None = field(
+        default=None,
+        metadata={
+            "help": "Public domain that serves MCP Apps UI resources.",
+            "tags": ("apps",),
+            "wizard": {"group": "MCP Apps", "when": "server"},
+        },
+    )
+
+    auth_mode: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Resolved authentication mode. Inferred from which auth "
+                "variables are set, so no dedicated control is offered for it."
+            ),
+            "tags": ("auth",),
+            "wizard": "inferred",
+        },
+    )
+
+    bearer_tokens_file: Path | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Path to a TOML file mapping bearer tokens to subjects; "
+                "overrides the single-token ``bearer_token`` mode."
+            ),
+            "tags": ("auth", "bearer"),
+            "wizard": {"group": "Auth", "when": "bearer"},
+        },
+    )
+    bearer_default_subject: str = field(
+        default=DEFAULT_BEARER_SUBJECT,
+        metadata={
+            "help": (
+                "Subject assigned to the single-token bearer mode; ignored "
+                "when ``bearer_tokens_file`` is set, since mapped mode carries "
+                "per-token subjects."
+            ),
+            "tags": ("auth", "bearer"),
+            "wizard": {"group": "Auth", "when": "bearer"},
+        },
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py -v`
+
+Expected: all pass, including the pre-existing `ServerConfig` tests. The pre-existing ones passing is the behaviour-preservation evidence.
+
+- [ ] **Step 5: Confirm the migrated comments are gone**
+
+```bash
+grep -n 'Legacy override, honoured by build_event_store' src/fastmcp_pvl_core/_config.py
+grep -n 'Subject for the single-token bearer mode' src/fastmcp_pvl_core/_config.py
+```
+
+Expected: no output from either. Both explanations now live in `help`. If either prints a line, delete that comment.
+
+- [ ] **Step 6: Run the full gate**
+
+```bash
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
+uv run pytest
+```
+
+Expected: all clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_config.py tests/test_config.py
+git commit -m "feat(config): document and tag all 18 ServerConfig env fields
+
+Each field now carries help text, semantic tags, and wizard presentation
+hints, so consumers can generate config docs instead of hand-copying the
+env surface. Tags are layout-agnostic: core says what a field is about,
+never which file documents it, and a field may carry several.
+
+auth_mode is marked inferred — it is derived from which auth variables
+are set, so no control should be offered for it. That removes the need
+for consumers to maintain a local exception list for it.
+
+The event_store_url and bearer_default_subject explanatory comments move
+into their help text; help is now the single home for both.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01As25PstUQeTR47J5SP5g7P"
+```
+
+---
+
+## Task 3: Derive the env-suffix set from the fields
+
+The same duplication this whole effort removes downstream also exists here: `_SERVER_CONFIG_ENV_SUFFIXES` is a hand-maintained 18-string `frozenset` literal that must be edited in lockstep with the field declarations. Since suffix is mechanically `name.upper()` for every field, the literal is derivable — and the AST-scan guard becomes a *stronger* invariant once it compares `from_env`'s reads against the fields themselves.
+
+**This task is independently cuttable.** Tasks 1 and 2 fully satisfy the upstream spec's Stage 0 without it. Skip it if you want the smallest possible release.
+
+**Files:**
+- Modify: `src/fastmcp_pvl_core/_config.py:173-194` (the literal) — anchor by the grep in Step 2 rather than by line number, since Task 2 shifted the file
+- Test: `tests/test_config.py`
+
+**Interfaces:**
+- Consumes: `ServerConfig`, `server_config_surface()`.
+- Produces: no new symbols. `server_config_env_suffixes()` keeps its exact signature and return type, `frozenset[str]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing `TestServerConfigEnvSuffixes` class in `tests/test_config.py`.
+
+```python
+    def test_suffix_set_is_derived_from_the_fields(self):
+        """No hand-maintained literal: the set must fall out of the declarations."""
+        from fastmcp_pvl_core import server_config_env_suffixes
+
+        assert server_config_env_suffixes() == {
+            f.name.upper() for f in dataclasses.fields(ServerConfig)
+        }
+```
+
+- [ ] **Step 2: Run it and confirm it passes for the wrong reason**
+
+Run: `uv run pytest tests/test_config.py::TestServerConfigEnvSuffixes -v`
+
+Expected: **PASS**, because the hand-maintained literal currently happens to agree with the fields. That is the point — this test pins the invariant *before* the refactor, so it will catch a mistake during it. Confirm the literal is still there and is what you are about to replace:
+
+```bash
+grep -n '"BEARER_DEFAULT_SUBJECT",' src/fastmcp_pvl_core/_config.py
+```
+
+Expected: one line inside the `_SERVER_CONFIG_ENV_SUFFIXES` literal.
+
+- [ ] **Step 3: Replace the literal with a derived set**
+
+Replace the whole `_SERVER_CONFIG_ENV_SUFFIXES` assignment — the comment block above it plus the 18-line `frozenset({...})` literal — with:
+
+```python
+# Derived from the ``ServerConfig`` field declarations: every field is read
+# from ``{PREFIX}_{NAME.upper()}`` by ``from_env``, so the field list is the
+# single source of truth. ``TestServerConfigEnvSuffixes`` checks this against
+# an AST scan of ``from_env``, which catches a field that is never read and a
+# read that has no field.
+#
+# Keep every ``from_env`` read in the ``env(prefix, "LITERAL")`` form: a suffix
+# built from a variable or passed by keyword would not be seen by that scan.
+_SERVER_CONFIG_ENV_SUFFIXES: frozenset[str] = frozenset(
+    f.name.upper() for f in dataclasses.fields(ServerConfig)
+)
+```
+
+- [ ] **Step 4: Run the suffix tests**
+
+Run: `uv run pytest tests/test_config.py::TestServerConfigEnvSuffixes -v`
+
+Expected: all pass, including the pre-existing `test_matches_what_from_env_actually_reads`, which now compares the AST scan of `from_env` against the field-derived set.
+
+- [ ] **Step 5: Confirm the literal is gone**
+
+```bash
+grep -n '"OIDC_VERIFY_ACCESS_TOKEN",' src/fastmcp_pvl_core/_config.py
+```
+
+Expected: no output. The only remaining mention of these suffixes as string literals should be in `from_env`'s `env(prefix, "…")` calls and in tests.
+
+- [ ] **Step 6: Run the full gate**
+
+```bash
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src
+uv run pytest
+```
+
+Expected: all clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/fastmcp_pvl_core/_config.py tests/test_config.py
+git commit -m "refactor(config): derive env-suffix set from field declarations
+
+_SERVER_CONFIG_ENV_SUFFIXES was a hand-maintained 18-string literal that
+had to be edited in lockstep with the fields. Suffix is mechanically
+name.upper() for every field, so the literal is derivable and the
+duplicate is removed.
+
+The AST-scan guard gets stronger as a result: it now compares what
+from_env actually reads against the field declarations, catching both a
+field that is never read and a read with no backing field.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01As25PstUQeTR47J5SP5g7P"
+```
+
+---
+
+## Wrap-up
+
+- [ ] **File the issue this PR closes**
+
+Every PR closes at least one issue. Run this first and note the number it prints:
+
+```bash
+gh issue create \
+  --title "ServerConfig fields carry no metadata, so consumers hand-copy the env surface" \
+  --body "$(cat <<'BODY'
+## Summary
+
+`ServerConfig`'s 18 fields expose only name, type, and default. Help text,
+grouping, secret-ness, and which documentation section a variable belongs to
+exist nowhere machine-readable, so every consumer hand-copies the env surface
+into its own wizard spec, env examples, and docs tables — and those copies go
+stale when this library adds a field.
+
+`server_config_env_suffixes()` gives the *set* of variables but returns a
+`frozenset`, whose iteration order varies between processes, so it cannot drive
+generated output.
+
+## Proposal
+
+- Carry `help`, semantic `tags`, and wizard presentation hints in each field's
+  `metadata=` mapping (stdlib `dataclasses`, no new dependency).
+- Add `server_config_surface() -> tuple[ConfigField, ...]` returning the fields
+  in declaration order, so generated output is byte-stable.
+- Mark `auth_mode` as inferred — it is derived from which auth variables are
+  set, so consumers should not have to maintain a local exception list for it.
+
+Tags stay layout-agnostic: this library says what a field is *about*, never
+which file documents it.
+
+## Context
+
+Prerequisite for Stage 0 of the config-generation design in
+`fastmcp-server-template`.
+
+— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
+BODY
+)"
+```
+
+- [ ] **Open the PR**
+
+Substitute the issue number from the previous step for `<ISSUE>` below. The body must end with the agent-attribution signature line.
+
+```bash
+gh pr create --base main \
+  --title "feat(config): field metadata + server_config_surface() for generated config docs" \
+  --body "$(cat <<'BODY'
+Closes #<ISSUE>
+
+Gives every `ServerConfig` env field self-describing metadata — help text,
+semantic tags, wizard presentation hints — and exposes it as
+`server_config_surface()`, returning the 18 fields in declaration order.
+
+Consumers can now generate their config documentation (wizard spec, env
+examples, docs tables) instead of hand-copying the env surface. Declaration
+order is contractual: it gives byte-stable generated output, which the
+`frozenset` from `server_config_env_suffixes()` cannot.
+
+`auth_mode` is marked `inferred`, so consumers no longer need a local
+exception list for it.
+
+Also removes core's own copy of the duplication this enables removing
+downstream: `_SERVER_CONFIG_ENV_SUFFIXES` is now derived from the field
+declarations rather than hand-maintained.
+
+Behaviour is unchanged — all defaults are immutable, so the conversion to
+`field(default=..., metadata=...)` is behaviour-preserving, and the
+pre-existing `ServerConfig` tests pass untouched.
+
+Prerequisite for Stage 0 of the config-generation design in
+`fastmcp-server-template`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01As25PstUQeTR47J5SP5g7P
+
+— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
+BODY
+)"
+```
+
+- [ ] **Do not merge and do not release.** Merging is human-only, and `v4.5.0` publication is a manual `workflow_dispatch` the maintainer runs. Report the PR URL and stop.
+
+## Downstream note
+
+Once v4.5.0 is published, `fastmcp-server-template` Stage 1 consumes `server_config_surface()` and raises its core floor to `>=4.5.0`. Template Stage 1 can be *written* before this releases but cannot merge until it does.

--- a/docs/superpowers/plans/2026-07-25-config-field-metadata.md
+++ b/docs/superpowers/plans/2026-07-25-config-field-metadata.md
@@ -24,6 +24,35 @@
 
 ---
 
+## ⚠️ Correction notice — read before reusing any help text from this plan
+
+Task 2's prescribed help strings below were **partly false** and were corrected
+during implementation. The text in this document is the original draft, kept for
+history. **Do not copy help text out of this plan.** The shipped, corrected
+wording is in `src/fastmcp_pvl_core/_config.py`; treat that as authoritative.
+
+Two claims were wrong:
+
+1. **`oidc_jwt_signing_key`** — this plan said the fallback key is "ephemeral and
+   invalidates every token on restart". False. fastmcp 3.3.1 derives it via
+   `derive_jwt_key(high_entropy_material=upstream_client_secret, salt="fastmcp-jwt-signing-key")`
+   — HKDF-SHA256 with a fixed salt, verified deterministic. Tokens survive a
+   restart; the real caveat is that rotating the client secret invalidates them.
+   The same falsehood was removed from `_auth.py`'s runtime warning, and is
+   tracked for the template repo as `fastmcp-server-template#260`.
+2. **`auth_mode`** — this plan described it as a derived/resolved value with no
+   control. False. It is read from `{PREFIX}_AUTH_MODE` and is an explicit
+   operator override accepting `remote` or `oidc-proxy`. `inferred` therefore
+   means "no wizard control offered", **not** "not operator-settable" — an
+   `inferred` field must still appear in env references and `.env.example`.
+
+Root cause: the drafts were taken from the template's existing wizard spec and
+docs without checking them against the implementation. Since generation
+propagates whatever the metadata says, every migrated claim needs verifying
+against the code that implements it.
+
+---
+
 ## File Structure
 
 | File | Responsibility | Change |

--- a/src/fastmcp_pvl_core/__init__.py
+++ b/src/fastmcp_pvl_core/__init__.py
@@ -23,10 +23,12 @@ from ._authorization import (
 )
 from ._cli import make_serve_parser, normalise_http_path
 from ._config import (
+    ConfigField,
     ServerConfig,
     Transport,
     domain_env_suffixes,
     server_config_env_suffixes,
+    server_config_surface,
 )
 from ._debug import maybe_start_debugpy
 from ._env import (
@@ -69,6 +71,7 @@ __version__ = "4.4.0"  # PSR overrides at build time
 
 __all__ = [
     "AuthMode",
+    "ConfigField",
     "ConfigurationError",
     "FetchResult",
     "IconSpec",
@@ -119,5 +122,6 @@ __all__ = [
     "register_transfer_routes",
     "resolve_auth_mode",
     "server_config_env_suffixes",
+    "server_config_surface",
     "wire_middleware_stack",
 ]

--- a/src/fastmcp_pvl_core/_auth.py
+++ b/src/fastmcp_pvl_core/_auth.py
@@ -287,14 +287,11 @@ def build_bearer_auth(config: ServerConfig) -> StaticTokenVerifier | None:
     )
 
 
-def _warn_oidc_caveats(
-    *, required_scopes: list[str], verify_id_token: bool, signing_key: str | None
-) -> None:
+def _warn_oidc_caveats(*, required_scopes: list[str], verify_id_token: bool) -> None:
     """Emit operator warnings for misconfiguration-prone OIDC-proxy settings.
 
     Warns when id_token verification is on but ``openid`` is absent from
-    *required_scopes* (the id_token may never be issued), and when no JWT
-    signing key is set on Linux (tokens are invalidated on every restart).
+    *required_scopes* (the id_token may never be issued).
     """
     if verify_id_token and "openid" not in required_scopes:
         logger.warning(
@@ -303,14 +300,6 @@ def _warn_oidc_caveats(
             "the id_token may be absent from the token response; "
             "add 'openid' to required_scopes or set "
             "oidc_verify_access_token=True"
-        )
-
-    if signing_key is None and sys.platform.startswith("linux"):
-        logger.warning(
-            "oidc_proxy_auth_ephemeral_signing_key "
-            "oidc_jwt_signing_key=<unset> — tokens will be invalidated on "
-            "every server restart; configure OIDC_JWT_SIGNING_KEY in "
-            "production"
         )
 
 
@@ -365,7 +354,6 @@ def build_oidc_proxy_auth(config: ServerConfig) -> OIDCProxy | None:
     _warn_oidc_caveats(
         required_scopes=required_scopes,
         verify_id_token=verify_id_token,
-        signing_key=config.oidc_jwt_signing_key,
     )
 
     from fastmcp.server.auth.oidc_proxy import OIDCProxy

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -13,7 +13,7 @@ import typing
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from ._env import env, env_int, parse_bool, parse_scopes
 
@@ -68,8 +68,9 @@ class ServerConfig:
         metadata={
             "help": (
                 "Public base URL of the deployed server, e.g. "
-                "``https://mcp.example.com``. Required for OIDC and for MCP "
-                "Apps resource URLs."
+                "``https://mcp.example.com``. Required for OIDC. Also the "
+                "fallback source of the MCP Apps domain when ``app_domain`` "
+                "is unset."
             ),
             "tags": ("server", "oidc", "apps"),
             "wizard": {"when": "server"},
@@ -80,7 +81,8 @@ class ServerConfig:
         default=None,
         metadata={
             "help": (
-                "Single shared bearer token; any non-empty value enables bearer auth."
+                "Single shared bearer token; enables bearer auth unless "
+                "``bearer_tokens_file`` is set, which takes precedence."
             ),
             "tags": ("auth", "bearer"),
             "wizard": {"when": "bearer", "secret": True},
@@ -128,7 +130,7 @@ class ServerConfig:
     oidc_required_scopes: tuple[str, ...] = field(
         default_factory=tuple,
         metadata={
-            "help": "Comma-separated scopes a caller must present to be authorised.",
+            "help": "Scopes a caller must present, space- or comma-separated.",
             "tags": ("auth", "oidc"),
             "wizard": {"group": "Auth", "when": "oidc"},
         },
@@ -137,9 +139,10 @@ class ServerConfig:
         default=None,
         metadata={
             "help": (
-                "Signing key for issued JWTs. Required on Linux/Docker — the "
-                "generated fallback is ephemeral and invalidates every token "
-                "on restart. Generate with ``openssl rand -hex 32``."
+                "Signing key for issued JWTs. Strongly recommended on "
+                "Linux/Docker — without it the generated fallback is "
+                "ephemeral and invalidates every token on restart. Generate "
+                "with ``openssl rand -hex 32``."
             ),
             "tags": ("auth", "oidc"),
             "wizard": {"when": "oidc", "secret": True},
@@ -158,9 +161,11 @@ class ServerConfig:
         default=None,
         metadata={
             "help": (
-                "Persistent-state backend URL for pvl-core subsystems: "
-                "``file:///path`` survives restarts, ``memory://`` is "
-                "ephemeral and for development only."
+                "Persistent-state backend URL shared by every pvl-core "
+                "subsystem that needs state. ``memory://`` is in-process and "
+                "lost on restart; ``file:///path`` persists on one server; "
+                "``redis://``, ``dynamodb://`` and ``mongodb://`` each need "
+                "their matching extra."
             ),
             "tags": ("persistence", "readme"),
             "wizard": {"group": "Persistence", "when": "server"},
@@ -170,11 +175,11 @@ class ServerConfig:
         default=None,
         metadata={
             "help": (
-                "Legacy override for HTTP resumability, honoured by "
+                "Legacy state-backend override, honoured by "
                 "``build_event_store`` and ``build_kv_store`` only when "
-                "``kv_store_url`` is unset. Prefer ``kv_store_url`` for new "
-                "deployments — a single URL drives every pvl-core subsystem "
-                "that needs persistent state."
+                "``kv_store_url`` is unset — it then backs every namespace, "
+                "not just HTTP resumability. Prefer ``kv_store_url`` for new "
+                "deployments."
             ),
             "tags": ("persistence",),
             "wizard": {"group": "Persistence", "when": "server"},
@@ -183,7 +188,10 @@ class ServerConfig:
     app_domain: str | None = field(
         default=None,
         metadata={
-            "help": "Public domain that serves MCP Apps UI resources.",
+            "help": (
+                "MCP Apps iframe domain, used for CSP sandboxing. Overrides "
+                "the host derived from ``base_url``."
+            ),
             "tags": ("apps",),
             "wizard": {"group": "MCP Apps", "when": "server"},
         },
@@ -413,6 +421,51 @@ class ConfigField:
     ``when``. Empty for inferred fields."""
 
 
+def _config_field_from(f: dataclasses.Field[Any]) -> ConfigField:
+    """Build one :class:`ConfigField` record from a ``ServerConfig`` field.
+
+    Raises:
+        ValueError: If ``metadata["wizard"]`` is a string other than the
+            recognised ``"inferred"`` shorthand — e.g. a typo like
+            ``"infered"``. Falling through silently would otherwise crash
+            later on ``raw_wizard.items()`` since a plain string has no
+            ``.items()``.
+    """
+    if f.default is not dataclasses.MISSING:
+        default: object = f.default
+    elif f.default_factory is not dataclasses.MISSING:
+        default = f.default_factory()
+    else:  # pragma: no cover — every current field has a default
+        default = None
+
+    tags = tuple(str(tag) for tag in f.metadata.get("tags", ()))
+
+    # ``metadata={"wizard": "inferred"}`` is the shorthand for a field with
+    # no control; anything else is a mapping of presentation hints.
+    raw_wizard = f.metadata.get("wizard", {})
+    inferred = raw_wizard == "inferred"
+    wizard: dict[str, object] = {}
+    if not inferred and raw_wizard:
+        if isinstance(raw_wizard, str):
+            raise ValueError(
+                f"ServerConfig.{f.name}: metadata['wizard'] is the string "
+                f"{raw_wizard!r}; the only accepted string form is "
+                f"'inferred'. Use a mapping of hints for anything else."
+            )
+        wizard = {str(k): v for k, v in raw_wizard.items()}
+
+    return ConfigField(
+        suffix=f.name.upper(),
+        name=f.name,
+        type_name=f.type if isinstance(f.type, str) else str(f.type),
+        default=default,
+        help=str(f.metadata.get("help", "")),
+        tags=tags,
+        inferred=inferred,
+        wizard=wizard,
+    )
+
+
 def server_config_surface() -> tuple[ConfigField, ...]:
     """Return every :class:`ServerConfig` env field, in declaration order.
 
@@ -424,38 +477,7 @@ def server_config_surface() -> tuple[ConfigField, ...]:
     Covers the same 18 variables as :func:`server_config_env_suffixes`, adding
     each field's type, default, help text, tags, and wizard hints.
     """
-    records: list[ConfigField] = []
-    for f in dataclasses.fields(ServerConfig):
-        if f.default is not dataclasses.MISSING:
-            default: object = f.default
-        elif f.default_factory is not dataclasses.MISSING:
-            default = f.default_factory()
-        else:  # pragma: no cover — every current field has a default
-            default = None
-
-        tags = tuple(str(tag) for tag in f.metadata.get("tags", ()))
-
-        # ``metadata={"wizard": "inferred"}`` is the shorthand for a field with
-        # no control; anything else is a mapping of presentation hints.
-        raw_wizard = f.metadata.get("wizard", {})
-        inferred = raw_wizard == "inferred"
-        wizard: dict[str, object] = {}
-        if not inferred and raw_wizard:
-            wizard = {str(k): v for k, v in raw_wizard.items()}
-
-        records.append(
-            ConfigField(
-                suffix=f.name.upper(),
-                name=f.name,
-                type_name=f.type if isinstance(f.type, str) else str(f.type),
-                default=default,
-                help=str(f.metadata.get("help", "")),
-                tags=tags,
-                inferred=inferred,
-                wizard=wizard,
-            )
-        )
-    return tuple(records)
+    return tuple(_config_field_from(f) for f in dataclasses.fields(ServerConfig))
 
 
 def domain_env_suffixes(config_cls: type) -> frozenset[str]:

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import dataclasses
 import typing
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -208,6 +209,93 @@ def server_config_env_suffixes() -> frozenset[str]:
     surface.
     """
     return _SERVER_CONFIG_ENV_SUFFIXES
+
+
+@dataclass(frozen=True)
+class ConfigField:
+    """One env-configurable :class:`ServerConfig` field and its metadata.
+
+    ``help`` deliberately does **not** restate a scalar default: ``default``
+    carries it structurally, and a documentation generator renders both. The
+    one exception is ``transport``, where naming the accepted literal values is
+    the documentation.
+    """
+
+    suffix: str
+    """Env suffix, i.e. the part after ``{PREFIX}_`` — e.g. ``BASE_URL``."""
+
+    name: str
+    """Python field name — e.g. ``base_url``."""
+
+    type_name: str
+    """The annotation as written, e.g. ``str | None``."""
+
+    default: object
+    """The declared default. ``default_factory`` fields report the built value."""
+
+    help: str
+    """One-or-two-sentence description. Empty when undocumented."""
+
+    tags: tuple[str, ...]
+    """Semantic tags used to route this field into documentation sections.
+
+    Layout-agnostic by design: core says *what* a field is about, never which
+    file it belongs in. A field may carry several tags, and appearing in more
+    than one destination is intentional.
+    """
+
+    inferred: bool
+    """True when the value is derived rather than set directly, so no control
+    should be offered for it."""
+
+    wizard: Mapping[str, object]
+    """Presentation hints for a config wizard — e.g. ``group``, ``secret``,
+    ``when``. Empty for inferred fields."""
+
+
+def server_config_surface() -> tuple[ConfigField, ...]:
+    """Return every :class:`ServerConfig` env field, in declaration order.
+
+    Declaration order is part of the contract: a consumer that renders this
+    tuple produces byte-identical output on every run. Prefer this over
+    :func:`server_config_env_suffixes`, which returns a ``frozenset`` whose
+    iteration order varies between processes under hash randomisation.
+
+    Covers the same 18 variables as :func:`server_config_env_suffixes`, adding
+    each field's type, default, help text, tags, and wizard hints.
+    """
+    records: list[ConfigField] = []
+    for f in dataclasses.fields(ServerConfig):
+        if f.default is not dataclasses.MISSING:
+            default: object = f.default
+        elif f.default_factory is not dataclasses.MISSING:
+            default = f.default_factory()
+        else:  # pragma: no cover — every current field has a default
+            default = None
+
+        tags = tuple(str(tag) for tag in f.metadata.get("tags", ()))
+
+        # ``metadata={"wizard": "inferred"}`` is the shorthand for a field with
+        # no control; anything else is a mapping of presentation hints.
+        raw_wizard = f.metadata.get("wizard", {})
+        inferred = raw_wizard == "inferred"
+        wizard: dict[str, object] = {}
+        if not inferred and raw_wizard:
+            wizard = {str(k): v for k, v in raw_wizard.items()}
+
+        records.append(
+            ConfigField(
+                suffix=f.name.upper(),
+                name=f.name,
+                type_name=f.type if isinstance(f.type, str) else str(f.type),
+                default=default,
+                help=str(f.metadata.get("help", "")),
+                tags=tags,
+                inferred=inferred,
+                wizard=wizard,
+            )
+        )
+    return tuple(records)
 
 
 def domain_env_suffixes(config_cls: type) -> frozenset[str]:

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -130,7 +130,10 @@ class ServerConfig:
     oidc_required_scopes: tuple[str, ...] = field(
         default_factory=tuple,
         metadata={
-            "help": "Scopes a caller must present, space- or comma-separated.",
+            "help": (
+                "Scopes a caller must present, space- or comma-separated. "
+                "Defaults to ``openid`` in oidc-proxy mode."
+            ),
             "tags": ("auth", "oidc"),
             "wizard": {"group": "Auth", "when": "oidc"},
         },
@@ -139,10 +142,12 @@ class ServerConfig:
         default=None,
         metadata={
             "help": (
-                "Signing key for issued JWTs. Strongly recommended on "
-                "Linux/Docker — without it the generated fallback is "
-                "ephemeral and invalidates every token on restart. Generate "
-                "with ``openssl rand -hex 32``."
+                "Signing key for issued JWTs; used in oidc-proxy mode only. "
+                "When unset, the key is derived deterministically from "
+                "``oidc_client_secret``, so tokens survive a restart — but "
+                "rotating that secret invalidates every issued token. Set "
+                "this explicitly to decouple token validity from secret "
+                "rotation. Generate with ``openssl rand -hex 32``."
             ),
             "tags": ("auth", "oidc"),
             "wizard": {"when": "oidc", "secret": True},
@@ -165,7 +170,8 @@ class ServerConfig:
                 "subsystem that needs state. ``memory://`` is in-process and "
                 "lost on restart; ``file:///path`` persists on one server; "
                 "``redis://``, ``dynamodb://`` and ``mongodb://`` each need "
-                "their matching extra."
+                "their matching extra. Defaults to ``file:///data/state`` "
+                "when unset."
             ),
             "tags": ("persistence", "readme"),
             "wizard": {"group": "Persistence", "when": "server"},
@@ -201,8 +207,12 @@ class ServerConfig:
         default=None,
         metadata={
             "help": (
-                "Resolved authentication mode. Inferred from which auth "
-                "variables are set, so no dedicated control is offered for it."
+                "Explicit auth-mode override, accepting ``remote`` or "
+                "``oidc-proxy`` (case- and whitespace-insensitive). When "
+                "unset the mode is auto-detected from which auth variables "
+                "are set; the override exists because having all four OIDC "
+                "variables set is ambiguous between those two modes. Other "
+                "values are ignored with a warning."
             ),
             "tags": ("auth",),
             "wizard": "inferred",
@@ -407,29 +417,51 @@ class ConfigField:
     tags: tuple[str, ...]
     """Semantic tags used to route this field into documentation sections.
 
-    Layout-agnostic by design: core says *what* a field is about, never which
-    file it belongs in. A field may carry several tags, and appearing in more
-    than one destination is intentional.
+    Mostly semantic — core says *what* a field is about, not which file
+    documents it. One exception: ``readme`` marks a field prominent
+    enough for a landing-page summary table, which is a prominence
+    signal rather than a topic. A field may carry several tags, and
+    appearing in more than one destination is intentional.
     """
 
     inferred: bool
-    """True when the value is derived rather than set directly, so no control
-    should be offered for it."""
+    """True when no wizard control is offered for this field.
+
+    A wizard-presentation concern only. The variable remains
+    operator-settable and MUST still appear in env references and
+    ``.env.example`` — this flag is not a signal that the value cannot
+    be set.
+    """
 
     wizard: Mapping[str, object]
-    """Presentation hints for a config wizard — e.g. ``group``, ``secret``,
-    ``when``. Empty for inferred fields."""
+    """Presentation hints for a config wizard.
+
+    Recognised keys:
+
+    - ``group`` — name of the wizard's collapsed "Advanced" section.
+      Absence means the field is a primary question.
+    - ``when`` — the context in which the question applies: ``"server"``
+      for HTTP deployments, or ``"oidc"`` / ``"bearer"`` for the
+      matching auth selection (both of which also imply an HTTP
+      deployment).
+    - ``secret`` — ``True`` when the value must never appear in a
+      shareable link.
+    - ``control`` — ``"emit"`` when a routing select emits this value
+      and the field gets no question of its own.
+
+    Empty when :attr:`inferred` is True.
+    """
 
 
 def _config_field_from(f: dataclasses.Field[Any]) -> ConfigField:
     """Build one :class:`ConfigField` record from a ``ServerConfig`` field.
 
     Raises:
-        ValueError: If ``metadata["wizard"]`` is a string other than the
-            recognised ``"inferred"`` shorthand — e.g. a typo like
-            ``"infered"``. Falling through silently would otherwise crash
-            later on ``raw_wizard.items()`` since a plain string has no
-            ``.items()``.
+        ValueError: If ``metadata["wizard"]`` is neither a mapping of hints
+            nor the recognised ``"inferred"`` shorthand — e.g. a typo like
+            ``"infered"``, or an accidental list. Falling through silently
+            would otherwise crash later on ``raw_wizard.items()``, since
+            only a mapping has ``.items()``.
     """
     if f.default is not dataclasses.MISSING:
         default: object = f.default
@@ -446,11 +478,11 @@ def _config_field_from(f: dataclasses.Field[Any]) -> ConfigField:
     inferred = raw_wizard == "inferred"
     wizard: dict[str, object] = {}
     if not inferred and raw_wizard:
-        if isinstance(raw_wizard, str):
+        if not isinstance(raw_wizard, Mapping):
             raise ValueError(
-                f"ServerConfig.{f.name}: metadata['wizard'] is the string "
-                f"{raw_wizard!r}; the only accepted string form is "
-                f"'inferred'. Use a mapping of hints for anything else."
+                f"ServerConfig.{f.name}: metadata['wizard'] must be a "
+                f"mapping of hints or the string 'inferred'; got "
+                f"{raw_wizard!r}."
             )
         wizard = {str(k): v for k, v in raw_wizard.items()}
 

--- a/src/fastmcp_pvl_core/_config.py
+++ b/src/fastmcp_pvl_core/_config.py
@@ -35,35 +35,195 @@ class ServerConfig:
     Compose into a domain config; never inherit from this class.
     """
 
-    transport: Transport = "stdio"
-    host: str = "127.0.0.1"
-    port: int = 8000
-    base_url: str | None = None
+    transport: Transport = field(
+        default="stdio",
+        metadata={
+            "help": (
+                "Transport the server speaks: ``stdio`` for local Claude "
+                "Desktop/Code, ``http`` or ``sse`` for a network server."
+            ),
+            "tags": ("server",),
+            # Emitted by a routing select in the wizard, not a free-text field.
+            "wizard": {"control": "emit"},
+        },
+    )
+    host: str = field(
+        default="127.0.0.1",
+        metadata={
+            "help": "Interface the HTTP server binds to.",
+            "tags": ("server",),
+            "wizard": {"group": "Server", "when": "server"},
+        },
+    )
+    port: int = field(
+        default=8000,
+        metadata={
+            "help": "TCP port for the HTTP server.",
+            "tags": ("server",),
+            "wizard": {"group": "Server", "when": "server"},
+        },
+    )
+    base_url: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Public base URL of the deployed server, e.g. "
+                "``https://mcp.example.com``. Required for OIDC and for MCP "
+                "Apps resource URLs."
+            ),
+            "tags": ("server", "oidc", "apps"),
+            "wizard": {"when": "server"},
+        },
+    )
 
-    bearer_token: str | None = None
+    bearer_token: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Single shared bearer token; any non-empty value enables bearer auth."
+            ),
+            "tags": ("auth", "bearer"),
+            "wizard": {"when": "bearer", "secret": True},
+        },
+    )
 
-    oidc_config_url: str | None = None
-    oidc_client_id: str | None = None
-    oidc_client_secret: str | None = None
-    oidc_audience: str | None = None
-    oidc_required_scopes: tuple[str, ...] = field(default_factory=tuple)
-    oidc_jwt_signing_key: str | None = None
-    oidc_verify_access_token: bool = False
+    oidc_config_url: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "OIDC discovery document URL, e.g. "
+                "``https://auth.example.com/.well-known/openid-configuration``."
+            ),
+            "tags": ("auth", "oidc"),
+            "wizard": {"when": "oidc"},
+        },
+    )
+    oidc_client_id: str | None = field(
+        default=None,
+        metadata={
+            "help": "OIDC client identifier registered with the provider.",
+            "tags": ("auth", "oidc"),
+            "wizard": {"when": "oidc"},
+        },
+    )
+    oidc_client_secret: str | None = field(
+        default=None,
+        metadata={
+            "help": "OIDC client secret registered with the provider.",
+            "tags": ("auth", "oidc"),
+            "wizard": {"when": "oidc", "secret": True},
+        },
+    )
+    oidc_audience: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Expected ``aud`` claim; tokens issued for another audience "
+                "are rejected."
+            ),
+            "tags": ("auth", "oidc"),
+            "wizard": {"group": "Auth", "when": "oidc"},
+        },
+    )
+    oidc_required_scopes: tuple[str, ...] = field(
+        default_factory=tuple,
+        metadata={
+            "help": "Comma-separated scopes a caller must present to be authorised.",
+            "tags": ("auth", "oidc"),
+            "wizard": {"group": "Auth", "when": "oidc"},
+        },
+    )
+    oidc_jwt_signing_key: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Signing key for issued JWTs. Required on Linux/Docker — the "
+                "generated fallback is ephemeral and invalidates every token "
+                "on restart. Generate with ``openssl rand -hex 32``."
+            ),
+            "tags": ("auth", "oidc"),
+            "wizard": {"when": "oidc", "secret": True},
+        },
+    )
+    oidc_verify_access_token: bool = field(
+        default=False,
+        metadata={
+            "help": "Validate the access token instead of the id token.",
+            "tags": ("auth", "oidc"),
+            "wizard": {"group": "Auth", "when": "oidc"},
+        },
+    )
 
-    kv_store_url: str | None = None
-    # Legacy override, honoured by build_event_store and build_kv_store
-    # when ``kv_store_url`` is unset. Set ``kv_store_url`` instead for
-    # new deployments — a single URL drives every pvl-core subsystem
-    # that needs persistent state.
-    event_store_url: str | None = None
-    app_domain: str | None = None
+    kv_store_url: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Persistent-state backend URL for pvl-core subsystems: "
+                "``file:///path`` survives restarts, ``memory://`` is "
+                "ephemeral and for development only."
+            ),
+            "tags": ("persistence", "readme"),
+            "wizard": {"group": "Persistence", "when": "server"},
+        },
+    )
+    event_store_url: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Legacy override for HTTP resumability, honoured by "
+                "``build_event_store`` and ``build_kv_store`` only when "
+                "``kv_store_url`` is unset. Prefer ``kv_store_url`` for new "
+                "deployments — a single URL drives every pvl-core subsystem "
+                "that needs persistent state."
+            ),
+            "tags": ("persistence",),
+            "wizard": {"group": "Persistence", "when": "server"},
+        },
+    )
+    app_domain: str | None = field(
+        default=None,
+        metadata={
+            "help": "Public domain that serves MCP Apps UI resources.",
+            "tags": ("apps",),
+            "wizard": {"group": "MCP Apps", "when": "server"},
+        },
+    )
 
-    auth_mode: str | None = None
+    auth_mode: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Resolved authentication mode. Inferred from which auth "
+                "variables are set, so no dedicated control is offered for it."
+            ),
+            "tags": ("auth",),
+            "wizard": "inferred",
+        },
+    )
 
-    bearer_tokens_file: Path | None = None
-    # Subject for the single-token bearer mode; ignored when
-    # ``bearer_tokens_file`` is set (mapped mode uses per-token subjects).
-    bearer_default_subject: str = DEFAULT_BEARER_SUBJECT
+    bearer_tokens_file: Path | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Path to a TOML file mapping bearer tokens to subjects; "
+                "overrides the single-token ``bearer_token`` mode."
+            ),
+            "tags": ("auth", "bearer"),
+            "wizard": {"group": "Auth", "when": "bearer"},
+        },
+    )
+    bearer_default_subject: str = field(
+        default=DEFAULT_BEARER_SUBJECT,
+        metadata={
+            "help": (
+                "Subject assigned to the single-token bearer mode; ignored "
+                "when ``bearer_tokens_file`` is set, since mapped mode carries "
+                "per-token subjects."
+            ),
+            "tags": ("auth", "bearer"),
+            "wizard": {"group": "Auth", "when": "bearer"},
+        },
+    )
 
     def __post_init__(self) -> None:
         """Enforce the non-blank ``bearer_default_subject`` invariant.

--- a/tests/test_auth_builders.py
+++ b/tests/test_auth_builders.py
@@ -121,15 +121,17 @@ class TestBuildOIDCProxyAuth:
             for r in caplog.records
         )
 
-    def test_linux_ephemeral_key_warning(self, caplog: pytest.LogCaptureFixture):
+    def test_no_ephemeral_key_warning_when_signing_key_unset(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """The derived signing key survives a restart (fixed-salt HKDF), so
+        leaving ``oidc_jwt_signing_key`` unset is not a misconfiguration and
+        must never warn, on any platform.
+        """
         mock_cls = MagicMock()
-        with (
-            patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls),
-            patch("fastmcp_pvl_core._auth.sys") as mock_sys,
-        ):
-            mock_sys.platform = "linux"
+        with patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", mock_cls):
             build_oidc_proxy_auth(_oidc_config())
-        assert any(
+        assert not any(
             "ephemeral_signing_key" in r.message and r.levelname == "WARNING"
             for r in caplog.records
         )

--- a/tests/test_auth_internal_helpers.py
+++ b/tests/test_auth_internal_helpers.py
@@ -8,7 +8,6 @@ directly, at a finer grain than the public-builder tests exercise them.
 from __future__ import annotations
 
 import logging
-import sys
 from pathlib import Path
 
 import pytest
@@ -98,9 +97,7 @@ def test_coerce_subject_empty_string_raises() -> None:
 
 def test_caveats_warns_missing_openid_scope(caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
-        _warn_oidc_caveats(
-            required_scopes=["email"], verify_id_token=True, signing_key="k"
-        )
+        _warn_oidc_caveats(required_scopes=["email"], verify_id_token=True)
     assert [r for r in caplog.records if "scope_warning" in r.getMessage()]
 
 
@@ -108,9 +105,7 @@ def test_caveats_no_scope_warning_when_openid_present(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
-        _warn_oidc_caveats(
-            required_scopes=["openid"], verify_id_token=True, signing_key="k"
-        )
+        _warn_oidc_caveats(required_scopes=["openid"], verify_id_token=True)
     assert not [r for r in caplog.records if "scope_warning" in r.getMessage()]
 
 
@@ -118,40 +113,19 @@ def test_caveats_no_scope_warning_when_verifying_access_token(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
-        _warn_oidc_caveats(
-            required_scopes=["email"], verify_id_token=False, signing_key="k"
-        )
+        _warn_oidc_caveats(required_scopes=["email"], verify_id_token=False)
     assert not [r for r in caplog.records if "scope_warning" in r.getMessage()]
 
 
-def test_caveats_warns_ephemeral_key_on_linux(
-    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+def test_caveats_no_ephemeral_warning_regardless_of_signing_key(
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.setattr(sys, "platform", "linux")
+    """The derived signing key survives a restart (fixed-salt HKDF), so an
+    unset ``oidc_jwt_signing_key`` is not a misconfiguration and must never
+    warn — regardless of platform, since HKDF derivation is
+    platform-independent. ``_warn_oidc_caveats`` no longer accepts a
+    ``signing_key`` parameter at all.
+    """
     with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
-        _warn_oidc_caveats(
-            required_scopes=["openid"], verify_id_token=True, signing_key=None
-        )
-    assert [r for r in caplog.records if "ephemeral_signing_key" in r.getMessage()]
-
-
-def test_caveats_no_ephemeral_warning_when_key_set(
-    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(sys, "platform", "linux")
-    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
-        _warn_oidc_caveats(
-            required_scopes=["openid"], verify_id_token=True, signing_key="k"
-        )
-    assert not [r for r in caplog.records if "ephemeral_signing_key" in r.getMessage()]
-
-
-def test_caveats_no_ephemeral_warning_off_linux(
-    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(sys, "platform", "darwin")
-    with caplog.at_level(logging.WARNING, logger="fastmcp_pvl_core._auth"):
-        _warn_oidc_caveats(
-            required_scopes=["openid"], verify_id_token=True, signing_key=None
-        )
+        _warn_oidc_caveats(required_scopes=["openid"], verify_id_token=True)
     assert not [r for r in caplog.records if "ephemeral_signing_key" in r.getMessage()]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import dataclasses
+import os
+import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
 
 from fastmcp_pvl_core import (
+    ConfigField,
     ConfigurationError,
     ServerConfig,
     build_bearer_auth,
@@ -15,6 +20,8 @@ from fastmcp_pvl_core import (
     env,
     env_float,
     env_int,
+    server_config_env_suffixes,
+    server_config_surface,
 )
 
 # ---------------------------------------------------------------------------
@@ -462,3 +469,70 @@ class TestDomainEnvSuffixes:
         """An annotation not importable at module scope propagates as NameError."""
         with pytest.raises(NameError, match="domain_env_suffixes"):
             domain_env_suffixes(_BadRef)
+
+
+class TestServerConfigSurface:
+    def test_surface_returns_config_field_records(self):
+        assert all(isinstance(c, ConfigField) for c in server_config_surface())
+
+    def test_covers_every_field_in_declaration_order(self):
+        """Declaration order is the contract — it makes generated output stable."""
+        surface = server_config_surface()
+        assert tuple(c.name for c in surface) == tuple(
+            f.name for f in dataclasses.fields(ServerConfig)
+        )
+
+    def test_returns_eighteen_fields(self):
+        assert len(server_config_surface()) == 18
+
+    def test_suffix_is_the_upper_cased_field_name(self):
+        assert all(c.suffix == c.name.upper() for c in server_config_surface())
+
+    def test_suffixes_match_the_env_suffix_set(self):
+        """The surface and the existing frozenset describe the same 18 vars."""
+        assert {
+            c.suffix for c in server_config_surface()
+        } == server_config_env_suffixes()
+
+    def test_scalar_default_is_carried_through(self):
+        host = next(c for c in server_config_surface() if c.name == "host")
+        assert host.default == "127.0.0.1"
+
+    def test_default_factory_is_resolved_to_a_value(self):
+        """oidc_required_scopes uses default_factory=tuple; the surface reports ()."""
+        scopes = next(
+            c for c in server_config_surface() if c.name == "oidc_required_scopes"
+        )
+        assert scopes.default == ()
+
+    def test_type_name_is_the_annotation_string(self):
+        port = next(c for c in server_config_surface() if c.name == "port")
+        assert port.type_name == "int"
+
+    def test_records_are_frozen(self):
+        record = server_config_surface()[0]
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            record.help = "mutated"  # type: ignore[misc]
+
+    def test_order_is_stable_under_hash_randomisation(self):
+        """Guards the generated-output byte-stability failure mode.
+
+        server_config_env_suffixes() returns a frozenset, whose iteration order
+        varies between processes because CPython randomises string hashing. The
+        surface must not inherit that.
+        """
+        program = (
+            "from fastmcp_pvl_core import server_config_surface;"
+            "print(','.join(c.suffix for c in server_config_surface()))"
+        )
+        outputs = set()
+        for seed in ("1", "2", "3"):
+            result = subprocess.run(
+                [sys.executable, "-c", program],
+                capture_output=True,
+                text=True,
+                check=True,
+                env={**os.environ, "PYTHONHASHSEED": seed},
+            )
+            outputs.add(result.stdout.strip())
+        assert len(outputs) == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,7 @@ from fastmcp_pvl_core import (
     server_config_env_suffixes,
     server_config_surface,
 )
-from fastmcp_pvl_core._config import DEFAULT_BEARER_SUBJECT
+from fastmcp_pvl_core._config import DEFAULT_BEARER_SUBJECT, _config_field_from
 
 # ---------------------------------------------------------------------------
 # Module-level fixture classes for TestDomainEnvSuffixes
@@ -595,3 +595,14 @@ class TestServerConfigSurface:
         assert config.oidc_verify_access_token is False
         assert config.bearer_default_subject == DEFAULT_BEARER_SUBJECT
         assert config.base_url is None
+
+    def test_unknown_wizard_string_is_rejected(self):
+        """A typo like "infered" must fail loudly, not crash on .items()."""
+
+        @dataclass(frozen=True)
+        class _BadWizard:
+            oops: str = field(default="x", metadata={"wizard": "infered"})
+
+        (bad,) = dataclasses.fields(_BadWizard)
+        with pytest.raises(ValueError, match="only accepted string form"):
+            _config_field_from(bad)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,6 +23,7 @@ from fastmcp_pvl_core import (
     server_config_env_suffixes,
     server_config_surface,
 )
+from fastmcp_pvl_core._config import DEFAULT_BEARER_SUBJECT
 
 # ---------------------------------------------------------------------------
 # Module-level fixture classes for TestDomainEnvSuffixes
@@ -536,3 +537,61 @@ class TestServerConfigSurface:
             )
             outputs.add(result.stdout.strip())
         assert len(outputs) == 1
+
+    def test_every_field_is_documented(self):
+        undocumented = [c.name for c in server_config_surface() if not c.help]
+        assert undocumented == []
+
+    def test_every_field_is_tagged(self):
+        untagged = [c.name for c in server_config_surface() if not c.tags]
+        assert untagged == []
+
+    def test_auth_mode_is_the_only_inferred_field(self):
+        """AUTH_MODE is derived from which auth vars are set, so it gets no control."""
+        assert [c.name for c in server_config_surface() if c.inferred] == ["auth_mode"]
+
+    def test_inferred_field_carries_no_wizard_hints(self):
+        auth_mode = next(c for c in server_config_surface() if c.name == "auth_mode")
+        assert auth_mode.wizard == {}
+
+    def test_base_url_carries_several_tags(self):
+        """A field can honestly belong to several documentation sections."""
+        base_url = next(c for c in server_config_surface() if c.name == "base_url")
+        assert set(base_url.tags) == {"server", "oidc", "apps"}
+
+    def test_secret_fields_are_marked(self):
+        secrets = {c.suffix for c in server_config_surface() if c.wizard.get("secret")}
+        assert secrets == {
+            "BEARER_TOKEN",
+            "OIDC_CLIENT_SECRET",
+            "OIDC_JWT_SIGNING_KEY",
+        }
+
+    def test_oidc_fields_share_the_oidc_tag(self):
+        tagged = {c.suffix for c in server_config_surface() if "oidc" in c.tags}
+        assert tagged == {
+            "BASE_URL",
+            "OIDC_CONFIG_URL",
+            "OIDC_CLIENT_ID",
+            "OIDC_CLIENT_SECRET",
+            "OIDC_AUDIENCE",
+            "OIDC_REQUIRED_SCOPES",
+            "OIDC_JWT_SIGNING_KEY",
+            "OIDC_VERIFY_ACCESS_TOKEN",
+        }
+
+    def test_kv_store_url_is_readme_prominent(self):
+        """The consuming README shows a 3-row curated table; this is its core row."""
+        kv = next(c for c in server_config_surface() if c.name == "kv_store_url")
+        assert "readme" in kv.tags
+
+    def test_defaults_are_unchanged_by_the_metadata_migration(self):
+        """Behaviour guard: converting to field(default=...) must not alter values."""
+        config = ServerConfig()
+        assert config.host == "127.0.0.1"
+        assert config.port == 8000
+        assert config.transport == "stdio"
+        assert config.oidc_required_scopes == ()
+        assert config.oidc_verify_access_token is False
+        assert config.bearer_default_subject == DEFAULT_BEARER_SUBJECT
+        assert config.base_url is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -547,7 +547,7 @@ class TestServerConfigSurface:
         assert untagged == []
 
     def test_auth_mode_is_the_only_inferred_field(self):
-        """AUTH_MODE is derived from which auth vars are set, so it gets no control."""
+        """AUTH_MODE is an expert override, so the wizard offers no control for it."""
         assert [c.name for c in server_config_surface() if c.inferred] == ["auth_mode"]
 
     def test_inferred_field_carries_no_wizard_hints(self):
@@ -604,5 +604,51 @@ class TestServerConfigSurface:
             oops: str = field(default="x", metadata={"wizard": "infered"})
 
         (bad,) = dataclasses.fields(_BadWizard)
-        with pytest.raises(ValueError, match="only accepted string form"):
+        with pytest.raises(ValueError, match="must be a mapping of hints"):
             _config_field_from(bad)
+
+    def test_non_mapping_non_string_wizard_is_rejected(self):
+        """The class is "any non-mapping", not just a mistyped string."""
+
+        @dataclass(frozen=True)
+        class _BadWizard:
+            oops: str = field(default="x", metadata={"wizard": ["inferred"]})
+
+        (bad,) = dataclasses.fields(_BadWizard)
+        with pytest.raises(ValueError, match="must be a mapping of hints"):
+            _config_field_from(bad)
+
+    def test_wizard_hints_use_only_documented_keys(self):
+        """An unrecognised hint key (e.g. a typo) would be silently ignored."""
+        documented = {"group", "when", "secret", "control"}
+        offenders = {
+            c.name: sorted(set(c.wizard) - documented)
+            for c in server_config_surface()
+            if set(c.wizard) - documented
+        }
+        assert offenders == {}
+
+    def test_every_declared_default_is_unchanged(self):
+        """Full 18-field guard; a spot check would miss a silent default change."""
+        expected = {
+            "transport": "stdio",
+            "host": "127.0.0.1",
+            "port": 8000,
+            "base_url": None,
+            "bearer_token": None,
+            "oidc_config_url": None,
+            "oidc_client_id": None,
+            "oidc_client_secret": None,
+            "oidc_audience": None,
+            "oidc_required_scopes": (),
+            "oidc_jwt_signing_key": None,
+            "oidc_verify_access_token": False,
+            "kv_store_url": None,
+            "event_store_url": None,
+            "app_domain": None,
+            "auth_mode": None,
+            "bearer_tokens_file": None,
+            "bearer_default_subject": DEFAULT_BEARER_SUBJECT,
+        }
+        actual = {c.name: c.default for c in server_config_surface()}
+        assert actual == expected


### PR DESCRIPTION
Closes #235

Gives every `ServerConfig` env field self-describing metadata — help text, semantic tags, wizard presentation hints — and exposes it as `server_config_surface()`, returning the 18 fields in **declaration order**.

Consumers can now generate their config documentation (wizard spec, env examples, docs tables) instead of hand-copying the env surface. Declaration order is contractual: it gives byte-stable generated output, which the `frozenset` from `server_config_env_suffixes()` cannot, because CPython randomises string hashing between processes.

Behaviour of the config itself is unchanged. All 18 defaults are immutable, so converting to `field(default=..., metadata=...)` is behaviour-preserving, and the pre-existing `ServerConfig` tests pass untouched. A new `test_every_declared_default_is_unchanged` pins all 18 declared defaults as a real guard rather than a spot check.

## ⚠️ One behaviour change, deliberate: a false warning is removed

`_warn_oidc_caveats` logged `oidc_proxy_auth_ephemeral_signing_key` when `oidc_jwt_signing_key` was unset on Linux, claiming "tokens will be invalidated on every server restart". **That was false**, and this PR deletes it.

Verified against fastmcp 3.3.1 (`server/auth/oauth_proxy/proxy.py:454-463`): when `jwt_signing_key is None`, `OAuthProxy` derives it via

```python
derive_jwt_key(
    high_entropy_material=upstream_client_secret,
    salt="fastmcp-jwt-signing-key",
)
```

which is HKDF-SHA256 with a **fixed** salt — confirmed deterministic by calling it twice with the same input. Since `build_oidc_proxy_auth` only constructs `OIDCProxy` when `oidc_client_secret` is present, this derivation path always applies. Same secret in, same key out: **tokens survive a restart.** The `sys.platform.startswith("linux")` gate was meaningless too, as HKDF derivation is platform-independent.

The real caveat, now documented in the field's help: because the key is derived from the client secret, **rotating that secret invalidates every issued token** — which is the actual reason to set an explicit key.

Two tests asserted the warning fires. Both are **rewritten to assert it does not**, scoped to the `ephemeral_signing_key` message substring rather than "no warnings at all", so a re-added warning still fails them. `_warn_oidc_caveats`'s now-unused `signing_key` parameter is removed; all call sites were already keyword-form.

The same falsehood exists in `fastmcp-server-template` and is tracked there as pvliesdonk/fastmcp-server-template#260.

## `auth_mode` was documented as derived; it is an operator override

`from_env` reads `{PREFIX}_AUTH_MODE`, and `resolve_auth_mode` treats it as an explicit override accepting `remote` or `oidc-proxy` — it exists because having all four OIDC variables set is ambiguous between those two modes. Its help now says so.

Consequently `ConfigField.inferred` is defined as **"no wizard control is offered"**, explicitly *not* "not operator-settable": an `inferred` variable must still appear in env references and `.env.example`. Getting that wrong in a consumer would silently drop a supported variable from every downstream's documentation.

## Notes for consumers

- `ConfigField.default` carries the *declared* default. Where the effective runtime default differs, the help text names it — `kv_store_url` defaults to `file:///data/state`, `oidc_required_scopes` to `openid` in oidc-proxy mode.
- The wizard hint vocabulary (`group`, `when`, `secret`, `control`) is documented on `ConfigField.wizard`, and a test pins it so an undocumented key cannot slip in unnoticed.
- `metadata["wizard"]` accepts either a mapping of hints or the string `"inferred"`; anything else raises `ValueError` naming the field, rather than an opaque `AttributeError`.

## Not in this PR

Deriving `_SERVER_CONFIG_ENV_SUFFIXES` from the field declarations — that hand-maintained literal is still hand-maintained. It ships as a separate follow-up so this PR stays a single concern.

Prerequisite for Stage 0 of the config-generation design in `fastmcp-server-template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01As25PstUQeTR47J5SP5g7P

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._